### PR TITLE
fix[vLLM x v5]: Default untied embeddings in AudioFlamingo3 and VibeVoice

### DIFF
--- a/src/transformers/models/audioflamingo3/configuration_audioflamingo3.py
+++ b/src/transformers/models/audioflamingo3/configuration_audioflamingo3.py
@@ -100,7 +100,7 @@ class AudioFlamingo3Config(PreTrainedConfig):
     audio_token_id: int = 151669
     projector_hidden_act: str = "gelu"
     projector_bias: bool = True
-    tie_word_embeddings: bool = True
+    tie_word_embeddings: bool = False
 
     def __post_init__(self, **kwargs):
         if isinstance(self.audio_config, dict):

--- a/src/transformers/models/vibevoice_asr/configuration_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/configuration_vibevoice_asr.py
@@ -75,7 +75,7 @@ class VibeVoiceAsrConfig(PreTrainedConfig):
     audio_bos_token_id: int = 151646
     audio_eos_token_id: int = 151647
     acoustic_tokenizer_chunk_size: int = 1440000
-    tie_word_embeddings: bool = True
+    tie_word_embeddings: bool = False
 
     def __post_init__(self, **kwargs):
         if isinstance(self.acoustic_tokenizer_encoder_config, dict):

--- a/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
@@ -88,7 +88,7 @@ class VibeVoiceAsrConfig(PreTrainedConfig):
     audio_bos_token_id: int = 151646
     audio_eos_token_id: int = 151647
     acoustic_tokenizer_chunk_size: int = 1440000
-    tie_word_embeddings: bool = True
+    tie_word_embeddings: bool = False
 
     def __post_init__(self, **kwargs):
         if isinstance(self.acoustic_tokenizer_encoder_config, dict):


### PR DESCRIPTION
### What does this PR do?

→ Fixes https://github.com/vllm-project/vllm/pull/39330#discussion_r3353859473
→ Corrects the `tie_word_embeddings` default for AudioFlamingo3 and VibeVoice for integration with the vLLM Transformers backend. This only causes issues with vLLM and not Transformers because Transformers always loads checkpoint weights regardless of `tie_word_embeddings` (or in other words, it's a hint for init-time tying, not a directive as in vLLM to my understanding).
→ Made sure this doesn't cause any regressions in `tests/models/audioflamingo3/` and `tests/models/vibevoice_asr/`

### Model-wise behavior

→ <ins>AudioFlamingo3 and VibeVoice</ins>: These models break under the current default; their checkpoints contain distinct `lm_head` and `embed_tokens` weights (with a max difference of ~1.0 to 1.7). Substitution produces garbage outputs.
→ <ins>GraniteSpeech</ins>: Works fine as-is because it genuinely ties its embeddings and has no separate `lm_head` in the checkpoint.
→ <ins>GLM-ASR</ins>: Works fine as-is. It has separate `lm_head` and `embed_tokens`, but they are bitwise identical (max diff = 0.0), so tying them produces the same result.

cc: @eustlb @vasqu

### Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

### Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you fix any necessary existing tests?