### PR TITLE
docs: update ACL Anthology URL in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -78,5 +78,5 @@ preferred-citation:
   title: "Transformers: State-of-the-Art Natural Language Processing"
   year: 2020
   publisher: "Association for Computational Linguistics"
-  url: "https://www.aclweb.org/anthology/2020.emnlp-demos.6"
+  url: "https://aclanthology.org/2020.emnlp-demos.6/"
   address: "Online"


### PR DESCRIPTION
# What does this PR do?

This PR updates the outdated ACL Anthology URL in the `CITATION.cff` file. The repository currently points to the legacy link format `https://www.aclweb.org/anthology/2020.emnlp-demos.6`. This change updates it to the current, official permanent canonical domain format: `https://aclanthology.org/2020.emnlp-demos.6/`.

Fixes # (Direct citation metadata enhancement - no tracking issue)

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

Tagging the documentation maintainer for a quick metadata review:

@stevhliu