### PR TITLE
fix: compatibility with torch<=2.7

### DIFF
--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -45,6 +45,17 @@ _FP8_MAX = torch.finfo(_FP8_DTYPE).max
 _UE8M0_SF_DTYPE = getattr(torch, "float8_e8m0fnu", None)
 
 
+def _ue8m0_sf_dtype():
+    """Return ``torch.float8_e8m0fnu`` or raise a clear error on torch without FP8 support.
+    """
+    if _UE8M0_SF_DTYPE is None:
+        raise RuntimeError(
+            "scale_fmt='ue8m0' requires torch.float8_e8m0fnu, which is only available in "
+            f"PyTorch >= 2.7 (found {torch.__version__}). Upgrade torch to use UE8M0 FP8 checkpoints."
+        )
+    return _UE8M0_SF_DTYPE
+
+
 def _first_attr(obj, *names):
     for name in names:
         if hasattr(obj, name):
@@ -279,7 +290,7 @@ class FP8Linear(nn.Linear):
             # If block size is None, it means that we are doing per-tensor quantization
             self.weight_scale_inv = nn.Parameter(torch.tensor(1.0, dtype=torch.float32))
         else:
-            sf_dtype = _UE8M0_SF_DTYPE if scale_fmt == "ue8m0" else torch.float32
+            sf_dtype = _ue8m0_sf_dtype() if scale_fmt == "ue8m0" else torch.float32
             scale_out_features = (out_features + self.block_size[0] - 1) // self.block_size[0]
             scale_in_features = (in_features + self.block_size[1] - 1) // self.block_size[1]
             self.weight_scale_inv = nn.Parameter(torch.empty(scale_out_features, scale_in_features, dtype=sf_dtype))
@@ -608,7 +619,7 @@ class FP8Experts(nn.Module):
         #   - weight is `int8`, K dim halved (2 e2m1 values per byte).
         #   - per-row SF at gran_k=32 (no block-wise SF; `block_size` ignored).
         is_fp4 = getattr(config, "expert_dtype", "fp8") == "fp4"
-        sf_dtype = _UE8M0_SF_DTYPE if scale_fmt == "ue8m0" else torch.float32
+        sf_dtype = _ue8m0_sf_dtype() if scale_fmt == "ue8m0" else torch.float32
         if is_fp4:
             alloc_kwargs = {
                 "weight_dtype": torch.int8,
@@ -866,7 +877,7 @@ class Fp8Quantize(ConversionOps):
         # matches the parameter allocation in `FP8Linear`/`FP8Experts`.
         if self.hf_quantizer.quantization_config.scale_fmt == "ue8m0":
             inv_scales = torch.pow(2.0, torch.ceil(torch.log2(inv_scales.clamp(min=torch.finfo(torch.float32).tiny))))
-            inv_scales = inv_scales.to(_UE8M0_SF_DTYPE)
+            inv_scales = inv_scales.to(_ue8m0_sf_dtype())
         scale_key = key.rsplit(".", 1)[0] + ".weight_scale_inv" if key.endswith("weight") else key + "_scale_inv"
         return {key: quantized, scale_key: inv_scales}
 

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -42,7 +42,7 @@ logger = logging.get_logger(__name__)
 _FP8_DTYPE = torch.float8_e4m3fn
 _FP8_MIN = torch.finfo(_FP8_DTYPE).min
 _FP8_MAX = torch.finfo(_FP8_DTYPE).max
-_UE8M0_SF_DTYPE = torch.float8_e8m0fnu
+_UE8M0_SF_DTYPE = getattr(torch, "float8_e8m0fnu", None)
 
 
 def _first_attr(obj, *names):
@@ -222,7 +222,7 @@ def fp8_linear(
     deepgemm_required = weight.dtype == torch.int8
     deepgemm_compatible = activation_scale is None and (
         deepgemm_required
-        or weight_scale_inv.dtype == torch.float8_e8m0fnu
+        or (_UE8M0_SF_DTYPE is not None and weight_scale_inv.dtype == _UE8M0_SF_DTYPE)
         or (block_size is not None and block_size[0] == block_size[1] == 128)
     )
 

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -46,8 +46,7 @@ _UE8M0_SF_DTYPE = getattr(torch, "float8_e8m0fnu", None)
 
 
 def _ue8m0_sf_dtype():
-    """Return ``torch.float8_e8m0fnu`` or raise a clear error on torch without FP8 support.
-    """
+    """Return ``torch.float8_e8m0fnu`` or raise a clear error on torch without FP8 support."""
     if _UE8M0_SF_DTYPE is None:
         raise RuntimeError(
             "scale_fmt='ue8m0' requires torch.float8_e8m0fnu, which is only available in "


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fixes https://github.com/huggingface/transformers/issues/46389, which is transformers' compatibility with torch<=2.7 which does not have FP8 support (missing torch.float8_e8m0fnu).

When installing 5.10.1 with torch<=2.7, importing `AutoProcessor` from transformers will import torch.float8_e8m0fnu in this line:

https://github.com/huggingface/transformers/blob/d3f05911abb216047a00aba79c8543c73633db05/src/transformers/integrations/finegrained_fp8.py#L45

As a result, the import will fail with ModuleNotFoundError with the following stack:

```
>>> from transformers import AutoProcessor
Traceback (most recent call last):
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/utils/import_utils.py", line 2254, in __getattr__
    module = self._get_module(self._class_to_module[name])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/utils/import_utils.py", line 2488, in _get_module
    raise e
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/utils/import_utils.py", line 2486, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/.python/cpython-3.11.14-linux-x86_64-gnu/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/models/auto/processing_auto.py", line 25, in <module>
    from ...image_processing_utils import ImageProcessingMixin
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/image_processing_utils.py", line 34, in <module>
    from .processing_utils import ImagesKwargs, Unpack
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/processing_utils.py", line 83, in <module>
    from .modeling_utils import PreTrainedAudioTokenizerBase
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/modeling_utils.py", line 69, in <module>
    from .integrations.finegrained_fp8 import ALL_FP8_EXPERTS_FUNCTIONS
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/integrations/finegrained_fp8.py", line 45, in <module>
    _UE8M0_SF_DTYPE = torch.float8_e8m0fnu
                      ^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/openvla/lib/python3.11/site-packages/torch/__init__.py", line 2681, in __getattr__
    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
AttributeError: module 'torch' has no attribute 'float8_e8m0fnu'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/utils/import_utils.py", line 2342, in __getattr__
    raise ModuleNotFoundError(
ModuleNotFoundError: Could not import module 'AutoProcessor'. Are this object's requirements defined correctly?
>>> ^D
^[[A#                                                                                                                                                                                                     
(openvla) ➜  transformers git:(bugfix/torch_compat) python
Python 3.11.14 (main, Jan 27 2026, 23:58:49) [Clang 21.1.4 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from transformers import AutoProcessor
Traceback (most recent call last):
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/utils/import_utils.py", line 2254, in __getattr__
    module = self._get_module(self._class_to_module[name])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/utils/import_utils.py", line 2488, in _get_module
    raise e
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/utils/import_utils.py", line 2486, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/.python/cpython-3.11.14-linux-x86_64-gnu/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/models/auto/processing_auto.py", line 25, in <module>
    from ...image_processing_utils import ImageProcessingMixin
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/image_processing_utils.py", line 34, in <module>
    from .processing_utils import ImagesKwargs, Unpack
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/processing_utils.py", line 83, in <module>
    from .modeling_utils import PreTrainedAudioTokenizerBase
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/modeling_utils.py", line 69, in <module>
    from .integrations.finegrained_fp8 import ALL_FP8_EXPERTS_FUNCTIONS
  File "/opt/venv/openvla/lib/python3.11/site-packages/transformers/integrations/finegrained_fp8.py", line 45, in <module>
    _UE8M0_SF_DTYPE = torch.float8_e8m0fnu
                      ^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/openvla/lib/python3.11/site-packages/torch/__init__.py", line 2681, in __getattr__
    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
AttributeError: module 'torch' has no attribute 'float8_e8m0fnu'
```

This can be reproduced by installing torch==2.7 and transformers 5.10.1. Since transformers' dependency only requires torch>=2.4, I believe it's necessary to maintain support for these non-FP8 torch versions.

The fix uses getattr to check if FP8 is supported in the current torch and modifies `deepgemm_compatible` based on the check.

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
