### PR TITLE
Fix TestAppRoutes test failures caused by deprecated asyncio.get_event_loop() on Python 3.10+

### DIFF
--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -305,16 +305,9 @@ class AsyncTextIteratorStreamer(TextStreamer):
 
     def on_finalized_text(self, text: str, stream_end: bool = False):
         """Put the new text in the queue. If the stream is ending, also put a stop signal in the queue."""
-        try:
-            self.loop.call_soon_threadsafe(self.text_queue.put_nowait, text)
-            if stream_end:
-                self.loop.call_soon_threadsafe(self.text_queue.put_nowait, self.stop_signal)
-        except RuntimeError:
-            # The event loop has been closed (e.g. the consumer exited early or the
-            # test runner tore down the loop before the background generate() thread
-            # finished).  Silently discard the remaining tokens so the thread can
-            # exit cleanly without printing an unhandled-exception warning.
-            pass
+        self.loop.call_soon_threadsafe(self.text_queue.put_nowait, text)
+        if stream_end:
+            self.loop.call_soon_threadsafe(self.text_queue.put_nowait, self.stop_signal)
 
     def __aiter__(self):
         return self

--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -305,9 +305,16 @@ class AsyncTextIteratorStreamer(TextStreamer):
 
     def on_finalized_text(self, text: str, stream_end: bool = False):
         """Put the new text in the queue. If the stream is ending, also put a stop signal in the queue."""
-        self.loop.call_soon_threadsafe(self.text_queue.put_nowait, text)
-        if stream_end:
-            self.loop.call_soon_threadsafe(self.text_queue.put_nowait, self.stop_signal)
+        try:
+            self.loop.call_soon_threadsafe(self.text_queue.put_nowait, text)
+            if stream_end:
+                self.loop.call_soon_threadsafe(self.text_queue.put_nowait, self.stop_signal)
+        except RuntimeError:
+            # The event loop has been closed (e.g. the consumer exited early or the
+            # test runner tore down the loop before the background generate() thread
+            # finished).  Silently discard the remaining tokens so the thread can
+            # exit cleanly without printing an unhandled-exception warning.
+            pass
 
     def __aiter__(self):
         return self

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -568,26 +568,24 @@ class TestAppRoutes(unittest.TestCase):
             return await c.request(method, path, **kwargs)
 
     def test_health(self):
-        resp = asyncio.get_event_loop().run_until_complete(self._request("GET", "/health"))
+        resp = asyncio.run(self._request("GET", "/health"))
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {"status": "ok"})
 
     def test_models_list(self):
-        resp = asyncio.get_event_loop().run_until_complete(self._request("GET", "/v1/models"))
+        resp = asyncio.run(self._request("GET", "/v1/models"))
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
         self.assertEqual(data["object"], "list")
         self.assertEqual(len(data["data"]), 1)
 
     def test_request_id_generated(self):
-        resp = asyncio.get_event_loop().run_until_complete(self._request("GET", "/health"))
+        resp = asyncio.run(self._request("GET", "/health"))
         self.assertIn("x-request-id", resp.headers)
         self.assertEqual(len(resp.headers["x-request-id"]), 36)  # UUID length
 
     def test_request_id_passthrough(self):
-        resp = asyncio.get_event_loop().run_until_complete(
-            self._request("GET", "/health", headers={"x-request-id": "my-id"})
-        )
+        resp = asyncio.run(self._request("GET", "/health", headers={"x-request-id": "my-id"}))
         self.assertEqual(resp.headers["x-request-id"], "my-id")
 
 


### PR DESCRIPTION
## Summary

I saw the following failures on our WIP CI migration from CircleCI to Github Actions:
(not sure if it happens on CircleCI too ... )

(I ran several times and always fails : [job runs that have failures](https://github.com/huggingface/transformers/actions/runs/26804978505/job/79056587764))


`TestAppRoutes` tests fail with:
```
RuntimeError: There is no current event loop in thread 'MainThread'.
```

In Python 3.10, `asyncio.get_event_loop()` was deprecated in synchronous contexts and no longer auto-creates a loop — it raises `RuntimeError` instead. This is especially triggered under pytest-xdist where worker threads have no event loop set up. See [cpython#93453](https://github.com/python/cpython/issues/93453).

Replace all 4 usages of `asyncio.get_event_loop().run_until_complete(...)` in `TestAppRoutes` with `asyncio.run()`, which is the recommended replacement since Python 3.10 ([docs](https://docs.python.org/3/library/asyncio-runner.html#asyncio.run)).

## Tests affected
`tests/cli/test_serve.py` — `TestAppRoutes.test_health`, `test_models_list`, `test_request_id_generated`, `test_request_id_passthrough`