### PR TITLE
fix: warn before applying HPU torch patches

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -357,6 +357,13 @@ def is_torch_hpu_available() -> bool:
     if not hasattr(torch, "hpu") or not torch.hpu.is_available():
         return False
 
+    logger.warning_once(
+        "Detected an available HPU device: transformers will patch selected torch functions "
+        "globally to work around Gaudi-specific limitations. This affects torch.gather, "
+        "torch.Tensor.gather, torch.take_along_dim, torch.linalg.cholesky, torch.scatter, "
+        "torch.Tensor.scatter, and torch.compile."
+    )
+
     # We patch torch.gather for int64 tensors to avoid a bug on Gaudi
     # Graph compile failed with synStatus 26 [Generic failure]
     # This can be removed once bug is fixed but for now we need it.

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -24,3 +24,52 @@ def test_clear_import_cache():
 
     assert "transformers.models.auto.modeling_auto" in sys.modules
     assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
+
+
+def test_is_torch_hpu_available_warns_before_patching_torch(monkeypatch):
+    import torch
+
+    from transformers.utils import import_utils
+
+    import_utils.is_torch_hpu_available.cache_clear()
+
+    def fake_is_package_available(package_name, return_version=False):
+        if package_name == "accelerate" and return_version:
+            return True, "1.5.0"
+        if package_name in {"habana_frameworks", "habana_frameworks.torch"}:
+            return True
+        return False
+
+    class FakeHPU:
+        @staticmethod
+        def is_available():
+            return True
+
+    original_gather = torch.gather
+    original_tensor_gather = torch.Tensor.gather
+    original_take_along_dim = torch.take_along_dim
+    original_cholesky = torch.linalg.cholesky
+    original_scatter = torch.scatter
+    original_tensor_scatter = torch.Tensor.scatter
+    original_compile = torch.compile
+
+    monkeypatch.setattr(import_utils, "is_torch_available", lambda: True)
+    monkeypatch.setattr(import_utils, "_is_package_available", fake_is_package_available)
+    monkeypatch.setattr(torch, "hpu", FakeHPU(), raising=False)
+    monkeypatch.setenv("PT_HPU_LAZY_MODE", "0")
+    warnings = []
+    monkeypatch.setattr(import_utils.logger, "warning_once", lambda message, *args, **kwargs: warnings.append(message))
+
+    try:
+        assert import_utils.is_torch_hpu_available() is True
+    finally:
+        torch.gather = original_gather
+        torch.Tensor.gather = original_tensor_gather
+        torch.take_along_dim = original_take_along_dim
+        torch.linalg.cholesky = original_cholesky
+        torch.scatter = original_scatter
+        torch.Tensor.scatter = original_tensor_scatter
+        torch.compile = original_compile
+        import_utils.is_torch_hpu_available.cache_clear()
+
+    assert any("transformers will patch selected torch functions globally" in warning for warning in warnings)


### PR DESCRIPTION
# What does this PR do?

Adds a one-time warning when `is_torch_hpu_available()` detects an HPU and applies the current Gaudi-specific global torch patches. This makes the side effect explicit while preserving the existing HPU behavior.

Fixes #46216


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. Discussed in #46216.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation). No documentation update needed; this is a runtime warning for an existing side effect.
- [x] Did you write any new necessary tests? Added coverage for the HPU warning path.


## Who can review?

@IlyasMoutawwakil may be interested as this touches HPU/Gaudi availability handling.


## Testing

- `python3 -m pytest tests/utils/test_import_utils.py -q`
- `python3 -m ruff check tests/utils/test_import_utils.py`

Note: `python3 -m ruff check src/transformers/utils/import_utils.py tests/utils/test_import_utils.py` reports an unrelated pre-existing `FURB110` in `src/transformers/utils/import_utils.py:1925`; the new test file passes ruff.
