### PR TITLE
fix(hub): prevent path traversal in sharded checkpoint loading

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -886,7 +886,24 @@ def get_checkpoint_shard_files(
 
     # First, let's deal with local folder.
     if os.path.isdir(pretrained_model_name_or_path):
+        # Validate shard filenames to prevent path traversal attacks.
+        # Reject any filename that contains path traversal sequences or absolute paths.
+        for filename in shard_filenames:
+            if ".." in filename or filename.startswith("/") or filename.startswith("\\"):
+                raise ValueError(
+                    f"Invalid shard filename '{filename}' in checkpoint index. "
+                    "Filenames must not contain '..' or start with a path separator."
+                )
         shard_filenames = [os.path.join(pretrained_model_name_or_path, subfolder, f) for f in shard_filenames]
+        # Resolve and verify each path stays within the model directory.
+        base_path = os.path.realpath(os.path.join(pretrained_model_name_or_path, subfolder))
+        for shard_path in shard_filenames:
+            resolved_path = os.path.realpath(shard_path)
+            if not resolved_path.startswith(base_path + os.sep) and resolved_path != base_path:
+                raise ValueError(
+                    f"Shard file path '{shard_path}' resolves outside the model directory. "
+                    "This may indicate a path traversal attempt in the checkpoint index."
+                )
         return shard_filenames, sharded_metadata
 
     # At this stage pretrained_model_name_or_path is a model identifier on the Hub. Try to get everything from cache,

--- a/tests/utils/test_hub_path_traversal.py
+++ b/tests/utils/test_hub_path_traversal.py
@@ -1,0 +1,61 @@
+import json
+import os
+import tempfile
+import unittest
+
+from transformers.utils.hub import get_checkpoint_shard_files
+
+
+class TestPathTraversalProtection(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.index_file = os.path.join(self.tmpdir, "model.safetensors.index.json")
+
+    def _write_index(self, weight_map):
+        with open(self.index_file, "w") as f:
+            json.dump({"metadata": {"total_size": 1000}, "weight_map": weight_map}, f)
+
+    def test_traversal_with_dotdot_raises(self):
+        """Shard filenames containing '..' must be rejected."""
+        self._write_index({"layer.weight": "../../etc/passwd"})
+        with self.assertRaises(ValueError) as ctx:
+            get_checkpoint_shard_files(self.tmpdir, self.index_file)
+        self.assertIn("Invalid shard filename", str(ctx.exception))
+
+    def test_absolute_path_raises(self):
+        """Shard filenames starting with '/' must be rejected."""
+        self._write_index({"layer.weight": "/etc/passwd"})
+        with self.assertRaises(ValueError) as ctx:
+            get_checkpoint_shard_files(self.tmpdir, self.index_file)
+        self.assertIn("Invalid shard filename", str(ctx.exception))
+
+    def test_symlink_escapes_directory(self):
+        """Symlinks that escape the model directory must be caught by realpath check."""
+        # Create a valid shard file
+        shard_path = os.path.join(self.tmpdir, "model-00001-of-00001.safetensors")
+        with open(shard_path, "w") as f:
+            f.write("")
+
+        # Create a symlink with a valid-looking name but pointing outside
+        symlink_path = os.path.join(self.tmpdir, "model-00002-of-00002.safetensors")
+        os.symlink("/etc/passwd", symlink_path)
+
+        self._write_index({"layer.weight": "model-00002-of-00002.safetensors"})
+        with self.assertRaises(ValueError) as ctx:
+            get_checkpoint_shard_files(self.tmpdir, self.index_file)
+        self.assertIn("resolves outside", str(ctx.exception))
+
+    def test_valid_local_shards_pass(self):
+        """Normal shard filenames in the same directory should work."""
+        shard_path = os.path.join(self.tmpdir, "model-00001-of-00001.safetensors")
+        with open(shard_path, "w") as f:
+            f.write("")
+
+        self._write_index({"layer.weight": "model-00001-of-00001.safetensors"})
+        filenames, _ = get_checkpoint_shard_files(self.tmpdir, self.index_file)
+        self.assertEqual(len(filenames), 1)
+        self.assertTrue(os.path.samefile(filenames[0], shard_path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #46097

This PR addresses a path traversal vulnerability (CWE-22) in `get_checkpoint_shard_files` where a malicious `model.safetensors.index.json` could reference arbitrary files outside the model directory.

## Changes

- **Validation before path construction**: Reject shard filenames containing `..` or starting with path separators (`/` or `\`)
- **Path resolution verification**: After `os.path.join`, use `os.path.realpath` to resolve symlinks and verify the resolved path stays within the model directory
- **Comprehensive tests**: Added 4 test cases covering:
  - Path traversal with `..`
  - Absolute paths
  - Symlink escapes
  - Valid local shards (ensure normal operation still works)

## Security Impact

This prevents arbitrary file reads when loading models from untrusted local directories. An attacker who can provide a malicious checkpoint index could previously access:
- System files (`/etc/passwd`, etc.)
- Other users' cached models
- API tokens stored in `~/.cache/huggingface/token`

## Testing

All new tests pass:
```
pytest tests/utils/test_hub_path_traversal.py -v
```

4 passed in 0.28s