### PR TITLE
Fix path traversal in sharded-checkpoint loader via the index weight_map

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -871,8 +871,17 @@ def get_checkpoint_shard_files(
 
     # First, let's deal with local folder.
     if os.path.isdir(pretrained_model_name_or_path):
-        shard_filenames = [os.path.join(pretrained_model_name_or_path, subfolder, f) for f in shard_filenames]
-        return shard_filenames, sharded_metadata
+        base_dir = Path(pretrained_model_name_or_path, subfolder).resolve()
+        resolved_shard_filenames = []
+        for shard_filename in shard_filenames:
+            shard_filepath = os.path.join(pretrained_model_name_or_path, subfolder, shard_filename)
+            # `shard_filename` is an untrusted value from the checkpoint index (`weight_map`); reject any
+            # that escapes the model directory via `..` or an absolute path (path traversal, CWE-22).
+            # Files in subdirectories of the model directory are still allowed.
+            if not Path(shard_filepath).resolve().is_relative_to(base_dir):
+                raise ValueError(f"Invalid checkpoint shard filename in the index: {shard_filename!r}")
+            resolved_shard_filenames.append(shard_filepath)
+        return resolved_shard_filenames, sharded_metadata
 
     # At this stage pretrained_model_name_or_path is a model identifier on the Hub. Try to get everything from cache,
     # or download the files

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -194,6 +194,32 @@ class GetFromCacheTests(unittest.TestCase):
                 # The error should be re-raised by cached_files, not caught in the exception handling block
                 cached_file(RANDOM_BERT, "nonexistent.json")
 
+    def test_get_checkpoint_shard_files_rejects_path_traversal(self):
+        # The shard filenames come from the untrusted `weight_map` of the checkpoint index. A value that
+        # escapes the model directory via `..` or an absolute path must be rejected so that loading a
+        # crafted local model cannot read files outside the model directory (path traversal, CWE-22).
+        from transformers.utils.hub import get_checkpoint_shard_files
+
+        for malicious in ["../escaped.safetensors", "/etc/escaped.safetensors"]:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                index_path = os.path.join(tmp_dir, "model.safetensors.index.json")
+                with open(index_path, "w") as f:
+                    json.dump({"metadata": {}, "weight_map": {"w": malicious}}, f)
+                with self.assertRaises(ValueError):
+                    get_checkpoint_shard_files(tmp_dir, index_path)
+
+    def test_get_checkpoint_shard_files_allows_subdirectories(self):
+        # Shards stored in a subdirectory of the model directory are legitimate and must still resolve:
+        # the traversal guard rejects escapes only, not nested paths.
+        from transformers.utils.hub import get_checkpoint_shard_files
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            index_path = os.path.join(tmp_dir, "model.safetensors.index.json")
+            with open(index_path, "w") as f:
+                json.dump({"metadata": {}, "weight_map": {"w": "sub/shard.safetensors"}}, f)
+            shard_files, _ = get_checkpoint_shard_files(tmp_dir, index_path)
+            self.assertEqual(shard_files, [os.path.join(tmp_dir, "sub/shard.safetensors")])
+
 
 class OfflineModeTests(unittest.TestCase):
     def test_list_repo_templates_w_offline(self):


### PR DESCRIPTION
`get_checkpoint_shard_files` reads the shard filenames from the model repo's untrusted index file (`model.safetensors.index.json` / `pytorch_model.bin.index.json`) `weight_map`, and for a **local** model directory joins them onto the directory with no containment check:

```python
shard_filenames = sorted(set(index["weight_map"].values()))
...
if os.path.isdir(pretrained_model_name_or_path):
    shard_filenames = [os.path.join(pretrained_model_name_or_path, subfolder, f) for f in shard_filenames]
```

A `weight_map` value such as `"../../x.safetensors"` or an absolute path escapes the model directory, so loading a crafted local model with `from_pretrained` opens/reads a file from elsewhere on the victim's filesystem (path traversal, CWE-22). Loading by Hub id is unaffected — those go through `cached_files`/`hf_hub_download`, which reject `..`.

The fix verifies each resolved shard path stays inside the model directory before returning it, allowing files in subdirectories but rejecting `..`/absolute escapes. Adds regression tests.

This is a sibling of the Bark (#46237), OneFormer (#46270) and chat-template (#46191) path traversals — the same trust-boundary mistake (an untrusted repo value used verbatim as a path), in the shared checkpoint loader.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

- model loading (from pretrained, etc): @CyrilVallez