### PR TITLE
fix: Enable flash_attention in Granite4Vision

### DIFF
--- a/src/transformers/models/granite4_vision/modeling_granite4_vision.py
+++ b/src/transformers/models/granite4_vision/modeling_granite4_vision.py
@@ -144,7 +144,7 @@ class Granite4VisionWindowQFormerDownsampler(nn.Module):
         self._spatial_offset = spatial_offset
         self._downsample_rate = config.downsample_rate
 
-        self.qformer = AutoModel.from_config(config.qformer_config)
+        self.qformer = AutoModel.from_config(config.qformer_config, attn_implementation="eager")
 
         self.image_side = config.vision_config.image_size // config.vision_config.patch_size
         query_side_str, window_side_str = config.downsample_rate.split("/")

--- a/src/transformers/models/granite4_vision/modular_granite4_vision.py
+++ b/src/transformers/models/granite4_vision/modular_granite4_vision.py
@@ -275,7 +275,7 @@ class Granite4VisionWindowQFormerDownsampler(nn.Module):
         self._spatial_offset = spatial_offset
         self._downsample_rate = config.downsample_rate
 
-        self.qformer = AutoModel.from_config(config.qformer_config)
+        self.qformer = AutoModel.from_config(config.qformer_config, attn_implementation="eager")
 
         self.image_side = config.vision_config.image_size // config.vision_config.patch_size
         query_side_str, window_side_str = config.downsample_rate.split("/")


### PR DESCRIPTION
# What does this PR do?
Fixes the following crash when loading the Granite4Vision with flash_attention_2:
```python
from transformers import AutoModelForImageTextToText
model = AutoModelForImageTextToText.from_pretrained(
    "ibm-granite/granite-vision-4.1-4b",
    dtype=torch.bfloat16,
    device_map="cuda",
    attn_implementation="flash_attention_2"
).eval()

# raises: ValueError: Blip2QFormerModel does not support Flash Attention 2 yet.
```
The change resolves the issue and enables running the larger components (encoder/llm) with efficient attention backends.


## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?
@zucchini-nlp @vasqu  do you mind reviewing? you both had some 
CC: @artem-spector 