### PR TITLE
Pass library_name/version to Hub calls via a shared HfApi

### DIFF
--- a/src/transformers/backbone_utils.py
+++ b/src/transformers/backbone_utils.py
@@ -18,9 +18,7 @@ import enum
 import functools
 import inspect
 
-from huggingface_hub import repo_exists
-
-from .utils import logging
+from .utils import hf_api, logging
 from .utils.output_capturing import maybe_install_capturing_hooks
 
 
@@ -334,7 +332,7 @@ def consolidate_backbone_kwargs_to_config(
     ):
         backbone_config = CONFIG_MAPPING["timm_backbone"](backbone=backbone, **timm_default_kwargs)
     elif backbone is not None and backbone_config is None:
-        if repo_exists(backbone):
+        if hf_api().repo_exists(backbone):
             config_dict, _ = PreTrainedConfig.get_config_dict(backbone)
             config_class = CONFIG_MAPPING[config_dict["model_type"]]
             config_dict.update(backbone_kwargs)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -23,7 +23,6 @@ from dataclasses import MISSING, dataclass, fields
 from functools import wraps
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, Union
 
-from huggingface_hub import create_repo
 from huggingface_hub.dataclasses import strict
 from packaging import version
 from typing_extensions import dataclass_transform
@@ -39,6 +38,7 @@ from .utils import (
     cached_file,
     copy_func,
     extract_commit_hash,
+    hf_api,
     is_torch_available,
     logging,
 )
@@ -521,7 +521,7 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
         if push_to_hub:
             commit_message = kwargs.pop("commit_message", None)
             repo_id = kwargs.pop("repo_id", save_directory.split(os.path.sep)[-1])
-            repo_id = create_repo(repo_id, exist_ok=True, **kwargs).repo_id
+            repo_id = hf_api().create_repo(repo_id, exist_ok=True, **kwargs).repo_id
             files_timestamps = self._get_files_timestamps(save_directory)
 
         # This attribute is important to know on load, but should not be serialized on save.

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -22,7 +22,7 @@ from collections import UserDict
 from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 import numpy as np
-from huggingface_hub import create_repo, is_offline_mode
+from huggingface_hub import is_offline_mode
 
 from .dynamic_module_utils import custom_object_save
 from .utils import (
@@ -40,7 +40,7 @@ from .utils import (
     requires_backends,
     safe_load_json_file,
 )
-from .utils.hub import cached_file
+from .utils.hub import cached_file, hf_api
 
 
 if TYPE_CHECKING:
@@ -403,7 +403,7 @@ class FeatureExtractionMixin(PushToHubMixin):
         if push_to_hub:
             commit_message = kwargs.pop("commit_message", None)
             repo_id = kwargs.pop("repo_id", save_directory.split(os.path.sep)[-1])
-            repo_id = create_repo(repo_id, exist_ok=True, **kwargs).repo_id
+            repo_id = hf_api().create_repo(repo_id, exist_ok=True, **kwargs).repo_id
             files_timestamps = self._get_files_timestamps(save_directory)
 
         # If we have a custom config, we copy the file defining it in the folder and set the attributes so it can be

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -21,8 +21,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, is_dataclass
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from huggingface_hub import create_repo
-
 from .. import __version__
 from ..utils import (
     GENERATION_CONFIG_NAME,
@@ -30,6 +28,7 @@ from ..utils import (
     PushToHubMixin,
     cached_file,
     extract_commit_hash,
+    hf_api,
     is_torch_available,
     logging,
 )
@@ -866,7 +865,7 @@ class GenerationConfig(PushToHubMixin):
         if push_to_hub:
             commit_message = kwargs.pop("commit_message", None)
             repo_id = kwargs.pop("repo_id", str(save_directory).split(os.path.sep)[-1])
-            repo_id = create_repo(repo_id, exist_ok=True, **kwargs).repo_id
+            repo_id = hf_api().create_repo(repo_id, exist_ok=True, **kwargs).repo_id
             files_timestamps = self._get_files_timestamps(save_directory)
 
         output_config_file = os.path.join(save_directory, config_file_name)

--- a/src/transformers/image_processing_base.py
+++ b/src/transformers/image_processing_base.py
@@ -18,7 +18,7 @@ import os
 from typing import Any, TypeVar
 
 import numpy as np
-from huggingface_hub import create_repo, is_offline_mode
+from huggingface_hub import is_offline_mode
 
 from .dynamic_module_utils import custom_object_save
 from .feature_extraction_utils import BatchFeature as BaseBatchFeature
@@ -31,7 +31,7 @@ from .utils import (
     logging,
     safe_load_json_file,
 )
-from .utils.hub import cached_file
+from .utils.hub import cached_file, hf_api
 
 
 ImageProcessorType = TypeVar("ImageProcessorType", bound="ImageProcessingMixin")
@@ -203,7 +203,7 @@ class ImageProcessingMixin(PushToHubMixin):
         if push_to_hub:
             commit_message = kwargs.pop("commit_message", None)
             repo_id = kwargs.pop("repo_id", save_directory.split(os.path.sep)[-1])
-            repo_id = create_repo(repo_id, exist_ok=True, **kwargs).repo_id
+            repo_id = hf_api().create_repo(repo_id, exist_ok=True, **kwargs).repo_id
             files_timestamps = self._get_files_timestamps(save_directory)
 
         # If we have a custom config, we copy the file defining it in the folder and set the attributes so it can be

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import httpx
 import yaml
-from huggingface_hub import is_offline_mode, model_info
+from huggingface_hub import is_offline_mode
 from huggingface_hub.errors import OfflineModeIsEnabled
 from huggingface_hub.utils import HFValidationError
 
@@ -44,6 +44,7 @@ from .models.auto.modeling_auto import (
 )
 from .training_args import ParallelMode
 from .utils import (
+    hf_api,
     is_datasets_available,
     is_tokenizers_available,
     is_torch_available,
@@ -194,7 +195,7 @@ class TrainingSummary:
             and len(self.finetuned_from) > 0
         ):
             try:
-                info = model_info(self.finetuned_from)
+                info = hf_api().model_info(self.finetuned_from)
                 for tag in info.tags:
                     if tag.startswith("license:"):
                         self.license = tag[8:]

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, get_type_hints, overload
 from zipfile import is_zipfile
 
 import torch
-from huggingface_hub import create_repo, is_offline_mode, split_torch_state_dict_into_shards
+from huggingface_hub import is_offline_mode, split_torch_state_dict_into_shards
 from packaging import version
 from safetensors import safe_open
 from safetensors.torch import load as _safe_load_bytes
@@ -122,7 +122,7 @@ from .utils import (
     logging,
 )
 from .utils.generic import GeneralInterface, is_flash_attention_requested, split_attention_implementation
-from .utils.hub import DownloadKwargs, create_and_tag_model_card, get_checkpoint_shard_files
+from .utils.hub import DownloadKwargs, create_and_tag_model_card, get_checkpoint_shard_files, hf_api
 from .utils.import_utils import (
     is_flash_attn_greater_or_equal,
     is_huggingface_hub_greater_or_equal,
@@ -3385,7 +3385,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             commit_message = kwargs.pop("commit_message", None)
             repo_id = kwargs.pop("repo_id", save_directory_path.split(os.path.sep)[-1])
             create_pr = kwargs.pop("create_pr", False)
-            repo_id = create_repo(repo_id, exist_ok=True, **kwargs).repo_id
+            repo_id = hf_api().create_repo(repo_id, exist_ok=True, **kwargs).repo_id
             files_timestamps = self._get_files_timestamps(save_directory)
 
         metadata = {}

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -21,8 +21,6 @@ from collections import OrderedDict
 from collections.abc import Iterator
 from typing import Any, TypeVar
 
-from huggingface_hub import repo_exists
-
 from ...configuration_utils import PreTrainedConfig
 from ...dynamic_module_utils import get_class_from_dynamic_module, resolve_trust_remote_code
 from ...utils import (
@@ -31,6 +29,7 @@ from ...utils import (
     copy_func,
     extract_commit_hash,
     find_adapter_config_file,
+    hf_api,
     is_peft_available,
     is_torch_available,
     logging,
@@ -463,7 +462,7 @@ class _BaseAutoBackboneClass(_BaseAutoModelClass):
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
         kwargs.pop("use_timm_backbone", None)
-        if not repo_exists(pretrained_model_name_or_path):
+        if not hf_api().repo_exists(pretrained_model_name_or_path):
             return cls._load_timm_backbone_from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
 
         return super().from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)

--- a/src/transformers/models/oneformer/image_processing_oneformer.py
+++ b/src/transformers/models/oneformer/image_processing_oneformer.py
@@ -18,7 +18,7 @@ import os
 from typing import Union
 
 import torch
-from huggingface_hub.errors import RepositoryNotFoundError
+from huggingface_hub.utils import RepositoryNotFoundError
 from torch import nn
 from torchvision.transforms.v2 import functional as tvF
 

--- a/src/transformers/models/oneformer/image_processing_oneformer.py
+++ b/src/transformers/models/oneformer/image_processing_oneformer.py
@@ -18,7 +18,7 @@ import os
 from typing import Union
 
 import torch
-from huggingface_hub import RepositoryNotFoundError
+from huggingface_hub.errors import RepositoryNotFoundError
 from torch import nn
 from torchvision.transforms.v2 import functional as tvF
 

--- a/src/transformers/models/oneformer/image_processing_oneformer.py
+++ b/src/transformers/models/oneformer/image_processing_oneformer.py
@@ -18,6 +18,7 @@ import os
 from typing import Union
 
 import torch
+from huggingface_hub import RepositoryNotFoundError
 from torch import nn
 from torchvision.transforms.v2 import functional as tvF
 
@@ -34,19 +35,7 @@ from ...image_utils import (
     get_max_height_width,
 )
 from ...processing_utils import ImagesKwargs, Unpack
-from ...utils import (
-    TensorType,
-    auto_docstring,
-    logging,
-)
-
-
-try:
-    from huggingface_hub import hf_hub_download
-    from huggingface_hub.utils import RepositoryNotFoundError
-except ImportError:
-    hf_hub_download = None
-    RepositoryNotFoundError = None
+from ...utils import TensorType, auto_docstring, hf_api, logging
 
 
 logger = logging.get_logger(__name__)
@@ -96,15 +85,11 @@ def load_metadata(repo_id, class_info_file):
     if not os.path.exists(fname) or not os.path.isfile(fname):
         if repo_id is None:
             raise ValueError(f"Could not file {fname} locally. repo_id must be defined if loading from the hub")
-        if hf_hub_download is None:
-            raise ImportError(
-                "huggingface_hub is required to download metadata files. Install it with `pip install huggingface_hub`"
-            )
         # We try downloading from a dataset by default for backward compatibility
         try:
-            fname = hf_hub_download(repo_id, class_info_file, repo_type="dataset")
+            fname = hf_api().hf_hub_download(repo_id, class_info_file, repo_type="dataset")
         except RepositoryNotFoundError:
-            fname = hf_hub_download(repo_id, class_info_file)
+            fname = hf_api().hf_hub_download(repo_id, class_info_file)
 
     with open(fname, "r") as f:
         class_info = json.load(f)

--- a/src/transformers/models/pix2struct/image_processing_pil_pix2struct.py
+++ b/src/transformers/models/pix2struct/image_processing_pil_pix2struct.py
@@ -18,7 +18,6 @@ import math
 import textwrap
 
 import numpy as np
-from huggingface_hub import hf_hub_download
 from PIL import Image, ImageDraw, ImageFont
 
 from ...image_processing_backends import PilBackend
@@ -27,6 +26,7 @@ from ...image_transforms import to_channel_dimension_format, to_pil_image
 from ...image_utils import ChannelDimension, ImageInput, SizeDict
 from ...processing_utils import ImagesKwargs, Unpack
 from ...utils import TensorType, auto_docstring, is_torch_available, requires_backends
+from ...utils.hub import hf_api
 from ...utils.import_utils import requires
 
 
@@ -109,7 +109,7 @@ def render_text(
     elif font_path is not None:
         font = font_path
     else:
-        font = hf_hub_download(DEFAULT_FONT_PATH, "Arial.TTF")
+        font = hf_api().hf_hub_download(DEFAULT_FONT_PATH, "Arial.TTF")
     font = ImageFont.truetype(font, encoding="UTF-8", size=text_size)
 
     # Use a temporary canvas to determine the width and height in pixels when

--- a/src/transformers/models/pix2struct/image_processing_pix2struct.py
+++ b/src/transformers/models/pix2struct/image_processing_pix2struct.py
@@ -19,7 +19,6 @@ from typing import Union
 
 import torch
 import torchvision.transforms.v2.functional as tvF
-from huggingface_hub import hf_hub_download
 from PIL import Image, ImageDraw, ImageFont
 
 from ...image_processing_backends import TorchvisionBackend
@@ -28,6 +27,7 @@ from ...image_transforms import group_images_by_shape, reorder_images
 from ...image_utils import ChannelDimension, ImageInput, SizeDict
 from ...processing_utils import ImagesKwargs, Unpack
 from ...utils import TensorType, auto_docstring
+from ...utils.hub import hf_api
 from ...utils.import_utils import requires_backends
 
 
@@ -104,7 +104,7 @@ def render_text(
     elif font_path is not None:
         font = font_path
     else:
-        font = hf_hub_download(DEFAULT_FONT_PATH, "Arial.TTF")
+        font = hf_api().hf_hub_download(DEFAULT_FONT_PATH, "Arial.TTF")
     font = ImageFont.truetype(font, encoding="UTF-8", size=text_size)
 
     # Use a temporary canvas to determine the width and height in pixels when

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -19,7 +19,7 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from huggingface_hub import is_offline_mode, model_info
+from huggingface_hub import is_offline_mode
 
 from ..configuration_utils import PreTrainedConfig
 from ..dynamic_module_utils import get_class_from_dynamic_module
@@ -38,6 +38,7 @@ from ..utils import (
     cached_file,
     extract_commit_hash,
     find_adapter_config_file,
+    hf_api,
     is_kenlm_available,
     is_peft_available,
     is_pyctcdecode_available,
@@ -304,7 +305,7 @@ def get_task(model: str, token: str | None = None, **deprecated_kwargs) -> str:
     if is_offline_mode():
         raise RuntimeError("You cannot infer task automatically within `pipeline` when using offline mode")
     try:
-        info = model_info(model, token=token)
+        info = hf_api().model_info(model, token=token)
     except Exception as e:
         raise RuntimeError(f"Instantiating a pipeline without a task set raised an error: {e}")
     if not info.pipeline_tag:

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -30,7 +30,7 @@ from typing import Annotated, Any, Literal, TypedDict, TypeVar, Union
 
 import numpy as np
 import typing_extensions
-from huggingface_hub import create_repo, is_offline_mode
+from huggingface_hub import is_offline_mode
 from huggingface_hub.dataclasses import validate_typed_dict
 from huggingface_hub.errors import EntryNotFoundError
 
@@ -57,6 +57,7 @@ from .utils import (
     cached_file,
     copy_func,
     direct_transformers_import,
+    hf_api,
     is_torch_available,
     list_repo_templates,
     logging,
@@ -1092,7 +1093,7 @@ class ProcessorMixin(PushToHubMixin):
         if push_to_hub:
             commit_message = kwargs.pop("commit_message", None)
             repo_id = kwargs.pop("repo_id", save_directory.split(os.path.sep)[-1])
-            repo_id = create_repo(repo_id, exist_ok=True, **kwargs).repo_id
+            repo_id = hf_api().create_repo(repo_id, exist_ok=True, **kwargs).repo_id
             files_timestamps = self._get_files_timestamps(save_directory)
         # If we have a custom config, we copy the file defining it in the folder and set the attributes so it can be
         # loaded from the Hub.

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import Any, Literal, Union, overload
 
 import numpy as np
-from huggingface_hub import create_repo
 
 from transformers.audio_utils import load_audio_as
 from transformers.image_utils import get_image_size
@@ -34,7 +33,7 @@ from transformers.tokenization_utils_base import (
     TextInput,
     TruncationStrategy,
 )
-from transformers.utils import PaddingStrategy, TensorType, add_end_docstrings, logging, to_py_obj
+from transformers.utils import PaddingStrategy, TensorType, add_end_docstrings, hf_api, logging, to_py_obj
 from transformers.utils.import_utils import is_mistral_common_available, is_torch_available, requires
 
 
@@ -1574,7 +1573,7 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
 
         if push_to_hub:
             repo_id = repo_id or str(save_directory).split(os.path.sep)[-1]
-            repo_id = create_repo(repo_id, token=token, private=private, exist_ok=True).repo_id
+            repo_id = hf_api().create_repo(repo_id, token=token, private=private, exist_ok=True).repo_id
             files_timestamps = self._get_files_timestamps(save_directory)
 
             self._upload_modified_files(

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, NamedTuple, Union, overload
 
 import numpy as np
-from huggingface_hub import create_repo, is_offline_mode, list_repo_files
+from huggingface_hub import is_offline_mode
 from packaging import version
 from typing_extensions import TypeVar
 
@@ -49,6 +49,7 @@ from .utils import (
     cached_file,
     copy_func,
     extract_commit_hash,
+    hf_api,
     is_mlx_available,
     is_numpy_array,
     is_protobuf_available,
@@ -1682,7 +1683,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         remote_files = []
         if not is_local and not local_files_only:
             try:
-                remote_files = list_repo_files(pretrained_model_name_or_path, revision=revision)
+                remote_files = hf_api().list_repo_files(pretrained_model_name_or_path, revision=revision)
             except Exception:
                 remote_files = []
         elif pretrained_model_name_or_path and os.path.isdir(pretrained_model_name_or_path):
@@ -2027,7 +2028,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         if push_to_hub:
             commit_message = kwargs.pop("commit_message", None)
             repo_id = kwargs.pop("repo_id", str(save_directory).split(os.path.sep)[-1])
-            repo_id = create_repo(repo_id, exist_ok=True, **kwargs).repo_id
+            repo_id = hf_api().create_repo(repo_id, exist_ok=True, **kwargs).repo_id
             files_timestamps = self._get_files_timestamps(save_directory)
 
         tokenizer_config_file = os.path.join(
@@ -3444,9 +3445,7 @@ def find_sentencepiece_model_file(pretrained_model_name_or_path, **kwargs):
     # Hub listing if allowed
     if not local_files_only:
         try:
-            from huggingface_hub import list_repo_tree
-
-            entries = list_repo_tree(
+            entries = hf_api().list_repo_tree(
                 repo_id=pretrained_model_name_or_path,
                 revision=kwargs.get("revision"),
                 path_in_repo=subfolder if subfolder else None,

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -1296,15 +1296,14 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         import re
         from functools import lru_cache
 
-        from huggingface_hub import model_info
         from packaging import version
 
-        from transformers.utils.hub import cached_file
+        from transformers.utils.hub import cached_file, hf_api
 
         @lru_cache(maxsize=128)
         def is_base_mistral(model_id: str) -> bool:
             try:
-                model = model_info(model_id)
+                model = hf_api().model_info(model_id)
             except Exception:
                 # Never block tokenizer init on a Hub error — assume non-Mistral.
                 return False

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -46,7 +46,7 @@ import numpy as np
 import safetensors.torch
 import torch
 import torch.distributed as dist
-from huggingface_hub import CommitInfo, ModelCard, create_repo, upload_folder
+from huggingface_hub import CommitInfo, ModelCard
 from packaging import version
 from torch import nn
 from torch.utils.data import DataLoader, Dataset, IterableDataset, RandomSampler, SequentialSampler
@@ -162,6 +162,7 @@ from .utils import (
     can_return_loss,
     check_torch_load_is_safe,
     find_labels,
+    hf_api,
     is_accelerate_available,
     is_datasets_available,
     is_in_notebook,
@@ -3940,7 +3941,7 @@ class Trainer:
             repo_name = self.args.hub_model_id
 
         token = token if token is not None else self.args.hub_token
-        repo_url = create_repo(repo_name, token=token, private=self.args.hub_private_repo, exist_ok=True)
+        repo_url = hf_api().create_repo(repo_name, token=token, private=self.args.hub_private_repo, exist_ok=True)
         self.hub_model_id = repo_url.repo_id
         self.push_in_progress = None
 
@@ -4090,7 +4091,7 @@ class Trainer:
         # Wait for the current upload to be finished.
         self._finish_current_push()
 
-        return upload_folder(
+        return hf_api().upload_folder(
             repo_id=self.hub_model_id,
             folder_path=self.args.output_dir,
             commit_message=commit_message,
@@ -4137,7 +4138,7 @@ class Trainer:
         else:
             commit_message = f"Training in progress, epoch {int(self.state.epoch)}"
 
-        model_push_job = upload_folder(
+        model_push_job = hf_api().upload_folder(
             repo_id=self.hub_model_id,
             folder_path=output_dir,
             commit_message=commit_message,
@@ -4153,7 +4154,7 @@ class Trainer:
             path_in_repo = (
                 "last-checkpoint" if self.args.hub_strategy == HubStrategy.CHECKPOINT else Path(checkpoint_folder).name
             )
-            checkpoint_push = upload_folder(
+            checkpoint_push = hf_api().upload_folder(
                 repo_id=self.hub_model_id,
                 folder_path=checkpoint_folder,
                 path_in_repo=path_in_repo,

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -90,6 +90,7 @@ from .hub import (
     define_sagemaker_information,
     extract_commit_hash,
     has_file,
+    hf_api,
     http_user_agent,
     list_repo_templates,
     try_to_load_from_cache,

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -29,16 +29,13 @@ import httpx
 from huggingface_hub import (
     _CACHED_NO_EXIST,
     CommitOperationAdd,
+    HfApi,
     ModelCard,
     ModelCardData,
     constants,
-    create_branch,
-    create_commit,
-    create_repo,
     hf_hub_download,
     hf_hub_url,
     is_offline_mode,
-    list_repo_tree,
     snapshot_download,
     try_to_load_from_cache,
 )
@@ -71,6 +68,24 @@ CHAT_TEMPLATE_DIR = "additional_chat_templates"
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+_hf_api: HfApi | None = None
+
+
+def hf_api() -> HfApi:
+    """Return a shared HfApi instance tagged with transformers's library info.
+
+    Routing Hub calls (create_repo, create_commit, snapshot_download, ...) through this
+    instance ensures the library_name/library_version are reported consistently to the Hub.
+    """
+    global _hf_api
+    if _hf_api is None:
+        _hf_api = HfApi(
+            library_name="transformers",
+            library_version=__version__,
+        )
+    return _hf_api
 
 
 class DownloadKwargs(TypedDict, total=False):
@@ -131,7 +146,7 @@ def list_repo_templates(
         try:
             return [
                 entry.path.removeprefix(f"{CHAT_TEMPLATE_DIR}/")
-                for entry in list_repo_tree(
+                for entry in hf_api().list_repo_tree(
                     repo_id=repo_id,
                     revision=revision,
                     path_in_repo=CHAT_TEMPLATE_DIR,
@@ -147,7 +162,7 @@ def list_repo_templates(
 
     # check local files
     try:
-        snapshot_dir = snapshot_download(
+        snapshot_dir = hf_api().snapshot_download(
             repo_id=repo_id, revision=revision, cache_dir=cache_dir, local_files_only=True
         )
     except LocalEntryNotFoundError:  # No local repo means no local files
@@ -692,7 +707,7 @@ class PushToHubMixin:
 
         if revision is not None and not revision.startswith("refs/pr"):
             try:
-                create_branch(repo_id=repo_id, branch=revision, token=token, exist_ok=True)
+                hf_api().create_branch(repo_id=repo_id, branch=revision, token=token, exist_ok=True)
             except HfHubHTTPError as e:
                 if e.response.status_code == 403 and create_pr:
                     # If we are creating a PR on a repo we don't have access to, we can't create the branch.
@@ -703,7 +718,7 @@ class PushToHubMixin:
                     raise
 
         logger.info(f"Uploading the following files to {repo_id}: {','.join(modified_files)}")
-        return create_commit(
+        return hf_api().create_commit(
             repo_id=repo_id,
             operations=operations,
             commit_message=commit_message,
@@ -775,7 +790,7 @@ class PushToHubMixin:
         ```
         """
         # Create repo if it doesn't exist yet
-        repo_id = create_repo(repo_id, private=private, token=token, exist_ok=True).repo_id
+        repo_id = hf_api().create_repo(repo_id, private=private, token=token, exist_ok=True).repo_id
 
         # Load model card or create a new one + eventually tag it
         model_card = create_and_tag_model_card(repo_id, tags, token=token)

--- a/src/transformers/video_processing_utils.py
+++ b/src/transformers/video_processing_utils.py
@@ -20,7 +20,7 @@ from functools import partial
 from typing import Any
 
 import numpy as np
-from huggingface_hub import create_repo, is_offline_mode
+from huggingface_hub import is_offline_mode
 from huggingface_hub.dataclasses import validate_typed_dict
 
 from .dynamic_module_utils import custom_object_save
@@ -46,7 +46,7 @@ from .utils import (
     logging,
     safe_load_json_file,
 )
-from .utils.hub import cached_file
+from .utils.hub import cached_file, hf_api
 from .utils.import_utils import requires
 from .video_utils import (
     VideoInput,
@@ -538,7 +538,7 @@ class BaseVideoProcessor(TorchvisionBackend):
         if push_to_hub:
             commit_message = kwargs.pop("commit_message", None)
             repo_id = kwargs.pop("repo_id", save_directory.split(os.path.sep)[-1])
-            repo_id = create_repo(repo_id, exist_ok=True, **kwargs).repo_id
+            repo_id = hf_api().create_repo(repo_id, exist_ok=True, **kwargs).repo_id
             files_timestamps = self._get_files_timestamps(save_directory)
 
         # If we have a custom config, we copy the file defining it in the folder and set the attributes so it can be

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -199,8 +199,9 @@ class GetFromCacheTests(unittest.TestCase):
 
 class OfflineModeTests(unittest.TestCase):
     def test_list_repo_templates_w_offline(self):
-        with mock.patch("transformers.utils.hub.list_repo_tree", side_effect=OfflineModeIsEnabled()):
+        with mock.patch("transformers.utils.hub.HfApi.list_repo_tree", side_effect=OfflineModeIsEnabled()):
             with mock.patch(
-                "transformers.utils.hub.snapshot_download", side_effect=LocalEntryNotFoundError("no snapshot found")
+                "transformers.utils.hub.HfApi.snapshot_download",
+                side_effect=LocalEntryNotFoundError("no snapshot found"),
             ):
                 self.assertEqual(list_repo_templates(RANDOM_BERT, local_files_only=False), [])


### PR DESCRIPTION
Closes #45721. Similar PR as vllm-project/vllm#43857 for VLLM.

This adds an `hf_api()` helper in `utils/hub.py` that lazily builds and reuses a single `HfApi(library_name="transformers", library_version=__version__)`, and routes the repo-management, metadata and lightweight download calls (`create_repo`, `create_commit`, `create_branch`, `upload_folder`, `model_info`, `repo_exists`, `list_repo_files`, `list_repo_tree`, and a couple of small `hf_hub_download`/`snapshot_download` lookups) through it so the library info is attributed consistently on the Hub.

Some calls are already passing `transformers` version in a built-in user-agent. When that's the case we are deduplicating the value on `huggingface_hub` so that's not a problem. 

Left `tests/`, `examples/` and `utils/` folders untouched.

(I used Claude Code for this PR, reviewed everything manually)

---


**NOTE:** there are likely some mocked tests that will fail, I'll handle them. **EDIT:** done :) :heavy_check_mark: 