### PR TITLE
Propagation of output_hidden_states in  sub_configs

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -310,7 +310,8 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
         # Propagate hidden-states capture to sub-configs when requested on parent config.
         if self.output_hidden_states:
             for subconfig_key in self.sub_configs:
-                self.sub_configs[subconfig_key].output_hidden_states = True
+                subconfig = getattr(self, subconfig_key)
+                subconfig.output_hidden_states = True
 
     def __init_subclass__(cls, *args, **kwargs):
         super().__init_subclass__(*args, **kwargs)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -307,6 +307,11 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
                     logger.error(f"Can't set {key} with value {value} for {self}")
                     raise err
 
+        # Propagate hidden-states capture to sub-configs when requested on parent config.
+        if self.output_hidden_states:
+            for subconfig_key in self.sub_configs:
+                self.sub_configs[subconfig_key].output_hidden_states = True
+
     def __init_subclass__(cls, *args, **kwargs):
         super().__init_subclass__(*args, **kwargs)
         cls_has_custom_init = "__init__" in cls.__dict__

--- a/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -144,6 +144,10 @@ class Qwen3VLConfig(PreTrainedConfig):
         elif self.text_config is None:
             self.text_config = self.sub_configs["text_config"]()
 
+        if self.output_hidden_states:
+            self.text_config.output_hidden_states = True
+            self.vision_config.output_hidden_states = True
+
         super().__post_init__(**kwargs)
 
 

--- a/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -144,10 +144,6 @@ class Qwen3VLConfig(PreTrainedConfig):
         elif self.text_config is None:
             self.text_config = self.sub_configs["text_config"]()
 
-        if self.output_hidden_states:
-            self.text_config.output_hidden_states = True
-            self.vision_config.output_hidden_states = True
-
         super().__post_init__(**kwargs)
 
 

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -397,3 +397,47 @@ class ConfigSubclassKwOnlyTest(unittest.TestCase):
         cfg = BertWithPooling(pooling="mean", hidden_size=256)
         self.assertEqual(cfg.pooling, "mean")
         self.assertEqual(cfg.hidden_size, 256)
+
+
+class ConfigSubConfigOutputHiddenStatesPropagationTest(unittest.TestCase):
+    def test_output_hidden_states_propagates_to_subconfigs(self):
+        class ChildConfig(PreTrainedConfig):
+            pass
+
+        class ParentConfig(PreTrainedConfig):
+            sub_configs = {"child_a": ChildConfig, "child_b": ChildConfig}
+
+            child_a: PreTrainedConfig | None = None
+            child_b: PreTrainedConfig | None = None
+
+            def __post_init__(self, **kwargs):
+                if self.child_a is None:
+                    self.child_a = ChildConfig()
+                if self.child_b is None:
+                    self.child_b = ChildConfig()
+                super().__post_init__(**kwargs)
+
+        config = ParentConfig(output_hidden_states=True)
+        self.assertTrue(config.child_a.output_hidden_states)
+        self.assertTrue(config.child_b.output_hidden_states)
+
+    def test_output_hidden_states_false_does_not_force_subconfigs(self):
+        class ChildConfig(PreTrainedConfig):
+            pass
+
+        class ParentConfig(PreTrainedConfig):
+            sub_configs = {"child_a": ChildConfig, "child_b": ChildConfig}
+
+            child_a: PreTrainedConfig | None = None
+            child_b: PreTrainedConfig | None = None
+
+            def __post_init__(self, **kwargs):
+                if self.child_a is None:
+                    self.child_a = ChildConfig(output_hidden_states=True)
+                if self.child_b is None:
+                    self.child_b = ChildConfig(output_hidden_states=False)
+                super().__post_init__(**kwargs)
+
+        config = ParentConfig()
+        self.assertTrue(config.child_a.output_hidden_states)
+        self.assertFalse(config.child_b.output_hidden_states)


### PR DESCRIPTION
# What does this PR do?

Small change to ensure that when `output_hidden_states` is enabled, the setting is correctly propagated to the underlying `sub_configs`. This consistency allows for the extraction of hidden states from all modality-specific backbones during model inference or training.
Corresponding tests are also added.

This PR fixes https://github.com/huggingface/transformers/issues/46382.

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@zucchini-nlp