### PR TITLE
cache_utils: fix `StaticLayer.get_seq_length()` returning `Tensor` instead of `int`

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -377,7 +377,7 @@ class StaticLayer(CacheLayerMixin):
 
     def get_seq_length(self) -> int:
         """Returns the sequence length of the cached states."""
-        return self.cumulative_length if self.is_initialized else 0
+        return int(self.cumulative_length.item()) if self.is_initialized else 0
 
     def get_max_cache_shape(self) -> int:
         """Return the maximum cache shape of the cache"""

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -881,6 +881,27 @@ class SyntheticCacheTest(unittest.TestCase):
             static_cache.layers[0].keys[0, 0, :, 0].tolist(), [1.0, 2.0, 3.0, 4.0], "StaticCache Scenario 2 failed"
         )
 
+    def test_static_layer_get_seq_length_returns_int(self):
+        """Test that StaticCache.get_seq_length() returns a Python int, not a Tensor.
+
+        StaticLayer stores `cumulative_length` as a torch.Tensor for CUDA-graph
+        stability, but get_seq_length() must return a plain Python int as declared
+        by its `-> int` signature and as required by callers that use the result in
+        standard Python arithmetic (e.g. `input_ids.shape[1] - past_length`).
+        """
+        static_cache = StaticCache(config=self.config, max_cache_len=self.max_cache_len)
+        # Before any update the cache is not initialized: must return 0 (int)
+        self.assertIsInstance(static_cache.get_seq_length(), int, "get_seq_length() must return int before initialization")
+        self.assertEqual(static_cache.get_seq_length(), 0)
+
+        # After an update the cache is initialized and cumulative_length is a Tensor internally,
+        # but get_seq_length() must still return a plain Python int.
+        prefill = torch.tensor([1.0, 2.0])[None, None, :, None]
+        static_cache.update(key_states=prefill, value_states=prefill, layer_idx=0)
+        seq_len = static_cache.get_seq_length()
+        self.assertIsInstance(seq_len, int, "get_seq_length() must return int after initialization, not a Tensor")
+        self.assertEqual(seq_len, 2)
+
     def test_sliding_window_cache(self):
         """Test fully sliding StaticCache with manually prefilled states and hardcoded assertions.
 


### PR DESCRIPTION
# What does this PR do?

Fixes a type contract violation in `StaticLayer.get_seq_length()` in `src/transformers/cache_utils.py`.

`StaticLayer` stores `cumulative_length` as a `torch.Tensor` (a single-element tensor) rather than a plain Python `int`. This is intentional and necessary for `torch.compile` / CUDA-graph stability — a tensor has a stable static address, whereas reassigning a Python `int` would cause graph recompilation.

However, `get_seq_length()` is declared as `-> int` and was returning `self.cumulative_length` (the raw tensor) directly after initialization, breaking its own type contract. Callers across the codebase — including `generation/utils.py` — consume this return value in plain Python arithmetic such as:

    next_sequence_length = input_ids.shape[1] - past_length
    position_ids = torch.arange(seq_length + past_length, ...)

When `past_length` is silently a `torch.Tensor` instead of an `int`, these expressions return tensors where scalars are expected, which can cause subtle downstream failures.

**Fix:** call `.item()` and cast to `int` at the return site, so the method truly returns a Python `int` as its signature promises. The internal `self.cumulative_length` tensor is never reassigned — it is only mutated via `.add_()` — so the CUDA-graph static-address guarantee is fully preserved.

A new unit test (`test_static_layer_get_seq_length_returns_int`) is added to `tests/utils/test_cache_utils.py` inside `SyntheticCacheTest`. It asserts that `get_seq_length()` returns a plain Python `int` both before initialization (trivially `0`) and after an update (when `cumulative_length` is an initialized tensor internally). This test fails on the original code and passes after the fix.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

# What does this PR do?

Fixes a type contract violation in `StaticLayer.get_seq_length()` in `src/transformers/cache_utils.py`.

`StaticLayer` stores `cumulative_length` as a `torch.Tensor` (a single-element tensor) rather than a plain Python `int`. This is intentional and necessary for `torch.compile` / CUDA-graph stability — a tensor has a stable static address, whereas reassigning a Python `int` would cause graph recompilation.

However, `get_seq_length()` is declared as `-> int` and was returning `self.cumulative_length` (the raw tensor) directly after initialization, breaking its own type contract. Callers across the codebase — including `generation/utils.py` — consume this return value in plain Python arithmetic such as:

    next_sequence_length = input_ids.shape[1] - past_length
    position_ids = torch.arange(seq_length + past_length, ...)

When `past_length` is silently a `torch.Tensor` instead of an `int`, these expressions return tensors where scalars are expected, which can cause subtle downstream failures.

**Fix:** call `.item()` and cast to `int` at the return site, so the method truly returns a Python `int` as its signature promises. The internal `self.cumulative_length` tensor is never reassigned — it is only mutated via `.add_()` — so the CUDA-graph static-address guarantee is fully preserved.

A new unit test (`test_static_layer_get_seq_length_returns_int`) is added to `tests/utils/test_cache_utils.py` inside `SyntheticCacheTest`. It asserts that `get_seq_length()` returns a plain Python `int` both before initialization (trivially `0`) and after an update (when `cumulative_length` is an initialized tensor internally). This test fails on the original code and passes after the fix.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@gante @ArthurZucker

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.