### PR TITLE
Export is_falcon_mamba_ssm_available from utils

### DIFF
--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -130,6 +130,7 @@ from .import_utils import (
     is_env_variable_true,
     is_essentia_available,
     is_faiss_available,
+    is_falcon_mamba_ssm_available,
     is_fbgemm_gpu_available,
     is_flash_attn_2_available,
     is_flash_attn_3_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -829,6 +829,9 @@ def is_mamba_2_ssm_available() -> bool:
     return is_torch_cuda_available() and is_available and version.parse(mamba_ssm_version) >= version.parse("2.0.4")
 
 
+is_falcon_mamba_ssm_available = is_mamba_ssm_available
+
+
 @lru_cache
 def is_flash_linear_attention_available():
     is_available, fla_version = _is_package_available("fla", return_version=True)


### PR DESCRIPTION
## What does this PR do?

`is_falcon_mamba_ssm_available` is missing from `transformers.utils`, causing `ImportError` when FalconMamba models try to use hub kernels via `lazy_load_kernel("falcon_mamba-ssm")`.

When the `kernels` package is not installed, `lazy_load_kernel` falls back to looking up `is_falcon_mamba_ssm_available` in `utils.import_utils` via `getattr`. The function did not exist, so the lookup returned `None` and the model silently fell into `slow_forward` with a misleading warning.

This PR adds `is_falcon_mamba_ssm_available` as an alias for `is_mamba_ssm_available` in `import_utils.py` (Falcon-Mamba shares the same underlying `mamba_ssm` kernel) and exports it from `utils/__init__.py`.

Fixes #46234