### PR TITLE
Fix: strip EOS token when continue_final_message=True in MistralCommo…

### DIFF
--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -1185,7 +1185,10 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
 
             tokenized_request = self.tokenizer.encode_chat_completion(chat_request)
             if tokenize:
-                outputs.append(tokenized_request.tokens)
+                tokens = tokenized_request.tokens
+                if continue_final_message and tokens and tokens[-1] == self.eos_token_id:
+                    tokens = tokens[:-1]
+                outputs.append(tokens)
             else:
                 outputs.append(tokenized_request.text)
             images.extend(tokenized_request.images)

--- a/tests/test_tokenization_mistral_common.py
+++ b/tests/test_tokenization_mistral_common.py
@@ -919,13 +919,34 @@ class TestMistralCommonBackend(unittest.TestCase):
             self.tokenizer.apply_chat_template(conversation, tokenize=False, continue_final_message=True),
             expected_tokenized.text,
         )
+        # mistral-common itself has a bug where it adds EOS even with continue_final_message=True.
+        # Transformers strips it defensively, so compare against expected without the trailing EOS.
+        expected_tokens = list(expected_tokenized.tokens)
+        if expected_tokens and expected_tokens[-1] == self.tokenizer.eos_token_id:
+            expected_tokens = expected_tokens[:-1]
         self.assertEqual(
             self.tokenizer.apply_chat_template(conversation, tokenize=True, continue_final_message=True).input_ids,
-            expected_tokenized.tokens,
+            expected_tokens,
         )
 
         with self.assertRaises(InvalidMessageStructureException):
             self.tokenizer.apply_chat_template(conversation, tokenize=False, continue_final_message=False)
+
+        # Regression test: EOS must not appear with continue_final_message=True (#46326)
+        # Minimal 3-message conversation: system + user + assistant
+        short_conversation = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hi!"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        tokens = self.tokenizer.apply_chat_template(
+            short_conversation, tokenize=True, continue_final_message=True
+        ).input_ids
+        self.assertNotEqual(
+            tokens[-1],
+            self.tokenizer.eos_token_id,
+            "EOS token must not be present when continue_final_message=True",
+        )
 
     def test_apply_chat_template_with_add_generation_prompt(self):
         conversation = [
@@ -1372,7 +1393,12 @@ class TestMistralCommonBackend(unittest.TestCase):
         ).input_ids
 
         for output, expected in zip(token_outputs, expected_tokenized):
-            self.assertEqual(output, expected.tokens)
+            # mistral-common adds EOS even with continue_final_message=True (bug).
+            # Transformers strips it, so strip from expected before comparing.
+            expected_tokens = list(expected.tokens)
+            if expected_tokens and expected_tokens[-1] == self.tokenizer.eos_token_id:
+                expected_tokens = expected_tokens[:-1]
+            self.assertEqual(output, expected_tokens)
 
         # Test 2:
         # without continue_final_message


### PR DESCRIPTION
## Summary

  Fixes #46326

  When calling `apply_chat_template(..., continue_final_message=True)` on a
  `MistralCommonBackend` tokenizer, the output incorrectly included a trailing
  EOS token (ID `2`), disrupting model inference in serving frameworks like vLLM
  that rely on prefill continuation.

  **Root cause:** `mistral_common`'s `encode_chat_completion` adds an EOS token
  at the end of the final assistant message even when `continue_final_message=True`.
  This is a bug in the underlying library. Since transformers wraps that library,
  it must defensively strip the rogue EOS.

  ## Changes

  - **`src/transformers/tokenization_mistral_common.py`** — After
    `encode_chat_completion`, strip the trailing EOS token if
    `continue_final_message=True` and the last token equals `eos_token_id`.

  - **`tests/test_tokenization_mistral_common.py`** — Updated two existing tests
    to account for the mistral-common bug (reference output also has the trailing
    EOS, so we strip it before comparing). Added one new regression test covering
    the minimal 3-message case (system + user + assistant) from the issue report.
