### PR TITLE
perf(feature_extraction_sequence): skip re-splitting already-batched numpy arrays in pad()

### DIFF
--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -169,7 +169,10 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
         for key, value in processed_features.items():
             if isinstance(value[0], (int, float)):
                 processed_features[key] = to_numpy(value)
-            else:
+            elif not isinstance(value, np.ndarray):
+                # An already-batched numpy array can be used as-is; splitting it
+                # into a list of per-example arrays is pure overhead and is very
+                # slow for large inputs (e.g. long audio).
                 processed_features[key] = [to_numpy(v) for v in value]
 
         # Convert padding_strategy in PaddingStrategy


### PR DESCRIPTION
## What does this PR do?

Fixes #46328.

`SequenceFeatureExtractor.pad()` normalizes its inputs with:

```python
for key, value in processed_features.items():
    if isinstance(value[0], (int, float)):
        processed_features[key] = to_numpy(value)
    else:
        processed_features[key] = [to_numpy(v) for v in value]
```

When `value` is already a batched numpy array, the `else` branch rebuilds it into a
Python list of per-example arrays (`[to_numpy(v) for v in value]`). That iteration and
per-row copy is pure overhead and becomes very slow for large inputs (the issue reports
several minutes on a 25-minute audio file).

It is also unnecessary: the downstream `_truncate`/`_pad` logic only ever indexes
`value[i]`, which behaves identically for a list of arrays and for a batched `ndarray`
(same per-example shapes, same `len()` for the batch dimension). So an already-batched
array can be used as-is.

This PR skips the conversion when `value` is already an `np.ndarray`. The common
list-of-arrays / list-of-tensors path is unchanged, so existing behavior is preserved.

## Before submitting
- [x] This PR fixes a reported issue (#46328).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?

Generated with [Claude Code](https://claude.com/claude-code) (AI-assisted, human reviewed).
