### PR TITLE
Raise tqdm minimum to 4.60 to match tqdm.contrib.logging import

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - huggingface_hub
     - packaging
     - filelock
-    - tqdm >=4.27
+    - tqdm >=4.60
     - sacremoses
     - regex !=2019.12.17
     - protobuf
@@ -34,7 +34,7 @@ requirements:
     - huggingface_hub
     - packaging
     - filelock
-    - tqdm >=4.27
+    - tqdm >=4.60
     - sacremoses
     - regex !=2019.12.17
     - protobuf

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ _deps = [
     "torchaudio",
     "torchvision",
     "pyctcdecode>=0.4.0",
-    "tqdm>=4.27",
+    "tqdm>=4.60",
     "typer",
     "unidic>=1.0.2",
     "unidic_lite>=1.0.7",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -79,7 +79,7 @@ deps = {
     "torchaudio": "torchaudio",
     "torchvision": "torchvision",
     "pyctcdecode": "pyctcdecode>=0.4.0",
-    "tqdm": "tqdm>=4.27",
+    "tqdm": "tqdm>=4.60",
     "typer": "typer",
     "unidic": "unidic>=1.0.2",
     "unidic_lite": "unidic_lite>=1.0.7",

--- a/src/transformers/utils/versions.py
+++ b/src/transformers/utils/versions.py
@@ -52,7 +52,7 @@ def require_version(requirement: str, hint: str | None = None) -> None:
     The installed module version comes from the *site-packages* dir via *importlib.metadata*.
 
     Args:
-        requirement (`str`): pip style definition, e.g.,  "tokenizers==0.9.4", "tqdm>=4.27", "numpy"
+        requirement (`str`): pip style definition, e.g.,  "tokenizers==0.9.4", "tqdm>=4.60", "numpy"
         hint (`str`, *optional*): what suggestion to print in case of requirements not being met
 
     Example:


### PR DESCRIPTION
# What does this PR do?

`transformers/generation/continuous_batching/continuous_api.py` imports `tqdm.contrib.logging`, which was added in tqdm [4.60](https://tqdm.github.io/releases/#v4600-2021-04-06). The current declared minimum `tqdm>=4.27` lets resolvers pick older versions (we hit tqdm 4.49 in our environment when a transitive cap forced it), causing `ModuleNotFoundError`.

Quick repro:
```
uv pip install "tqdm==4.59" && python src/transformers/generation/continuous_batching/continuous_api.py
Resolved 1 package in 30ms
Uninstalled 1 package in 12ms
Installed 1 package in 10ms
 - tqdm==4.67.3
 + tqdm==4.59.0
Traceback (most recent call last):
  File "/workspace/huggingface/transformers/src/transformers/generation/continuous_batching/continuous_api.py", line 29, in <module>
    from tqdm.contrib.logging import logging_redirect_tqdm
ModuleNotFoundError: No module named 'tqdm.contrib.logging'
```

After this PR (ModuleNotFoundError is gone; the remaining ImportError is unrelated noise):
```
❯ uv pip install "tqdm==4.60" && python src/transformers/generation/continuous_batching/continuous_api.py
Resolved 1 package in 77ms
Prepared 1 package in 22ms
Uninstalled 1 package in 5ms
Installed 1 package in 4ms
 - tqdm==4.59.0
 + tqdm==4.60.0
Traceback (most recent call last):
  File "/workspace/huggingface/transformers/src/transformers/generation/continuous_batching/continuous_api.py", line 31, in <module>
    from ...configuration_utils import PretrainedConfig
ImportError: attempted relative import with no known parent package
```

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->

@zucchini-nlp @gante 
