### PR TITLE
fix(moonshine_streaming): include full right window in sliding_window_mask_function

### DIFF
--- a/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
@@ -356,7 +356,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask

--- a/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
@@ -269,7 +269,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask


### PR DESCRIPTION
## What

`sliding_window_mask_function` in `modeling_moonshine_streaming.py` builds the right-context mask with a strict less-than:

```python
right_mask = (dist < 0) & (-dist < right_window_size)
```

For `right_window_size=4`, this only lets a query attend to `kv - q ∈ {1, 2, 3}` — **3 future frames** — instead of 4.

## Why

The Moonshine v2 paper (arXiv:2602.12241) defines the right window as the algorithmic lookahead:

> "a right window of w_right=4 implies an algorithmic lookahead of 4×20 ms = 80 ms"

At 50 Hz, 80 ms is 4 frames. The strict `<` produced only 60 ms (3 frames), an off-by-one against the documented behavior. (The left/causal branch already attends to `left_window_size` frames including the current one, so this only affects the right context.)

## Fix

Use `<=` so a query attends to exactly `right_window_size` future frames:

```python
right_mask = (dist < 0) & (-dist <= right_window_size)
```

Applied to both `modular_moonshine_streaming.py` (the source) and the generated `modeling_moonshine_streaming.py` so they stay in sync.

## Verification

Using the reproduction from #46305 with `sliding_window_mask_function((16, 4))` and a query at position 10:

- Before: future frames attended `= [11, 12, 13]` (3 frames, 60 ms)
- After:  future frames attended `= [11, 12, 13, 14]` (4 frames, 80 ms) ✅

Fixes #46305

🤖 Generated with [Claude Code](https://claude.com/claude-code)