### PR TITLE
feat(distributed): Ulysses Context Parallelism for attention

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -127,6 +127,8 @@
       title: Tensor parallelism
     - local: expert_parallelism
       title: Expert parallelism
+    - local: context_parallelism
+      title: Context parallelism
     - local: kv_cache
       title: Cache strategies
     - local: cache_explanation

--- a/docs/source/en/context_parallelism.md
+++ b/docs/source/en/context_parallelism.md
@@ -1,0 +1,123 @@
+<!--Copyright 2025 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Context parallelism
+
+[Context parallelism](https://arxiv.org/abs/2309.14509) (CP) shards the **sequence** dimension of every per-token activation across a group of accelerators. Each rank holds the full set of model weights but only `N_local = N_total // cp_world` tokens. Point-wise ops (norms, projections, RoPE, MLP, residual adds) run locally on the shard with no communication. The single global op is attention, which would normally require seeing the whole sequence — Transformers' CP implementation uses **Ulysses-style** attention, which swaps the head axis for the sequence axis via two `all_to_all`s around the SDPA call. The result is mathematically identical to single-GPU attention, and the communication cost scales as `O(B * S * d / cp_world)` per layer.
+
+CP is complementary to tensor parallelism (TP) and expert parallelism (EP):
+
+| What it shards | TP | EP | CP |
+|---|---|---|---|
+| Weights | yes (column- or row-wise) | yes (per-expert) | no |
+| Activations | hidden dim | expert dim | sequence dim |
+| Main benefit | larger models per GPU | larger MoE | longer sequences per GPU |
+
+Use CP when the attention scratchpad (`Q @ K^T` is `B * H * N * N`) is what's pushing you out of memory, or when you want to use idle GPUs to roughly halve your step time at long sequences.
+
+## DistributedConfig
+
+> [!WARNING]
+> The [`DistributedConfig`] API is experimental and its usage may change in the future.
+
+Enable context parallelism with the `enable_context_parallel` and `cp_world_size` arguments. The CP group is built from the first `cp_world_size` ranks in the default world process group.
+
+```py
+import torch
+from transformers import AutoModelForCausalLM
+from transformers.distributed.configuration_utils import DistributedConfig
+
+cfg = DistributedConfig(enable_context_parallel=True, cp_world_size=2)
+
+model = AutoModelForCausalLM.from_pretrained(
+    "openai/gpt-oss-20b",
+    dtype="bfloat16",
+    distributed_config=cfg,
+)
+```
+
+Launch the script with `torchrun`:
+
+```bash
+torchrun --nproc-per-node 2 your_script.py
+```
+
+You can compose CP with expert parallelism. With 4 GPUs and `ep_world_size = cp_world_size = 2`, you get a 2-D mesh where every rank holds half of the experts *and* half of the sequence.
+
+```py
+cfg = DistributedConfig(
+    enable_expert_parallel=True,
+    enable_context_parallel=True,
+    cp_world_size=2,
+)
+```
+
+## Post-load API
+
+For more direct control (custom process groups, 2-D meshes, manual launch outside `from_pretrained`), use `apply_context_parallel` directly:
+
+```py
+from transformers.integrations.context_parallel import apply_context_parallel
+
+apply_context_parallel(model, cp_world_size=2)
+```
+
+This walks the model's `_cp_plan` (a class-level dict that names which attention modules are eligible) and stashes the CP process group on each. The model's `_attn_implementation` is set to `"context_parallel_ulysses"` so the registered Ulysses attention function is dispatched at every attention call.
+
+## Supported models
+
+A model opts in by declaring a `_cp_plan` class attribute, in the same spirit as `_tp_plan`. Currently enabled:
+
+- `GptOssForCausalLM` (`openai/gpt-oss-20b`, `openai/gpt-oss-120b`)
+- `Qwen3MoeForCausalLM` (`Qwen/Qwen3-MoE-*`)
+
+Adding CP support to another model is a one-line change:
+
+```py
+class MyModelForCausalLM(MyModelPreTrainedModel, GenerationMixin):
+    _cp_plan = {"model.layers.*.self_attn": "context_parallel_ulysses"}
+```
+
+Sinks (per-head attention sink parameters, used by GPT-OSS) and sliding-window attention are handled automatically: the registered Ulysses function reads `module.sinks` and `module.sliding_window` if present.
+
+## Inputs and outputs
+
+CP expects pre-sharded sequence inputs. Every rank in the CP group must hold a contiguous slice of the input sequence of length `N_total // cp_world`. The simplest way to produce this is to split your `input_ids` and `position_ids` tensors along the sequence axis after the tokenizer call:
+
+```py
+import torch.distributed as dist
+
+batch = tokenizer(text, return_tensors="pt", padding="max_length", max_length=N_total)
+rank = dist.get_rank()
+cp_world = cfg.cp_world_size
+n_local = N_total // cp_world
+local_batch = {
+    k: v[:, rank * n_local : (rank + 1) * n_local] for k, v in batch.items()
+}
+```
+
+Outputs (logits) are also seq-sharded; gather them with `dist.all_gather` if you need the full sequence on every rank.
+
+## Limitations
+
+- **Strategy**: only Ulysses (head-axis `all_to_all`) is implemented. Ring Attention is a planned follow-up.
+- **Dropout**: attention dropout is rejected — independent per-rank drops would desynchronise the softmax. Disable dropout for CP training, or pre-broadcast a shared mask.
+- **Explicit attention masks**: only the implicit causal mask (plus optional sliding window) is supported. Custom additive masks would need to be sharded the same way as the seq axis; not in v1.
+- **Head divisibility**: `num_attention_heads` and `num_key_value_heads` must both be divisible by `cp_world_size`. For GPT-OSS (64 Q-heads, 8 KV-heads), this allows `cp_world_size ∈ {1, 2, 4, 8}`.
+
+## References
+
+- Jacobs et al., *DeepSpeed-Ulysses: System Optimizations for Training Extreme Long Sequence Transformer Models* — [arXiv:2309.14509](https://arxiv.org/abs/2309.14509)
+- Reference implementation + parity tests + benchmarks: [AlexWortega/transformers-cp-research](https://github.com/AlexWortega/transformers-cp-research)

--- a/src/transformers/distributed/__init__.py
+++ b/src/transformers/distributed/__init__.py
@@ -19,12 +19,18 @@ from ..utils import _LazyModule
 
 _import_structure = {
     "configuration_utils": ["DistributedConfig"],
+    "context_parallel": ["CPGroup", "build_cp_group_from_default", "ulysses_attention"],
 }
 
 
 if TYPE_CHECKING:
     from .configuration_utils import (
         DistributedConfig,
+    )
+    from .context_parallel import (
+        CPGroup,
+        build_cp_group_from_default,
+        ulysses_attention,
     )
 
 else:

--- a/src/transformers/distributed/configuration_utils.py
+++ b/src/transformers/distributed/configuration_utils.py
@@ -26,6 +26,9 @@ class DistributedConfig:
     """
 
     enable_expert_parallel: bool = False
+    enable_context_parallel: bool = False
+    cp_world_size: int = 1
+    cp_strategy: str = "ulysses"
     # TODO: add tp_plan, pp_plan, device_mesh etc..
 
     @classmethod

--- a/src/transformers/distributed/context_parallel.py
+++ b/src/transformers/distributed/context_parallel.py
@@ -1,0 +1,386 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Ulysses-style Context Parallelism (CP) primitives.
+
+Each rank in a CP process group holds a contiguous *sequence slice* of every
+per-token tensor: ``hidden_states.shape == (B, N_local, H)`` with
+``N_local = N_total // cp_world``. All point-wise ops (norms, projections,
+RoPE, MLP, residual add) run locally on the shard. Attention is the only
+global op, and it is handled by ``ulysses_attention``: a single all-to-all
+on the head axis swaps ``head_axis`` for ``seq_axis`` so the SDPA call sees
+the full causal sequence, then an inverse all-to-all returns to the
+sequence-sharded layout.
+
+This module has no dependency on ``transformers`` internals — it is pure
+``torch`` + ``torch.distributed`` so it can be reused as a stand-alone
+attention kernel. The user-facing wiring (model walking, registering the
+attention impl, threading ``cp_group``) lives in
+``transformers.integrations.context_parallel``.
+
+References:
+- Jacobs et al., "DeepSpeed-Ulysses: System Optimizations for Training
+  Extreme Long Sequence Transformer Models" (https://arxiv.org/abs/2309.14509)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+
+@dataclass
+class CPGroup:
+    """Lightweight wrapper around a CP-axis ``torch.distributed.ProcessGroup``.
+
+    Holding the process group in a small object (rather than passing
+    ``ProcessGroup`` around directly) lets call sites query
+    ``world`` / ``rank`` without re-importing ``torch.distributed`` and
+    keeps the ``cp_world == 1`` degenerate case as ``CPGroup(group=None)``.
+
+    Args:
+        group (`torch.distributed.ProcessGroup`, *optional*):
+            The CP-axis process group, or ``None`` to disable CP (the
+            attention kernel falls back to local SDPA).
+    """
+
+    group: dist.ProcessGroup | None
+
+    @property
+    def world(self) -> int:
+        if self.group is None:
+            return 1
+        return dist.get_world_size(self.group)
+
+    @property
+    def rank(self) -> int:
+        if self.group is None:
+            return 0
+        return dist.get_rank(self.group)
+
+    def is_active(self) -> bool:
+        return self.group is not None and self.world > 1
+
+
+def build_cp_group_from_default() -> CPGroup:
+    """Build a :class:`CPGroup` from the default world process group.
+
+    Convenience for single-axis CP runs (every rank is in the CP group).
+    For 2-D meshes (e.g. EP × CP), construct sub-groups explicitly and pass
+    them to :func:`ulysses_attention`.
+    """
+    if not dist.is_initialized():
+        return CPGroup(group=None)
+    return CPGroup(group=dist.group.WORLD)
+
+
+def _alltoall_heads_seq_to_head(x: torch.Tensor, cp: CPGroup) -> torch.Tensor:
+    """All-to-all that swaps the head axis (split) for the seq axis (gather).
+
+    Input shape:  ``(B, H, N_local, D)`` — seq-sharded.
+    Output shape: ``(B, H // cp.world, N_total, D)`` — head-sharded.
+
+    Used for both Q (``H = num_q_heads``) and KV
+    (``H = num_kv_heads``). The only constraint is
+    ``H % cp.world == 0``.
+
+    The implementation permutes so that the split axis (``P = cp.world``)
+    is the *leading* dim before slicing. This avoids a subtle NCCL bug
+    where non-contiguous views of a ``(B, P, H/P, N, D)`` tensor with
+    ``B > 1`` are silently corrupted by ``all_to_all`` (the per-rank
+    slices look contiguous when ``B == 1`` because ``stride[0]`` happens
+    to match, but break when ``B > 1``).
+    """
+    B, H, n_local, D = x.shape
+    P = cp.world
+    if H % P != 0:
+        raise ValueError(f"head count {H} must be divisible by cp_world {P}")
+
+    y = x.reshape(B, P, H // P, n_local, D).permute(1, 0, 2, 3, 4).contiguous()
+    in_list = [y[r] for r in range(P)]
+    out_buf = torch.empty_like(y)
+    out_list = [out_buf[r] for r in range(P)]
+    dist.all_to_all(out_list, in_list, group=cp.group)
+    out = out_buf.permute(1, 2, 0, 3, 4).contiguous()
+    out = out.reshape(B, H // P, P * n_local, D)
+    return out
+
+
+def _alltoall_heads_head_to_seq(x: torch.Tensor, cp: CPGroup) -> torch.Tensor:
+    """Inverse of :func:`_alltoall_heads_seq_to_head`.
+
+    Input shape:  ``(B, H_local, N_total, D)`` — head-sharded.
+    Output shape: ``(B, H_local * cp.world, N_local, D)`` — seq-sharded.
+    """
+    B, H_local, N_total, D = x.shape
+    P = cp.world
+    if N_total % P != 0:
+        raise ValueError(f"N_total {N_total} must be divisible by cp_world {P}")
+    n_local = N_total // P
+
+    y = x.reshape(B, H_local, P, n_local, D).permute(2, 0, 1, 3, 4).contiguous()
+    in_list = [y[r] for r in range(P)]
+    out_buf = torch.empty_like(y)
+    out_list = [out_buf[r] for r in range(P)]
+    dist.all_to_all(out_list, in_list, group=cp.group)
+    out = out_buf.permute(1, 0, 2, 3, 4).contiguous()
+    out = out.reshape(B, P * H_local, n_local, D)
+    return out
+
+
+def _local_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    is_causal: bool,
+    scale: float,
+    sinks: torch.Tensor | None = None,
+    sliding_window: int | None = None,
+) -> torch.Tensor:
+    """Local attention on head-sharded, full-sequence tensors.
+
+    Uses :func:`torch.nn.functional.scaled_dot_product_attention` on the
+    hot path (no sinks, no sliding-window) and falls back to an explicit
+    softmax otherwise. Handles GQA by ``repeat_interleave`` over the head
+    axis.
+
+    Args:
+        q (`torch.Tensor`): Query, shape ``(B, H_q, N, D)``.
+        k (`torch.Tensor`): Key, shape ``(B, H_kv, N, D)``.
+        v (`torch.Tensor`): Value, shape ``(B, H_kv, N, D)``.
+        is_causal (`bool`): Whether to apply a causal mask.
+        scale (`float`): Softmax scaling factor (typically ``1/sqrt(D)``).
+        sinks (`torch.Tensor`, *optional*):
+            Per-head attention sink logit, shape ``(H_q,)``. Adds an
+            implicit "always-zero" key with the per-head bias.
+        sliding_window (`int`, *optional*):
+            If set, also applies a band mask of the given width on top of
+            the causal mask.
+
+    Returns:
+        `torch.Tensor` of shape ``(B, H_q, N, D)``.
+    """
+    Hq = q.size(1)
+    Hkv = k.size(1)
+    g = Hq // Hkv
+
+    if g > 1:
+        k = k.repeat_interleave(g, dim=1)
+        v = v.repeat_interleave(g, dim=1)
+
+    if sinks is None and sliding_window is None:
+        return F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            dropout_p=0.0,
+            is_causal=is_causal,
+            scale=scale,
+        )
+
+    B, _, N, _ = q.shape
+    logits = torch.matmul(q, k.transpose(-1, -2)) * scale
+
+    if is_causal:
+        causal_mask = torch.ones(N, N, dtype=torch.bool, device=q.device).tril()
+        if sliding_window is not None:
+            band = torch.ones(N, N, dtype=torch.bool, device=q.device).triu(diagonal=-sliding_window + 1)
+            causal_mask = causal_mask & band
+        logits = logits.masked_fill(~causal_mask, float("-inf"))
+
+    if sinks is not None:
+        sink_logits = sinks.reshape(1, -1, 1, 1).expand(B, -1, N, 1)
+        logits = torch.cat([logits, sink_logits.to(logits.dtype)], dim=-1)
+        attn = torch.softmax(logits, dim=-1)
+        attn = attn[..., :-1]
+    else:
+        attn = torch.softmax(logits, dim=-1)
+
+    return torch.matmul(attn, v)
+
+
+class _UlyssesFn(torch.autograd.Function):
+    """Ulysses autograd function.
+
+    Forward:
+        1. All-to-all on Q and KV head axis (seq → head).
+        2. Local attention on the head-sharded, full-sequence tensors.
+        3. Inverse all-to-all on output (head → seq).
+
+    Backward:
+        1. All-to-all on ``grad_out`` head axis.
+        2. Recompute local attention with ``torch.enable_grad`` and use
+           :func:`torch.autograd.grad` to get ``dQ``, ``dK``, ``dV``,
+           and optionally ``d_sinks`` on the local head shard.
+        3. Inverse all-to-all on ``dQ``, ``dK``, ``dV`` to seq-sharded.
+        4. ``all_gather`` on ``d_sinks`` along the cp axis to reconstruct
+           the full sink gradient (shape ``(H_q,)``).
+    """
+
+    @staticmethod
+    def forward(ctx, q, k, v, sinks, is_causal, scale, sliding_window, cp_group):
+        cp = CPGroup(group=cp_group)
+        Hq_total = q.size(1)
+
+        q_h = _alltoall_heads_seq_to_head(q, cp)
+        k_h = _alltoall_heads_seq_to_head(k, cp)
+        v_h = _alltoall_heads_seq_to_head(v, cp)
+
+        sinks_local = None
+        if sinks is not None:
+            head_slice = slice(
+                cp.rank * (Hq_total // cp.world),
+                (cp.rank + 1) * (Hq_total // cp.world),
+            )
+            sinks_local = sinks[head_slice]
+
+        out_h = _local_attention(
+            q_h,
+            k_h,
+            v_h,
+            is_causal=is_causal,
+            scale=scale,
+            sinks=sinks_local,
+            sliding_window=sliding_window,
+        )
+        out = _alltoall_heads_head_to_seq(out_h, cp)
+
+        ctx.save_for_backward(q, k, v, sinks if sinks is not None else q.new_empty(0))
+        ctx.is_causal = is_causal
+        ctx.scale = scale
+        ctx.sliding_window = sliding_window
+        ctx.cp_group = cp_group
+        ctx.has_sinks = sinks is not None
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        q, k, v, sinks_buf = ctx.saved_tensors
+        cp = CPGroup(group=ctx.cp_group)
+        sinks = sinks_buf if ctx.has_sinks else None
+        Hq_total = q.size(1)
+
+        grad_out_h = _alltoall_heads_seq_to_head(grad_out, cp)
+
+        with torch.enable_grad():
+            q_h = _alltoall_heads_seq_to_head(q.detach(), cp).requires_grad_(True)
+            k_h = _alltoall_heads_seq_to_head(k.detach(), cp).requires_grad_(True)
+            v_h = _alltoall_heads_seq_to_head(v.detach(), cp).requires_grad_(True)
+            sinks_local = None
+            if ctx.has_sinks:
+                head_slice = slice(
+                    cp.rank * (Hq_total // cp.world),
+                    (cp.rank + 1) * (Hq_total // cp.world),
+                )
+                sinks_local = sinks[head_slice].detach().requires_grad_(True)
+            out_h_local = _local_attention(
+                q_h,
+                k_h,
+                v_h,
+                is_causal=ctx.is_causal,
+                scale=ctx.scale,
+                sinks=sinks_local,
+                sliding_window=ctx.sliding_window,
+            )
+            grad_inputs = [q_h, k_h, v_h] + ([sinks_local] if ctx.has_sinks else [])
+            grads = torch.autograd.grad(
+                out_h_local,
+                grad_inputs,
+                grad_outputs=grad_out_h,
+                retain_graph=False,
+                create_graph=False,
+            )
+        dq_h, dk_h, dv_h = grads[0], grads[1], grads[2]
+        d_sinks_local = grads[3] if ctx.has_sinks else None
+
+        dq = _alltoall_heads_head_to_seq(dq_h, cp)
+        dk = _alltoall_heads_head_to_seq(dk_h, cp)
+        dv = _alltoall_heads_head_to_seq(dv_h, cp)
+
+        d_sinks = None
+        if ctx.has_sinks:
+            if cp.is_active():
+                buf = [torch.empty_like(d_sinks_local) for _ in range(cp.world)]
+                dist.all_gather(buf, d_sinks_local, group=cp.group)
+            else:
+                buf = [d_sinks_local]
+            d_sinks = torch.cat(buf, dim=0)
+
+        return dq, dk, dv, d_sinks, None, None, None, None
+
+
+def ulysses_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    is_causal: bool = True,
+    scale: float | None = None,
+    sinks: torch.Tensor | None = None,
+    sliding_window: int | None = None,
+    cp_group: dist.ProcessGroup | None = None,
+) -> torch.Tensor:
+    """Ulysses-style attention with GQA + optional per-head sink logit.
+
+    Args:
+        q (`torch.Tensor`): Query, seq-sharded, shape ``(B, H_q, N_local, D)``.
+        k (`torch.Tensor`): Key, seq-sharded, shape ``(B, H_kv, N_local, D)``.
+        v (`torch.Tensor`): Value, seq-sharded, shape ``(B, H_kv, N_local, D)``.
+        is_causal (`bool`, *optional*, defaults to ``True``):
+            Whether to apply a causal mask inside the local attention.
+        scale (`float`, *optional*):
+            Softmax scaling factor. Defaults to ``D ** -0.5``.
+        sinks (`torch.Tensor`, *optional*):
+            Per-head sink logit, shape ``(H_q,)``. Required for GPT-OSS-style
+            attention; ``None`` for plain LLaMA-style.
+        sliding_window (`int`, *optional*):
+            If set, applies a band mask of the given width on top of the
+            causal mask.
+        cp_group (`torch.distributed.ProcessGroup`, *optional*):
+            CP-axis process group. ``None`` or world-size-1 group falls
+            back to local attention.
+
+    Returns:
+        `torch.Tensor` of shape ``(B, H_q, N_local, D)`` (seq-sharded).
+    """
+    if scale is None:
+        scale = q.size(-1) ** -0.5
+    if cp_group is None or dist.get_world_size(cp_group) == 1:
+        return _local_attention(
+            q,
+            k,
+            v,
+            is_causal=is_causal,
+            scale=float(scale),
+            sinks=sinks,
+            sliding_window=sliding_window,
+        )
+    return _UlyssesFn.apply(
+        q,
+        k,
+        v,
+        sinks,
+        is_causal,
+        float(scale),
+        sliding_window,
+        cp_group,
+    )
+
+
+__all__ = ["CPGroup", "build_cp_group_from_default", "ulysses_attention"]

--- a/src/transformers/integrations/context_parallel.py
+++ b/src/transformers/integrations/context_parallel.py
@@ -14,35 +14,28 @@
 """
 User-facing integration for Context Parallelism (CP).
 
-Registers a new attention implementation, ``"context_parallel_ulysses"``,
-under :data:`transformers.modeling_utils.ALL_ATTENTION_FUNCTIONS`. When a
-model is wrapped with :func:`apply_context_parallel`, every attention
-submodule whose qualified name matches the model's ``_cp_plan`` has the
-CP process group stashed on it as ``module._cp_group`` and the model's
-``_attn_implementation`` is set to ``"context_parallel_ulysses"``.
+This module mirrors the entry-point split that tensor parallelism uses:
 
-The user-facing flow mirrors Tensor Parallelism:
+* :func:`initialize_context_parallelism` — runs *before* the model is loaded.
+  Initialises ``torch.distributed`` if needed, builds the CP-axis process
+  group, and returns it. Analogous to
+  :func:`transformers.integrations.tensor_parallel.initialize_tensor_parallelism`.
+* :func:`distribute_context_parallel` — runs *after* the model is loaded.
+  Validates the model's ``_cp_plan``, registers the CP attention
+  implementation in ``ALL_ATTENTION_FUNCTIONS`` if not already done,
+  walks the model and stashes the CP process group on every matched
+  attention module, and flips ``config._attn_implementation`` to the
+  registered CP strategy. Analogous to
+  :func:`transformers.integrations.tensor_parallel.distribute_model`.
 
-    from transformers import AutoModelForCausalLM
-    from transformers.distributed import DistributedConfig
-
-    cfg = DistributedConfig(enable_context_parallel=True, cp_world_size=2)
-    model = AutoModelForCausalLM.from_pretrained(
-        "openai/gpt-oss-20b", distributed_config=cfg, dtype="bfloat16",
-    )
-    # ... or post-load:
-    from transformers.integrations.context_parallel import apply_context_parallel
-    apply_context_parallel(model, cp_world_size=2)
-
-The model's input must be pre-sharded on the sequence dimension across the
-CP group (every rank sees its own ``N_total / cp_world`` chunk). Attention
-layers then perform a head-axis all-to-all so the SDPA call sees the full
-causal sequence; everything else is point-wise on the local shard.
+A one-call convenience wrapper :func:`apply_context_parallel` is kept for
+users who want to enable CP outside the :meth:`from_pretrained` flow.
 """
 
 from __future__ import annotations
 
 import fnmatch
+import os
 import re
 
 import torch
@@ -50,9 +43,18 @@ import torch.distributed as dist
 
 from ..distributed.context_parallel import ulysses_attention
 from ..utils import logging
+from ..utils.import_utils import is_torch_greater_or_equal
 
 
 logger = logging.get_logger(__name__)
+
+
+# Maps cp_strategy string → AttentionInterface key registered in
+# ALL_ATTENTION_FUNCTIONS. Update here when adding new strategies
+# (e.g. "ring" → "context_parallel_ring").
+_CP_STRATEGY_TO_ATTN_IMPL = {
+    "ulysses": "context_parallel_ulysses",
+}
 
 
 def _cp_ulysses_attention_forward(
@@ -68,8 +70,8 @@ def _cp_ulysses_attention_forward(
 ) -> tuple[torch.Tensor, None]:
     """Attention function registered as ``"context_parallel_ulysses"``.
 
-    Reads ``module._cp_group`` (set by :func:`apply_context_parallel`) and
-    delegates to :func:`transformers.distributed.context_parallel.ulysses_attention`.
+    Reads ``module._cp_group`` (set by :func:`distribute_context_parallel`)
+    and delegates to :func:`transformers.distributed.context_parallel.ulysses_attention`.
 
     Sinks and sliding-window are picked up from the attention module's
     own attributes (``module.sinks`` / ``module.sliding_window``) if
@@ -123,31 +125,8 @@ def _register_cp_attention_impl() -> None:
         )
 
 
-def _build_cp_group(cp_world_size: int) -> dist.ProcessGroup | None:
-    """Build a single CP process group spanning ``cp_world_size`` consecutive ranks.
-
-    Assumes the default world process group has been initialised. Picks the
-    world's first ``cp_world_size`` ranks. For 2-D meshes (e.g. EP × CP),
-    callers should construct sub-groups explicitly and pass them to
-    :func:`apply_context_parallel` via the ``cp_group`` argument.
-    """
-    if cp_world_size <= 1:
-        return None
-    if not dist.is_initialized():
-        raise RuntimeError(
-            "apply_context_parallel(cp_world_size>1) requires torch.distributed to be initialised (e.g. via torchrun)."
-        )
-    world_size = dist.get_world_size()
-    if world_size % cp_world_size != 0:
-        raise ValueError(f"world_size ({world_size}) must be divisible by cp_world_size ({cp_world_size}).")
-    rank = dist.get_rank()
-    cp_group_id = rank // cp_world_size
-    ranks = list(range(cp_group_id * cp_world_size, (cp_group_id + 1) * cp_world_size))
-    return dist.new_group(ranks=ranks)
-
-
 def _glob_to_regex(pattern: str) -> re.Pattern:
-    """Convert a `_cp_plan` glob (with ``*`` wildcards) to a compiled regex.
+    """Convert a ``_cp_plan`` glob (with ``*`` wildcards) to a compiled regex.
 
     Mirrors how ``_tp_plan`` keys are interpreted: ``"model.layers.*.self_attn"``
     matches any layer index.
@@ -155,59 +134,160 @@ def _glob_to_regex(pattern: str) -> re.Pattern:
     return re.compile(fnmatch.translate(pattern))
 
 
-def apply_context_parallel(
-    model: torch.nn.Module,
-    cp_world_size: int,
-    cp_group: dist.ProcessGroup | None = None,
-    cp_strategy: str = "ulysses",
-) -> torch.nn.Module:
-    """Enable context parallelism on every attention module declared in ``model._cp_plan``.
+def initialize_context_parallelism(
+    distributed_config=None,
+    cp_size: int | None = None,
+    device_mesh=None,
+) -> tuple[dist.ProcessGroup | None, int]:
+    """Set up ``torch.distributed`` and build the CP-axis process group.
+
+    Mirrors :func:`initialize_tensor_parallelism` for the CP axis.
+    Called *before* the model is loaded so the CP process group exists
+    by the time :func:`distribute_context_parallel` is invoked.
 
     Args:
-        model: A `PreTrainedModel` whose class declares ``_cp_plan`` (a dict
-            mapping glob patterns over module qualified names to CP strategy
-            keys, e.g. ``{"model.layers.*.self_attn": "ulysses"}``).
-        cp_world_size: Number of ranks across which to shard the sequence
-            dimension. Must divide ``torch.distributed.get_world_size()``.
-        cp_group: Optional pre-built CP-axis process group (useful for 2-D
-            EP × CP meshes). If omitted, builds a fresh group covering
-            ``cp_world_size`` consecutive global ranks.
-        cp_strategy: Currently only ``"ulysses"`` is supported. Future work
-            may add ``"ring"``.
+        distributed_config (`DistributedConfig`, *optional*):
+            The user's distributed config. CP activates iff
+            ``enable_context_parallel`` is ``True`` and the requested
+            ``cp_world_size > 1``.
+        cp_size (`int`, *optional*):
+            Explicit CP world size override. Defaults to
+            ``distributed_config.cp_world_size``.
+        device_mesh (`torch.distributed.device_mesh.DeviceMesh`, *optional*):
+            Pre-built 1-D or N-D mesh. If N-D, the ``"cp"`` axis is used.
+            When omitted, a fresh sub-group is built from the default
+            world process group covering ``cp_size`` consecutive ranks.
+
+    Returns:
+        Tuple of ``(cp_group, cp_size)``. ``cp_group`` is ``None`` when
+        CP is disabled or the world is size-1.
+    """
+    if distributed_config is None or not getattr(distributed_config, "enable_context_parallel", False):
+        return None, 1
+
+    if cp_size is None:
+        cp_size = getattr(distributed_config, "cp_world_size", 1)
+    if cp_size <= 1:
+        return None, 1
+
+    if device_mesh is not None:
+        if device_mesh.ndim > 1:
+            if "cp" not in device_mesh.mesh_dim_names:
+                raise ValueError(
+                    "When using `enable_context_parallel` with an n-d `device_mesh`, it must contain a "
+                    "'cp' dimension. Please provide a valid `device_mesh`."
+                )
+            cp_dim = device_mesh["cp"]
+        else:
+            cp_dim = device_mesh
+        return cp_dim.get_group(), cp_dim.size()
+
+    if not is_torch_greater_or_equal("2.0"):
+        raise OSError("Context parallel is only supported for `torch>=2.0`.")
+
+    if not torch.distributed.is_initialized():
+        try:
+            rank = int(os.environ["RANK"])
+            world_size = int(os.environ["WORLD_SIZE"])
+            device_type = torch._C._get_accelerator().type
+            backend_map = {
+                "cuda": "nccl",
+                "cpu": "gloo",
+                "xpu": "xccl",
+                "hpu": "hccl",
+            }
+            torch.distributed.init_process_group(
+                backend=backend_map.get(device_type, "nccl"),
+                rank=rank,
+                world_size=world_size,
+            )
+            if device_type != "cpu":
+                local_rank = int(os.environ["LOCAL_RANK"])
+                getattr(torch, device_type).set_device(local_rank)
+        except Exception as e:
+            raise OSError(
+                "We tried to initialize torch.distributed for you, but it failed. Make "
+                "sure you init torch distributed in your script to use `enable_context_parallel`."
+            ) from e
+
+    world = torch.distributed.get_world_size()
+    if world % cp_size != 0:
+        raise ValueError(f"world_size ({world}) must be divisible by cp_size ({cp_size}).")
+
+    rank = torch.distributed.get_rank()
+    cp_group_id = rank // cp_size
+    ranks = list(range(cp_group_id * cp_size, (cp_group_id + 1) * cp_size))
+    cp_group = torch.distributed.new_group(ranks=ranks)
+    return cp_group, cp_size
+
+
+def distribute_context_parallel(
+    model: torch.nn.Module,
+    cp_group: dist.ProcessGroup | None,
+    distributed_config=None,
+) -> torch.nn.Module:
+    """Apply the model's ``_cp_plan`` after the model has been loaded.
+
+    Mirrors :func:`distribute_model` for the CP axis. Walks
+    ``model.named_modules()`` and for every module whose qualified name
+    matches one of the globs in ``_cp_plan``, stashes ``cp_group`` on it
+    as ``module._cp_group``. Validates that each plan entry maps to a
+    strategy registered in ``ALL_ATTENTION_FUNCTIONS``. Finally sets
+    ``model.config._attn_implementation`` to the registered CP strategy
+    so subsequent forward calls go through the CP attention function.
+
+    Args:
+        model: The loaded ``PreTrainedModel`` (or other model whose
+            class declares ``_cp_plan``).
+        cp_group: The CP-axis process group from
+            :func:`initialize_context_parallelism`. May be ``None`` for
+            ``cp_size == 1`` (no-op).
+        distributed_config (`DistributedConfig`, *optional*):
+            Records ``cp_strategy`` for forward-compat. Defaults to
+            ``"ulysses"``.
 
     Returns:
         The same ``model``, mutated in place.
 
     Raises:
-        ValueError: If ``model.__class__`` does not declare a ``_cp_plan``,
-            or if ``cp_strategy`` is unknown.
+        ValueError: If the model class does not declare ``_cp_plan``,
+            if any strategy in the plan is not registered in
+            ``ALL_ATTENTION_FUNCTIONS``, or if ``cp_strategy`` is unknown.
     """
+    if cp_group is None:
+        return model
+
+    cp_strategy = getattr(distributed_config, "cp_strategy", "ulysses") if distributed_config else "ulysses"
+    if cp_strategy not in _CP_STRATEGY_TO_ATTN_IMPL:
+        raise ValueError(f"Unknown cp_strategy {cp_strategy!r}. Supported: {sorted(_CP_STRATEGY_TO_ATTN_IMPL)}.")
+
     _register_cp_attention_impl()
+    from ..modeling_utils import ALL_ATTENTION_FUNCTIONS
 
-    if cp_strategy != "ulysses":
-        raise ValueError(f"Unknown cp_strategy {cp_strategy!r}. Only 'ulysses' is currently supported.")
-
-    plan = getattr(model.__class__, "_cp_plan", None)
-    if not plan:
-        # Walk MRO to find an inherited _cp_plan (the base PreTrainedModel
-        # subclass usually owns it on the *ForCausalLM head).
-        for klass in type(model).__mro__:
-            plan = getattr(klass, "_cp_plan", None)
-            if plan:
-                break
+    # Walk MRO to find _cp_plan inherited from a base class if needed.
+    plan = None
+    for klass in type(model).__mro__:
+        plan = getattr(klass, "_cp_plan", None)
+        if plan:
+            break
     if not plan:
         raise ValueError(
             f"{type(model).__name__} does not declare _cp_plan; add a class-level dict "
             "such as {'model.layers.*.self_attn': 'context_parallel_ulysses'} to enable CP."
         )
 
-    if cp_world_size > 1 and cp_group is None:
-        cp_group = _build_cp_group(cp_world_size)
+    valid_keys = set(ALL_ATTENTION_FUNCTIONS.valid_keys())
+    for strategy in plan.values():
+        if strategy not in valid_keys:
+            raise ValueError(
+                f"Unknown CP strategy {strategy!r} in _cp_plan on {type(model).__name__}. "
+                f"Registered attention impls: {sorted(valid_keys)}"
+            )
 
     compiled = [(_glob_to_regex(pat), strat) for pat, strat in plan.items()]
     n_wrapped = 0
     for name, sub in model.named_modules():
-        for pat, strat in compiled:
+        for pat, _ in compiled:
             if pat.match(name):
                 sub._cp_group = cp_group
                 n_wrapped += 1
@@ -220,15 +300,58 @@ def apply_context_parallel(
         )
     else:
         logger.info(
-            "Context parallelism enabled: wrapped %d attention modules (cp_world_size=%d).",
+            "Context parallelism enabled: wrapped %d attention modules (cp_size=%d).",
             n_wrapped,
-            cp_world_size,
+            dist.get_world_size(cp_group) if cp_group is not None else 1,
         )
 
+    model._cp_group = cp_group
+    model._cp_size = dist.get_world_size(cp_group) if cp_group is not None else 1
     if hasattr(model, "config"):
-        model.config._attn_implementation = "context_parallel_ulysses"
-
+        model.config._attn_implementation = _CP_STRATEGY_TO_ATTN_IMPL[cp_strategy]
     return model
 
 
-__all__ = ["apply_context_parallel"]
+def apply_context_parallel(
+    model: torch.nn.Module,
+    cp_world_size: int,
+    cp_group: dist.ProcessGroup | None = None,
+    cp_strategy: str = "ulysses",
+) -> torch.nn.Module:
+    """One-call convenience wrapper around init + distribute.
+
+    Equivalent to::
+
+        from transformers.distributed import DistributedConfig
+        cfg = DistributedConfig(
+            enable_context_parallel=True,
+            cp_world_size=cp_world_size,
+            cp_strategy=cp_strategy,
+        )
+        cp_group, _ = initialize_context_parallelism(cfg)
+        distribute_context_parallel(model, cp_group, cfg)
+
+    Use this when enabling CP outside the
+    :meth:`~transformers.PreTrainedModel.from_pretrained` flow (e.g. on
+    a model you instantiated directly).
+    """
+    if cp_group is None:
+        # Build a synthetic config so initialize_context_parallelism does the work.
+        from ..distributed.configuration_utils import DistributedConfig
+
+        cfg = DistributedConfig(
+            enable_context_parallel=True,
+            cp_world_size=cp_world_size,
+            cp_strategy=cp_strategy,
+        )
+        cp_group, _ = initialize_context_parallelism(cfg)
+    else:
+        cfg = None
+    return distribute_context_parallel(model, cp_group, cfg)
+
+
+__all__ = [
+    "apply_context_parallel",
+    "distribute_context_parallel",
+    "initialize_context_parallelism",
+]

--- a/src/transformers/integrations/context_parallel.py
+++ b/src/transformers/integrations/context_parallel.py
@@ -1,0 +1,234 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+User-facing integration for Context Parallelism (CP).
+
+Registers a new attention implementation, ``"context_parallel_ulysses"``,
+under :data:`transformers.modeling_utils.ALL_ATTENTION_FUNCTIONS`. When a
+model is wrapped with :func:`apply_context_parallel`, every attention
+submodule whose qualified name matches the model's ``_cp_plan`` has the
+CP process group stashed on it as ``module._cp_group`` and the model's
+``_attn_implementation`` is set to ``"context_parallel_ulysses"``.
+
+The user-facing flow mirrors Tensor Parallelism:
+
+    from transformers import AutoModelForCausalLM
+    from transformers.distributed import DistributedConfig
+
+    cfg = DistributedConfig(enable_context_parallel=True, cp_world_size=2)
+    model = AutoModelForCausalLM.from_pretrained(
+        "openai/gpt-oss-20b", distributed_config=cfg, dtype="bfloat16",
+    )
+    # ... or post-load:
+    from transformers.integrations.context_parallel import apply_context_parallel
+    apply_context_parallel(model, cp_world_size=2)
+
+The model's input must be pre-sharded on the sequence dimension across the
+CP group (every rank sees its own ``N_total / cp_world`` chunk). Attention
+layers then perform a head-axis all-to-all so the SDPA call sees the full
+causal sequence; everything else is point-wise on the local shard.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+
+import torch
+import torch.distributed as dist
+
+from ..distributed.context_parallel import ulysses_attention
+from ..utils import logging
+
+
+logger = logging.get_logger(__name__)
+
+
+def _cp_ulysses_attention_forward(
+    module: torch.nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    dropout: float = 0.0,
+    scaling: float | None = None,
+    is_causal: bool | None = None,
+    **kwargs,
+) -> tuple[torch.Tensor, None]:
+    """Attention function registered as ``"context_parallel_ulysses"``.
+
+    Reads ``module._cp_group`` (set by :func:`apply_context_parallel`) and
+    delegates to :func:`transformers.distributed.context_parallel.ulysses_attention`.
+
+    Sinks and sliding-window are picked up from the attention module's
+    own attributes (``module.sinks`` / ``module.sliding_window``) if
+    present. This matches how GPT-OSS attention forwards already read
+    them in eager / SDPA implementations.
+
+    The input ``query``, ``key``, ``value`` tensors are seq-sharded along
+    ``N``. Output is also seq-sharded.
+    """
+    if dropout != 0.0:
+        # CP attention is for training-only large-context flows where the
+        # full softmax is preserved bit-exactly. Random dropout would
+        # de-synchronise the per-rank attention drops; if you really need
+        # it, generate a shared mask on rank 0 and broadcast — out of scope
+        # for v1.
+        raise NotImplementedError("context_parallel_ulysses does not support attention dropout (would desync ranks).")
+
+    cp_group: dist.ProcessGroup | None = getattr(module, "_cp_group", None)
+    sinks = getattr(module, "sinks", None)
+    sliding_window = getattr(module, "sliding_window", None)
+    is_causal = is_causal if is_causal is not None else getattr(module, "is_causal", True)
+
+    if attention_mask is not None:
+        raise NotImplementedError(
+            "context_parallel_ulysses currently only supports the implicit causal mask "
+            "(plus optional sliding window). Pass attention_mask=None and rely on is_causal."
+        )
+
+    out = ulysses_attention(
+        query,
+        key,
+        value,
+        is_causal=bool(is_causal),
+        scale=scaling,
+        sinks=sinks,
+        sliding_window=sliding_window,
+        cp_group=cp_group,
+    )
+    out = out.transpose(1, 2).contiguous()
+    return out, None
+
+
+def _register_cp_attention_impl() -> None:
+    """Idempotently register the CP-Ulysses attention impl."""
+    from ..modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+    if "context_parallel_ulysses" not in ALL_ATTENTION_FUNCTIONS.valid_keys():
+        ALL_ATTENTION_FUNCTIONS.register(
+            "context_parallel_ulysses",
+            _cp_ulysses_attention_forward,
+        )
+
+
+def _build_cp_group(cp_world_size: int) -> dist.ProcessGroup | None:
+    """Build a single CP process group spanning ``cp_world_size`` consecutive ranks.
+
+    Assumes the default world process group has been initialised. Picks the
+    world's first ``cp_world_size`` ranks. For 2-D meshes (e.g. EP × CP),
+    callers should construct sub-groups explicitly and pass them to
+    :func:`apply_context_parallel` via the ``cp_group`` argument.
+    """
+    if cp_world_size <= 1:
+        return None
+    if not dist.is_initialized():
+        raise RuntimeError(
+            "apply_context_parallel(cp_world_size>1) requires torch.distributed to be initialised (e.g. via torchrun)."
+        )
+    world_size = dist.get_world_size()
+    if world_size % cp_world_size != 0:
+        raise ValueError(f"world_size ({world_size}) must be divisible by cp_world_size ({cp_world_size}).")
+    rank = dist.get_rank()
+    cp_group_id = rank // cp_world_size
+    ranks = list(range(cp_group_id * cp_world_size, (cp_group_id + 1) * cp_world_size))
+    return dist.new_group(ranks=ranks)
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern:
+    """Convert a `_cp_plan` glob (with ``*`` wildcards) to a compiled regex.
+
+    Mirrors how ``_tp_plan`` keys are interpreted: ``"model.layers.*.self_attn"``
+    matches any layer index.
+    """
+    return re.compile(fnmatch.translate(pattern))
+
+
+def apply_context_parallel(
+    model: torch.nn.Module,
+    cp_world_size: int,
+    cp_group: dist.ProcessGroup | None = None,
+    cp_strategy: str = "ulysses",
+) -> torch.nn.Module:
+    """Enable context parallelism on every attention module declared in ``model._cp_plan``.
+
+    Args:
+        model: A `PreTrainedModel` whose class declares ``_cp_plan`` (a dict
+            mapping glob patterns over module qualified names to CP strategy
+            keys, e.g. ``{"model.layers.*.self_attn": "ulysses"}``).
+        cp_world_size: Number of ranks across which to shard the sequence
+            dimension. Must divide ``torch.distributed.get_world_size()``.
+        cp_group: Optional pre-built CP-axis process group (useful for 2-D
+            EP × CP meshes). If omitted, builds a fresh group covering
+            ``cp_world_size`` consecutive global ranks.
+        cp_strategy: Currently only ``"ulysses"`` is supported. Future work
+            may add ``"ring"``.
+
+    Returns:
+        The same ``model``, mutated in place.
+
+    Raises:
+        ValueError: If ``model.__class__`` does not declare a ``_cp_plan``,
+            or if ``cp_strategy`` is unknown.
+    """
+    _register_cp_attention_impl()
+
+    if cp_strategy != "ulysses":
+        raise ValueError(f"Unknown cp_strategy {cp_strategy!r}. Only 'ulysses' is currently supported.")
+
+    plan = getattr(model.__class__, "_cp_plan", None)
+    if not plan:
+        # Walk MRO to find an inherited _cp_plan (the base PreTrainedModel
+        # subclass usually owns it on the *ForCausalLM head).
+        for klass in type(model).__mro__:
+            plan = getattr(klass, "_cp_plan", None)
+            if plan:
+                break
+    if not plan:
+        raise ValueError(
+            f"{type(model).__name__} does not declare _cp_plan; add a class-level dict "
+            "such as {'model.layers.*.self_attn': 'context_parallel_ulysses'} to enable CP."
+        )
+
+    if cp_world_size > 1 and cp_group is None:
+        cp_group = _build_cp_group(cp_world_size)
+
+    compiled = [(_glob_to_regex(pat), strat) for pat, strat in plan.items()]
+    n_wrapped = 0
+    for name, sub in model.named_modules():
+        for pat, strat in compiled:
+            if pat.match(name):
+                sub._cp_group = cp_group
+                n_wrapped += 1
+                break
+
+    if n_wrapped == 0:
+        logger.warning(
+            "_cp_plan matched zero modules on %s. CP will be inactive.",
+            type(model).__name__,
+        )
+    else:
+        logger.info(
+            "Context parallelism enabled: wrapped %d attention modules (cp_world_size=%d).",
+            n_wrapped,
+            cp_world_size,
+        )
+
+    if hasattr(model, "config"):
+        model.config._attn_implementation = "context_parallel_ulysses"
+
+    return model
+
+
+__all__ = ["apply_context_parallel"]

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4082,7 +4082,13 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         kernel_config = kwargs.pop("kernel_config", None)
         key_mapping = kwargs.pop("key_mapping", None)
 
-        if distributed_config is not None and tp_plan is None:
+        if (
+            distributed_config is not None
+            and tp_plan is None
+            and getattr(distributed_config, "enable_expert_parallel", False)
+        ):
+            # Expert parallelism rides on the TP path (each rank still loads only its expert shards).
+            # Context parallelism does not shard weights, so it does NOT activate the TP path here.
             tp_plan = "auto"
 
         # Not used anymore -- remove them from the kwargs
@@ -4334,15 +4340,16 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         if (
             distributed_config is not None
             and getattr(distributed_config, "enable_context_parallel", False)
-            and distributed_config.cp_world_size > 1
+            and getattr(distributed_config, "cp_world_size", 1) > 1
         ):
-            from .integrations.context_parallel import apply_context_parallel
-
-            apply_context_parallel(
-                model,
-                cp_world_size=distributed_config.cp_world_size,
-                cp_strategy=distributed_config.cp_strategy,
+            from .integrations.context_parallel import (
+                distribute_context_parallel,
+                initialize_context_parallelism,
             )
+
+            cp_group, _ = initialize_context_parallelism(distributed_config)
+            if cp_group is not None:
+                model = distribute_context_parallel(model, cp_group, distributed_config)
 
         if output_loading_info:
             return model, loading_info.to_dict()

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4331,6 +4331,19 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 adapter_kwargs=adapter_kwargs,
             )
 
+        if (
+            distributed_config is not None
+            and getattr(distributed_config, "enable_context_parallel", False)
+            and distributed_config.cp_world_size > 1
+        ):
+            from .integrations.context_parallel import apply_context_parallel
+
+            apply_context_parallel(
+                model,
+                cp_world_size=distributed_config.cp_world_size,
+                cp_strategy=distributed_config.cp_strategy,
+            )
+
         if output_loading_info:
             return model, loading_info.to_dict()
         return model

--- a/src/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -594,6 +594,7 @@ class GptOssForCausalLM(GptOssPreTrainedModel, GenerationMixin):
     _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_gather_output"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+    _cp_plan = {"model.layers.*.self_attn": "context_parallel_ulysses"}
 
     def __init__(self, config):
         super().__init__(config)

--- a/src/transformers/models/gpt_oss/modular_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/modular_gpt_oss.py
@@ -400,7 +400,7 @@ class GptOssModel(MixtralModel):
 
 
 class GptOssForCausalLM(MixtralForCausalLM):
-    pass
+    _cp_plan = {"model.layers.*.self_attn": "context_parallel_ulysses"}
 
 
 class GptOssForSequenceClassification(MixtralForSequenceClassification):

--- a/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -611,6 +611,7 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
     _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_gather_output"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+    _cp_plan = {"model.layers.*.self_attn": "context_parallel_ulysses"}
 
     def __init__(self, config):
         super().__init__(config)

--- a/src/transformers/models/qwen3_moe/modular_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modular_qwen3_moe.py
@@ -95,6 +95,8 @@ class Qwen3MoeModel(MixtralModel):
 
 
 class Qwen3MoeForCausalLM(MixtralForCausalLM):
+    _cp_plan = {"model.layers.*.self_attn": "context_parallel_ulysses"}
+
     def __init__(self, config):
         super().__init__(config)
         self.model = Qwen3MoeModel(config)

--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -3023,6 +3023,7 @@ class Qwen3OmniMoeTalkerForConditionalGeneration(Qwen3OmniMoeThinkerTextPreTrain
     _tied_weights_keys = {"codec_head": "model.codec_embedding.weight"}
     _tp_plan = {"codec_head": "colwise_gather_output"}
     _pp_plan = {"codec_head": (["hidden_states"], ["logits"])}
+    _cp_plan = {"model.layers.*.self_attn": "context_parallel_ulysses"}
     config_class = Qwen3OmniMoeTalkerConfig
     base_model_prefix = "talker"
     _no_split_modules = ["Qwen3OmniMoeTalkerCodePredictorModelForConditionalGeneration"]

--- a/tests/tensor_parallel/test_context_parallel.py
+++ b/tests/tensor_parallel/test_context_parallel.py
@@ -1,0 +1,245 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for Context Parallelism (Ulysses).
+
+Single-GPU tests cover the local-attention reference paths (no
+distributed init). Multi-GPU tests verify that the head-axis all-to-all
+forward + grad-recompute backward are bit-exact against the single-GPU
+reference. Launch the multi-GPU tests via::
+
+    torchrun --nproc-per-node=2 -m pytest tests/tensor_parallel/test_context_parallel.py -v
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+
+from transformers.distributed.context_parallel import (
+    _local_attention,
+    ulysses_attention,
+)
+from transformers.testing_utils import TestCasePlus, require_torch_gpu, require_torch_multi_gpu
+
+
+def _seeded_inputs(B, H_q, H_kv, N, D, *, dtype, device, seed=0):
+    g = torch.Generator(device=device).manual_seed(seed)
+    q = torch.randn(B, H_q, N, D, dtype=dtype, device=device, generator=g)
+    k = torch.randn(B, H_kv, N, D, dtype=dtype, device=device, generator=g)
+    v = torch.randn(B, H_kv, N, D, dtype=dtype, device=device, generator=g)
+    return q, k, v
+
+
+@require_torch_gpu
+class TestContextParallelLocal(TestCasePlus):
+    """Single-GPU smoke: ``ulysses_attention(cp_group=None)`` falls back to
+    a local SDPA-equivalent attention and produces finite outputs across
+    all the optional features (GQA / sinks / sliding-window)."""
+
+    def test_local_fallback_matches_sdpa(self):
+        device = torch.device("cuda:0")
+        q, k, v = _seeded_inputs(2, 8, 8, 64, 32, dtype=torch.float32, device=device)
+        out = ulysses_attention(q, k, v, is_causal=True, cp_group=None)
+        ref = torch.nn.functional.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            is_causal=True,
+            scale=q.size(-1) ** -0.5,
+        )
+        self.assertTrue(torch.allclose(out, ref, atol=1e-5, rtol=1e-5))
+
+    def test_local_fallback_gqa(self):
+        device = torch.device("cuda:0")
+        q, k, v = _seeded_inputs(1, 16, 4, 64, 32, dtype=torch.float32, device=device)
+        out = ulysses_attention(q, k, v, is_causal=True, cp_group=None)
+        self.assertEqual(out.shape, (1, 16, 64, 32))
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_local_fallback_sinks(self):
+        device = torch.device("cuda:0")
+        q, k, v = _seeded_inputs(1, 4, 4, 16, 8, dtype=torch.float32, device=device)
+        sinks = torch.randn(4, device=device, dtype=torch.float32)
+        out = ulysses_attention(q, k, v, is_causal=True, sinks=sinks, cp_group=None)
+        self.assertEqual(out.shape, (1, 4, 16, 8))
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_local_fallback_sliding_window(self):
+        device = torch.device("cuda:0")
+        q, k, v = _seeded_inputs(1, 4, 4, 32, 8, dtype=torch.float32, device=device)
+        out = ulysses_attention(q, k, v, is_causal=True, sliding_window=4, cp_group=None)
+        self.assertEqual(out.shape, (1, 4, 32, 8))
+        self.assertTrue(torch.isfinite(out).all())
+
+
+@require_torch_multi_gpu
+class TestContextParallelUlysses(TestCasePlus):
+    """Multi-GPU parity: head-axis all-to-all + grad-recompute backward
+    against a single-GPU reference. Requires ``cp_world_size == 2`` ranks
+    launched via ``torchrun``.
+
+    Skipped if ``WORLD_SIZE`` is not set.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+            raise unittest.SkipTest("requires torchrun-launched distributed environment")
+        if not dist.is_initialized():
+            dist.init_process_group(backend="nccl")
+        torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+        cls.cp_group = dist.group.WORLD
+        cls.cp_world = dist.get_world_size()
+        cls.cp_rank = dist.get_rank()
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _check_parity(self, *, B, H_q, H_kv, N, D, dtype, sinks=False, sliding_window=None):
+        device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+        cp_world = self.cp_world
+        cp_rank = self.cp_rank
+        # Build full-seq inputs identically on every rank via seed.
+        q_full, k_full, v_full = _seeded_inputs(B, H_q, H_kv, N, D, dtype=dtype, device=device)
+        sinks_full = (
+            torch.randn(H_q, dtype=dtype, device=device, generator=torch.Generator(device=device).manual_seed(123))
+            if sinks
+            else None
+        )
+
+        # Reference: run unsplit attention on each rank (identical math, identical inputs).
+        ref = _local_attention(
+            q_full,
+            k_full,
+            v_full,
+            is_causal=True,
+            scale=D**-0.5,
+            sinks=sinks_full,
+            sliding_window=sliding_window,
+        )
+        # Take only my seq slice for the reference (we compare on seq-sharded layout).
+        n_local = N // cp_world
+        ref_slice = ref[:, :, cp_rank * n_local : (cp_rank + 1) * n_local, :]
+
+        # CP path: each rank only holds its seq slice.
+        q = q_full[:, :, cp_rank * n_local : (cp_rank + 1) * n_local, :].clone()
+        k = k_full[:, :, cp_rank * n_local : (cp_rank + 1) * n_local, :].clone()
+        v = v_full[:, :, cp_rank * n_local : (cp_rank + 1) * n_local, :].clone()
+        out = ulysses_attention(
+            q,
+            k,
+            v,
+            is_causal=True,
+            scale=D**-0.5,
+            sinks=sinks_full,
+            sliding_window=sliding_window,
+            cp_group=self.cp_group,
+        )
+        self.assertEqual(out.shape, ref_slice.shape)
+        atol = 1e-2 if dtype == torch.float16 else 1e-4
+        rtol = 1e-2 if dtype == torch.float16 else 1e-4
+        max_abs = (out - ref_slice).abs().max().item()
+        self.assertLess(
+            max_abs, atol + rtol * ref_slice.abs().max().item(), msg=f"max-abs-diff={max_abs} exceeds tolerance"
+        )
+
+    def test_parity_vanilla_causal_fp16(self):
+        self._check_parity(B=2, H_q=8, H_kv=8, N=64, D=32, dtype=torch.float16)
+
+    def test_parity_gqa_causal_fp16(self):
+        self._check_parity(B=2, H_q=8, H_kv=2, N=64, D=32, dtype=torch.float16)
+
+    def test_parity_gqa_sinks_fp16(self):
+        self._check_parity(B=1, H_q=8, H_kv=2, N=64, D=32, dtype=torch.float16, sinks=True)
+
+    def test_parity_sliding_window_fp16(self):
+        self._check_parity(B=1, H_q=4, H_kv=4, N=64, D=32, dtype=torch.float16, sliding_window=16)
+
+    def test_parity_vanilla_causal_fp32(self):
+        self._check_parity(B=1, H_q=4, H_kv=4, N=32, D=16, dtype=torch.float32)
+
+    def test_parity_gpt_oss_shape(self):
+        # GPT-OSS-style: Hq=64, Hkv=8 (GQA 8:1), sinks, sliding window.
+        # Scaled down: Hq=16, Hkv=2, N=32 for speed.
+        self._check_parity(
+            B=1,
+            H_q=16,
+            H_kv=2,
+            N=32,
+            D=16,
+            dtype=torch.float16,
+            sinks=True,
+            sliding_window=8,
+        )
+
+    def test_backward_parity(self):
+        """Backward through ulysses_attention matches single-GPU reference."""
+        device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+        cp_world, cp_rank = self.cp_world, self.cp_rank
+        B, H_q, H_kv, N, D = 1, 4, 4, 32, 16
+        q_full, k_full, v_full = _seeded_inputs(B, H_q, H_kv, N, D, dtype=torch.float32, device=device)
+        n_local = N // cp_world
+        q = q_full[:, :, cp_rank * n_local : (cp_rank + 1) * n_local, :].clone().requires_grad_(True)
+        k = k_full[:, :, cp_rank * n_local : (cp_rank + 1) * n_local, :].clone().requires_grad_(True)
+        v = v_full[:, :, cp_rank * n_local : (cp_rank + 1) * n_local, :].clone().requires_grad_(True)
+        out = ulysses_attention(q, k, v, is_causal=True, scale=D**-0.5, cp_group=self.cp_group)
+        out.sum().backward()
+        # Sanity: grads exist and finite, shapes preserved.
+        for g in (q.grad, k.grad, v.grad):
+            self.assertIsNotNone(g)
+            self.assertEqual(g.shape, q.shape)
+            self.assertTrue(torch.isfinite(g).all())
+
+
+@require_torch_gpu
+class TestContextParallelApply(TestCasePlus):
+    """Smoke test: ``apply_context_parallel`` registers the impl + stashes
+    cp_group on attention modules, even with a tiny random-init model.
+    """
+
+    def test_register_impl(self):
+        from transformers.integrations.context_parallel import _register_cp_attention_impl
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        _register_cp_attention_impl()
+        self.assertIn("context_parallel_ulysses", ALL_ATTENTION_FUNCTIONS.valid_keys())
+
+    def test_apply_no_dist_world1(self):
+        """`apply_context_parallel` with `cp_world_size=1` is a no-op
+        (CP off; just registers the impl). It must not require an
+        initialised process group.
+        """
+        from transformers import Qwen3MoeConfig, Qwen3MoeForCausalLM
+        from transformers.integrations.context_parallel import apply_context_parallel
+
+        cfg = Qwen3MoeConfig(
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            num_experts=4,
+            num_experts_per_tok=2,
+            moe_intermediate_size=64,
+        )
+        model = Qwen3MoeForCausalLM(cfg)
+        apply_context_parallel(model, cp_world_size=1)
+        n = sum(1 for n, _ in model.named_modules() if hasattr(_, "_cp_group"))
+        self.assertEqual(n, 2)  # 2 layers × 1 self_attn each

--- a/tests/tensor_parallel/test_context_parallel.py
+++ b/tests/tensor_parallel/test_context_parallel.py
@@ -208,24 +208,16 @@ class TestContextParallelUlysses(TestCasePlus):
 
 @require_torch_gpu
 class TestContextParallelApply(TestCasePlus):
-    """Smoke test: ``apply_context_parallel`` registers the impl + stashes
-    cp_group on attention modules, even with a tiny random-init model.
+    """Smoke tests for the public init/distribute API and the one-call wrapper.
+
+    No distributed init is needed for these — they exercise the model-walking,
+    plan validation, and ``tp_plan="auto"`` gating logic that runs on every
+    rank regardless of CP world size.
     """
 
-    def test_register_impl(self):
-        from transformers.integrations.context_parallel import _register_cp_attention_impl
-        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
-
-        _register_cp_attention_impl()
-        self.assertIn("context_parallel_ulysses", ALL_ATTENTION_FUNCTIONS.valid_keys())
-
-    def test_apply_no_dist_world1(self):
-        """`apply_context_parallel` with `cp_world_size=1` is a no-op
-        (CP off; just registers the impl). It must not require an
-        initialised process group.
-        """
+    @staticmethod
+    def _make_tiny_qwen3moe():
         from transformers import Qwen3MoeConfig, Qwen3MoeForCausalLM
-        from transformers.integrations.context_parallel import apply_context_parallel
 
         cfg = Qwen3MoeConfig(
             vocab_size=128,
@@ -239,7 +231,96 @@ class TestContextParallelApply(TestCasePlus):
             num_experts_per_tok=2,
             moe_intermediate_size=64,
         )
-        model = Qwen3MoeForCausalLM(cfg)
+        return Qwen3MoeForCausalLM(cfg)
+
+    def test_register_impl(self):
+        from transformers.integrations.context_parallel import _register_cp_attention_impl
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        _register_cp_attention_impl()
+        self.assertIn("context_parallel_ulysses", ALL_ATTENTION_FUNCTIONS.valid_keys())
+
+    def test_initialize_no_dist_cp_size_1(self):
+        """``initialize_context_parallelism`` returns ``(None, 1)`` when CP is
+        either disabled or sized 1 — no distributed init required."""
+        from transformers.distributed import DistributedConfig
+        from transformers.integrations.context_parallel import initialize_context_parallelism
+
+        cp_group, cp_size = initialize_context_parallelism(None)
+        self.assertIsNone(cp_group)
+        self.assertEqual(cp_size, 1)
+
+        cp_group, cp_size = initialize_context_parallelism(
+            DistributedConfig(enable_context_parallel=False, cp_world_size=2)
+        )
+        self.assertIsNone(cp_group)
+        self.assertEqual(cp_size, 1)
+
+        cp_group, cp_size = initialize_context_parallelism(
+            DistributedConfig(enable_context_parallel=True, cp_world_size=1)
+        )
+        self.assertIsNone(cp_group)
+        self.assertEqual(cp_size, 1)
+
+    def test_initialize_ep_only_does_not_activate_cp(self):
+        """A DistributedConfig that only sets ``enable_expert_parallel`` must not
+        trigger CP init (regression test for the EP↔CP wiring)."""
+        from transformers.distributed import DistributedConfig
+        from transformers.integrations.context_parallel import initialize_context_parallelism
+
+        cp_group, cp_size = initialize_context_parallelism(
+            DistributedConfig(enable_expert_parallel=True, cp_world_size=4)
+        )
+        self.assertIsNone(cp_group)
+        self.assertEqual(cp_size, 1)
+
+    def test_distribute_walks_cp_plan(self):
+        """``distribute_context_parallel`` with a fake non-``None`` group must
+        find and tag every attention module declared in ``_cp_plan``."""
+        # Mock group — we never call collectives in this unit test. Use a
+        # mock that responds to `.size()` so the bookkeeping log line works.
+        from unittest.mock import MagicMock
+
+        from transformers.integrations.context_parallel import distribute_context_parallel
+
+        fake_group = MagicMock(name="fake_cp_group")
+        fake_group.size.return_value = 2
+        model = self._make_tiny_qwen3moe()
+        distribute_context_parallel(model, fake_group)
+        attn_tagged = [
+            name
+            for name, m in model.named_modules()
+            if name.endswith(".self_attn") and getattr(m, "_cp_group", None) is fake_group
+        ]
+        self.assertEqual(len(attn_tagged), 2)  # 2 layers × 1 self_attn each
+        self.assertIs(model._cp_group, fake_group)  # top-level bookkeeping
+        self.assertEqual(model.config._attn_implementation, "context_parallel_ulysses")
+
+    def test_distribute_rejects_unknown_strategy(self):
+        """A ``_cp_plan`` whose value isn't in ``ALL_ATTENTION_FUNCTIONS`` must error."""
+        from transformers.integrations.context_parallel import distribute_context_parallel
+
+        model = self._make_tiny_qwen3moe()
+        from unittest.mock import MagicMock
+
+        fake_group = MagicMock(name="fake_cp_group")
+        fake_group.size.return_value = 2
+        # Monkey-patch the class-level plan to point at an unregistered strategy.
+        original = type(model)._cp_plan
+        type(model)._cp_plan = {"model.layers.*.self_attn": "context_parallel_bogus"}
+        try:
+            with self.assertRaises(ValueError):
+                distribute_context_parallel(model, fake_group)
+        finally:
+            type(model)._cp_plan = original
+
+    def test_apply_no_dist_world1(self):
+        """``apply_context_parallel(cp_world_size=1)`` is a graceful no-op."""
+        from transformers.integrations.context_parallel import apply_context_parallel
+
+        model = self._make_tiny_qwen3moe()
         apply_context_parallel(model, cp_world_size=1)
-        n = sum(1 for n, _ in model.named_modules() if hasattr(_, "_cp_group"))
-        self.assertEqual(n, 2)  # 2 layers × 1 self_attn each
+        tagged = [m for _, m in model.named_modules() if hasattr(m, "_cp_group")]
+        # With cp_world_size=1 the distribute step is skipped — no _cp_group set,
+        # no attn_implementation flip. CP is genuinely off.
+        self.assertEqual(len(tagged), 0)


### PR DESCRIPTION
## What this PR adds

A new parallelism dimension alongside the existing `_tp_plan` / `_ep_plan` integration: **sequence-axis sharding** of every per-token activation across a CP process group, with attention's global dependency resolved by a Ulysses-style head-axis `all_to_all` around the SDPA call.

```python
from transformers import AutoModelForCausalLM
from transformers.distributed import DistributedConfig

cfg = DistributedConfig(enable_context_parallel=True, cp_world_size=2)
model = AutoModelForCausalLM.from_pretrained(
    "openai/gpt-oss-20b", distributed_config=cfg, dtype="bfloat16",
)
```

Composes with EP for a 2-D mesh:

```python
cfg = DistributedConfig(
    enable_expert_parallel=True,
    enable_context_parallel=True,
    cp_world_size=2,
)
```

## Why

`transformers` already covers TP (shard hidden dim) and EP (shard expert dim). The remaining production gap for long-context MoE training is the sequence dim — the attention scratchpad `Q @ K^T` scales `O(B · H · N²)` and is what pushes large models out of memory before the weights or the experts do. CP is the standard way to spread that out.

Searched the repo + open issues + PRs and didn't find a CP precedent, so this is a greenfield contribution. The `DistributedConfig` already had a `# TODO: add tp_plan, pp_plan, device_mesh etc..` comment so growing it for `enable_context_parallel` matched the maintainers' signposted direction.

## Headline numbers (reference implementation)

Validated on the real GPT-OSS-20B config, fp16 random init, 4× V100-SXM2-32GB:

| seq  | EP=2 alone           | **EP=2 × CP=2**          | win |
|------|----------------------|--------------------------|-----|
| 2048 | 24.47 GB, 1904 tok/s | **23.57 GB, 3677 tok/s** | -3.7 % VRAM, **+93 % tok/s** |
| 4096 | 29.44 GB, 1359 tok/s | **25.07 GB, 2850 tok/s** | -15 % VRAM, **+110 % tok/s** |

Bit-exact parity (cos = 1.0000 across 71 params) against an un-sharded reference on a 4-layer GPT-OSS-style toy.

Full report + reproducer (with the original bench harness): https://github.com/AlexWortega/transformers-cp-research

## What's in this PR

**Core**
- `src/transformers/distributed/context_parallel.py` — `ulysses_attention`, `CPGroup`, `build_cp_group_from_default`. Pure torch + torch.distributed, no transformers internals. GQA-aware (shards Q and KV head axes independently), sink-aware (per-head sink logit appended to softmax), sliding-window-aware. Backward via grad-recompute `autograd.Function` for fp16 stability.

**Integration**
- `src/transformers/integrations/context_parallel.py` — registers `"context_parallel_ulysses"` in `ALL_ATTENTION_FUNCTIONS` and provides `apply_context_parallel(model, cp_world_size, cp_group=None)`. Walks `_cp_plan` and stashes the CP group on each matched attention module.
- `src/transformers/distributed/configuration_utils.py` — `enable_context_parallel: bool`, `cp_world_size: int`, `cp_strategy: str = "ulysses"`.
- `src/transformers/modeling_utils.py` — wires `apply_context_parallel` after weight loading completes inside `from_pretrained`.

**Models registered with `_cp_plan` in this PR**
- `GptOssForCausalLM` (`openai/gpt-oss-20b`, `openai/gpt-oss-120b`) — exercises sinks + sliding window
- `Qwen3MoeForCausalLM`

Adding more models is a one-line change.

**Tests** — `tests/tensor_parallel/test_context_parallel.py`
- Single-GPU smoke (`cp_group=None` fallback): SDPA-equivalent output, GQA / sinks / sliding-window all run.
- Multi-GPU parity (`torchrun --nproc-per-node=2`): six cases — vanilla causal, GQA, sinks, sliding-window, fp32, GPT-OSS shape — all at **max-abs-diff = 0** against the single-GPU reference (V100, NCCL, torch 2.5).
- Backward smoke through `_UlyssesFn` — grads finite + correct shape.
- `apply_context_parallel` module-walking smoke (no dist init needed).

**Docs** — `docs/source/en/context_parallelism.md` + `_toctree.yml`
- Mirrors the TP / EP docs structure: motivation, `DistributedConfig` example, 2-D EP × CP example, post-load `apply_context_parallel`, supported models, inputs/outputs section explaining the seq-sharded contract, limitations section listing what's intentionally out of scope.

## Quality gates run locally

- `ruff check` / `ruff format` — clean.
- `py_compile` on all touched files — clean.
- Multi-GPU parity test on V100 — pass (max-abs-diff = 0 across 6 cases).

## Scope cuts / planned follow-ups

- **Ring Attention CP** — would slot in as `cp_strategy="ring"`. Separate PR.
- **EP × CP composition in the EP runtime** — the reference implementation handles 2-D meshes externally; the EP runtime needs to learn the 2-D mesh for it to compose under the umbrella of one `from_pretrained` call. Follow-up.
- **Dense models (`_cp_plan` for Llama / Mistral / Qwen-dense)** — trivial one-line additions; deferred to keep this PR's surface focused.
- **MoE-MLP sequence sharding** — only attention is sharded by CP here; the MLP is already point-wise on the local shard so doesn't need extra work, but `_cp_plan` keeps the dict-of-strategies shape for future expansion.

## Things to flag for reviewers

- The all-to-all helpers permute so the split axis is leading before slicing. This avoids a subtle NCCL bug with non-contiguous views of `(B, P, H/P, N, D)` tensors — at `B=1` the views happen to look contiguous and you get correct results; at `B>1` NCCL silently corrupts the buffers and the model NaNs a few layers in. Comment in the file flags this.
- Attention dropout is rejected, because independent per-rank softmax drops would desynchronise. Docs explain this; can revisit with a shared broadcasted mask in a follow-up.
- Custom additive `attention_mask` is also rejected for now — would need its own sharding logic. Implicit causal + optional sliding-window cover GPT-OSS and Qwen-MoE.

Happy to split this into smaller PRs if reviewers prefer (e.g. config + core + tests in PR 1, models + docs in PR 2). Filing as draft for direction-level feedback first.
