### PR TITLE
Fix StopIteration crash in ProcessorMixin.get_text_with_replacements for unmatched multimodal tokens

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -876,7 +876,11 @@ class ProcessorMixin(PushToHubMixin):
                 expanded_sample.append(text[batch_idx][last:start])
 
                 mm_type = m.lastgroup
-                replacement_text = next(replacements_iters[mm_type])
+                replacement_text = next(replacements_iters[mm_type], None)
+                if replacement_text is None:
+                    expanded_sample.append(text[batch_idx][last:end])
+                    last = end
+                    continue
                 replacement_offsets.append(
                     {
                         "type": mm_type,


### PR DESCRIPTION
## What does this PR do?

Fixes a `StopIteration` crash in `ProcessorMixin.get_text_with_replacements` when the input text contains multimodal placeholder tokens (e.g. `<|video|>`) but no corresponding modality data is provided.

**Root cause**: PR #45493 refactored `ProcessorMixin.__call__` to use `get_text_with_replacements`, which scans text for all multimodal tokens via regex and calls `next()` on a per-modality replacement iterator for each match. When a token is present in the text but its modality data is `None` (so the replacement list is empty), `next()` on the exhausted iterator raises `StopIteration`.

**Before #45493**: Each modality was processed independently in `__call__`. If `videos=None`, the video processor was skipped entirely. Multimodal tokens in the text with no data were left untouched and tokenized as-is. No crash.

**After #45493**: The new code always scans text for all multimodal tokens and strictly requires a replacement for each match:
```python
# Line 879 — crashes when replacements_iters[mm_type] is exhausted
replacement_text = next(replacements_iters[mm_type])
```

**Fix**: Use `next(iter, None)` with a `None` sentinel. When no replacement is available, the original token text is preserved in the output, matching pre-#45493 behavior:
```python
replacement_text = next(replacements_iters[mm_type], None)
if replacement_text is None:
    expanded_sample.append(text[batch_idx][last:end])
    last = end
    continue
```

**Reproducer**: Any multimodal model where text contains a placeholder token without matching data. Downstream frameworks like vLLM trigger this during memory profiling, where a dummy prompt with `<|video|>` is sent to the processor without video data attached.

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@zucchini-nlp @ArthurZucker