### PR TITLE
Validate Bark speaker embedding save paths

### DIFF
--- a/src/transformers/models/bark/processing_bark.py
+++ b/src/transformers/models/bark/processing_bark.py
@@ -17,6 +17,7 @@ Processor class for Bark
 
 import json
 import os
+from pathlib import Path
 
 import numpy as np
 
@@ -29,6 +30,11 @@ from ..auto import AutoTokenizer
 
 
 logger = logging.get_logger(__name__)
+
+
+def _validate_speaker_embedding_path(path: str | os.PathLike, base_directory: str | os.PathLike):
+    if Path(path).resolve().parent != Path(base_directory).resolve():
+        raise ValueError(f"Invalid speaker embedding path: {path!r}")
 
 
 @auto_docstring
@@ -139,7 +145,8 @@ class BarkProcessor(ProcessorMixin):
                 Additional key word arguments passed along to the [`~utils.PushToHubMixin.push_to_hub`] method.
         """
         if self.speaker_embeddings is not None:
-            os.makedirs(os.path.join(save_directory, speaker_embeddings_directory, "v2"), exist_ok=True)
+            speaker_embeddings_dir = os.path.join(save_directory, speaker_embeddings_directory)
+            os.makedirs(os.path.join(speaker_embeddings_dir, "v2"), exist_ok=True)
 
             embeddings_dict = {}
 
@@ -150,10 +157,10 @@ class BarkProcessor(ProcessorMixin):
 
                 tmp_dict = {}
                 for key in self.speaker_embeddings[prompt_key]:
+                    speaker_embedding_path = os.path.join(speaker_embeddings_dir, f"{prompt_key}_{key}.npy")
+                    _validate_speaker_embedding_path(speaker_embedding_path, speaker_embeddings_dir)
                     np.save(
-                        os.path.join(
-                            embeddings_dict["repo_or_path"], speaker_embeddings_directory, f"{prompt_key}_{key}"
-                        ),
+                        speaker_embedding_path,
                         voice_preset[key],
                         allow_pickle=False,
                     )

--- a/tests/models/bark/test_processing_bark.py
+++ b/tests/models/bark/test_processing_bark.py
@@ -49,6 +49,31 @@ class BarkProcessorTest(unittest.TestCase):
 
         self.assertEqual(processor.tokenizer.get_vocab(), tokenizer.get_vocab())
 
+    def test_save_pretrained_rejects_speaker_embedding_path_traversal(self):
+        tokenizer = self.get_tokenizer()
+
+        voice_preset = {
+            "semantic_prompt": np.ones(1),
+            "coarse_prompt": np.ones((2, 1)),
+            "fine_prompt": np.ones((8, 1)),
+        }
+        for key, value in voice_preset.items():
+            np.save(os.path.join(self.tmpdirname, f"{key}.npy"), value, allow_pickle=False)
+
+        processor = BarkProcessor(
+            tokenizer=tokenizer,
+            speaker_embeddings={
+                "repo_or_path": self.tmpdirname,
+                "../escaped": {key: f"{key}.npy" for key in voice_preset},
+            },
+        )
+        save_dir = os.path.join(self.tmpdirname, "save")
+
+        with self.assertRaisesRegex(ValueError, "Invalid speaker embedding path"):
+            processor.save_pretrained(save_dir)
+
+        self.assertFalse(os.path.exists(os.path.join(save_dir, "escaped_semantic_prompt.npy")))
+
     @slow
     def test_save_load_pretrained_additional_features(self):
         processor = BarkProcessor.from_pretrained(


### PR DESCRIPTION
## What does this PR do?

This PR validates the file paths generated when `BarkProcessor.save_pretrained()` writes speaker embedding `.npy` files.

Speaker preset names come from `speaker_embeddings_path.json` loaded by `BarkProcessor.from_pretrained()`. Before this change, those names were interpolated into output filenames without checking that the resolved output stayed inside the intended `speaker_embeddings` directory. This adds a small path-boundary check before `np.save()` and rejects generated paths that escape that directory.

## Why is it needed?

A malformed or untrusted Bark processor repo can provide an unexpected speaker preset name. If a caller later saves that processor, generated speaker embedding files should not be able to land outside the speaker embedding output directory.

## Tests

```bash
PYTHONPATH=src python -m pytest tests/models/bark/test_processing_bark.py::BarkProcessorTest::test_save_pretrained_rejects_speaker_embedding_path_traversal -q -vv
PYTHONPATH=src python -m pytest tests/models/bark/test_processing_bark.py::BarkProcessorTest::test_save_load_pretrained_default -q -vv
PYTHONPATH=src python -m py_compile src/transformers/models/bark/processing_bark.py tests/models/bark/test_processing_bark.py
git diff --check
```