### PR TITLE
Fix wrong changes produced by style/repo. check bot

### DIFF
--- a/.github/workflows/pr-repo-consistency-bot.yml
+++ b/.github/workflows/pr-repo-consistency-bot.yml
@@ -192,29 +192,10 @@ jobs:
             const modified = files.some(f => UTIL_SCRIPTS.has(f.filename));
             core.setOutput('util_scripts_modified', modified ? 'true' : 'false');
 
-      - name: Copy trusted scripts from main branch
+      - name: Install editable transformers from PR branch
         if: steps.check_util_scripts.outputs.util_scripts_modified != 'true'
         run: |
-          # Security: Copy trusted scripts from main branch and run commands explicitly (not via make)
-          # to avoid executing potentially malicious Makefile or scripts from the PR
-          cp setup.py pr-repo/setup.py
-          cp utils/custom_init_isort.py pr-repo/utils/custom_init_isort.py
-          cp utils/sort_auto_mappings.py pr-repo/utils/sort_auto_mappings.py
-          cp utils/check_doc_toc.py pr-repo/utils/check_doc_toc.py
-          cp utils/check_copies.py pr-repo/utils/check_copies.py
-          cp utils/check_modular_conversion.py pr-repo/utils/check_modular_conversion.py
-          cp utils/check_dummies.py pr-repo/utils/check_dummies.py
-          cp utils/check_pipeline_typing.py pr-repo/utils/check_pipeline_typing.py
-          cp utils/check_doctest_list.py pr-repo/utils/check_doctest_list.py
-          cp utils/check_docstrings.py pr-repo/utils/check_docstrings.py
-          cp utils/add_dates.py pr-repo/utils/add_dates.py
-
-      - name: Install editable transformers from PR branch with copied scripts
-        if: steps.check_util_scripts.outputs.util_scripts_modified != 'true'
-        run: |
-          # Run commands in PR directory (with the copied trusted scripts)
           cd pr-repo
-
           pip install -e .
 
       - name: Run repo consistency checks with trusted script
@@ -382,7 +363,7 @@ jobs:
           fi
 
           if [ "$UTIL_SCRIPTS_MODIFIED" = 'true' ]; then
-            echo "final_comment=${MESSAGE_PREFIX}: some script files under the \`utils\` directory are modified in this PR. Please run style/repo. checks/fixes locally." >> $GITHUB_OUTPUT
+            echo "final_comment=${MESSAGE_PREFIX}: \`setup.py\` or some script files under the \`utils/\` directory are modified in this PR. Please run style/repo. checks/fixes locally." >> $GITHUB_OUTPUT
           elif [ "$CHANGES_DETECTED" = 'true' ]; then
             echo "final_comment=${MESSAGE_PREFIX} bot fixed some files and pushed the changes." >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/pr-repo-consistency-bot.yml
+++ b/.github/workflows/pr-repo-consistency-bot.yml
@@ -117,9 +117,12 @@ jobs:
   run-repo-consistency-checks:
     runs-on: ubuntu-22.04
     needs: [get-pr-info, check-timestamps, init_comment_with_url]
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       changes_detected: ${{ steps.run_repo_checks.outputs.changes_detected || steps.run_style_checks.outputs.changes_detected }}
-      util_scripts_modified: ${{ steps.check_trusted_scripts.outputs.util_scripts_modified }}
+      util_scripts_modified: ${{ steps.check_util_scripts.outputs.util_scripts_modified }}
     steps:
       # Checkout the trusted base repository (main branch) - this is safe
       - name: Checkout base repository
@@ -159,31 +162,38 @@ jobs:
           git remote add upstream https://github.com/${{ github.repository }}.git
           git fetch upstream main:main
 
-      - name: Check if trusted scripts are modified in PR
-        id: check_trusted_scripts
-        run: |
-          cd pr-repo
-          COPIED_FILES=(
-            setup.py
-            utils/custom_init_isort.py
-            utils/sort_auto_mappings.py
-            utils/check_doc_toc.py
-            utils/check_copies.py
-            utils/check_modular_conversion.py
-            utils/check_dummies.py
-            utils/check_pipeline_typing.py
-            utils/check_doctest_list.py
-            utils/check_docstrings.py
-            utils/add_dates.py
-          )
-          if git diff --name-only main HEAD -- "${COPIED_FILES[@]}" | grep -q .; then
-            echo "util_scripts_modified=true" >> $GITHUB_OUTPUT
-          else
-            echo "util_scripts_modified=false" >> $GITHUB_OUTPUT
-          fi
+      - name: Check if util scripts are modified in PR
+        id: check_util_scripts
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
+          script: |
+            // Re-fetch the PR file list from the API rather than using get-pr-info's PR_FILES
+            // output, to avoid template injection and E2BIG issues (see pr_slow_ci_suggestion.yml).
+            const UTIL_SCRIPTS = new Set([
+              'setup.py',
+              'utils/custom_init_isort.py',
+              'utils/sort_auto_mappings.py',
+              'utils/check_doc_toc.py',
+              'utils/check_copies.py',
+              'utils/check_modular_conversion.py',
+              'utils/check_dummies.py',
+              'utils/check_pipeline_typing.py',
+              'utils/check_doctest_list.py',
+              'utils/check_docstrings.py',
+              'utils/add_dates.py',
+            ]);
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+
+            const modified = files.some(f => UTIL_SCRIPTS.has(f.filename));
+            core.setOutput('util_scripts_modified', modified ? 'true' : 'false');
 
       - name: Copy trusted scripts from main branch
-        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true'
+        if: steps.check_util_scripts.outputs.util_scripts_modified != 'true'
         run: |
           # Security: Copy trusted scripts from main branch and run commands explicitly (not via make)
           # to avoid executing potentially malicious Makefile or scripts from the PR
@@ -200,7 +210,7 @@ jobs:
           cp utils/add_dates.py pr-repo/utils/add_dates.py
 
       - name: Install editable transformers from PR branch with copied scripts
-        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true'
+        if: steps.check_util_scripts.outputs.util_scripts_modified != 'true'
         run: |
           # Run commands in PR directory (with the copied trusted scripts)
           cd pr-repo
@@ -209,7 +219,7 @@ jobs:
 
       - name: Run repo consistency checks with trusted script
         id: run_repo_checks
-        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true' && startsWith(github.event.comment.body, '@bot /repo')
+        if: steps.check_util_scripts.outputs.util_scripts_modified != 'true' && startsWith(github.event.comment.body, '@bot /repo')
         run: |
           # Continue on errors (like Makefile's - prefix)
           set +e
@@ -243,7 +253,7 @@ jobs:
 
       - name: Run style checks with trusted script
         id: run_style_checks
-        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true' && startsWith(github.event.comment.body, '@bot /style')
+        if: steps.check_util_scripts.outputs.util_scripts_modified != 'true' && startsWith(github.event.comment.body, '@bot /style')
         run: |
           # Continue on errors (like Makefile's - prefix)
           set +e
@@ -269,7 +279,7 @@ jobs:
           fi
 
       - name: Save modified files
-        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true' && (steps.run_repo_checks.outputs.changes_detected == 'true' || steps.run_style_checks.outputs.changes_detected == 'true')
+        if: steps.check_util_scripts.outputs.util_scripts_modified != 'true' && (steps.run_repo_checks.outputs.changes_detected == 'true' || steps.run_style_checks.outputs.changes_detected == 'true')
         run: |
           cd pr-repo
           mkdir -p ../artifact-staging
@@ -281,7 +291,7 @@ jobs:
           done < ../artifact-staging/modified-files.txt
 
       - name: Upload modified files
-        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true' && (steps.run_repo_checks.outputs.changes_detected == 'true' || steps.run_style_checks.outputs.changes_detected == 'true')
+        if: steps.check_util_scripts.outputs.util_scripts_modified != 'true' && (steps.run_repo_checks.outputs.changes_detected == 'true' || steps.run_style_checks.outputs.changes_detected == 'true')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: modified-files

--- a/.github/workflows/pr-repo-consistency-bot.yml
+++ b/.github/workflows/pr-repo-consistency-bot.yml
@@ -119,6 +119,7 @@ jobs:
     needs: [get-pr-info, check-timestamps, init_comment_with_url]
     outputs:
       changes_detected: ${{ steps.run_repo_checks.outputs.changes_detected || steps.run_style_checks.outputs.changes_detected }}
+      util_scripts_modified: ${{ steps.check_trusted_scripts.outputs.util_scripts_modified }}
     steps:
       # Checkout the trusted base repository (main branch) - this is safe
       - name: Checkout base repository
@@ -158,7 +159,31 @@ jobs:
           git remote add upstream https://github.com/${{ github.repository }}.git
           git fetch upstream main:main
 
+      - name: Check if trusted scripts are modified in PR
+        id: check_trusted_scripts
+        run: |
+          cd pr-repo
+          COPIED_FILES=(
+            setup.py
+            utils/custom_init_isort.py
+            utils/sort_auto_mappings.py
+            utils/check_doc_toc.py
+            utils/check_copies.py
+            utils/check_modular_conversion.py
+            utils/check_dummies.py
+            utils/check_pipeline_typing.py
+            utils/check_doctest_list.py
+            utils/check_docstrings.py
+            utils/add_dates.py
+          )
+          if git diff --name-only main HEAD -- "${COPIED_FILES[@]}" | grep -q .; then
+            echo "util_scripts_modified=true" >> $GITHUB_OUTPUT
+          else
+            echo "util_scripts_modified=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Copy trusted scripts from main branch
+        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true'
         run: |
           # Security: Copy trusted scripts from main branch and run commands explicitly (not via make)
           # to avoid executing potentially malicious Makefile or scripts from the PR
@@ -175,6 +200,7 @@ jobs:
           cp utils/add_dates.py pr-repo/utils/add_dates.py
 
       - name: Install editable transformers from PR branch with copied scripts
+        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true'
         run: |
           # Run commands in PR directory (with the copied trusted scripts)
           cd pr-repo
@@ -183,7 +209,7 @@ jobs:
 
       - name: Run repo consistency checks with trusted script
         id: run_repo_checks
-        if: startsWith(github.event.comment.body, '@bot /repo')
+        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true' && startsWith(github.event.comment.body, '@bot /repo')
         run: |
           # Continue on errors (like Makefile's - prefix)
           set +e
@@ -217,7 +243,7 @@ jobs:
 
       - name: Run style checks with trusted script
         id: run_style_checks
-        if: startsWith(github.event.comment.body, '@bot /style')
+        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true' && startsWith(github.event.comment.body, '@bot /style')
         run: |
           # Continue on errors (like Makefile's - prefix)
           set +e
@@ -243,7 +269,7 @@ jobs:
           fi
 
       - name: Save modified files
-        if: steps.run_repo_checks.outputs.changes_detected == 'true' || steps.run_style_checks.outputs.changes_detected == 'true'
+        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true' && (steps.run_repo_checks.outputs.changes_detected == 'true' || steps.run_style_checks.outputs.changes_detected == 'true')
         run: |
           cd pr-repo
           mkdir -p ../artifact-staging
@@ -255,7 +281,7 @@ jobs:
           done < ../artifact-staging/modified-files.txt
 
       - name: Upload modified files
-        if: steps.run_repo_checks.outputs.changes_detected == 'true' || steps.run_style_checks.outputs.changes_detected == 'true'
+        if: steps.check_trusted_scripts.outputs.util_scripts_modified != 'true' && (steps.run_repo_checks.outputs.changes_detected == 'true' || steps.run_style_checks.outputs.changes_detected == 'true')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: modified-files
@@ -335,6 +361,7 @@ jobs:
         if: needs.init_comment_with_url.result == 'success'
         env:
           CHANGES_DETECTED: ${{ needs.run-repo-consistency-checks.outputs.changes_detected }}
+          UTIL_SCRIPTS_MODIFIED: ${{ needs.run-repo-consistency-checks.outputs.util_scripts_modified }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           # Determine which command was used
@@ -343,8 +370,10 @@ jobs:
           else
             MESSAGE_PREFIX="Repo. Consistency"
           fi
-          
-          if [ "$CHANGES_DETECTED" = 'true' ]; then
+
+          if [ "$UTIL_SCRIPTS_MODIFIED" = 'true' ]; then
+            echo "final_comment=${MESSAGE_PREFIX}: some script files under the \`utils\` directory are modified in this PR. Please run style/repo. checks/fixes locally." >> $GITHUB_OUTPUT
+          elif [ "$CHANGES_DETECTED" = 'true' ]; then
             echo "final_comment=${MESSAGE_PREFIX} bot fixed some files and pushed the changes." >> $GITHUB_OUTPUT
           else
             echo "final_comment=${MESSAGE_PREFIX} fix runs successfully without any file modified." >> $GITHUB_OUTPUT


### PR DESCRIPTION
# What does this PR do?

When running repo/style checks, some utility scripts (e.g. `utils/check_copies.py`, `setup.py`)
were copied from `main` into the PR directory before running checks. If those scripts had changed
on `main` after the PR branched off, they would show up in `git diff` as modified and get
incorrectly included in the bot's fix commit — a false positive.

This PR fixes this by detecting whether the PR itself modifies any of those scripts. If it does,
checks are skipped entirely and a comment is posted instead:

> \`setup.py\` or some script files under the \`utils/\` directory are modified in this PR. Please run style/repo. checks/fixes locally.

If the PR doesn't touch those scripts, they are used as-is from the PR checkout (no longer copied
from \`main\`), so the git diff stays clean.