### PR TITLE
Fix missing f-string prefixes in error messages

### DIFF
--- a/src/transformers/models/grounding_dino/modeling_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/modeling_grounding_dino.py
@@ -1703,7 +1703,7 @@ class GroundingDinoDecoder(GroundingDinoPreTrainedModel):
             elif num_coordinates == 2:
                 reference_points_input = reference_points[:, :, None] * valid_ratios[:, None]
             else:
-                raise ValueError("Last dim of reference_points must be 2 or 4, but got {reference_points.shape[-1]}")
+                raise ValueError(f"Last dim of reference_points must be 2 or 4, but got {reference_points.shape[-1]}")
             query_pos = encode_sinusoidal_position_embedding(
                 reference_points_input[:, :, 0, :], num_pos_feats=self.config.d_model // 2
             )

--- a/src/transformers/models/mm_grounding_dino/modeling_mm_grounding_dino.py
+++ b/src/transformers/models/mm_grounding_dino/modeling_mm_grounding_dino.py
@@ -1517,7 +1517,7 @@ class MMGroundingDinoDecoder(MMGroundingDinoPreTrainedModel):
             elif num_coordinates == 2:
                 reference_points_input = reference_points[:, :, None] * valid_ratios[:, None]
             else:
-                raise ValueError("Last dim of reference_points must be 2 or 4, but got {reference_points.shape[-1]}")
+                raise ValueError(f"Last dim of reference_points must be 2 or 4, but got {reference_points.shape[-1]}")
             query_pos = encode_sinusoidal_position_embedding(
                 reference_points_input[:, :, 0, :], num_pos_feats=self.config.d_model // 2
             )

--- a/src/transformers/models/phi4_multimodal/convert_phi4_multimodal_weights_to_hf.py
+++ b/src/transformers/models/phi4_multimodal/convert_phi4_multimodal_weights_to_hf.py
@@ -158,7 +158,7 @@ def convert_and_write_model(input_dir: str, output_dir: str):
     missing, unexpected = model.load_state_dict(full_state_dict, strict=False, assign=True)
     # The lm_head is missing because it's tied
     if missing != ["lm_head.weight"]:
-        raise ValueError("Missing keys:\n{missing}")
+        raise ValueError(f"Missing keys:\n{missing}")
     if len(unexpected) > 0:
         raise ValueError(f"Unexpected keys:\n{unexpected}")
 

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -590,7 +590,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             outputs = self.model.generate(**inputs)
             out = {"tokens": outputs.sequences}
         else:
-            raise ValueError("Unsupported model type {self.type}.")
+            raise ValueError(f"Unsupported model type {self.type}.")
 
         # Leftover
         extra = model_inputs


### PR DESCRIPTION
## What does this PR do?

Several error messages in the library were written as plain strings even though they contain placeholder expressions such as `{self.type}` or `{reference_points.shape[-1]}` that were meant to be interpolated. Because the f prefix was missing, those messages print the literal text inside the braces instead of the actual value, so they tell you nothing useful at the exact moment something has gone wrong. This PR adds the missing f prefix in four places so each message renders the real value.

The first fix is in the Grounding DINO decoder, where the `reference_points` dimension error sat directly between two correctly written copies of the same message. The second is the matching line in the MM Grounding DINO decoder, which is generated from the modular file and inherits this method from Grounding DINO, so it was regenerated to stay in sync. The third is in the automatic speech recognition pipeline, on the unsupported model type error. The fourth is in the Phi4 multimodal weight conversion script, on the missing keys error, whose neighbouring unexpected keys message already used an f string. There is no behavioural change beyond the messages now showing the values they were always meant to show.

There is no associated issue. These are small standalone fixes spotted while reading through the code.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@Rocketknight1