### PR TITLE
Fix path traversal via vocab-file arguments in tokenizer_config.json

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1840,7 +1840,13 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         added_tokens_file = resolved_vocab_files.pop("added_tokens_file", None)
         special_tokens_map_file = resolved_vocab_files.pop("special_tokens_map_file", None)
         for args_name, file_path in resolved_vocab_files.items():
-            if args_name not in init_kwargs or init_kwargs[args_name] is None:
+            # `init_kwargs` also carries the values loaded from the (untrusted) `tokenizer_config.json`,
+            # which `save_pretrained` never serializes for these vocab-file arguments. A value present
+            # here therefore originates from the config and would be opened verbatim, so it could point
+            # at an arbitrary location outside the repository (path traversal, CWE-22). Let the
+            # repo-resolved path take precedence; only an explicit caller-provided path (in `kwargs`)
+            # is allowed to override it.
+            if args_name not in kwargs or kwargs[args_name] is None:
                 init_kwargs[args_name] = file_path
         tokenizer_file = resolved_vocab_files.get("tokenizer_file", None)
 

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -15,6 +15,7 @@
 ruff: isort: skip_file
 """
 
+import json
 import os
 import tempfile
 import unittest
@@ -263,6 +264,26 @@ class TokenizerUtilsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             bert_tokenizer.save(os.path.join(tmpdirname, "tokenizer.json"))
             PreTrainedTokenizerFast(tokenizer_file=os.path.join(tmpdirname, "tokenizer.json"))
+
+    def test_vocab_file_in_config_does_not_escape_repo(self):
+        # Regression test for path traversal (CWE-22): a vocab-file argument injected into
+        # `tokenizer_config.json` must not override the repository-resolved path nor be opened
+        # verbatim. Otherwise an attacker-controlled repo could read an arbitrary local file via
+        # `AutoTokenizer.from_pretrained(...)` with no `trust_remote_code`.
+        with tempfile.TemporaryDirectory() as repo, tempfile.TemporaryDirectory() as outside:
+            secret_path = os.path.join(outside, "secret.txt")
+            with open(secret_path, "w", encoding="utf-8") as f:
+                f.write("\n".join(["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]", "secret_leaked_token"]))
+            with open(os.path.join(repo, "vocab.txt"), "w", encoding="utf-8") as f:
+                f.write("\n".join(["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]", "benign_repo_token"]))
+            with open(os.path.join(repo, "tokenizer_config.json"), "w", encoding="utf-8") as f:
+                json.dump({"tokenizer_class": "BertTokenizer", "vocab_file": secret_path}, f)
+
+            tokenizer = AutoTokenizer.from_pretrained(repo, use_fast=False)
+            vocab = tokenizer.get_vocab()
+            # The repository's own vocab must win; the injected out-of-repo file must not be read.
+            self.assertIn("benign_repo_token", vocab)
+            self.assertNotIn("secret_leaked_token", vocab)
 
     def test_len_tokenizer(self):
         for tokenizer_class in [BertTokenizer, BertTokenizer]:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46279)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46279)
<!-- ci-dashboard-badge:end -->

`tokenizer_config.json` is loaded into the tokenizer's `init_kwargs` by `from_pretrained`, but `save_pretrained` never serializes the vocab-file arguments (`vocab_file`, `merges_file`, `tokenizer_file`, …) — they are reconstructed from `cls.vocab_files_names` and resolved inside the repo. When merging the resolved paths into `init_kwargs`, `_from_pretrained` kept a value that was already present, so a repo that puts e.g. `"vocab_file": "/etc/x"` (or `"../x"`) in `tokenizer_config.json` keeps its own value, which `convert_to_native_format` then opens verbatim (`os.path.isfile(...)` + read). This lets a malicious model read an arbitrary local file via `AutoTokenizer.from_pretrained(...)` with **no** `trust_remote_code`.

The fix lets the repo-resolved path take precedence over a config-supplied value for these arguments, while still honoring an explicit user-provided path passed as a `from_pretrained` kwarg. A regression test asserts that an injected `vocab_file` path is ignored on reload.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

- tokenizers: @ArthurZucker @itazap

<!-- ci-dashboard-recap:start -->

---

### CI recap

**Dashboard:** [View test results in Grafana](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46279)
**Latest run:** [28373528937:2](https://github.com/huggingface/transformers/actions/runs/28373528937)
**Result:** `success` | **Jobs:** 14 | **Tests:** 65,342 | **Failures:** 0 | **Duration:** 9h 45m

<!-- ci-dashboard-recap:end -->