### PR TITLE
fix: harden check_bad_commit.py against GitHub API rate limits and error responses

### DIFF
--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -240,7 +240,7 @@ jobs:
           n_runners: ${{ needs.setup_check_new_failures.outputs.n_runners }}
           run_idx: ${{ matrix.run_idx }}
           pr_number: ${{ inputs.pr_number }}
-        run: python3 utils/check_bad_commit.py --start_commit "$START_SHA" --end_commit "$END_SHA" --file "ci_results_${job}/new_failures.json" --output_file "new_failures_with_bad_commit_${job}_${run_idx}.json"
+        run: python3 utils/check_bad_commit.py --start_commit "$START_SHA" --end_commit "$END_SHA" --file "ci_results_${job}/new_failures.json" --output_file "new_failures_with_bad_commit_${job}_${run_idx}.json" --github_token "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Show results
         working-directory: /transformers

--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -240,7 +240,8 @@ jobs:
           n_runners: ${{ needs.setup_check_new_failures.outputs.n_runners }}
           run_idx: ${{ matrix.run_idx }}
           pr_number: ${{ inputs.pr_number }}
-        run: python3 utils/check_bad_commit.py --start_commit "$START_SHA" --end_commit "$END_SHA" --file "ci_results_${job}/new_failures.json" --output_file "new_failures_with_bad_commit_${job}_${run_idx}.json" --github_token "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 utils/check_bad_commit.py --start_commit "$START_SHA" --end_commit "$END_SHA" --file "ci_results_${job}/new_failures.json" --output_file "new_failures_with_bad_commit_${job}_${run_idx}.json"
 
       - name: Show results
         working-directory: /transformers

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -304,7 +304,8 @@ def get_commit_info(commit, pr_number=None, github_token=None):
         if merged_by is not None:
             merged_author = merged_by.get("login")
 
-    parent = commit_info["parents"][0]["sha"]
+    parents = commit_info.get("parents", [])
+    parent = parents[0]["sha"] if parents else None
     if author is None:
         author = (commit_info.get("author") or {}).get("login")
 

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -263,7 +263,7 @@ def get_commit_info(commit, pr_number=None, github_token=None):
     author = None
     merged_author = None
 
-    headers = {"Authorization": f"token {github_token}"} if github_token else {}
+    headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {github_token}"} if github_token else {}
 
     # Use PR number from environment if not provided
     if pr_number is None:

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -292,20 +292,21 @@ def get_commit_info(commit, pr_number=None, github_token=None):
     if not pr_number:
         url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit_to_query}/pulls"
         pr_info_for_commit = requests.get(url, headers=headers).json()
-        if len(pr_info_for_commit) > 0:
-            pr_number = pr_info_for_commit[0]["number"]
+        if isinstance(pr_info_for_commit, list) and len(pr_info_for_commit) > 0:
+            pr_number = pr_info_for_commit[0].get("number")
 
     # If we have a PR number, get author and merged_by info
     if pr_number:
         url = f"https://api.github.com/repos/huggingface/transformers/pulls/{pr_number}"
         pr_for_commit = requests.get(url, headers=headers).json()
-        author = pr_for_commit["user"]["login"]
-        if pr_for_commit["merged_by"] is not None:
-            merged_author = pr_for_commit["merged_by"]["login"]
+        author = pr_for_commit.get("user", {}).get("login")
+        merged_by = pr_for_commit.get("merged_by")
+        if merged_by is not None:
+            merged_author = merged_by.get("login")
 
     parent = commit_info["parents"][0]["sha"]
     if author is None:
-        author = commit_info["author"]["login"]
+        author = (commit_info.get("author") or {}).get("login")
 
     return {"commit": commit, "pr_number": pr_number, "author": author, "merged_by": merged_author, "parent": parent}
 

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -258,7 +258,7 @@ git bisect run python3 target_script.py
 def get_commit_info(commit, pr_number=None, github_token=None):
     """Get information for a commit via `api.github.com`."""
     if commit is None:
-        return {"commit": None, "pr_number": None, "author": None, "merged_by": None}
+        return {"commit": None, "pr_number": None, "author": None, "merged_by": None, "parent": None}
 
     author = None
     merged_author = None
@@ -288,14 +288,16 @@ def get_commit_info(commit, pr_number=None, github_token=None):
             # Use the first SHA (the PR commit)
             commit_to_query = match.group(1)
 
-    # If no PR number yet, try to discover it from the commit
+    # If no PR number yet, try to discover it from the commit.
+    # The API can return an error dict (e.g. rate limit) instead of a list, so guard with isinstance.
     if not pr_number:
         url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit_to_query}/pulls"
         pr_info_for_commit = requests.get(url, headers=headers).json()
         if isinstance(pr_info_for_commit, list) and len(pr_info_for_commit) > 0:
             pr_number = pr_info_for_commit[0].get("number")
 
-    # If we have a PR number, get author and merged_by info
+    # If we have a PR number, get author and merged_by info.
+    # Use .get() throughout: on rate-limit/403 the API returns an error dict, not the expected PR object.
     if pr_number:
         url = f"https://api.github.com/repos/huggingface/transformers/pulls/{pr_number}"
         pr_for_commit = requests.get(url, headers=headers).json()
@@ -319,8 +321,10 @@ if __name__ == "__main__":
     parser.add_argument("--test", type=str, help="The test to check.")
     parser.add_argument("--file", type=str, help="The report file.")
     parser.add_argument("--output_file", type=str, required=True, help="The path of the output file.")
-    parser.add_argument("--github_token", type=str, default=None, help="GitHub token to avoid API rate limits.")
+    parser.add_argument("--github_token", type=str, default=None, help="GitHub token to avoid API rate limits. Falls back to GITHUB_TOKEN env var.")
     args = parser.parse_args()
+    if args.github_token is None:
+        args.github_token = os.environ.get("GITHUB_TOKEN")
 
     run_idx = os.environ.get("run_idx")
     n_runners = os.environ.get("n_runners")

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -263,7 +263,9 @@ def get_commit_info(commit, pr_number=None, github_token=None):
     author = None
     merged_author = None
 
-    headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {github_token}"} if github_token else {}
+    headers = (
+        {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {github_token}"} if github_token else {}
+    )
 
     # Use PR number from environment if not provided
     if pr_number is None:

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -321,7 +321,12 @@ if __name__ == "__main__":
     parser.add_argument("--test", type=str, help="The test to check.")
     parser.add_argument("--file", type=str, help="The report file.")
     parser.add_argument("--output_file", type=str, required=True, help="The path of the output file.")
-    parser.add_argument("--github_token", type=str, default=None, help="GitHub token to avoid API rate limits. Falls back to GITHUB_TOKEN env var.")
+    parser.add_argument(
+        "--github_token",
+        type=str,
+        default=None,
+        help="GitHub token to avoid API rate limits. Falls back to GITHUB_TOKEN env var.",
+    )
     args = parser.parse_args()
     if args.github_token is None:
         args.github_token = os.environ.get("GITHUB_TOKEN")

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -255,7 +255,7 @@ git bisect run python3 target_script.py
     return result
 
 
-def get_commit_info(commit, pr_number=None):
+def get_commit_info(commit, pr_number=None, github_token=None):
     """Get information for a commit via `api.github.com`."""
     if commit is None:
         return {"commit": None, "pr_number": None, "author": None, "merged_by": None}
@@ -263,13 +263,15 @@ def get_commit_info(commit, pr_number=None):
     author = None
     merged_author = None
 
+    headers = {"Authorization": f"token {github_token}"} if github_token else {}
+
     # Use PR number from environment if not provided
     if pr_number is None:
         pr_number = os.environ.get("pr_number")
 
     # First, get commit info to check if it's a merge commit
     url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit}"
-    commit_info = requests.get(url).json()
+    commit_info = requests.get(url, headers=headers).json()
 
     commit_to_query = commit
 
@@ -287,14 +289,14 @@ def get_commit_info(commit, pr_number=None):
     # If no PR number yet, try to discover it from the commit
     if not pr_number:
         url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit_to_query}/pulls"
-        pr_info_for_commit = requests.get(url).json()
+        pr_info_for_commit = requests.get(url, headers=headers).json()
         if len(pr_info_for_commit) > 0:
             pr_number = pr_info_for_commit[0]["number"]
 
     # If we have a PR number, get author and merged_by info
     if pr_number:
         url = f"https://api.github.com/repos/huggingface/transformers/pulls/{pr_number}"
-        pr_for_commit = requests.get(url).json()
+        pr_for_commit = requests.get(url, headers=headers).json()
         author = pr_for_commit["user"]["login"]
         if pr_for_commit["merged_by"] is not None:
             merged_author = pr_for_commit["merged_by"]["login"]
@@ -313,6 +315,7 @@ if __name__ == "__main__":
     parser.add_argument("--test", type=str, help="The test to check.")
     parser.add_argument("--file", type=str, help="The report file.")
     parser.add_argument("--output_file", type=str, required=True, help="The path of the output file.")
+    parser.add_argument("--github_token", type=str, default=None, help="GitHub token to avoid API rate limits.")
     args = parser.parse_args()
 
     run_idx = os.environ.get("run_idx")
@@ -321,10 +324,7 @@ if __name__ == "__main__":
     print(f"start_commit: {args.start_commit}")
     print(f"end_commit: {args.end_commit}")
 
-    # `get_commit_info` uses `requests.get()` to request info. via `api.github.com` without using token.
-    # If there are many new failed tests in a workflow run, this script may fail at some point with `KeyError` at
-    # `pr_number = pr_info_for_commit[0]["number"]` due to the rate limit.
-    # Let's cache the commit info. and reuse them whenever possible.
+    # Cache commit info to avoid redundant API calls and reduce rate limit pressure.
     commit_info_cache = {}
 
     if len({args.test is None, args.file is None}) != 2:
@@ -385,7 +385,7 @@ if __name__ == "__main__":
             if bad_commit in commit_info_cache:
                 commit_info = commit_info_cache[bad_commit]
             else:
-                commit_info = get_commit_info(bad_commit)
+                commit_info = get_commit_info(bad_commit, github_token=args.github_token)
                 commit_info_cache[bad_commit] = commit_info
 
             commit_info_copied = copy.deepcopy(commit_info)


### PR DESCRIPTION
## Summary

- Adds `--github_token` CLI arg (falls back to `GITHUB_TOKEN` env var) and sends it as `Authorization: Bearer`, raising the API rate limit from 60 to 5,000 req/hour
- Passes the token via env var in the workflow instead of CLI arg to avoid process-list exposure
- Guards all GitHub API responses against error payloads (rate-limit/403 returns a dict, not the expected object): uses `isinstance` checks and `.get()` throughout
- Fixes inconsistent early-return schema in `get_commit_info` (was missing `parent` key)