### PR TITLE
Add some AITER kernel routing for ROCm

### DIFF
--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -206,11 +206,16 @@ if is_kernels_available():
                 ),
             },
             "rocm": {
-                Mode.INFERENCE: LayerRepository(
-                    repo_id="ahadnagy/megablocks",
+                Mode.TRAINING: LayerRepository(
+                    repo_id="kernels-community/megablocks",
                     layer_name="MegaBlocksMoeMLP",
                     version=1,
-                )
+                ),
+                Mode.INFERENCE: LayerRepository(
+                    repo_id="kernels-community/megablocks",
+                    layer_name="MegaBlocksMoeMLP",
+                    version=1,
+                ),
             },
             "xpu": {
                 Mode.INFERENCE: LayerRepository(

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -293,6 +293,11 @@ if is_kernels_available():
             "cuda": FuncRepository(
                 repo_id="kernels-community/rotary", func_name="apply_rotary_transformers", version=1
             ),
+            "rocm": {
+                Mode.INFERENCE: FuncRepository(
+                    repo_id="kernels-community/aiter-rope", func_name="apply_rotary_transformers", version=1
+                )
+            },
         },
         "ForCausalLMLoss": {
             "cuda": {

--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -25,6 +25,7 @@ from .utils import (
     is_flash_attn_2_available,
     is_flash_attn_3_available,
     is_flash_attn_4_available,
+    is_rocm_platform,
     is_torch_cuda_available,
     is_torch_mlu_available,
     is_torch_npu_available,
@@ -59,10 +60,13 @@ def is_flash_attn_available():
     )
 
 
-# Mapping from flash attention implementations to their kernel fallback repositories
+# Mapping from flash attention implementations to their kernel fallback repositories.
+
 FLASH_ATTN_KERNEL_FALLBACK = {
     "flash_attention_2": "kernels-community/flash-attn2",
-    "flash_attention_3": "kernels-community/vllm-flash-attn3",
+    "flash_attention_3": (
+        "kernels-community/aiter-flash-attn" if is_rocm_platform() else "kernels-community/vllm-flash-attn3"
+    ),
     "flash_attention_4": "kernels-community/flash-attn4",
 }
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -128,6 +128,7 @@ from .utils.import_utils import (
     KERNELS_MIN_VERSION,
     is_flash_attn_greater_or_equal,
     is_huggingface_hub_greater_or_equal,
+    is_rocm_platform,
     is_sagemaker_mp_enabled,
     is_torch_cuda_available,
     is_tracing,
@@ -4676,6 +4677,12 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             )
         from kernels import Device, Mode, kernelize
 
+        def resolve_kernel_device_type(torch_device_type: str) -> str:
+            """Map torch's device.type to the kernels library's device key (refines `"cuda"` → `"rocm"` on ROCm)."""
+            if torch_device_type == "cuda" and is_rocm_platform():
+                return "rocm"
+            return torch_device_type
+
         def attach_hidden_kernels(module):
             for name, fn in getattr(module, "_hidden_kernels", {}).items():
                 if name not in dict(module.named_children()):
@@ -4698,14 +4705,15 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             self.apply(attach_hidden_kernels)
 
             mode = (Mode.TRAINING if self.training else Mode.INFERENCE) if mode is None else mode
+            device = Device(type=resolve_kernel_device_type(self.device.type))
             if self.kernel_config is not None:
                 from kernels import use_kernel_mapping
 
                 inherit_mapping = not self.kernel_config.use_local_kernel
                 with use_kernel_mapping(self.kernel_config.kernel_mapping, inherit_mapping=inherit_mapping):
-                    kernelize(self, device=Device(type=self.device.type), mode=mode)
+                    kernelize(self, device=device, mode=mode)
             else:
-                kernelize(self, device=Device(type=self.device.type), mode=mode)
+                kernelize(self, device=device, mode=mode)
 
             self._use_kernels = True
 


### PR DESCRIPTION
Routes ROCm to AITER Triton kernels on AMD GPUs:
  - `flash_attention_3` → [`kernels-community/aiter-flash-attn`](https://huggingface.co/kernels-community/aiter-flash-attn)
  - `megablocks` → [`kernels-community/megablocks`](https://huggingface.co/kernels/kernels-community/megablocks) now has rocm builds.
  
  - `rotary_pos_emb` → [`kernels-community/aiter-rope`](https://huggingface.co/kernels-community/aiter-rope)

Longer-term goal: ship the full AITER in Kernels (same model as `liger-kernels`) rather than one repo per kernel. We're starting with `aiter-rope` and `aiter-flash-attn` because those are the two we need in transformers right now.