### PR TITLE
Fix PR CI workflow cancellation condition

### DIFF
--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -7,7 +7,8 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  # Group by PR number, commit SHA (main) to avoid cross-branch cancellation, or branch ref for cancellation within each branch
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/main' && github.sha) || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
# What does this PR do?

The current cancellation is not good. This PR improves it to:

- cancel previous runs from a branch if a new commit is pushed to the same branch - if that branch is not `main`
- for `main`: never cancel previous runs
-    