### PR TITLE
Fix arbitrary code execution via compressed-tensors sparsity format

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -1158,8 +1158,14 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
             )
 
         if sparsity_config:
+            sparsity_config_format = sparsity_config.get("format")
+            # `format` is an untrusted config.json value used as a compressed_tensors registry name. A name
+            # containing ":" is resolved as a "<path>:<attr>" plugin spec and the file is imported and
+            # executed (arbitrary code execution, CWE-94), so reject it before the lookup.
+            if sparsity_config_format is not None and ":" in str(sparsity_config_format):
+                raise ValueError(f"Invalid sparsity_config format: {sparsity_config_format!r}")
             self.sparsity_config = SparsityCompressionConfig.load_from_registry(
-                sparsity_config.get("format"), **sparsity_config
+                sparsity_config_format, **sparsity_config
             )
 
         self.quant_method = QuantizationMethod.COMPRESSED_TENSORS

--- a/tests/quantization/compressed_tensors_integration/test_compressed_tensors.py
+++ b/tests/quantization/compressed_tensors_integration/test_compressed_tensors.py
@@ -36,6 +36,24 @@ class CompressedTensorsTest(unittest.TestCase):
             sparsity_config={"format": "dense"},
         )
 
+    def test_sparsity_config_format_rejects_path_import(self):
+        # `sparsity_config["format"]` is an untrusted config.json value forwarded to compressed_tensors'
+        # SparsityCompressionConfig.load_from_registry. A name shaped like "<path>:<attr>" is resolved by the
+        # registry as a plugin file that is imported and executed (arbitrary code execution, CWE-94).
+        # CompressedTensorsConfig must reject such values before reaching that code path.
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            payload = os.path.join(tmp_dir, "payload.py")
+            canary = os.path.join(tmp_dir, "executed")
+            with open(payload, "w") as f:
+                f.write(f"open({canary!r}, 'w').close()\n")
+            with self.assertRaises(ValueError):
+                CompressedTensorsConfig(sparsity_config={"format": f"{payload}:x"})
+            # the payload module must not have been imported/executed
+            self.assertFalse(os.path.exists(canary))
+
     def test_config_to_from_dict(self):
         config = CompressedTensorsConfig(config_groups={"FP8": ["Linear"]}, sparsity_config={"format": "dense"})
         config_dict = config.to_dict()


### PR DESCRIPTION
The `sparsity_config` of a `compressed-tensors` quantization config is read from an untrusted `config.json`, and its `format` value is passed straight into `compressed_tensors.SparsityCompressionConfig.load_from_registry()` as the registry lookup name. That registry treats a name containing a colon as a `"<path>:<attr>"` plugin spec and imports and executes the file at that path (`importlib.util.spec_from_file_location` + `exec_module`). A malicious model loaded with `AutoModelForCausalLM.from_pretrained(...)` and `trust_remote_code=False` therefore runs arbitrary code during quantizer setup, before any weights are loaded. This is the same class of issue as the previously fixed `_attn_implementation_internal` config injection (an untrusted `config.json` field reaching a code-loading sink).

This rejects `sparsity_config["format"]` values containing `:` before the lookup in `CompressedTensorsConfig.__init__` — that colon syntax can only select the registry's file-import branch, while legitimate sparsity formats are plain registry names (e.g. `dense`, `sparse-24-bitmask`). A regression test asserts that a colon-bearing `format` raises `ValueError` and does not import/execute the referenced file.

## Tests

```
python -m pytest tests/quantization/compressed_tensors_integration/test_compressed_tensors.py \
  -k "sparsity_config_format or config_args or config_to_from_dict"
```
All pass (`test_sparsity_config_format_rejects_path_import` + the existing `test_config_args` / `test_config_to_from_dict`).

## Who can review?

- quantization: @SunMarc
- model loading (from_pretrained, etc): @CyrilVallez
