### PR TITLE
Fix hub kernels compatibility with kernels>=0.15.0

### DIFF
--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -89,12 +89,14 @@ try:
             "cuda": LayerRepository(
                 repo_id="kernels-community/deformable-detr",
                 layer_name="MultiScaleDeformableAttention",
+                version=1,
             )
         },
         "Llama4TextMoe": {
             "cuda": LayerRepository(
                 repo_id="kernels-community/moe",
                 layer_name="Llama4TextMoe",
+                version=1,
             )
         },
         "RMSNorm": {
@@ -102,31 +104,35 @@ try:
                 Mode.INFERENCE: LayerRepository(
                     repo_id="kernels-community/liger-kernels",
                     layer_name="LigerRMSNorm",
-                    # revision="pure-layer-test",
+                    version=1,
                 ),
             },
             "rocm": {
                 Mode.INFERENCE: LayerRepository(
                     repo_id="kernels-community/liger-kernels",
                     layer_name="LigerRMSNorm",
+                    version=1,
                 )
             },
             "xpu": {
                 Mode.INFERENCE: LayerRepository(
                     repo_id="kernels-community/rmsnorm",
                     layer_name="RMSNorm",
+                    version=1,
                 )
             },
             "mps": {
                 Mode.INFERENCE: LayerRepository(
                     repo_id="kernels-community/mlx-rmsnorm",
                     layer_name="RMSNorm",
+                    version=1,
                 )
             },
             "npu": {
                 Mode.INFERENCE: LayerRepository(
                     repo_id="kernels-community/liger-kernels",
                     layer_name="LigerRMSNorm",
+                    version=1,
                 )
             },
         },
@@ -134,6 +140,7 @@ try:
             "cuda": LayerRepository(
                 repo_id="medmekk/triton-llama-mlp",
                 layer_name="TritonLlamaMLP",
+                version=1,
             )
         },
         "MegaBlocksMoeMLP": {
@@ -141,28 +148,33 @@ try:
                 Mode.TRAINING: LayerRepository(
                     repo_id="kernels-community/megablocks",
                     layer_name="MegaBlocksMoeMLP",
+                    version=1,
                 ),
                 Mode.INFERENCE: LayerRepository(
                     repo_id="kernels-community/megablocks",
                     layer_name="MegaBlocksMoeMLP",
+                    version=1,
                 ),
             },
             "rocm": {
                 Mode.INFERENCE: LayerRepository(
                     repo_id="ahadnagy/megablocks",
                     layer_name="MegaBlocksMoeMLP",
+                    version=1,
                 )
             },
             "xpu": {
                 Mode.INFERENCE: LayerRepository(
                     repo_id="kernels-community/megablocks",
                     layer_name="MegaBlocksMoeMLP",
+                    version=1,
                 )
             },
             "cpu": {
                 Mode.INFERENCE: LayerRepository(
                     repo_id="kernels-community/megablocks",
                     layer_name="CPUMegaBlocksMoeMLP",
+                    version=1,
                 )
             },
         },
@@ -221,15 +233,15 @@ try:
         _KERNEL_MAPPING["rotary_pos_emb"] = {
             "xpu": {
                 Mode.INFERENCE: FuncRepository(
-                    repo_id="kernels-community/rotary", func_name="apply_rotary_transformers"
+                    repo_id="kernels-community/rotary", func_name="apply_rotary_transformers", version=1
                 )
             },
             "cuda": {
                 Mode.TRAINING: FuncRepository(
-                    repo_id="kernels-community/rotary", func_name="apply_rotary_transformers"
+                    repo_id="kernels-community/rotary", func_name="apply_rotary_transformers", version=1
                 ),
                 Mode.INFERENCE: FuncRepository(
-                    repo_id="kernels-community/rotary", func_name="apply_rotary_transformers"
+                    repo_id="kernels-community/rotary", func_name="apply_rotary_transformers", version=1
                 ),
             },
         }

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -100,14 +100,14 @@ try:
         "RMSNorm": {
             "cuda": {
                 Mode.INFERENCE: LayerRepository(
-                    repo_id="kernels-community/liger_kernels",
+                    repo_id="kernels-community/liger-kernels",
                     layer_name="LigerRMSNorm",
                     # revision="pure-layer-test",
                 ),
             },
             "rocm": {
                 Mode.INFERENCE: LayerRepository(
-                    repo_id="kernels-community/liger_kernels",
+                    repo_id="kernels-community/liger-kernels",
                     layer_name="LigerRMSNorm",
                 )
             },
@@ -119,13 +119,13 @@ try:
             },
             "mps": {
                 Mode.INFERENCE: LayerRepository(
-                    repo_id="kernels-community/mlx_rmsnorm",
+                    repo_id="kernels-community/mlx-rmsnorm",
                     layer_name="RMSNorm",
                 )
             },
             "npu": {
                 Mode.INFERENCE: LayerRepository(
-                    repo_id="kernels-community/liger_kernels",
+                    repo_id="kernels-community/liger-kernels",
                     layer_name="LigerRMSNorm",
                 )
             },


### PR DESCRIPTION
# What does this PR do?

Fixes #46291

This PR fixes the [hub_kernels.py](https://github.com/huggingface/transformers/blob/main/src/transformers/integrations/hub_kernels.py) version error introduced by `kernels>=0.15.0`.

Starting from kernels v0.15.0, Hub-backed kernel repositories must specify either a version or a revision. This PR adds explicit versions to the affected kernel repository definitions. Since this only adds version metadata, it should remain compatible with earlier kernels versions.

This PR also updates two kernel repository names. According to the documentation, the previous names are marked for removal.

cc @drbh 
