### PR TITLE
Feat/executorch vision audio export

### DIFF
--- a/src/transformers/integrations/executorch.py
+++ b/src/transformers/integrations/executorch.py
@@ -562,6 +562,8 @@ class TorchExportableModuleWithStaticCache(torch.nn.Module):
         input_ids: torch.LongTensor | None = None,
         inputs_embeds: torch.Tensor | None = None,
         cache_position: torch.Tensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
+        input_features: torch.FloatTensor | None = None,
     ):
         """
         Forward pass of the module, which is compatible with the ExecuTorch runtime.
@@ -570,6 +572,10 @@ class TorchExportableModuleWithStaticCache(torch.nn.Module):
             input_ids (`torch.Tensor`): Tensor representing current input token id to the module.
             inputs_embeds (`torch.Tensor`): Tensor representing current input embeddings to the module.
             cache_position (`torch.Tensor`): Tensor representing current input position in the cache.
+            pixel_values (`Optional[torch.FloatTensor]`): Image pixel values for vision-language models.
+                Shape: `(batch_size, num_channels, image_height, image_width)`.
+            input_features (`Optional[torch.FloatTensor]`): Mel-spectrogram input for audio models.
+                Shape: `(batch_size, num_mel_bins, sequence_length)`.
 
         Returns:
             torch.Tensor: Logits output from the model.
@@ -592,12 +598,21 @@ class TorchExportableModuleWithStaticCache(torch.nn.Module):
 
         past_key_values = self.static_cache
 
+        # Build kwargs: only include modality-specific inputs when provided so
+        # that the exported graph signature stays minimal for text-only models.
+        extra_kwargs = {}
+        if pixel_values is not None:
+            extra_kwargs["pixel_values"] = pixel_values
+        if input_features is not None:
+            extra_kwargs["input_features"] = input_features
+
         outs = self.model(
             input_ids=input_ids,
             inputs_embeds=inputs_embeds,
             attention_mask=None,
             past_key_values=past_key_values,
             use_cache=True,
+            **extra_kwargs,
         )
         if hasattr(outs, "logits"):
             # Returned outputs is `CausalLMOutputWithPast`
@@ -771,10 +786,38 @@ class TorchExportableModuleWithHybridCache(torch.nn.Module):
         return outputs.logits
 
 
+def _make_example_vision_inputs(model: PreTrainedModel, device: torch.device) -> dict:
+    """Build dummy `pixel_values` for vision-language models using the model's vision config."""
+    vision_cfg = model.config.vision_config
+    image_size = vision_cfg.image_size
+    num_channels = getattr(vision_cfg, "num_channels", 3)
+    return {"pixel_values": torch.zeros(1, num_channels, image_size, image_size, dtype=torch.float32, device=device)}
+
+
+def _make_example_audio_inputs(model: PreTrainedModel, device: torch.device) -> dict:
+    """Build dummy `input_features` for audio/speech models using the model's mel config."""
+    num_mel_bins = model.config.num_mel_bins
+    return {"input_features": torch.zeros(1, num_mel_bins, 3000, dtype=torch.float32, device=device)}
+
+
+def _build_example_modality_inputs(model: PreTrainedModel, device: torch.device) -> dict:
+    """Return modality-specific example inputs based on the model's config.
+
+    Returns an empty dict for text-only models, ``pixel_values`` for vision-language
+    models, and ``input_features`` for audio models.
+    """
+    if hasattr(model.config, "vision_config"):
+        return _make_example_vision_inputs(model, device)
+    if hasattr(model.config, "num_mel_bins"):
+        return _make_example_audio_inputs(model, device)
+    return {}
+
+
 def convert_and_export_with_cache(
     model: PreTrainedModel,
     example_input_ids: torch.Tensor | None = None,
     example_cache_position: torch.Tensor | None = None,
+    example_modality_inputs: dict | None = None,
     dynamic_shapes: dict | None = None,
     strict: bool | None = None,
 ):
@@ -782,10 +825,17 @@ def convert_and_export_with_cache(
     Convert a `PreTrainedModel` into an exportable module and export it using `torch.export`,
     ensuring the exported model is compatible with `ExecuTorch`.
 
+    Supports text-only, vision-language, and audio models. Modality-specific example
+    inputs (e.g. ``pixel_values``, ``input_features``) are inferred automatically from
+    the model config when not supplied explicitly.
+
     Args:
         model (`PreTrainedModel`): The pretrained model to be exported.
         example_input_ids (`Optional[torch.Tensor]`): Example input token id used by `torch.export`.
         example_cache_position (`Optional[torch.Tensor]`): Example current cache position used by `torch.export`.
+        example_modality_inputs (`Optional[dict]`): Additional modality-specific example inputs
+            (e.g. ``{"pixel_values": ...}`` for VLMs or ``{"input_features": ...}`` for audio models).
+            When ``None``, inputs are inferred automatically from the model config.
         dynamic_shapes(`Optional[dict]`): Dynamic shapes used by `torch.export`.
         strict(`Optional[bool]`): Flag to instruct `torch.export` to use `torchdynamo`.
 
@@ -796,7 +846,6 @@ def convert_and_export_with_cache(
     import torch.export._trace
 
     with torch.no_grad():
-        # TODO: The default inputs only work for text models. We need to add support for vision/audio models.
         example_input_ids = (
             example_input_ids
             if example_input_ids is not None
@@ -807,12 +856,23 @@ def convert_and_export_with_cache(
             if example_cache_position is not None
             else torch.tensor([0], dtype=torch.long, device=model.device)
         )
+        example_modality_inputs = (
+            example_modality_inputs
+            if example_modality_inputs is not None
+            else _build_example_modality_inputs(model, model.device)
+        )
+
+        export_kwargs = {
+            "input_ids": example_input_ids,
+            "cache_position": example_cache_position,
+            **example_modality_inputs,
+        }
 
         if is_torch_greater_or_equal("2.6.0"):
             exported_program = torch.export.export(
                 TorchExportableModuleWithStaticCache(model),
                 args=(),
-                kwargs={"input_ids": example_input_ids, "cache_position": example_cache_position},
+                kwargs=export_kwargs,
                 dynamic_shapes=dynamic_shapes,
                 strict=strict if strict is not None else True,
             )
@@ -830,7 +890,7 @@ def convert_and_export_with_cache(
             exported_program = torch.export._trace._export(
                 TorchExportableModuleWithStaticCache(model),
                 args=(),
-                kwargs={"input_ids": example_input_ids, "cache_position": example_cache_position},
+                kwargs=export_kwargs,
                 pre_dispatch=False,
                 strict=True,
             )

--- a/tests/test_executorch.py
+++ b/tests/test_executorch.py
@@ -28,7 +28,7 @@ from transformers.integrations.executorch import (
     _make_example_audio_inputs,
     _make_example_vision_inputs,
 )
-from transformers.testing_utils import require_torch, slow
+from transformers.testing_utils import require_torch
 
 
 @require_torch
@@ -137,9 +137,7 @@ class ExampleModalityInputsTest(unittest.TestCase):
     def _make_model_with_vision_config(self, image_size=32, num_channels=3):
         model = MagicMock()
         model.device = torch.device("cpu")
-        model.config = SimpleNamespace(
-            vision_config=SimpleNamespace(image_size=image_size, num_channels=num_channels)
-        )
+        model.config = SimpleNamespace(vision_config=SimpleNamespace(image_size=image_size, num_channels=num_channels))
         return model
 
     def _make_model_with_audio_config(self, num_mel_bins=80):

--- a/tests/test_executorch.py
+++ b/tests/test_executorch.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import torch
 
@@ -22,8 +24,11 @@ from transformers.integrations.executorch import (
     TorchExportableModuleForDecoderOnlyLM,
     TorchExportableModuleWithHybridCache,
     TorchExportableModuleWithStaticCache,
+    _build_example_modality_inputs,
+    _make_example_audio_inputs,
+    _make_example_vision_inputs,
 )
-from transformers.testing_utils import require_torch
+from transformers.testing_utils import require_torch, slow
 
 
 @require_torch
@@ -123,3 +128,149 @@ class ExecutorchTest(unittest.TestCase):
             inputs_embeds=self.inputs_embeds, cache_position=self.cache_position
         )
         torch.testing.assert_close(eager_output_embeds, exported_output_embeds, atol=1e-4, rtol=1e-4)
+
+
+@require_torch
+class ExampleModalityInputsTest(unittest.TestCase):
+    """Tests for modality input helpers used by convert_and_export_with_cache."""
+
+    def _make_model_with_vision_config(self, image_size=32, num_channels=3):
+        model = MagicMock()
+        model.device = torch.device("cpu")
+        model.config = SimpleNamespace(
+            vision_config=SimpleNamespace(image_size=image_size, num_channels=num_channels)
+        )
+        return model
+
+    def _make_model_with_audio_config(self, num_mel_bins=80):
+        model = MagicMock()
+        model.device = torch.device("cpu")
+        model.config = SimpleNamespace(num_mel_bins=num_mel_bins)
+        return model
+
+    def _make_text_only_model(self):
+        model = MagicMock()
+        model.device = torch.device("cpu")
+        model.config = SimpleNamespace()
+        return model
+
+    def test_vision_inputs_shape(self):
+        model = self._make_model_with_vision_config(image_size=32, num_channels=3)
+        result = _make_example_vision_inputs(model, model.device)
+        self.assertIn("pixel_values", result)
+        self.assertEqual(result["pixel_values"].shape, (1, 3, 32, 32))
+        self.assertEqual(result["pixel_values"].dtype, torch.float32)
+
+    def test_vision_inputs_custom_channels(self):
+        model = self._make_model_with_vision_config(image_size=64, num_channels=1)
+        result = _make_example_vision_inputs(model, model.device)
+        self.assertEqual(result["pixel_values"].shape, (1, 1, 64, 64))
+
+    def test_audio_inputs_shape(self):
+        model = self._make_model_with_audio_config(num_mel_bins=80)
+        result = _make_example_audio_inputs(model, model.device)
+        self.assertIn("input_features", result)
+        self.assertEqual(result["input_features"].shape, (1, 80, 3000))
+        self.assertEqual(result["input_features"].dtype, torch.float32)
+
+    def test_dispatch_text_only(self):
+        model = self._make_text_only_model()
+        result = _build_example_modality_inputs(model, model.device)
+        self.assertEqual(result, {})
+
+    def test_dispatch_vision(self):
+        model = self._make_model_with_vision_config()
+        result = _build_example_modality_inputs(model, model.device)
+        self.assertIn("pixel_values", result)
+        self.assertNotIn("input_features", result)
+
+    def test_dispatch_audio(self):
+        model = self._make_model_with_audio_config()
+        result = _build_example_modality_inputs(model, model.device)
+        self.assertIn("input_features", result)
+        self.assertNotIn("pixel_values", result)
+
+    def test_vision_takes_priority_over_audio(self):
+        """vision_config check comes before num_mel_bins — multimodal models with both should get pixel_values."""
+        model = MagicMock()
+        model.device = torch.device("cpu")
+        model.config = SimpleNamespace(
+            vision_config=SimpleNamespace(image_size=32, num_channels=3),
+            num_mel_bins=80,
+        )
+        result = _build_example_modality_inputs(model, model.device)
+        self.assertIn("pixel_values", result)
+        self.assertNotIn("input_features", result)
+
+
+@require_torch
+class StaticCacheModuleModalityTest(unittest.TestCase):
+    """Tests that TorchExportableModuleWithStaticCache.forward accepts modality inputs."""
+
+    def setUp(self):
+        set_seed(42)
+        self.model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-LlamaForCausalLM")
+        self.model.eval()
+        self.model.generation_config = GenerationConfig(
+            use_cache=True,
+            cache_implementation="static",
+            cache_config={"batch_size": 1, "max_cache_len": 32, "device": "cpu"},
+        )
+        self.input_ids = torch.tensor([[1]], dtype=torch.long)
+        self.cache_position = torch.tensor([0], dtype=torch.long)
+
+    def test_forward_accepts_none_pixel_values(self):
+        """pixel_values=None must not change output vs not passing it at all."""
+        module = TorchExportableModuleWithStaticCache(self.model)
+        out_default = module.forward(input_ids=self.input_ids, cache_position=self.cache_position)
+        out_explicit_none = module.forward(
+            input_ids=self.input_ids, cache_position=self.cache_position, pixel_values=None
+        )
+        torch.testing.assert_close(out_default, out_explicit_none)
+
+    def test_forward_accepts_none_input_features(self):
+        """input_features=None must not change output vs not passing it at all."""
+        module = TorchExportableModuleWithStaticCache(self.model)
+        out_default = module.forward(input_ids=self.input_ids, cache_position=self.cache_position)
+        out_explicit_none = module.forward(
+            input_ids=self.input_ids, cache_position=self.cache_position, input_features=None
+        )
+        torch.testing.assert_close(out_default, out_explicit_none)
+
+    def test_forward_passes_pixel_values_to_model(self):
+        """pixel_values and input_features are forwarded to the underlying model when non-None."""
+        module = TorchExportableModuleWithStaticCache(self.model)
+
+        pixel_values = torch.zeros(1, 3, 32, 32)
+        input_features = torch.zeros(1, 80, 3000)
+
+        captured = {}
+
+        original_forward = self.model.forward
+
+        def capturing_forward(*args, **kwargs):
+            captured.update(kwargs)
+            return original_forward(*args, **kwargs)
+
+        self.model.forward = capturing_forward
+
+        # pixel_values forwarded
+        module.forward(input_ids=self.input_ids, cache_position=self.cache_position, pixel_values=pixel_values)
+        self.assertIn("pixel_values", captured)
+        self.assertTrue(torch.equal(captured["pixel_values"], pixel_values))
+
+        captured.clear()
+
+        # input_features forwarded
+        module.forward(input_ids=self.input_ids, cache_position=self.cache_position, input_features=input_features)
+        self.assertIn("input_features", captured)
+        self.assertTrue(torch.equal(captured["input_features"], input_features))
+
+        captured.clear()
+
+        # Neither forwarded when both are None
+        module.forward(input_ids=self.input_ids, cache_position=self.cache_position)
+        self.assertNotIn("pixel_values", captured)
+        self.assertNotIn("input_features", captured)
+
+        self.model.forward = original_forward


### PR DESCRIPTION
## What does this PR do?

Extends `convert_and_export_with_cache` and `TorchExportableModuleWithStaticCache.forward` 
to support vision-language and audio models. Previously both were limited to text-only models 
due to a hardcoded example input and missing `pixel_values`/`input_features` parameters.

Fixes #46358

## Changes

**`TorchExportableModuleWithStaticCache.forward`**
- Added `pixel_values` and `input_features` as optional parameters
- Passed through to the model only when non-`None` — text-only paths are unaffected

**`convert_and_export_with_cache`**
- Added `example_modality_inputs: dict | None` for explicit override
- Auto-inferred from model config when `None` via three private helpers:
  - `_make_example_vision_inputs` — builds dummy `pixel_values` from `vision_config`
  - `_make_example_audio_inputs` — builds dummy `input_features` from `num_mel_bins`
  - `_build_example_modality_inputs` — dispatches; returns `{}` for text-only models
- Consolidated `export_kwargs` eliminates duplication between `torch >= 2.6` and legacy `_export` branches

Resolves the TODO at line 799: *"The default inputs only work for text models. We need to add support for vision/audio models."*

## AI Assistance Disclosure

This PR was drafted with AI assistance (Claude) as a tool. Per the contributing guidelines:
- All changed lines were reviewed by the contributor
- Tests were written, run, and verified locally
- The contributor understands the implementation and can speak to design decisions in review

Test results:
`python -m pytest tests/test_executorch.py::ExampleModalityInputsTest tests/test_executorch.py::StaticCacheModuleModalityTest -v`


@zucchini-nlp (multimodal models / ExecuTorch integration)