### PR TITLE
Update hub metadata

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -995,7 +995,7 @@ MODEL_FOR_RETRIEVAL_MAPPING_NAMES = OrderedDict(
 MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES = OrderedDict(
     [
         # NOTE: DO NOT ADD new models here, this class will be deprecated
-        # in the future. Add in `MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES` instead 
+        # in the future. Add in `MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES` instead
         ("aria", "AriaForConditionalGeneration"),
         ("aya_vision", "AyaVisionForConditionalGeneration"),
         ("blip", "BlipForConditionalGeneration"),

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -994,8 +994,6 @@ MODEL_FOR_RETRIEVAL_MAPPING_NAMES = OrderedDict(
 
 MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES = OrderedDict(
     [
-        # NOTE: DO NOT ADD new models here, this class will be deprecated
-        # in the future. Add in `MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES` instead
         ("aria", "AriaForConditionalGeneration"),
         ("aya_vision", "AyaVisionForConditionalGeneration"),
         ("blip", "BlipForConditionalGeneration"),

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -994,6 +994,8 @@ MODEL_FOR_RETRIEVAL_MAPPING_NAMES = OrderedDict(
 
 MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES = OrderedDict(
     [
+        # NOTE: DO NOT ADD new models here, this class will be deprecated
+        # in the future. Add in `MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES` instead 
         ("aria", "AriaForConditionalGeneration"),
         ("aya_vision", "AyaVisionForConditionalGeneration"),
         ("blip", "BlipForConditionalGeneration"),

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -78,7 +78,6 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
     ("image-classification", "MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING_NAMES", "AutoModelForImageClassification"),
     ("image-segmentation", "MODEL_FOR_IMAGE_SEGMENTATION_MAPPING_NAMES", "AutoModelForImageSegmentation"),
     ("any-to-any", "MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES", "AutoModelForMultimodalLM"),
-    ("image-text-to-text", "MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES", "AutoModelForImageTextToText"),
     ("fill-mask", "MODEL_FOR_MASKED_LM_MAPPING_NAMES", "AutoModelForMaskedLM"),
     ("object-detection", "MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES", "AutoModelForObjectDetection"),
     (

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -130,6 +130,9 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
     ("any-to-any", "MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES", "AutoModelForMultimodalLM"),
 ]
 
+# Pipeline tags that do not necessarily have to be in the above list
+PIPELINES_TO_IGNORE = ["image-text-to-text"]
+
 
 def camel_case_split(identifier: str) -> list[str]:
     """
@@ -330,7 +333,7 @@ def check_pipeline_tags():
     pipeline_tasks = transformers_module.pipelines.SUPPORTED_TASKS
     missing = []
     for key in pipeline_tasks:
-        if key not in in_table:
+        if key not in in_table and key not in PIPELINES_TO_IGNORE:
             model = pipeline_tasks[key]["pt"]
             if isinstance(model, (list, tuple)):
                 model = model[0]

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -77,7 +77,6 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
     ("automatic-speech-recognition", "MODEL_FOR_CTC_MAPPING_NAMES", "AutoModelForCTC"),
     ("image-classification", "MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING_NAMES", "AutoModelForImageClassification"),
     ("image-segmentation", "MODEL_FOR_IMAGE_SEGMENTATION_MAPPING_NAMES", "AutoModelForImageSegmentation"),
-    ("any-to-any", "MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES", "AutoModelForMultimodalLM"),
     ("fill-mask", "MODEL_FOR_MASKED_LM_MAPPING_NAMES", "AutoModelForMaskedLM"),
     ("object-detection", "MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES", "AutoModelForObjectDetection"),
     (
@@ -128,6 +127,7 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
     ("text-to-audio", "MODEL_FOR_TEXT_TO_SPECTROGRAM_MAPPING_NAMES", "AutoModelForTextToSpectrogram"),
     ("text-to-audio", "MODEL_FOR_TEXT_TO_WAVEFORM_MAPPING_NAMES", "AutoModelForTextToWaveform"),
     ("keypoint-matching", "MODEL_FOR_KEYPOINT_MATCHING_MAPPING_NAMES", "AutoModelForKeypointMatching"),
+    ("any-to-any", "MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES", "AutoModelForMultimodalLM"),
 ]
 
 

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -38,6 +38,7 @@ import pandas as pd
 from datasets import Dataset
 from huggingface_hub import hf_hub_download, upload_folder
 
+from transformers.models.auto.modeling_auto import MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES
 from transformers.utils import direct_transformers_import
 
 
@@ -77,6 +78,7 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
     ("automatic-speech-recognition", "MODEL_FOR_CTC_MAPPING_NAMES", "AutoModelForCTC"),
     ("image-classification", "MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING_NAMES", "AutoModelForImageClassification"),
     ("image-segmentation", "MODEL_FOR_IMAGE_SEGMENTATION_MAPPING_NAMES", "AutoModelForImageSegmentation"),
+    ("any-to-any", "MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES", "AutoModelForMultimodalLM"),
     ("image-text-to-text", "MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES", "AutoModelForImageTextToText"),
     ("fill-mask", "MODEL_FOR_MASKED_LM_MAPPING_NAMES", "AutoModelForMaskedLM"),
     ("object-detection", "MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES", "AutoModelForObjectDetection"),
@@ -128,11 +130,7 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
     ("text-to-audio", "MODEL_FOR_TEXT_TO_SPECTROGRAM_MAPPING_NAMES", "AutoModelForTextToSpectrogram"),
     ("text-to-audio", "MODEL_FOR_TEXT_TO_WAVEFORM_MAPPING_NAMES", "AutoModelForTextToWaveform"),
     ("keypoint-matching", "MODEL_FOR_KEYPOINT_MATCHING_MAPPING_NAMES", "AutoModelForKeypointMatching"),
-    ("any-to-any", "MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES", "AutoModelForMultimodalLM"),
 ]
-
-# Pipeline tags that do not necessarily have to be in the above list
-PIPELINES_TO_IGNORE = ["image-text-to-text"]
 
 
 def camel_case_split(identifier: str) -> list[str]:
@@ -229,16 +227,19 @@ def update_pipeline_and_auto_class_table(table: dict[str, tuple[str, str]]) -> d
     for pipeline_tag, model_mapping, cls in PIPELINE_TAGS_AND_AUTO_MODELS:
         if not hasattr(module, model_mapping):
             continue
-        # First extract all model_names
-        model_names = []
-        for name in getattr(module, model_mapping).values():
-            if isinstance(name, str):
-                model_names.append(name)
-            else:
-                model_names.extend(list(name))
 
-        # Add pipeline tag and auto model class for those models
-        table.update(dict.fromkeys(model_names, (pipeline_tag, cls)))
+        # Iterate over all model_names for given mapping
+        for names in getattr(module, model_mapping).values():
+            if isinstance(names, str):
+                names = [names]
+
+            for name in names:
+                # For multimodal LLMs, keep the fine-grained pipeline tag but use a generic `AutoClass`
+                if name in MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES:
+                    cls = "AutoModelForMultimodalLM"
+
+                # Add pipeline tag and auto model class for those models
+                table[name] = (pipeline_tag, cls)
 
     return table
 
@@ -334,7 +335,7 @@ def check_pipeline_tags():
     pipeline_tasks = transformers_module.pipelines.SUPPORTED_TASKS
     missing = []
     for key in pipeline_tasks:
-        if key not in in_table and key not in PIPELINES_TO_IGNORE:
+        if key not in in_table:
             model = pipeline_tasks[key]["pt"]
             if isinstance(model, (list, tuple)):
                 model = model[0]

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -235,7 +235,7 @@ def update_pipeline_and_auto_class_table(table: dict[str, tuple[str, str]]) -> d
 
             for name in names:
                 # For multimodal LLMs, keep the fine-grained pipeline tag but use a generic `AutoClass`
-                if name in MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES:
+                if name in MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES.values():
                     cls = "AutoModelForMultimodalLM"
 
                 # Add pipeline tag and auto model class for those models

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -76,8 +76,8 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
     ("text-generation", "MODEL_FOR_CAUSAL_LM_MAPPING_NAMES", "AutoModelForCausalLM"),
     ("automatic-speech-recognition", "MODEL_FOR_CTC_MAPPING_NAMES", "AutoModelForCTC"),
     ("image-classification", "MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING_NAMES", "AutoModelForImageClassification"),
-    ("image-text-to-text", "MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES", "AutoModelForImageTextToText"),
     ("image-segmentation", "MODEL_FOR_IMAGE_SEGMENTATION_MAPPING_NAMES", "AutoModelForImageSegmentation"),
+    ("image-text-to-text", "MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES", "AutoModelForImageTextToText"),
     ("fill-mask", "MODEL_FOR_MASKED_LM_MAPPING_NAMES", "AutoModelForMaskedLM"),
     ("object-detection", "MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES", "AutoModelForObjectDetection"),
     (

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -76,6 +76,7 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
     ("text-generation", "MODEL_FOR_CAUSAL_LM_MAPPING_NAMES", "AutoModelForCausalLM"),
     ("automatic-speech-recognition", "MODEL_FOR_CTC_MAPPING_NAMES", "AutoModelForCTC"),
     ("image-classification", "MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING_NAMES", "AutoModelForImageClassification"),
+    ("image-text-to-text", "MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES", "AutoModelForImageTextToText"),
     ("image-segmentation", "MODEL_FOR_IMAGE_SEGMENTATION_MAPPING_NAMES", "AutoModelForImageSegmentation"),
     ("fill-mask", "MODEL_FOR_MASKED_LM_MAPPING_NAMES", "AutoModelForMaskedLM"),
     ("object-detection", "MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES", "AutoModelForObjectDetection"),


### PR DESCRIPTION
# What does this PR do?

We want to use `AutoModelForMultimodalLM` in usage snippets on the hub from now on, instead of `AutoModelForImageTextToText` and `AutoModelForTextToWaveform`. Got green light from Lucain in slack, and requesting review from Eustache for audio models. Do you think we can show usage with `AutoModelForMultimodalLM` for all models in the mapping?

For ex: omni-modal ones have a wrong snippet and imo not the right mapping in codebase (https://huggingface.co/Qwen/Qwen3-Omni-30B-A3B-Instruct?library=transformers)

❗ VLM, ALM and Omni-model LLMs will use to `AutoModelForMultimodalLM` in usage snippet after this PR