### PR TITLE
Replace assert with raise ImportError for optuna/ray dependency checks

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -452,7 +452,8 @@ def default_compute_objective(metrics: dict[str, float]) -> float:
 def default_hp_space_optuna(trial) -> dict[str, float]:
     from .integrations import is_optuna_available
 
-    assert is_optuna_available(), "This function needs Optuna installed: `pip install optuna`"
+    if not is_optuna_available():
+        raise ImportError("This function needs Optuna installed: `pip install optuna`")
     return {
         "learning_rate": trial.suggest_float("learning_rate", 1e-6, 1e-4, log=True),
         "num_train_epochs": trial.suggest_int("num_train_epochs", 1, 5),
@@ -464,7 +465,8 @@ def default_hp_space_optuna(trial) -> dict[str, float]:
 def default_hp_space_ray(trial) -> dict[str, Any]:
     from .integrations import is_ray_tune_available
 
-    assert is_ray_tune_available(), "This function needs ray installed: `pip install ray[tune]`"
+    if not is_ray_tune_available():
+        raise ImportError("This function needs ray installed: `pip install ray[tune]`")
     from ray import tune
 
     return {


### PR DESCRIPTION
## What does this PR do?

Replaces `assert` with `if/raise ImportError` in `default_hp_space_optuna()` and `default_hp_space_ray()`.

`assert` statements are silently stripped when Python runs with the `-O` (optimize) flag. This allows the functions to proceed without the required library installed, leading to confusing `NameError`s downstream instead of a clear `ImportError`.

The wandb equivalent (`default_hp_space_wandb`) already uses the correct `if/raise ImportError` pattern. This change makes optuna and ray consistent with it.

**Reproduction:**
```python
python -O -c "
def check(): assert False, 'should fail'
check()  # silently passes under -O
print('assert was stripped')"
```

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?

## Who can review?

@SunMarc (trainer owner)