### PR TITLE
Fix typo in mm_grounding_dino converter

### DIFF
--- a/src/transformers/models/mm_grounding_dino/convert_mm_grounding_dino_to_hf.py
+++ b/src/transformers/models/mm_grounding_dino/convert_mm_grounding_dino_to_hf.py
@@ -376,7 +376,7 @@ def preprocess_old_state(state_dict: dict, config: MMGroundingDinoConfig) -> dic
         if (
             k == "dn_query_generator.label_embedding.weight"
             or k == "language_model.language_backbone.body.model.embeddings.position_ids"
-            or k == "image_seperate.weight"
+            or k == "image_separate.weight"
             or k.startswith("lmm")
             or k.startswith("connector")
             or k.startswith("region_connector")


### PR DESCRIPTION
## Description
Fixed a straightforward typo in the weight initialization check within the `mm_grounding_dino` converter script. Changed `"image_seperate.weight"` to `"image_separate.weight"`.

## Code Agent Policy
I confirm that this PR is fully human-written and fixes a clear typographical error. No AI agents or automated bots were used to generate this contribution.

- [x] This pull request fixes a typo or improves the docs.
- [x] I speak human.