### PR TITLE
[Mistral] Raise ValueError when continue_final_message=True with mist…

### DIFF
--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -1055,10 +1055,8 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
                 This argument is a no-op for `MistralCommonBackend`. However, it cannot be used at the same time as `continue_final_message` to keep the API consistent.
                 If any conversation ends with an assistant message, it will raise an error. In such cases, use `continue_final_message` instead.
             continue_final_message (bool, *optional*):
-                If this is set, the chat will be formatted so that the final
-                message in the chat is open-ended, without any EOS tokens. The model will continue this message
-                rather than starting a new one. This allows you to "prefill" part of
-                the model's response for it. Cannot be used at the same time as `add_generation_prompt`.
+                `continue_final_message` is not supported for the mistral-common backend
+                and will raise a ValueError.
             tokenize (`bool`, defaults to `True`):
                 Whether to tokenize the output. If `False`, the output will be a string.
             padding (`bool`, `str` or [`~utils.PaddingStrategy`], *optional*, defaults to `False`):
@@ -1174,6 +1172,14 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
             for message in conversation:
                 message = _maybe_adapt_message(message)
                 messages.append(message)
+
+            if continue_final_message:
+                raise ValueError(
+                    "The `continue_final_message` option is not supported by the "
+                    "mistral-common tokenizer backend. Use a standard Jinja chat "
+                    "template tokenizer instead, or wait for mistral-common to "
+                    "add native support for this flag."
+                )
 
             chat_request = ChatCompletionRequest.from_openai(
                 messages=messages,

--- a/tests/test_tokenization_mistral_common.py
+++ b/tests/test_tokenization_mistral_common.py
@@ -902,30 +902,12 @@ class TestMistralCommonBackend(unittest.TestCase):
             expected_tokenized.tokens,
         )
 
-    def test_apply_chat_template_continue_final_message(self):
-        conversation = [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "Hi!"},
-            {"role": "assistant", "content": "Hello! How can I help you?"},
-            {"role": "user", "content": "What is the capital of France?"},
-            {"role": "assistant", "content": "Paris"},
-        ]
-
-        expected_tokenized = self.ref_tokenizer.encode_chat_completion(
-            ChatCompletionRequest.from_openai(conversation, continue_final_message=True)
-        )
-
-        self.assertEqual(
-            self.tokenizer.apply_chat_template(conversation, tokenize=False, continue_final_message=True),
-            expected_tokenized.text,
-        )
-        self.assertEqual(
-            self.tokenizer.apply_chat_template(conversation, tokenize=True, continue_final_message=True).input_ids,
-            expected_tokenized.tokens,
-        )
-
-        with self.assertRaises(InvalidMessageStructureException):
-            self.tokenizer.apply_chat_template(conversation, tokenize=False, continue_final_message=False)
+    def test_continue_final_message_raises_for_mistral_common(self):
+        with self.assertRaises(ValueError, msg="continue_final_message"):
+            self.tokenizer.apply_chat_template(
+                [{"role": "user", "content": "test"}, {"role": "assistant", "content": "partial"}],
+                continue_final_message=True,
+            )
 
     def test_apply_chat_template_with_add_generation_prompt(self):
         conversation = [
@@ -1344,56 +1326,13 @@ class TestMistralCommonBackend(unittest.TestCase):
         self.assertEqual(output["input_ids"].tolist(), [expected_tokenized.tokens] * 3)
         self.assertTrue(np.allclose(output["pixel_values"], np.array([expected_tokenized.images] * 3)))
 
-    def test_batch_apply_chat_template_with_continue_final_message(self):
-        conversations = [
-            [
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": "Hi!"},
-                {"role": "assistant", "content": "Hello! How can "},
-            ],
-            [
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": "Hi!"},
-                {"role": "assistant", "content": "Hello! How can I help you? Ou préférez vous "},
-            ],
-        ]
-
-        # Test 1:
-        # with continue_final_message
-        expected_tokenized = [
-            self.ref_tokenizer.encode_chat_completion(
-                ChatCompletionRequest.from_openai(conversation, continue_final_message=True)
-            )
-            for conversation in conversations
-        ]
-
-        token_outputs = self.tokenizer.apply_chat_template(
-            conversations, tokenize=True, continue_final_message=True
-        ).input_ids
-
-        for output, expected in zip(token_outputs, expected_tokenized):
-            self.assertEqual(output, expected.tokens)
-
-        # Test 2:
-        # without continue_final_message
-        with self.assertRaises(InvalidMessageStructureException):
+    def test_batch_continue_final_message_raises_for_mistral_common(self):
+        with self.assertRaises(ValueError, msg="continue_final_message"):
             self.tokenizer.apply_chat_template(
-                conversations,
-                tokenize=False,
-                continue_final_message=False,
-            )
-
-        # Test 3:
-        # with continue_final_message and last role is not assistant
-        with self.assertRaises(InvalidMessageStructureException):
-            self.tokenizer.apply_chat_template(
-                conversation=[
-                    [
-                        {"role": "system", "content": "You are a helpful assistant."},
-                        {"role": "user", "content": "Hi!"},
-                    ]
+                [
+                    [{"role": "user", "content": "test"}, {"role": "assistant", "content": "partial"}],
+                    [{"role": "user", "content": "test2"}, {"role": "assistant", "content": "partial2"}],
                 ],
-                tokenize=True,
                 continue_final_message=True,
             )
 

--- a/tests/test_tokenization_mistral_common.py
+++ b/tests/test_tokenization_mistral_common.py
@@ -34,7 +34,6 @@ from transformers.utils import PaddingStrategy, is_mistral_common_available
 
 if is_mistral_common_available():
     import mistral_common.tokens.tokenizers
-    from mistral_common.exceptions import InvalidMessageStructureException
     from mistral_common.protocol.instruct.request import ChatCompletionRequest
     from mistral_common.protocol.instruct.validator import (
         ValidationMode,


### PR DESCRIPTION
Fixes #46326

## Problem
When `continue_final_message=True` is passed to `apply_chat_template` 
with the mistral-common tokenizer backend, an unexpected EOS token 
(`</s>`, id=2) is appended to the output. This breaks model serving 
(e.g. vLLM) where prefix caching depends on clean continuation tokens.

Root cause: mistral-common does not support the `continue_final_message` 
flag — it silently ignores it and appends EOS regardless.

## Fix
Raise a clear `ValueError` when `continue_final_message=True` is used 
with the mistral-common backend, so users get an explicit error instead 
of silent wrong behavior.

When mistral-common adds native support for this flag, the error can be 
removed and proper support added.