### PR TITLE
docs: add docstrings to create_sinusoidal_embeddings in DistilBERT

### DIFF
--- a/src/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_distilbert.py
@@ -60,6 +60,26 @@ logger = logging.get_logger(__name__)
 
 
 def create_sinusoidal_embeddings(n_pos: int, dim: int, out: torch.Tensor):
+    """
+    Fill a pre-allocated embedding tensor with sinusoidal positional encodings,
+    with DeepSpeed ZeRO-3 support.
+
+    Sinusoidal embeddings encode each position using alternating sine and cosine
+    functions at geometrically spaced frequencies, as described in
+    *Attention Is All You Need* (Vaswani et al., 2017).
+
+    Args:
+        n_pos (`int`):
+            Number of positions to generate embeddings for (i.e. the maximum
+            sequence length).
+        dim (`int`):
+            Embedding dimension. Should be even so that sine and cosine values
+            alternate across the full dimension.
+        out (`torch.Tensor`):
+            Pre-allocated output tensor of shape `(n_pos, dim)` that will be
+            filled **in-place** with sinusoidal values. Gradient tracking is
+            disabled on this tensor before writing.
+    """
     if is_deepspeed_zero3_enabled():
         import deepspeed
 
@@ -71,6 +91,20 @@ def create_sinusoidal_embeddings(n_pos: int, dim: int, out: torch.Tensor):
 
 
 def _create_sinusoidal_embeddings(n_pos: int, dim: int, out: torch.Tensor):
+    """
+    Internal implementation of sinusoidal positional embedding generation,
+    without DeepSpeed ZeRO-3 handling.
+
+    Fills `out` in-place using the formula from *Attention Is All You Need*:
+
+    - ``out[pos, 2i]   = sin(pos / 10000 ** (2i / dim))``
+    - ``out[pos, 2i+1] = cos(pos / 10000 ** (2i / dim))``
+
+    Args:
+        n_pos (`int`): Number of positions (maximum sequence length).
+        dim (`int`): Embedding dimension.
+        out (`torch.Tensor`): Tensor of shape `(n_pos, dim)` to fill in-place.
+    """
     position_enc = np.array([[pos / np.power(10000, 2 * (j // 2) / dim) for j in range(dim)] for pos in range(n_pos)])
     out.requires_grad = False
     out[:, 0::2] = torch.FloatTensor(np.sin(position_enc[:, 0::2]))


### PR DESCRIPTION
## What does this PR do?

Adds docstrings to `create_sinusoidal_embeddings` and `_create_sinusoidal_embeddings` 
in `src/transformers/models/distilbert/modeling_distilbert.py`.

Both functions were previously undocumented. This makes it clear:
- What `n_pos`, `dim`, and `out` represent
- That `out` is modified **in-place** (not returned as a new tensor)
- That the encoding follows the formula from *Attention Is All You Need* (Vaswani et al., 2017)

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?