### PR TITLE
Fix path traversal when loading OneFormer image processor metadata

### DIFF
--- a/src/transformers/models/oneformer/image_processing_oneformer.py
+++ b/src/transformers/models/oneformer/image_processing_oneformer.py
@@ -15,6 +15,7 @@
 
 import json
 import os
+from pathlib import Path
 from typing import Union
 
 import torch
@@ -91,7 +92,13 @@ def prepare_metadata(class_info):
 
 
 def load_metadata(repo_id, class_info_file):
-    fname = os.path.join("" if repo_id is None else repo_id, class_info_file)
+    base_dir = "" if repo_id is None else repo_id
+    fname = os.path.join(base_dir, class_info_file)
+    # `class_info_file` comes from the (untrusted) image processor config and is documented to live
+    # inside `repo_id`. Reject values that escape it via `..` or an absolute path so a malicious config
+    # cannot read arbitrary local files (path traversal, CWE-22). Files in subdirectories are allowed.
+    if not Path(fname).resolve().is_relative_to(Path(base_dir).resolve()):
+        raise ValueError(f"Invalid class_info_file: {class_info_file!r}")
 
     if not os.path.exists(fname) or not os.path.isfile(fname):
         if repo_id is None:

--- a/src/transformers/models/oneformer/image_processing_pil_oneformer.py
+++ b/src/transformers/models/oneformer/image_processing_pil_oneformer.py
@@ -15,6 +15,7 @@
 
 import json
 import os
+from pathlib import Path
 
 import numpy as np
 
@@ -222,7 +223,13 @@ def convert_segmentation_to_rle(segmentation):
 
 # Adapted from transformers.models.oneformer.image_processing_oneformer.load_metadata
 def load_metadata(repo_id, class_info_file):
-    fname = os.path.join("" if repo_id is None else repo_id, class_info_file)
+    base_dir = "" if repo_id is None else repo_id
+    fname = os.path.join(base_dir, class_info_file)
+    # `class_info_file` comes from the (untrusted) image processor config and is documented to live
+    # inside `repo_id`. Reject values that escape it via `..` or an absolute path so a malicious config
+    # cannot read arbitrary local files (path traversal, CWE-22). Files in subdirectories are allowed.
+    if not Path(fname).resolve().is_relative_to(Path(base_dir).resolve()):
+        raise ValueError(f"Invalid class_info_file: {class_info_file!r}")
 
     if not os.path.exists(fname) or not os.path.isfile(fname):
         if repo_id is None:

--- a/tests/models/oneformer/test_image_processing_oneformer.py
+++ b/tests/models/oneformer/test_image_processing_oneformer.py
@@ -368,6 +368,47 @@ class OneFormerImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
 
             self.assertEqual(image_processor.metadata, metadata)
 
+    def test_load_metadata_rejects_path_traversal(self):
+        # `class_info_file` comes from the (untrusted) image processor config and is documented to live
+        # inside `repo_path`. A value that escapes it via `..` or an absolute path would let a malicious
+        # config read an arbitrary local file (path traversal, CWE-22), so it must be rejected.
+        class_info = {"0": {"isthing": 0, "name": "foo"}}
+        for image_processing_class in self.image_processing_classes.values():
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                repo_path = os.path.join(tmpdirname, "repo")
+                os.makedirs(repo_path)
+                # A readable json file that lives OUTSIDE repo_path and would be reached by traversal.
+                with open(os.path.join(tmpdirname, "secret.json"), "w") as f:
+                    json.dump(class_info, f)
+
+                config_dict = self.image_processor_dict
+                config_dict["repo_path"] = repo_path
+                config_dict["class_info_file"] = "../secret.json"
+                with self.assertRaises(ValueError):
+                    image_processing_class(**config_dict)
+
+    def test_can_load_metadata_from_subdirectory(self):
+        # Metadata stored in a subdirectory of `repo_path` is legitimate and must still load: the
+        # traversal guard rejects escapes only, not nested paths.
+        class_info = {
+            "0": {"isthing": 0, "name": "foo"},
+            "1": {"isthing": 1, "name": "bar"},
+        }
+        metadata = prepare_metadata(class_info)
+        for image_processing_class in self.image_processing_classes.values():
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                subdir = os.path.join(tmpdirname, "sub")
+                os.makedirs(subdir)
+                with open(os.path.join(subdir, "metadata.json"), "w") as f:
+                    json.dump(class_info, f)
+
+                config_dict = self.image_processor_dict
+                config_dict["repo_path"] = tmpdirname
+                config_dict["class_info_file"] = os.path.join("sub", "metadata.json")
+                image_processor = image_processing_class(**config_dict)
+
+            self.assertEqual(image_processor.metadata, metadata)
+
     def test_backends_equivalence(self):
         """Override base class test to also compare segmentation labels."""
         if len(self.image_processing_classes) < 2:


### PR DESCRIPTION
The `class_info_file` and `repo_path` fields of the OneFormer image processor config are loaded verbatim from `preprocessor_config.json` by `from_pretrained`, but they are untrusted. `class_info_file` is documented to live inside `repo_path`, yet it flows straight into `os.path.join(repo_path, class_info_file)` → `open(...)` → `json.load` in `load_metadata`, which runs during the processor's `__init__`. A value like `"../../secret.json"` or an absolute path escapes `repo_path`, so loading a malicious model via `AutoImageProcessor.from_pretrained(...)` (no `trust_remote_code`) reads an arbitrary local JSON file off the victim's machine.


The fix verifies the resolved metadata path stays inside `repo_path` before reading it, allowing files in subdirectories but rejecting `..`/absolute escapes. Applied to both the torchvision and PIL backends, with regression tests for the escape and the allowed-subdirectory case.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

- vision models: @yonigozlan @molbap