### PR TITLE
qa: fix ty caching and align CI with local run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,3 +120,4 @@ invalid-return-type = "ignore"         # Return type mismatches that would requi
 deprecated = "ignore"                  # Deprecation warnings from dependencies
 invalid-assignment = "ignore"          # Low-level assignments that are runtime-safe
 unused-ignore-comment = "ignore"       # Ignore comments that became unnecessary after adding broader per-file-ignores
+unused-type-ignore-comment = "ignore"  # A `# type: ignore` counts as "used" only when its suppressed error fires, which needs optional deps (torch, openai, ...) installed. CI's lean `quality` env lacks them, so directives used locally look unused in CI.

--- a/src/transformers/generation/continuous_batching/distributed.py
+++ b/src/transformers/generation/continuous_batching/distributed.py
@@ -12,13 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import torch
-import torch.distributed as dist
-from torch.distributed.tensor.device_mesh import DeviceMesh
+import torch.distributed as _dist
 
 from .requests import logger
+
+
+# torch marks `torch.distributed` members as possibly-missing, which leads to type check errors. To avoid them, we mark
+# the module as `Any` (same as `DeviceMeshLike` in `_typing.py`)
+dist: Any = _dist
+
+
+if TYPE_CHECKING or torch.distributed.is_available():  # prevents runtime import errors when distributed is off
+    from torch.distributed.device_mesh import DeviceMesh
+else:
+    DeviceMesh = object  # only used for type checking, so this is ok
 
 
 T = TypeVar("T")

--- a/utils/check_types.py
+++ b/utils/check_types.py
@@ -15,30 +15,14 @@ CHECKER_CONFIG = {
     # - `check_args` below are the exact roots passed to `ty check`.
     # - `cache_globs` here are only used by `utils/checkers.py` to decide when a
     #   previously clean `types` run can be reused from cache.
-    # Approximate: ty follows imports beyond the listed directories; these globs cover
-    # the explicitly targeted paths but not transitive dependencies.
+    # ty follows imports *beyond* the checked roots, so the cache key must cover every source file
+    # that could change a result -- not just the explicitly-checked paths. We hash the whole package
+    # (plus the standalone .circleci target) so any source edit busts the cache and forces a
+    # re-check. Otherwise a cached pass could silently hide a newly-introduced error in a
+    # transitively-imported module that ty pulls in but that isn't one of the checked roots.
     "cache_globs": [
-        "src/transformers/_typing.py",
-        "src/transformers/cli/**/*.py",
-        "src/transformers/modeling_utils.py",
-        "src/transformers/utils/**/*.py",
-        "src/transformers/generation/**/*.py",
-        "src/transformers/pipelines/__init__.py",
-        "src/transformers/pipelines/feature_extraction.py",
-        "src/transformers/pipelines/image_feature_extraction.py",
-        "src/transformers/pipelines/video_classification.py",
-        "src/transformers/quantizers/**/*.py",
+        "src/transformers/**/*.py",
         ".circleci/create_circleci_config.py",
-        "src/transformers/dependency_versions_table.py",
-        "src/transformers/dependency_versions_check.py",
-        "src/transformers/conversion_mapping.py",
-        "src/transformers/time_series_utils.py",
-        "src/transformers/debug_utils.py",
-        "src/transformers/hyperparameter_search.py",
-        "src/transformers/pytorch_utils.py",
-        "src/transformers/file_utils.py",
-        "src/transformers/trainer_jit_checkpoint.py",
-        "src/transformers/trainer_optimizer.py",
     ],
     "check_args": [
         "src/transformers/_typing.py",
@@ -74,8 +58,11 @@ def main():
 
     directories = sys.argv[1:]
     print(f"Running ty check on: {', '.join(directories)}")
+    # `--error-on-warning` makes ty exit non-zero on warning-level diagnostics (e.g.
+    # possibly-missing-attribute), not just errors. Without it, warnings print but ty exits 0, so
+    # `make typing` and CI both pass and the issue is never caught before commit.
     result = subprocess.run(
-        ["ty", "check", "--respect-ignore-files", "--exclude", "**/*_pb*", *directories],
+        ["ty", "check", "--respect-ignore-files", "--error-on-warning", "--exclude", "**/*_pb*", *directories],
     )
     sys.exit(result.returncode)
 


### PR DESCRIPTION
# What does this PR do?

I noticed `make typing` was failing locally but the ty checker was green in CI. This happened because the CI run did not error on warnings. 

There was also a bug in how we cache calls: when Ty was failing via make typing, the next cached call was appearing green because it was not busting the cache when ty errored out.

This patch fixes those discrepancies