### PR TITLE
Fix path traversal via the font config field in Ernie 4.5 VL MoE video processor

### DIFF
--- a/src/transformers/models/ernie4_5_vl_moe/video_processing_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/video_processing_ernie4_5_vl_moe.py
@@ -242,6 +242,12 @@ class Ernie4_5_VLMoeVideoProcessor(BaseVideoProcessor):
                 "Expected a `font` to be saved when using `draw_on_frames` in Ernie 4.5 VL Moe; found nothing."
             )
         if font_name is not None and draws_on_frames:
+            # `font_name` comes from the (untrusted) video processor config; reject values that escape
+            # the repo via `..` or an absolute path so a malicious config cannot open an arbitrary local
+            # file (path traversal, CWE-22). Files in subdirectories of the repo are still allowed.
+            base_dir = Path(pretrained_model_name_or_path).resolve()
+            if not Path(pretrained_model_name_or_path, font_name).resolve().is_relative_to(base_dir):
+                raise ValueError(f"Invalid font path: {font_name!r}")
             video_processor_dict["font"] = cached_file(
                 pretrained_model_name_or_path,
                 filename=font_name,

--- a/tests/models/ernie4_5_vl_moe/test_video_processing_ernie4_5_vl_moe.py
+++ b/tests/models/ernie4_5_vl_moe/test_video_processing_ernie4_5_vl_moe.py
@@ -172,6 +172,22 @@ class Ernie4_5_VLMoeVideoProcessingTest(VideoProcessingTestMixin, unittest.TestC
         )
         self.assertEqual(video_processor.size, {"longest_edge": 42, "shortest_edge": 42})
 
+    def test_get_video_processor_dict_rejects_font_path_traversal(self):
+        # `font` comes from the (untrusted) video processor config and is opened as a file when
+        # `draw_on_frames` is set. A value that escapes the repo via `..` or an absolute path would let
+        # a malicious config open an arbitrary local file (path traversal, CWE-22), so it must be rejected.
+        import json
+        import os
+        import tempfile
+
+        from transformers.utils import VIDEO_PROCESSOR_NAME
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with open(os.path.join(tmp_dir, VIDEO_PROCESSOR_NAME), "w", encoding="utf-8") as f:
+                json.dump({"draw_on_frames": True, "font": "../evil.ttf"}, f)
+            with self.assertRaises(ValueError):
+                self.fast_video_processing_class.get_video_processor_dict(tmp_dir)
+
     def test_call_pil(self):
         for video_processing_class in self.video_processor_list:
             video_processing = video_processing_class(**self.video_processor_dict)


### PR DESCRIPTION
`Ernie4_5_VLMoeVideoProcessor.get_video_processor_dict` reads `font` and `draw_on_frames` from the model repo's untrusted video processor config (`video_preprocessor_config.json` / `processor_config.json`) and passes `font` verbatim as the `filename` of `cached_file(pretrained_model_name_or_path, filename=font)`. For a local repo `cached_file` joins it onto the directory with no containment check, and the result is opened via `ImageFont.truetype(...)`. A `font` value such as `"../../x"` or an absolute path therefore escapes the model directory, so loading a malicious model can open an arbitrary local file (path traversal, CWE-22) — with no `trust_remote_code`.

The fix verifies the font path stays inside the repo before loading it, allowing files in subdirectories but rejecting `..`/absolute escapes. Adds a regression test.

This is a sibling of the Bark (#46237), OneFormer (#46270) and chat-template (#46191) path traversals — the same trust-boundary mistake (an untrusted config value used verbatim as a path).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

- vision models: @yonigozlan @molbap