### PR TITLE
fix(image_processing): don't warn/import on non-Fast attribute probes

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -833,6 +833,11 @@ else:
         # Also map XImageProcessorFast -> XImageProcessor for backward compat with old class names.
         def getattr_factory(target):
             def _getattr(name):
+                # Only names ending in "Fast" are genuine class aliases; arbitrary
+                # attribute probing (e.g. introspection by third-party libraries) must
+                # not emit a deprecation warning or trigger a spurious import.
+                if not name.endswith("Fast"):
+                    raise AttributeError(f"module {target!r} has no attribute {name!r}")
                 new_name = name.removesuffix("Fast")
                 logger.warning(
                     "Accessing `%s` from `%s`. Returning `%s` instead. Behavior may be "


### PR DESCRIPTION
### What does this PR do?

Fixes #46298.

The `*_fast` image-processing alias modules (created in `transformers/__init__.py` to keep `XImageProcessorFast` importable as a back-compat alias of `XImageProcessor`) install a `__getattr__` that, on **every** attribute access, logs a deprecation warning and imports the target module.

Because module-level `__getattr__` fires for *any* name that isn't already an attribute, third-party introspection triggers it for names that are not aliases at all. For example `import skops.io` (or `unittest.assertWarns`) probes arbitrary attributes and produces hundreds of messages like:

```
Accessing `zetac` from `.models.superpoint.image_processing_superpoint`. Returning `zetac` instead. ...
```

(`zetac` is not a class alias — it's just a name some library probed.)

### Fix

Only treat names ending in `Fast` as genuine aliases. For anything else, raise `AttributeError` like a normal module lookup would — no warning, no spurious import:

```python
def _getattr(name):
    if not name.endswith("Fast"):
        raise AttributeError(f"module {target!r} has no attribute {name!r}")
    new_name = name.removesuffix("Fast")
    logger.warning(...)
    return getattr(importlib.import_module(target, __name__), new_name)
```

Legitimate `XImageProcessorFast -> XImageProcessor` redirects are unaffected (those names end in `Fast`); the previous behavior for non-`Fast` names was to warn and then raise `AttributeError` anyway, so this only removes the noise and the redundant import attempt.

### Before submitting
- [x] This PR fixes a typo or improves the docs (no test needed).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue? #46298

### Who can review?
@yonigozlan @molbap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
