### PR TITLE
Update compressed tensors minimum version

### DIFF
--- a/docs/source/en/quantization/compressed_tensors.md
+++ b/docs/source/en/quantization/compressed_tensors.md
@@ -16,14 +16,13 @@ rendered properly in your Markdown viewer.
 
 # compressed-tensors
 
-[compressed-tensors](https://github.com/neuralmagic/compressed-tensors) extends [safetensors](https://github.com/huggingface/safetensors) files to compressed tensor data types to provide a unified checkpoint format for storing and loading various quantization and sparsity formats such dense, int-quantized (int8), float-quantized (fp8), and pack-quantized (int4 or int8 weight-quantized packed into int32).
+[compressed-tensors](https://github.com/neuralmagic/compressed-tensors) extends [safetensors](https://github.com/huggingface/safetensors) files to compressed tensor data types to provide a unified checkpoint format for storing and loading various quantization formats such as dense, int-quantized (int8), float-quantized (fp8), and pack-quantized (int4 or int8 weight-quantized packed into int32).
 
 compressed-tensors supports fine-tuning with [PEFT](https://huggingface.co/docs/peft) and includes the following features as well.
 
 - fp8, int4, int8 weight and activation precisions.
 - Quantization scales and zero-points strategies for [tensor, channel, group, block, token](https://github.com/neuralmagic/compressed-tensors/blob/83b2e7a969d70606421a76b9a3d112646077c8de/src/compressed_tensors/quantization/quant_args.py#L43-L52).
 - Dynamic per-token activation quantization (or any static strategy).
-- Weight sparsity (unstructured or semi-structured like 2:4) can be composed with quantization for extreme compression.
 - Quantization of arbitrary modules, not just [nn.Linear](https://pytorch.org/docs/stable/generated/torch.nn.Linear.html) modules.
 - Targeted support for specific modules by name or class.
 

--- a/src/transformers/quantizers/quantizer_compressed_tensors.py
+++ b/src/transformers/quantizers/quantizer_compressed_tensors.py
@@ -36,12 +36,6 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
     def __init__(self, quantization_config: CompressedTensorsConfig, **kwargs):
         super().__init__(quantization_config, **kwargs)
 
-        if not is_compressed_tensors_available():
-            raise ImportError(
-                "Using `compressed_tensors` quantized models requires the compressed-tensors library: "
-                "`pip install compressed-tensors`"
-            )
-
         # Call post_init here to ensure proper config setup when `run_compressed`
         # is provided directly via CompressedTensorsConfig, and to avoid duplicate logging.
 
@@ -55,8 +49,8 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
     def validate_environment(self, *args, **kwargs):
         if not is_compressed_tensors_available():
             raise ImportError(
-                "Using `compressed_tensors` quantized models requires the compressed-tensors library: "
-                "`pip install compressed-tensors`"
+                "Using `compressed_tensors` quantized models requires compressed-tensors>=0.15.0: "
+                "`pip install compressed-tensors>=0.15.0`"
             )
 
     def update_dtype(self, dtype: "torch.dtype") -> "torch.dtype":
@@ -71,18 +65,13 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
 
         # Always initialize compressed wrappers to match the checkpoint
         apply_quantization_config(model, ct_quantization_config, self.run_compressed)
-        if (
-            self.quantization_config.is_quantization_compressed
-            or self.quantization_config.is_sparsification_compressed
-        ):
+        if self.quantization_config.is_quantization_compressed:
             self.compressor.compress_model(model=model)
 
     def _process_model_after_weight_loading(self, model, **kwargs):
         """Decompress loaded model if necessary - need for qat"""
 
-        if (self.quantization_config.is_quantization_compressed and not self.run_compressed) or (
-            self.quantization_config.is_sparsification_compressed
-        ):
+        if self.quantization_config.is_quantization_compressed and not self.run_compressed:
             self.compressor.decompress_model(model=model)
 
     # NOTE: TP plan override for compressed tensors removed - unsupported styles were used.

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -135,6 +135,7 @@ XLA_FSDPV2_MIN_VERSION = "2.2.0"
 HQQ_MIN_VERSION = "0.2.1"
 VPTQ_MIN_VERSION = "0.0.4"
 TORCHAO_MIN_VERSION = "0.15.0"
+COMPRESSED_TENSORS_MIN_VERSION = "0.15.0"
 AUTOROUND_MIN_VERSION = "0.5.0"
 TRITON_MIN_VERSION = "1.0.0"
 KERNELS_MIN_VERSION = "0.10.2"
@@ -1167,8 +1168,9 @@ def is_qutlass_available():
 
 
 @lru_cache
-def is_compressed_tensors_available() -> bool:
-    return _is_package_available("compressed_tensors")[0]
+def is_compressed_tensors_available(min_version: str = COMPRESSED_TENSORS_MIN_VERSION) -> bool:
+    is_available, compressed_tensors_version = _is_package_available("compressed_tensors", return_version=True)
+    return is_available and version.parse(compressed_tensors_version) >= version.parse(min_version)
 
 
 @lru_cache

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -1156,9 +1156,7 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
 
     def post_init(self):
         if self.run_compressed and not self.is_quantization_compressed:
-            logger.warning(
-                "`run_compressed` is only supported for compressed models. Setting `run_compressed=False`"
-            )
+            logger.warning("`run_compressed` is only supported for compressed models. Setting `run_compressed=False`")
             self.run_compressed = False
 
     @classmethod

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -1109,8 +1109,6 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
             0-1 float percentage of model compression
         ignore (`typing.Union[typing.list[str], NoneType]`, *optional*):
             layer names or types to not quantize, supports regex prefixed by 're:'
-        sparsity_config (`typing.dict[str, typing.Any]`, *optional*):
-            configuration for sparsity compression
         quant_method (`str`, *optional*, defaults to `"compressed-tensors"`):
             do not override, should be compressed-tensors
         run_compressed (`bool`, *optional*, defaults to `True`): alter submodules (usually linear) in order to
@@ -1125,20 +1123,17 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
         kv_cache_scheme: Optional["QuantizationArgs"] = None,  # noqa: F821
         global_compression_ratio: float | None = None,
         ignore: list[str] | None = None,
-        sparsity_config: dict[str, Any] | None = None,
         quant_method: str = "compressed-tensors",
         run_compressed: bool = True,
         **kwargs,
     ):
         if is_compressed_tensors_available():
-            from compressed_tensors.config import SparsityCompressionConfig
             from compressed_tensors.quantization import QuantizationConfig
         else:
             raise ImportError(
-                "compressed_tensors is not installed and is required for compressed-tensors quantization. Please install it with `pip install compressed-tensors`."
+                "compressed-tensors>=0.15.0 is required for compressed-tensors quantization. Please install it with `pip install compressed-tensors>=0.15.0`."
             )
         self.quantization_config = None
-        self.sparsity_config = None
 
         self.run_compressed = run_compressed
 
@@ -1157,26 +1152,14 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
                 }
             )
 
-        if sparsity_config:
-            self.sparsity_config = SparsityCompressionConfig.load_from_registry(
-                sparsity_config.get("format"), **sparsity_config
-            )
-
         self.quant_method = QuantizationMethod.COMPRESSED_TENSORS
 
     def post_init(self):
-        if self.run_compressed:
-            if self.is_sparsification_compressed:
-                logger.warning(
-                    "`run_compressed` is only supported for quantized_compressed models"
-                    " and not for sparsified models. Setting `run_compressed=False`"
-                )
-                self.run_compressed = False
-            elif not self.is_quantization_compressed:
-                logger.warning(
-                    "`run_compressed` is only supported for compressed models. Setting `run_compressed=False`"
-                )
-                self.run_compressed = False
+        if self.run_compressed and not self.is_quantization_compressed:
+            logger.warning(
+                "`run_compressed` is only supported for compressed models. Setting `run_compressed=False`"
+            )
+            self.run_compressed = False
 
     @classmethod
     def from_dict(cls, config_dict, return_unused_kwargs=False, **kwargs):
@@ -1199,10 +1182,7 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
         """
 
         if "quantization_config" in config_dict:
-            config_dict = dict(
-                sparsity_config=config_dict.get("sparsity_config"),
-                **config_dict["quantization_config"],
-            )
+            config_dict = config_dict["quantization_config"]
 
         return super().from_dict(config_dict, return_unused_kwargs=return_unused_kwargs, **kwargs)
 
@@ -1218,11 +1198,6 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
             quantization_config = self.quantization_config.model_dump()
         else:
             quantization_config["quant_method"] = QuantizationMethod.COMPRESSED_TENSORS
-
-        if self.sparsity_config is not None:
-            quantization_config["sparsity_config"] = self.sparsity_config.model_dump()
-        else:
-            quantization_config["sparsity_config"] = {}
 
         return quantization_config
 
@@ -1260,18 +1235,6 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
 
         qc = self.quantization_config
         return self.is_quantized and (qc is not None and qc.quantization_status == QuantizationStatus.COMPRESSED)
-
-    @property
-    def is_sparsification_compressed(self):
-        from compressed_tensors.config import (
-            CompressionFormat,
-            SparsityCompressionConfig,
-        )
-
-        return (
-            isinstance(self.sparsity_config, SparsityCompressionConfig)
-            and self.sparsity_config.format != CompressionFormat.dense.value
-        )
 
 
 @dataclass

--- a/tests/quantization/compressed_tensors_integration/test_compressed_models.py
+++ b/tests/quantization/compressed_tensors_integration/test_compressed_models.py
@@ -16,8 +16,6 @@ if is_torch_available():
 @require_torch
 class StackCompressedModelTest(unittest.TestCase):
     # Define stubs as class attributes
-    # NOTE: sparse-only and stacked (sparse+quantized) model stubs removed — Sparse24 bitmask
-    # format is no longer supported by compressed-tensors>=0.15.
     compressed_uncompressed_model_stubs = [
         (
             "nm-testing/llama2.c-stories42M-gsm8k-quantized-only-compressed",

--- a/tests/quantization/compressed_tensors_integration/test_compressed_tensors.py
+++ b/tests/quantization/compressed_tensors_integration/test_compressed_tensors.py
@@ -13,10 +13,10 @@ if is_torch_available():
 @require_compressed_tensors
 @require_torch
 class CompressedTensorsTest(unittest.TestCase):
-    tinyllama_w4a16 = "nm-testing/TinyLlama-1.1B-Chat-v1.0-W4A16-e2e"
-    tinyllama_int8 = "nm-testing/TinyLlama-1.1B-Chat-v1.0-W8A8-e2e"
-    tinyllama_fp8 = "nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-e2e"
-    tinyllama_w8a16 = "nm-testing/TinyLlama-1.1B-Chat-v1.0-W8A16-e2e"
+    tinyllama_w4a16 = "nm-testing/TinyLlama-1.1B-Chat-v1.0-W4A16-G128-compressed"
+    tinyllama_int8 = "nm-testing/TinyLlama-1.1B-Chat-v1.0-W8A8-Dynamic-Per-Token-compressed"
+    tinyllama_fp8 = "nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-Dynamic-compressed"
+    tinyllama_w8a16 = "nm-testing/TinyLlama-1.1B-Chat-v1.0-W8A16-G128-compressed"
 
     prompt = "The capital of France is Paris, the capital of Germany is Berlin"
 
@@ -33,18 +33,16 @@ class CompressedTensorsTest(unittest.TestCase):
             config_groups={"FP8": ["Linear"]},
             ignore=["lm_head"],
             quantization_status="frozen",
-            sparsity_config={"format": "dense"},
         )
 
     def test_config_to_from_dict(self):
-        config = CompressedTensorsConfig(config_groups={"FP8": ["Linear"]}, sparsity_config={"format": "dense"})
+        config = CompressedTensorsConfig(config_groups={"FP8": ["Linear"]})
         config_dict = config.to_dict()
         config_from_dict = CompressedTensorsConfig.from_dict(config_dict)
 
-        from compressed_tensors import QuantizationConfig, SparsityCompressionConfig
+        from compressed_tensors import QuantizationConfig
 
         self.assertIsInstance(config_from_dict.quantization_config, QuantizationConfig)
-        self.assertIsInstance(config_from_dict.sparsity_config, SparsityCompressionConfig)
 
     def test_tinyllama_w4a16(self):
         self._test_quantized_model(self.tinyllama_w4a16, 20.0)


### PR DESCRIPTION
# What does this PR do?

This PR bumps compressed tensors min version to 0.15.0. By doing so, we can remove things related to sparsity that got dropped from the lib and other downstream lib like vllm. It also removes a code-execution sink: sparsity_config["format"] from an untrusted `config.json` was passed to compressed-tensors' which executes a Python file. Thanks @LinZiyuu for the report and the PR.