### PR TITLE
fix(hub): guard get_checkpoint_shard_files against path-traversal in weight_map

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -871,6 +871,28 @@ def get_checkpoint_shard_files(
 
     # First, let's deal with local folder.
     if os.path.isdir(pretrained_model_name_or_path):
+        # Validate shard filenames before joining with the model directory.
+        # A malicious or hand-crafted index.json could carry path-traversal
+        # sequences (e.g. "../../etc/passwd") or absolute paths that would
+        # escape the model directory and expose arbitrary files on the host.
+        # Guard against that by rejecting any filename that:
+        #   - is an absolute path, or
+        #   - contains a ".." component after normalisation.
+        # See https://github.com/huggingface/transformers/issues/46097
+        base_dir = os.path.realpath(pretrained_model_name_or_path)
+        for shard_filename in shard_filenames:
+            if os.path.isabs(shard_filename):
+                raise ValueError(
+                    f"Shard filename '{shard_filename}' in the checkpoint index is an absolute path. "
+                    "Loading checkpoints with absolute shard paths is not supported for security reasons."
+                )
+            resolved = os.path.realpath(os.path.join(base_dir, subfolder, shard_filename))
+            if not resolved.startswith(base_dir + os.sep) and resolved != base_dir:
+                raise ValueError(
+                    f"Shard filename '{shard_filename}' in the checkpoint index resolves outside the "
+                    f"model directory '{pretrained_model_name_or_path}'. This may be a path-traversal "
+                    "attempt; refusing to load."
+                )
         shard_filenames = [os.path.join(pretrained_model_name_or_path, subfolder, f) for f in shard_filenames]
         return shard_filenames, sharded_metadata
 

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -202,3 +202,52 @@ class OfflineModeTests(unittest.TestCase):
                 "transformers.utils.hub.snapshot_download", side_effect=LocalEntryNotFoundError("no snapshot found")
             ):
                 self.assertEqual(list_repo_templates(RANDOM_BERT, local_files_only=False), [])
+
+
+class TestGetCheckpointShardFilesPathTraversal(unittest.TestCase):
+    """Regression tests for path-traversal in get_checkpoint_shard_files.
+
+    A malicious index.json could carry ``weight_map`` entries with
+    ``..`` components or absolute paths that would escape the model
+    directory.  See https://github.com/huggingface/transformers/issues/46097
+    """
+
+    def _make_index(self, tmp_path, shard_name):
+        import json as _json
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        index = {"metadata": {"total_size": 1}, "weight_map": {"weight": shard_name}}
+        index_file = model_dir / "model.safetensors.index.json"
+        index_file.write_text(_json.dumps(index))
+        return str(model_dir), str(index_file)
+
+    def test_path_traversal_dotdot_raises(self):
+        import tempfile, pathlib
+        from transformers.utils.hub import get_checkpoint_shard_files
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir, index_file = self._make_index(pathlib.Path(tmp), "../../etc/passwd")
+            with self.assertRaises(ValueError):
+                get_checkpoint_shard_files(model_dir, index_file)
+
+    def test_absolute_path_raises(self):
+        import tempfile, pathlib
+        from transformers.utils.hub import get_checkpoint_shard_files
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir, index_file = self._make_index(pathlib.Path(tmp), "/etc/passwd")
+            with self.assertRaises(ValueError):
+                get_checkpoint_shard_files(model_dir, index_file)
+
+    def test_valid_shard_filename_accepted(self):
+        import tempfile, pathlib, json as _json
+        from transformers.utils.hub import get_checkpoint_shard_files
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp) / "model"
+            d.mkdir()
+            shard = "model-00001-of-00001.safetensors"
+            (d / shard).write_bytes(b"")
+            idx = {"metadata": {"total_size": 1}, "weight_map": {"w": shard}}
+            f = d / "model.safetensors.index.json"
+            f.write_text(_json.dumps(idx))
+            files, _ = get_checkpoint_shard_files(str(d), str(f))
+            self.assertEqual(len(files), 1)
+            self.assertTrue(files[0].startswith(str(d)))


### PR DESCRIPTION
## What does this fix?

`get_checkpoint_shard_files()` reads shard filenames from the
`weight_map` field of a checkpoint index JSON and joins them directly
to the model directory path via `os.path.join` with no validation:

```python
shard_filenames = sorted(set(index["weight_map"].values()))
...
shard_filenames = [os.path.join(pretrained_model_name_or_path, subfolder, f)
                   for f in shard_filenames]
```

A crafted or malicious `*.safetensors.index.json` / `*.bin.index.json`
could carry entries such as `../../etc/passwd` or `/etc/shadow`, causing
the loader to open arbitrary files the process has access to.

The attack surface is:

* Loading a model from a **local directory** where the attacker controls
  the index file (untrusted model from the internet extracted to disk).
* Shared-cluster environments where a malicious checkpoint is co-located
  with sensitive configuration files.

## Fix

Before building the final paths, the function now:

1. Rejects any filename that is already an **absolute path**.
2. Resolves the candidate path under the model directory with
   `os.path.realpath` and rejects any result that **escapes the base
   directory** (i.e. doesn't start with `base_dir + os.sep`).

Hub-downloaded shards are not affected — the `cached_files` path was
already guarded by the Hub's own validation.

## Tests

Three regression tests added to `tests/utils/test_hub_utils.py`:

| Test | Expected |
|------|----------|
| `../../etc/passwd` in `weight_map` | `ValueError` |
| `/etc/passwd` in `weight_map` | `ValueError` |
| `model-00001-of-00001.safetensors` | accepted, path inside model dir |

Fixes #46097