### PR TITLE
Centralize multimodal token expansion via get_text_with_replacements

### DIFF
--- a/src/transformers/models/cohere2_vision/processing_cohere2_vision.py
+++ b/src/transformers/models/cohere2_vision/processing_cohere2_vision.py
@@ -59,6 +59,17 @@ class Cohere2VisionProcessor(ProcessorMixin):
             ]
         )
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        num_patches = image_inputs["num_patches"][image_idx]
+        img_patches_per_tile = int(self.patch_size**2)
+
+        img_string = f"{self.boi_token}"
+        for idx in range(1, num_patches):
+            img_string += self.image_token * img_patches_per_tile + self.img_line_break_token
+        img_string += self.image_token * img_patches_per_tile + self.img_line_break_token
+        img_string += f"{self.eoi_token}"
+        return img_string
+
     @auto_docstring
     def __call__(
         self,
@@ -91,22 +102,10 @@ class Cohere2VisionProcessor(ProcessorMixin):
         image_inputs = {}
         if images is not None:
             image_inputs = self.image_processor(images=images, **output_kwargs["images_kwargs"])
-            batch_num_patches = iter(image_inputs.pop("num_patches"))
-            processed_text = []
-            for sample in text:
-                while self.image_token in sample:
-                    num_patches = next(batch_num_patches)
-                    img_patches_per_tile = int(self.patch_size**2)
-
-                    img_string = f"{self.boi_token}"
-                    for idx in range(1, num_patches):
-                        img_string += "<placeholder>" * img_patches_per_tile + self.img_line_break_token
-                    img_string += "<placeholder>" * img_patches_per_tile + self.img_line_break_token
-                    img_string += f"{self.eoi_token}"
-
-                    sample = sample.replace(self.image_token, img_string, 1)
-                processed_text.append(sample)
-            text = [sample.replace("<placeholder>", self.image_token) for sample in processed_text]
+            num_images = len(image_inputs["num_patches"])
+            images_replacements = [self.replace_image_token(image_inputs, i) for i in range(num_images)]
+            image_inputs.pop("num_patches")
+            text, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)

--- a/src/transformers/models/colqwen2/modular_colqwen2.py
+++ b/src/transformers/models/colqwen2/modular_colqwen2.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from dataclasses import dataclass
 
 from ...cache_utils import Cache
@@ -115,13 +116,15 @@ class ColQwen2Processor(ColPaliProcessor):
             if image_grid_thw is not None:
                 merge_length = self.image_processor.merge_size**2
                 index = 0
-                for i in range(len(texts_doc)):
-                    while self.image_token in texts_doc[i]:
-                        texts_doc[i] = texts_doc[i].replace(
-                            self.image_token, "<|placeholder|>" * (image_grid_thw[index].prod() // merge_length), 1
-                        )
-                        index += 1
-                    texts_doc[i] = texts_doc[i].replace("<|placeholder|>", self.image_token)
+
+                def expand(_match):
+                    nonlocal index
+                    num_image_tokens = image_grid_thw[index].prod() // merge_length
+                    index += 1
+                    return self.image_token * num_image_tokens
+
+                pattern = re.escape(self.image_token)
+                texts_doc = [re.sub(pattern, expand, text) for text in texts_doc]
 
             text_inputs = self.tokenizer(
                 texts_doc,

--- a/src/transformers/models/colqwen2/modular_colqwen2.py
+++ b/src/transformers/models/colqwen2/modular_colqwen2.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 from dataclasses import dataclass
 
 from ...cache_utils import Cache
@@ -70,6 +69,11 @@ class ColQwen2Processor(ColPaliProcessor):
         )
         self.query_prefix = query_prefix or "Query: "
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        merge_length = self.image_processor.merge_size**2
+        num_image_tokens = image_inputs["image_grid_thw"][image_idx].prod() // merge_length
+        return self.image_token * num_image_tokens
+
     def __call__(
         self,
         images: ImageInput | None = None,
@@ -114,17 +118,8 @@ class ColQwen2Processor(ColPaliProcessor):
             image_grid_thw = image_inputs["image_grid_thw"]
 
             if image_grid_thw is not None:
-                merge_length = self.image_processor.merge_size**2
-                index = 0
-
-                def expand(_match):
-                    nonlocal index
-                    num_image_tokens = image_grid_thw[index].prod() // merge_length
-                    index += 1
-                    return self.image_token * num_image_tokens
-
-                pattern = re.escape(self.image_token)
-                texts_doc = [re.sub(pattern, expand, text) for text in texts_doc]
+                images_replacements = [self.replace_image_token(image_inputs, i) for i in range(len(image_grid_thw))]
+                texts_doc, _ = self.get_text_with_replacements(texts_doc, images_replacements=images_replacements)
 
             text_inputs = self.tokenizer(
                 texts_doc,

--- a/src/transformers/models/colqwen2/processing_colqwen2.py
+++ b/src/transformers/models/colqwen2/processing_colqwen2.py
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from typing import Optional, Union
 
 from ...feature_extraction_utils import BatchFeature
@@ -117,13 +118,15 @@ class ColQwen2Processor(ProcessorMixin):
             if image_grid_thw is not None:
                 merge_length = self.image_processor.merge_size**2
                 index = 0
-                for i in range(len(texts_doc)):
-                    while self.image_token in texts_doc[i]:
-                        texts_doc[i] = texts_doc[i].replace(
-                            self.image_token, "<|placeholder|>" * (image_grid_thw[index].prod() // merge_length), 1
-                        )
-                        index += 1
-                    texts_doc[i] = texts_doc[i].replace("<|placeholder|>", self.image_token)
+
+                def expand(_match):
+                    nonlocal index
+                    num_image_tokens = image_grid_thw[index].prod() // merge_length
+                    index += 1
+                    return self.image_token * num_image_tokens
+
+                pattern = re.escape(self.image_token)
+                texts_doc = [re.sub(pattern, expand, text) for text in texts_doc]
 
             text_inputs = self.tokenizer(
                 texts_doc,

--- a/src/transformers/models/colqwen2/processing_colqwen2.py
+++ b/src/transformers/models/colqwen2/processing_colqwen2.py
@@ -18,7 +18,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 from typing import Optional, Union
 
 from ...feature_extraction_utils import BatchFeature
@@ -116,17 +115,8 @@ class ColQwen2Processor(ProcessorMixin):
             image_grid_thw = image_inputs["image_grid_thw"]
 
             if image_grid_thw is not None:
-                merge_length = self.image_processor.merge_size**2
-                index = 0
-
-                def expand(_match):
-                    nonlocal index
-                    num_image_tokens = image_grid_thw[index].prod() // merge_length
-                    index += 1
-                    return self.image_token * num_image_tokens
-
-                pattern = re.escape(self.image_token)
-                texts_doc = [re.sub(pattern, expand, text) for text in texts_doc]
+                images_replacements = [self.replace_image_token(image_inputs, i) for i in range(len(image_grid_thw))]
+                texts_doc, _ = self.get_text_with_replacements(texts_doc, images_replacements=images_replacements)
 
             text_inputs = self.tokenizer(
                 texts_doc,
@@ -353,6 +343,11 @@ class ColQwen2Processor(ProcessorMixin):
             scores.append(torch.cat(batch_scores, dim=1).to(output_dtype).to(output_device))
 
         return torch.cat(scores, dim=0)
+
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        merge_length = self.image_processor.merge_size**2
+        num_image_tokens = image_inputs["image_grid_thw"][image_idx].prod() // merge_length
+        return self.image_token * num_image_tokens
 
 
 __all__ = ["ColQwen2Processor"]

--- a/src/transformers/models/csm/processing_csm.py
+++ b/src/transformers/models/csm/processing_csm.py
@@ -228,24 +228,10 @@ class CsmProcessor(ProcessorMixin):
             num_audio_tokens_list = [
                 self._get_encoded_length(audio_array.shape[-1], **encoded_length_kwargs) for audio_array in audio
             ]
-            num_audio_tokens_list_copy = num_audio_tokens_list.copy()
 
             # expand the text to repeat the audio token for the corresponding number of frames
-            expanded_text = []
-            for sample in text:
-                replace_str = []
-                while self.audio_token in sample:
-                    num_audio_tokens = num_audio_tokens_list_copy.pop(0)
-                    expanded_audio_token = self.audio_token * num_audio_tokens
-
-                    replace_str.append(expanded_audio_token)
-                    sample = sample.replace(self.audio_token, "<placeholder>", 1)
-
-                while "<placeholder>" in sample:
-                    sample = sample.replace("<placeholder>", replace_str.pop(0), 1)
-                expanded_text.append(sample)
-
-            text = expanded_text
+            audio_replacements = [self.audio_token * num_audio_tokens for num_audio_tokens in num_audio_tokens_list]
+            text, _ = self.get_text_with_replacements(list(text), audio_replacements=audio_replacements)
 
         encoding = self.tokenizer(text, **text_kwargs)
         data = {}

--- a/src/transformers/models/deepseek_ocr2/processing_deepseek_ocr2.py
+++ b/src/transformers/models/deepseek_ocr2/processing_deepseek_ocr2.py
@@ -16,7 +16,6 @@ Processor class for DeepSeek-OCR-2.
 """
 
 import math
-import re
 
 from ...feature_extraction_utils import BatchFeature
 from ...image_utils import ImageInput
@@ -64,24 +63,7 @@ class DeepseekOcr2Processor(ProcessorMixin):
         self.image_token_id = tokenizer.convert_tokens_to_ids(self.image_token)
         super().__init__(image_processor, tokenizer, chat_template=chat_template, **kwargs)
 
-    def _expand_image_tokens(
-        self,
-        text: list[TextInput],
-        num_crops_list: list[int],
-    ) -> list[str]:
-        """
-        Expand each `<image>` placeholder in the text to the correct number of image tokens.
-
-        Args:
-            text (`list[str]`):
-                List of text strings, each potentially containing `<image>` placeholders.
-            num_crops_list (`list[int]`):
-                Number of crops for each image, consumed in order as `<image>` placeholders
-                are encountered across all text samples.
-
-        Returns:
-            `list[str]`: Text with expanded image token placeholders.
-        """
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
         size = self.image_processor.size["height"]
         tile_size = self.image_processor.tile_size
 
@@ -91,16 +73,8 @@ class DeepseekOcr2Processor(ProcessorMixin):
         num_queries_local = math.ceil(tile_size / self.patch_size / self.downsample_ratio)
         local_tokens = num_queries_local * num_queries_local
 
-        crop_index = 0
-
-        def expand(_match):
-            nonlocal crop_index
-            num_tokens = global_tokens + local_tokens * num_crops_list[crop_index] + 1
-            crop_index += 1
-            return self.image_token * num_tokens
-
-        pattern = re.escape(self.image_token)
-        return [re.sub(pattern, expand, text_i) for text_i in text]
+        num_tokens = global_tokens + local_tokens * image_inputs["num_local_patches"][image_idx] + 1
+        return self.image_token * num_tokens
 
     @auto_docstring
     def __call__(
@@ -139,8 +113,10 @@ class DeepseekOcr2Processor(ProcessorMixin):
         text = text.copy()  # below lines change text in-place
 
         image_inputs = self.image_processor(images, **output_kwargs["images_kwargs"])
-        num_crops_list = image_inputs["num_local_patches"]
-        text = self._expand_image_tokens(text, num_crops_list)
+        images_replacements = [
+            self.replace_image_token(image_inputs, i) for i in range(len(image_inputs["num_local_patches"]))
+        ]
+        text, _ = self.get_text_with_replacements(text, images_replacements=images_replacements)
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         text_inputs = self.tokenizer(text, **output_kwargs["text_kwargs"])

--- a/src/transformers/models/deepseek_ocr2/processing_deepseek_ocr2.py
+++ b/src/transformers/models/deepseek_ocr2/processing_deepseek_ocr2.py
@@ -16,6 +16,7 @@ Processor class for DeepSeek-OCR-2.
 """
 
 import math
+import re
 
 from ...feature_extraction_utils import BatchFeature
 from ...image_utils import ImageInput
@@ -91,13 +92,15 @@ class DeepseekOcr2Processor(ProcessorMixin):
         local_tokens = num_queries_local * num_queries_local
 
         crop_index = 0
-        for i in range(len(text)):
-            while self.image_token in text[i]:
-                num_tokens = global_tokens + local_tokens * num_crops_list[crop_index] + 1
-                text[i] = text[i].replace(self.image_token, "<|placeholder|>" * num_tokens, 1)
-                crop_index += 1
-            text[i] = text[i].replace("<|placeholder|>", self.image_token)
-        return text
+
+        def expand(_match):
+            nonlocal crop_index
+            num_tokens = global_tokens + local_tokens * num_crops_list[crop_index] + 1
+            crop_index += 1
+            return self.image_token * num_tokens
+
+        pattern = re.escape(self.image_token)
+        return [re.sub(pattern, expand, text_i) for text_i in text]
 
     @auto_docstring
     def __call__(

--- a/src/transformers/models/deepseek_vl/modular_deepseek_vl.py
+++ b/src/transformers/models/deepseek_vl/modular_deepseek_vl.py
@@ -190,6 +190,9 @@ class DeepseekVLProcessor(ProcessorMixin):
 
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        return self.image_token * self.num_image_tokens
+
     @auto_docstring
     def __call__(
         self,
@@ -219,11 +222,9 @@ class DeepseekVLProcessor(ProcessorMixin):
             elif not (isinstance(text, (list, tuple)) and all(isinstance(t, str) for t in text)):
                 raise ValueError("Invalid input text. Please provide a string, or a list of strings")
 
-        prompt_strings = []
-        one_img_tokens = self.image_token * self.num_image_tokens
-        for prompt in text:
-            prompt = prompt.replace(self.image_token, one_img_tokens)
-            prompt_strings.append(prompt)
+        num_images = sum(prompt.count(self.image_token) for prompt in text)
+        images_replacements = [self.replace_image_token(None, i) for i in range(num_images)]
+        prompt_strings, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
 
         data = self.tokenizer(prompt_strings, **output_kwargs["text_kwargs"])
 

--- a/src/transformers/models/deepseek_vl/processing_deepseek_vl.py
+++ b/src/transformers/models/deepseek_vl/processing_deepseek_vl.py
@@ -51,6 +51,9 @@ class DeepseekVLProcessor(ProcessorMixin):
 
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        return self.image_token * self.num_image_tokens
+
     @auto_docstring
     def __call__(
         self,
@@ -80,11 +83,9 @@ class DeepseekVLProcessor(ProcessorMixin):
             elif not (isinstance(text, (list, tuple)) and all(isinstance(t, str) for t in text)):
                 raise ValueError("Invalid input text. Please provide a string, or a list of strings")
 
-        prompt_strings = []
-        one_img_tokens = self.image_token * self.num_image_tokens
-        for prompt in text:
-            prompt = prompt.replace(self.image_token, one_img_tokens)
-            prompt_strings.append(prompt)
+        num_images = sum(prompt.count(self.image_token) for prompt in text)
+        images_replacements = [self.replace_image_token(None, i) for i in range(num_images)]
+        prompt_strings, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
 
         data = self.tokenizer(prompt_strings, **output_kwargs["text_kwargs"])
 

--- a/src/transformers/models/deepseek_vl_hybrid/modular_deepseek_vl_hybrid.py
+++ b/src/transformers/models/deepseek_vl_hybrid/modular_deepseek_vl_hybrid.py
@@ -731,6 +731,9 @@ class DeepseekVLHybridProcessorKwargs(DeepseekVLProcessorKwargs):
 
 
 class DeepseekVLHybridProcessor(DeepseekVLProcessor):
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        return self.image_token * self.num_image_tokens
+
     def __call__(
         self,
         text: TextInput | PreTokenizedInput | list[TextInput] | list[PreTokenizedInput] = None,
@@ -759,11 +762,9 @@ class DeepseekVLHybridProcessor(DeepseekVLProcessor):
             elif not (isinstance(text, (list, tuple)) and all(isinstance(t, str) for t in text)):
                 raise ValueError("Invalid input text. Please provide a string, or a list of strings")
 
-        prompt_strings = []
-        one_img_tokens = self.image_token * self.num_image_tokens
-        for prompt in text:
-            prompt = prompt.replace(self.image_token, one_img_tokens)
-            prompt_strings.append(prompt)
+        num_image_tokens = sum(prompt.count(self.image_token) for prompt in text)
+        images_replacements = [self.replace_image_token(None, i) for i in range(num_image_tokens)]
+        prompt_strings, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
 
         data = self.tokenizer(prompt_strings, **output_kwargs["text_kwargs"])
 

--- a/src/transformers/models/deepseek_vl_hybrid/processing_deepseek_vl_hybrid.py
+++ b/src/transformers/models/deepseek_vl_hybrid/processing_deepseek_vl_hybrid.py
@@ -50,6 +50,9 @@ class DeepseekVLHybridProcessor(ProcessorMixin):
 
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        return self.image_token * self.num_image_tokens
+
     @auto_docstring
     def __call__(
         self,
@@ -79,11 +82,9 @@ class DeepseekVLHybridProcessor(ProcessorMixin):
             elif not (isinstance(text, (list, tuple)) and all(isinstance(t, str) for t in text)):
                 raise ValueError("Invalid input text. Please provide a string, or a list of strings")
 
-        prompt_strings = []
-        one_img_tokens = self.image_token * self.num_image_tokens
-        for prompt in text:
-            prompt = prompt.replace(self.image_token, one_img_tokens)
-            prompt_strings.append(prompt)
+        num_image_tokens = sum(prompt.count(self.image_token) for prompt in text)
+        images_replacements = [self.replace_image_token(None, i) for i in range(num_image_tokens)]
+        prompt_strings, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
 
         data = self.tokenizer(prompt_strings, **output_kwargs["text_kwargs"])
 

--- a/src/transformers/models/emu3/processing_emu3.py
+++ b/src/transformers/models/emu3/processing_emu3.py
@@ -114,27 +114,18 @@ class Emu3Processor(ProcessorMixin):
 
         image_features = {}
         image_start_tokens = f"{self.image_start_token}"
-        image_end_tokens = f"{self.eof_token}{self.image_end_token}"
 
         # generate text from image + text input, so we add placeholders for image tokens
         if not return_for_image_generation and images is not None:
             image_features = self.image_processor(images, **output_kwargs["images_kwargs"])
-            image_sizes = iter(image_features.image_sizes)
 
-            prompt_strings = []
-            for sample in text:
-                while self.image_token in sample:
-                    image_size = next(image_sizes)
-                    height, width = image_size
-                    height = height // self.downsample_ratio
-                    width = width // self.downsample_ratio
-                    image_seq_length = height * (width + 1)  # +1 for extra row when converting to BPE in modeling code
+            # Prepend BOS once per image token occurrence (GPT tokenizer doesn't add it), matching the
+            # legacy per-occurrence behavior, then expand image tokens via the shared helper.
+            prompt_strings = [f"{self.bos_token * sample.count(self.image_token)}{sample}" for sample in text]
 
-                    image_placeholder = f"{image_start_tokens}{height}*{width}{self.fake_token_around_image}{'<placeholder>' * image_seq_length}{image_end_tokens}"
-                    sample = sample.replace(self.image_token, image_placeholder, 1)
-                    sample = f"{self.bos_token}{sample}"  # add BOS because GPT tokenizer doesn't add it
-                prompt_strings.append(sample)
-            text = [sample.replace("<placeholder>", self.image_token) for sample in prompt_strings]
+            num_images = sum(sample.count(self.image_token) for sample in text)
+            images_replacements = [self.replace_image_token(image_features, i) for i in range(num_images)]
+            text, _ = self.get_text_with_replacements(prompt_strings, images_replacements=images_replacements)
 
         # generate image from text input, so we add begin-of-image tokens from where image generation starts
         elif return_for_image_generation:
@@ -152,6 +143,20 @@ class Emu3Processor(ProcessorMixin):
         if return_mm_token_type_ids:
             text_inputs["mm_token_type_ids"] = self.create_mm_token_type_ids(text_inputs["input_ids"])
         return BatchFeature(data={**text_inputs, **image_features}, tensor_type=return_tensors)
+
+    def replace_image_token(self, image_inputs, image_idx: int) -> str:
+        image_start_tokens = f"{self.image_start_token}"
+        image_end_tokens = f"{self.eof_token}{self.image_end_token}"
+
+        height, width = image_inputs.image_sizes[image_idx]
+        height = height // self.downsample_ratio
+        width = width // self.downsample_ratio
+        image_seq_length = height * (width + 1)  # +1 for extra row when converting to BPE in modeling code
+
+        return (
+            f"{image_start_tokens}{height}*{width}{self.fake_token_around_image}"
+            f"{self.image_token * image_seq_length}{image_end_tokens}"
+        )
 
     def _get_num_multimodal_tokens(self, image_sizes=None, **kwargs):
         """

--- a/src/transformers/models/ernie4_5_vl_moe/processing_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/processing_ernie4_5_vl_moe.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os.path
+import re
 from pathlib import Path
 from shutil import SameFileError, copyfile
 
@@ -145,22 +146,28 @@ class Ernie4_5_VLMoeProcessor(ProcessorMixin):
         if images is not None:
             merge_length = self.image_processor.merge_size**2
             index = 0
-            for i in range(len(text)):
-                while self.image_token in text[i]:
-                    num_image_tokens = image_grid_thw[index].prod() // merge_length
-                    text[i] = text[i].replace(self.image_token, "<|placeholder|>" * num_image_tokens, 1)
-                    index += 1
-                text[i] = text[i].replace("<|placeholder|>", self.image_token)
+
+            def expand_image(_match):
+                nonlocal index
+                num_image_tokens = image_grid_thw[index].prod() // merge_length
+                index += 1
+                return self.image_token * num_image_tokens
+
+            pattern = re.escape(self.image_token)
+            text = [re.sub(pattern, expand_image, text_i) for text_i in text]
 
         if videos is not None:
             merge_length = self.video_processor.merge_size**2 * self.video_processor.temporal_patch_size
             index = 0
-            for i in range(len(text)):
-                while self.video_token in text[i]:
-                    num_video_tokens = video_grid_thw[index].prod() // merge_length
-                    text[i] = text[i].replace(self.video_token, "<|placeholder|>" * num_video_tokens, 1)
-                    index += 1
-                text[i] = text[i].replace("<|placeholder|>", self.video_token)
+
+            def expand_video(_match):
+                nonlocal index
+                num_video_tokens = video_grid_thw[index].prod() // merge_length
+                index += 1
+                return self.video_token * num_video_tokens
+
+            pattern = re.escape(self.video_token)
+            text = [re.sub(pattern, expand_video, text_i) for text_i in text]
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)

--- a/src/transformers/models/ernie4_5_vl_moe/processing_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/processing_ernie4_5_vl_moe.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os.path
-import re
 from pathlib import Path
 from shutil import SameFileError, copyfile
 
@@ -80,6 +79,16 @@ class Ernie4_5_VLMoeProcessor(ProcessorMixin):
 
         return super().save_pretrained(save_directory, push_to_hub, **kwargs)
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        merge_length = self.image_processor.merge_size**2
+        num_image_tokens = image_inputs["image_grid_thw"][image_idx].prod() // merge_length
+        return self.image_token * num_image_tokens
+
+    def replace_video_token(self, video_inputs: dict, video_idx: int) -> str:
+        merge_length = self.video_processor.merge_size**2 * self.video_processor.temporal_patch_size
+        num_video_tokens = video_inputs["video_grid_thw"][video_idx].prod() // merge_length
+        return self.video_token * num_video_tokens
+
     def __call__(
         self,
         images: ImageInput | None = None,
@@ -143,31 +152,15 @@ class Ernie4_5_VLMoeProcessor(ProcessorMixin):
 
         text = text.copy()  # below lines change text in-place
 
+        images_replacements = videos_replacements = []
         if images is not None:
-            merge_length = self.image_processor.merge_size**2
-            index = 0
-
-            def expand_image(_match):
-                nonlocal index
-                num_image_tokens = image_grid_thw[index].prod() // merge_length
-                index += 1
-                return self.image_token * num_image_tokens
-
-            pattern = re.escape(self.image_token)
-            text = [re.sub(pattern, expand_image, text_i) for text_i in text]
-
+            images_replacements = [self.replace_image_token(image_inputs, i) for i in range(len(image_grid_thw))]
         if videos is not None:
-            merge_length = self.video_processor.merge_size**2 * self.video_processor.temporal_patch_size
-            index = 0
-
-            def expand_video(_match):
-                nonlocal index
-                num_video_tokens = video_grid_thw[index].prod() // merge_length
-                index += 1
-                return self.video_token * num_video_tokens
-
-            pattern = re.escape(self.video_token)
-            text = [re.sub(pattern, expand_video, text_i) for text_i in text]
+            videos_replacements = [self.replace_video_token(videos_inputs, i) for i in range(len(video_grid_thw))]
+        if images is not None or videos is not None:
+            text, _ = self.get_text_with_replacements(
+                text, images_replacements=images_replacements, videos_replacements=videos_replacements
+            )
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)

--- a/src/transformers/models/florence2/modular_florence2.py
+++ b/src/transformers/models/florence2/modular_florence2.py
@@ -252,6 +252,9 @@ class Florence2Processor(ProcessorMixin):
             prompts.append(prompt)
         return prompts
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        return self.image_token * self.num_image_tokens
+
     @auto_docstring
     def __call__(
         self,
@@ -298,17 +301,16 @@ class Florence2Processor(ProcessorMixin):
 
         # Add image tokens and special tokens if images are provided
         if image_inputs.get("pixel_values") is not None:
-            # Replace the image token with the expanded image token sequence
-            expanded_image_prompts = []
-            for sample in prompt_strings:
-                sample = (
-                    self.image_token * self.num_image_tokens
-                    + self.tokenizer.bos_token
-                    + sample
-                    + self.tokenizer.eos_token
-                )
-                expanded_image_prompts.append(sample)
-            prompt_strings = expanded_image_prompts
+            # Prepend a single image placeholder (plus bos/eos wrapping), then expand it via the
+            # shared `get_text_with_replacements` helper into the full image token sequence.
+            prompt_strings = [
+                self.image_token + self.tokenizer.bos_token + sample + self.tokenizer.eos_token
+                for sample in prompt_strings
+            ]
+            images_replacements = [self.replace_image_token(image_inputs, i) for i in range(len(prompt_strings))]
+            prompt_strings, _ = self.get_text_with_replacements(
+                prompt_strings, images_replacements=images_replacements
+            )
 
         # Construct and tokenize prompts
         output_kwargs["text_kwargs"].pop("add_special_tokens", None)

--- a/src/transformers/models/florence2/processing_florence2.py
+++ b/src/transformers/models/florence2/processing_florence2.py
@@ -130,6 +130,9 @@ class Florence2Processor(ProcessorMixin):
             prompts.append(prompt)
         return prompts
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        return self.image_token * self.num_image_tokens
+
     @auto_docstring
     def __call__(
         self,
@@ -176,17 +179,16 @@ class Florence2Processor(ProcessorMixin):
 
         # Add image tokens and special tokens if images are provided
         if image_inputs.get("pixel_values") is not None:
-            # Replace the image token with the expanded image token sequence
-            expanded_image_prompts = []
-            for sample in prompt_strings:
-                sample = (
-                    self.image_token * self.num_image_tokens
-                    + self.tokenizer.bos_token
-                    + sample
-                    + self.tokenizer.eos_token
-                )
-                expanded_image_prompts.append(sample)
-            prompt_strings = expanded_image_prompts
+            # Prepend a single image placeholder (plus bos/eos wrapping), then expand it via the
+            # shared `get_text_with_replacements` helper into the full image token sequence.
+            prompt_strings = [
+                self.image_token + self.tokenizer.bos_token + sample + self.tokenizer.eos_token
+                for sample in prompt_strings
+            ]
+            images_replacements = [self.replace_image_token(image_inputs, i) for i in range(len(prompt_strings))]
+            prompt_strings, _ = self.get_text_with_replacements(
+                prompt_strings, images_replacements=images_replacements
+            )
 
         # Construct and tokenize prompts
         output_kwargs["text_kwargs"].pop("add_special_tokens", None)

--- a/src/transformers/models/gemma3/processing_gemma3.py
+++ b/src/transformers/models/gemma3/processing_gemma3.py
@@ -18,10 +18,7 @@ from ...feature_extraction_utils import BatchFeature
 from ...image_utils import ImageInput, make_nested_list_of_images
 from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
-from ...utils import auto_docstring, logging, to_py_obj
-
-
-logger = logging.get_logger(__name__)
+from ...utils import auto_docstring, to_py_obj
 
 
 class Gemma3ProcessorKwargs(ProcessingKwargs, total=False):
@@ -53,8 +50,12 @@ class Gemma3Processor(ProcessorMixin):
         **kwargs,
     ):
         self.image_seq_length = image_seq_length
-        self.image_token_id = tokenizer.image_token_id
+        # The placeholder expanded by `get_text_with_replacements` is the begin-of-image token; the
+        # repeated `<image_soft_token>` (id below) is only used to build `mm_token_type_ids`.
         self.boi_token = tokenizer.boi_token
+        self.image_token = tokenizer.boi_token
+        self.image_token_id = tokenizer.convert_tokens_to_ids(tokenizer.boi_token)
+        self.mm_image_token_id = tokenizer.image_token_id
         image_tokens_expanded = "".join([tokenizer.image_token] * image_seq_length)
         self.full_image_sequence = f"\n\n{tokenizer.boi_token}{image_tokens_expanded}{tokenizer.eoi_token}\n\n"
 
@@ -122,8 +123,10 @@ class Gemma3Processor(ProcessorMixin):
                         prompt = prompt[:idx] + formatted_image_text + prompt[idx + len(self.boi_token) :]
                         text[batch_idx] = prompt
 
-            # Expand placeholder image tokens to the full image token sequence
-            text = [prompt.replace(self.boi_token, self.full_image_sequence) for prompt in text]
+            # Expand each begin-of-image placeholder to the full image token sequence
+            num_images = sum(prompt.count(self.boi_token) for prompt in text)
+            images_replacements = [self.replace_image_token(image_inputs, i) for i in range(num_images)]
+            text, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)
@@ -133,6 +136,11 @@ class Gemma3Processor(ProcessorMixin):
         if return_mm_token_type_ids:
             text_inputs["token_type_ids"] = self.create_mm_token_type_ids(text_inputs["input_ids"])
         return BatchFeature(data={**text_inputs, **image_inputs}, tensor_type=return_tensors)
+
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        # Every begin-of-image placeholder expands to the same fixed-length sequence, so the
+        # replacement does not depend on `image_idx`.
+        return self.full_image_sequence
 
     def _get_num_multimodal_tokens(self, image_sizes=None, **kwargs):
         """
@@ -166,12 +174,10 @@ class Gemma3Processor(ProcessorMixin):
         return ["num_crops"]
 
     @property
-    def image_token(self) -> list[str]:
-        logger.warning_once(
-            "Deprecated: `processor.image_token` will switch from returning "
-            "`tokenizer.image_token` to `tokenizer.boi_token` in v5.11."
-        )
-        return self.tokenizer.image_token
+    def image_token_ids(self) -> list[int | None]:
+        # `mm_token_type_ids` must mark the repeated `<image_soft_token>` positions, not the
+        # begin-of-image placeholder that `image_token_id` now points to.
+        return [self.mm_image_token_id]
 
 
 __all__ = ["Gemma3Processor"]

--- a/src/transformers/models/glm_image/modular_glm_image.py
+++ b/src/transformers/models/glm_image/modular_glm_image.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+import re
 import warnings
 from collections.abc import Callable
 from typing import Any
@@ -1346,13 +1347,16 @@ class GlmImageProcessor(ProcessorMixin):
         # Replace image tokens with the correct number of placeholder tokens
         if not is_text_to_image:
             index = 0
-            for i in range(batch_size):
-                while self.image_token in text[i]:
-                    grid = image_grid_thw[index]
-                    num_image_tokens = int(grid[1] * grid[2])
-                    text[i] = text[i].replace(self.image_token, "<|placeholder|>" * num_image_tokens, 1)
-                    index += 1
-                text[i] = text[i].replace("<|placeholder|>", self.image_token)
+
+            def expand(_match):
+                nonlocal index
+                grid = image_grid_thw[index]
+                num_image_tokens = int(grid[1] * grid[2])
+                index += 1
+                return self.image_token * num_image_tokens
+
+            pattern = re.escape(self.image_token)
+            text = [re.sub(pattern, expand, text_i) for text_i in text]
 
         # Build prompt with target shape and combine grids in a single loop
         # Format: [sample0_source_grids..., sample0_target_grids, sample1_source_grids..., sample1_target_grids, ...]

--- a/src/transformers/models/glm_image/modular_glm_image.py
+++ b/src/transformers/models/glm_image/modular_glm_image.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-import re
 import warnings
 from collections.abc import Callable
 from typing import Any
@@ -1276,6 +1275,11 @@ class GlmImageProcessor(ProcessorMixin):
         self.image_token_id = tokenizer.convert_tokens_to_ids(self.image_token)
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        grid = image_inputs["image_grid_thw"][image_idx]
+        num_image_tokens = int(grid[1] * grid[2])
+        return self.image_token * num_image_tokens
+
     def __call__(
         self,
         images: ImageInput | None = None,
@@ -1346,17 +1350,8 @@ class GlmImageProcessor(ProcessorMixin):
 
         # Replace image tokens with the correct number of placeholder tokens
         if not is_text_to_image:
-            index = 0
-
-            def expand(_match):
-                nonlocal index
-                grid = image_grid_thw[index]
-                num_image_tokens = int(grid[1] * grid[2])
-                index += 1
-                return self.image_token * num_image_tokens
-
-            pattern = re.escape(self.image_token)
-            text = [re.sub(pattern, expand, text_i) for text_i in text]
+            images_replacements = [self.replace_image_token(image_inputs, i) for i in range(len(image_grid_thw))]
+            text, _ = self.get_text_with_replacements(text, images_replacements=images_replacements)
 
         # Build prompt with target shape and combine grids in a single loop
         # Format: [sample0_source_grids..., sample0_target_grids, sample1_source_grids..., sample1_target_grids, ...]

--- a/src/transformers/models/glm_image/processing_glm_image.py
+++ b/src/transformers/models/glm_image/processing_glm_image.py
@@ -19,7 +19,6 @@
 # limitations under the License.
 
 import math
-import re
 
 import torch
 
@@ -79,6 +78,11 @@ class GlmImageProcessor(ProcessorMixin):
         self.bos_token = tokenizer.bos_token
         self.image_token_id = tokenizer.convert_tokens_to_ids(self.image_token)
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
+
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        grid = image_inputs["image_grid_thw"][image_idx]
+        num_image_tokens = int(grid[1] * grid[2])
+        return self.image_token * num_image_tokens
 
     def __call__(
         self,
@@ -150,17 +154,8 @@ class GlmImageProcessor(ProcessorMixin):
 
         # Replace image tokens with the correct number of placeholder tokens
         if not is_text_to_image:
-            index = 0
-
-            def expand(_match):
-                nonlocal index
-                grid = image_grid_thw[index]
-                num_image_tokens = int(grid[1] * grid[2])
-                index += 1
-                return self.image_token * num_image_tokens
-
-            pattern = re.escape(self.image_token)
-            text = [re.sub(pattern, expand, text_i) for text_i in text]
+            images_replacements = [self.replace_image_token(image_inputs, i) for i in range(len(image_grid_thw))]
+            text, _ = self.get_text_with_replacements(text, images_replacements=images_replacements)
 
         # Build prompt with target shape and combine grids in a single loop
         # Format: [sample0_source_grids..., sample0_target_grids, sample1_source_grids..., sample1_target_grids, ...]

--- a/src/transformers/models/glm_image/processing_glm_image.py
+++ b/src/transformers/models/glm_image/processing_glm_image.py
@@ -19,6 +19,7 @@
 # limitations under the License.
 
 import math
+import re
 
 import torch
 
@@ -150,13 +151,16 @@ class GlmImageProcessor(ProcessorMixin):
         # Replace image tokens with the correct number of placeholder tokens
         if not is_text_to_image:
             index = 0
-            for i in range(batch_size):
-                while self.image_token in text[i]:
-                    grid = image_grid_thw[index]
-                    num_image_tokens = int(grid[1] * grid[2])
-                    text[i] = text[i].replace(self.image_token, "<|placeholder|>" * num_image_tokens, 1)
-                    index += 1
-                text[i] = text[i].replace("<|placeholder|>", self.image_token)
+
+            def expand(_match):
+                nonlocal index
+                grid = image_grid_thw[index]
+                num_image_tokens = int(grid[1] * grid[2])
+                index += 1
+                return self.image_token * num_image_tokens
+
+            pattern = re.escape(self.image_token)
+            text = [re.sub(pattern, expand, text_i) for text_i in text]
 
         # Build prompt with target shape and combine grids in a single loop
         # Format: [sample0_source_grids..., sample0_target_grids, sample1_source_grids..., sample1_target_grids, ...]

--- a/src/transformers/models/granite4_vision/processing_granite4_vision.py
+++ b/src/transformers/models/granite4_vision/processing_granite4_vision.py
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from fractions import Fraction
 
 from ...feature_extraction_utils import BatchFeature
@@ -119,20 +120,19 @@ class Granite4VisionProcessor(ProcessorMixin):
         if image_inputs:
             image_sizes = iter(image_inputs["image_sizes"])
             height, width = get_image_size(to_numpy_array(image_inputs["pixel_values"][0][0]))
-            prompt_strings = []
-            for sample in text:
-                while self.image_token in sample:
-                    image_size = next(image_sizes)
-                    if not isinstance(image_size, (list, tuple)):
-                        # cast to list to avoid numerical precision errors when calculating unpadding
-                        image_size = image_size.tolist()
-                    orig_height, orig_width = image_size
-                    num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
-                    if self.vision_feature_select_strategy == "default":
-                        num_image_tokens -= 1
-                    sample = sample.replace(self.image_token, "<placeholder>" * num_image_tokens, 1)
-                prompt_strings.append(sample)
-            prompt_strings = [sample.replace("<placeholder>", self.image_token) for sample in prompt_strings]
+            def expand(_match):
+                image_size = next(image_sizes)
+                if not isinstance(image_size, (list, tuple)):
+                    # cast to list to avoid numerical precision errors when calculating unpadding
+                    image_size = image_size.tolist()
+                orig_height, orig_width = image_size
+                num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
+                if self.vision_feature_select_strategy == "default":
+                    num_image_tokens -= 1
+                return self.image_token * num_image_tokens
+
+            pattern = re.escape(self.image_token)
+            prompt_strings = [re.sub(pattern, expand, sample) for sample in text]
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", None)

--- a/src/transformers/models/granite4_vision/processing_granite4_vision.py
+++ b/src/transformers/models/granite4_vision/processing_granite4_vision.py
@@ -18,7 +18,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 from fractions import Fraction
 
 from ...feature_extraction_utils import BatchFeature
@@ -81,6 +80,18 @@ class Granite4VisionProcessor(ProcessorMixin):
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
         self.downsample_rate = downsample_rate
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        height, width = get_image_size(to_numpy_array(image_inputs["pixel_values"][0][0]))
+        image_size = image_inputs["image_sizes"][image_idx]
+        if not isinstance(image_size, (list, tuple)):
+            # cast to list to avoid numerical precision errors when calculating unpadding
+            image_size = image_size.tolist()
+        orig_height, orig_width = image_size
+        num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
+        if self.vision_feature_select_strategy == "default":
+            num_image_tokens -= 1
+        return self.image_token * num_image_tokens
+
     @auto_docstring
     def __call__(
         self,
@@ -118,22 +129,11 @@ class Granite4VisionProcessor(ProcessorMixin):
 
         prompt_strings = text
         if image_inputs:
-            image_sizes = iter(image_inputs["image_sizes"])
-            height, width = get_image_size(to_numpy_array(image_inputs["pixel_values"][0][0]))
-
-            def expand(_match):
-                image_size = next(image_sizes)
-                if not isinstance(image_size, (list, tuple)):
-                    # cast to list to avoid numerical precision errors when calculating unpadding
-                    image_size = image_size.tolist()
-                orig_height, orig_width = image_size
-                num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
-                if self.vision_feature_select_strategy == "default":
-                    num_image_tokens -= 1
-                return self.image_token * num_image_tokens
-
-            pattern = re.escape(self.image_token)
-            prompt_strings = [re.sub(pattern, expand, sample) for sample in text]
+            images_replacements = [
+                self.replace_image_token(image_inputs, i) for i in range(len(image_inputs["image_sizes"]))
+            ]
+            # `get_text_with_replacements` mutates the list in place, so copy to avoid editing the caller's input
+            prompt_strings, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", None)

--- a/src/transformers/models/granite4_vision/processing_granite4_vision.py
+++ b/src/transformers/models/granite4_vision/processing_granite4_vision.py
@@ -120,6 +120,7 @@ class Granite4VisionProcessor(ProcessorMixin):
         if image_inputs:
             image_sizes = iter(image_inputs["image_sizes"])
             height, width = get_image_size(to_numpy_array(image_inputs["pixel_values"][0][0]))
+
             def expand(_match):
                 image_size = next(image_sizes)
                 if not isinstance(image_size, (list, tuple)):

--- a/src/transformers/models/granite_speech/processing_granite_speech.py
+++ b/src/transformers/models/granite_speech/processing_granite_speech.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Processor class for Granite Speech."""
 
+import re
 from typing import Union
 
 from ...feature_extraction_utils import BatchFeature
@@ -73,19 +74,16 @@ class GraniteSpeechProcessor(ProcessorMixin):
 
             # Expand the audio placeholders to match the feature dims; this
             # is similar to how many VLMs handle image tokens, e.g., llava next
-            prompt_strings = []
             num_replaced = 0
-            for sample in text:
-                while self.audio_token in sample:
-                    sample = sample.replace(
-                        self.audio_token,
-                        "<placeholder>" * audio_embed_sizes[num_replaced],
-                        1,
-                    )
-                    num_replaced += 1
-                prompt_strings.append(sample)
 
-            prompt_strings = [sample.replace("<placeholder>", self.audio_token) for sample in prompt_strings]
+            def expand(_match):
+                nonlocal num_replaced
+                num_tokens = audio_embed_sizes[num_replaced]
+                num_replaced += 1
+                return self.audio_token * num_tokens
+
+            pattern = re.escape(self.audio_token)
+            prompt_strings = [re.sub(pattern, expand, sample) for sample in text]
         else:
             audio_inputs = {}
 

--- a/src/transformers/models/granite_speech/processing_granite_speech.py
+++ b/src/transformers/models/granite_speech/processing_granite_speech.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Processor class for Granite Speech."""
 
-import re
 from typing import Union
 
 from ...feature_extraction_utils import BatchFeature
@@ -47,6 +46,9 @@ class GraniteSpeechProcessor(ProcessorMixin):
         self.audio_token = tokenizer.audio_token if hasattr(tokenizer, "audio_token") else audio_token
         super().__init__(audio_processor, tokenizer, chat_template=chat_template)
 
+    def replace_audio_token(self, audio_inputs: dict, audio_idx: int) -> str:
+        return self.audio_token * audio_inputs["audio_embed_sizes"][audio_idx]
+
     @auto_docstring
     def __call__(
         self,
@@ -70,20 +72,14 @@ class GraniteSpeechProcessor(ProcessorMixin):
             # TODO (@alex-jw-brooks); we should add a util to get_num_audio_tokens
             # from feature lengths and call it here, rather than returning it
             # from the feature extractor.
-            audio_embed_sizes = audio_inputs.pop("audio_embed_sizes")
-
             # Expand the audio placeholders to match the feature dims; this
             # is similar to how many VLMs handle image tokens, e.g., llava next
-            num_replaced = 0
-
-            def expand(_match):
-                nonlocal num_replaced
-                num_tokens = audio_embed_sizes[num_replaced]
-                num_replaced += 1
-                return self.audio_token * num_tokens
-
-            pattern = re.escape(self.audio_token)
-            prompt_strings = [re.sub(pattern, expand, sample) for sample in text]
+            audio_replacements = [
+                self.replace_audio_token(audio_inputs, i) for i in range(len(audio_inputs["audio_embed_sizes"]))
+            ]
+            audio_inputs.pop("audio_embed_sizes")
+            # `get_text_with_replacements` mutates the list in place, so copy to avoid editing the caller's input
+            prompt_strings, _ = self.get_text_with_replacements(list(text), audio_replacements=audio_replacements)
         else:
             audio_inputs = {}
 

--- a/src/transformers/models/higgs_audio_v2/processing_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/processing_higgs_audio_v2.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 from itertools import islice
 from pathlib import Path
 
@@ -185,13 +184,11 @@ class HiggsAudioV2Processor(ProcessorMixin):
                 audio_input_ids = self.build_delay_pattern(audio_input_ids)
                 audio_input_ids_list.append(audio_input_ids[0].transpose(0, 1))
 
-            # expand audio tokens in text
-            num_audio_tokens_iter = iter(len(audio_input_ids) for audio_input_ids in audio_input_ids_list)
-            for i in range(len(text)):
-                expanded = re.sub(
-                    re.escape(self.audio_token), lambda _: self.get_audio_tokens(next(num_audio_tokens_iter)), text[i]
-                )
-                text[i] = expanded
+            # expand audio tokens in text, one replacement per audio token in document order
+            audio_replacements = [
+                self.get_audio_tokens(len(audio_input_ids)) for audio_input_ids in audio_input_ids_list
+            ]
+            text, _ = self.get_text_with_replacements(list(text), audio_replacements=audio_replacements)
 
             # convert to nested list according to n_audio_in_text
             # [audio_1, audio_2, ...] -> [[audio_1_1, audio_1_2, ...], [audio_2_1, audio_2_2, ...], ...]

--- a/src/transformers/models/internvl/processing_internvl.py
+++ b/src/transformers/models/internvl/processing_internvl.py
@@ -86,9 +86,9 @@ class InternVLProcessor(ProcessorMixin):
         """
         image_index = 0
         video_index = 0
-        processed_text = []
         image_video_patches = []
-        replace_strings = []
+        images_replacements = []
+        videos_replacements = []
         # Support interleaved image and video in prompts:
         # Processed patches of images and videos are inserted in `image_video_patches` in the order they appear in the prompts
         for prompt in text:
@@ -102,11 +102,11 @@ class InternVLProcessor(ProcessorMixin):
                     start_index = image_num_patches_indices[image_index - 1] if image_index > 0 else 0
                     end_index = image_num_patches_indices[image_index]
                     image_video_patches.append(image_pixel_values[start_index:end_index])
-                    # Replace the corresponding image placeholder with the correct number of image tokens
-                    new_prompt = new_prompt.replace(self.image_token, "<placeholder>", 1)
-                    replace_strings.append(
+                    # Build the replacement string with the correct number of image tokens
+                    images_replacements.append(
                         f"{self.start_image_token}{self.image_token * self.image_seq_length * image_num_patches[image_index]}{self.end_image_token}"
                     )
+                    new_prompt = new_prompt.replace(self.image_token, "", 1)
                     image_index += 1
                 else:
                     # Get the slice of patches corresponding to the current video
@@ -117,19 +117,19 @@ class InternVLProcessor(ProcessorMixin):
                     start_index = video_num_patches_indices[current_patch_index]
                     end_index = video_num_patches_indices[end_patch_index]
                     image_video_patches.append(video_pixel_values[start_index:end_index])
-                    # Get the number of patches per frame and replace the video placeholder with the correct number of image tokens
+                    # Get the number of patches per frame and build the replacement string with the correct number of image tokens
                     num_patches = list(video_num_patches[current_patch_index:end_patch_index])
                     video_prompt = "\n".join(
                         f"Frame{i + 1}: {self.start_image_token}{self.image_token * self.image_seq_length * num_patches[i]}{self.end_image_token}"
                         for i in range(len(num_patches))
                     )
-                    replace_strings.append(video_prompt)
-                    new_prompt = new_prompt.replace(self.video_token, "<placeholder>", 1)
+                    videos_replacements.append(video_prompt)
+                    new_prompt = new_prompt.replace(self.video_token, "", 1)
                     video_index += 1
-            while "<placeholder>" in new_prompt:
-                replace_str = replace_strings.pop(0)
-                new_prompt = new_prompt.replace("<placeholder>", replace_str, 1)
-            processed_text.append(new_prompt)
+
+        processed_text, _ = self.get_text_with_replacements(
+            list(text), images_replacements=images_replacements, videos_replacements=videos_replacements
+        )
 
         return processed_text, image_video_patches, image_index, video_index
 

--- a/src/transformers/models/kosmos2/processing_kosmos2.py
+++ b/src/transformers/models/kosmos2/processing_kosmos2.py
@@ -97,6 +97,10 @@ class Kosmos2Processor(ProcessorMixin):
         self.boi_token = "<image>"
         self.eoi_token = "</image>"
 
+        # The (fake) `<image>` token is used as the multimodal placeholder that the centralized
+        # `get_text_with_replacements` API expands into the full image subsequence.
+        self.image_token = self.boi_token
+
         self.eoc_token = "</chunk>"
         self.eol_token = "</line>"
 
@@ -310,11 +314,18 @@ class Kosmos2Processor(ProcessorMixin):
                         "batches or both for a single example."
                     )
 
-    def _preprocess_single_example(self, text, image, bboxes, img_info_tokens):
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        """Return the full image subsequence `<image> ... (fake) image tokens ... </image>` that the
+        single `<image>` placeholder is expanded into for one image."""
+        img_tokens = [self.boi_token] * self.num_image_tokens
+        return " ".join([self.boi_token] + img_tokens + [self.eoi_token])
+
+    def _preprocess_single_example(self, text, image, bboxes):
         text = text.strip()
         if image is not None:
-            # Add `<image> ... (fake) image tokens ... </image>`
-            text = f"{img_info_tokens} {text}"
+            # Prepend a single `<image>` placeholder; it is later expanded into the full image
+            # subsequence by `get_text_with_replacements`.
+            text = f"{self.boi_token} {text}"
 
         # Add `<object> <patch_idx_xxxx> <patch_idx_yyy> </object>` after `<phrase> phrase text </phrase>`
         text = self._insert_patch_index_tokens(text, bboxes)
@@ -341,9 +352,9 @@ class Kosmos2Processor(ProcessorMixin):
         Returns:
             `Union[TextInput, list[TextInput]]`: The processed texts with image and patch index tokens.
         """
-        # These are fake `<image>` tokens enclosed between (the actual) `<image>` token and `</image>`.
-        img_tokens = [self.boi_token] * num_image_tokens
-        img_info_tokens = " ".join([self.boi_token] + img_tokens + [self.eoi_token])
+        # Used by `replace_image_token` to build the (fake) `<image>` subsequence enclosed between
+        # (the actual) `<image>` token and `</image>`.
+        self.num_image_tokens = num_image_tokens
 
         # make batch to simplify processing logic
         batched = True
@@ -377,9 +388,16 @@ class Kosmos2Processor(ProcessorMixin):
             )
 
         result = [
-            self._preprocess_single_example(text, image, bbox, img_info_tokens)
-            for text, image, bbox in zip(texts, images, bboxes)
+            self._preprocess_single_example(text, image, bbox) for text, image, bbox in zip(texts, images, bboxes)
         ]
+
+        # Expand the single `<image>` placeholder of each example with an image into the full image
+        # subsequence via the centralized token-expansion API (one replacement per image, in order).
+        images_replacements = [
+            self.replace_image_token(None, image_idx=idx) for idx, image in enumerate(images) if image is not None
+        ]
+        result, _ = self.get_text_with_replacements(result, images_replacements=images_replacements)
+
         # un-batch if necessary
         if not batched:
             result = result[0]

--- a/src/transformers/models/lighton_ocr/modular_lighton_ocr.py
+++ b/src/transformers/models/lighton_ocr/modular_lighton_ocr.py
@@ -157,6 +157,13 @@ class LightOnOcrProcessor(ProcessorMixin):
     def image_token_ids(self) -> list[int]:
         return [self.image_token_id, self.image_break_token_id, self.image_end_token_id]
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        image_height, image_width = image_inputs["image_sizes"][image_idx]
+        num_height_tokens = image_height // self.effective_patch_size
+        num_width_tokens = image_width // self.effective_patch_size
+        num_patches = num_height_tokens * num_width_tokens
+        return self.image_token * num_patches
+
     def __call__(
         self,
         images: ImageInput | None = None,
@@ -182,28 +189,9 @@ class LightOnOcrProcessor(ProcessorMixin):
             raise TypeError("Invalid input text. Please provide a string, or a list of strings")
 
         if image_inputs.get("pixel_values") is not None:
-            image_sizes_iter = iter(image_inputs["image_sizes"])
-            prompt_strings = []
-
-            for sample in text:
-                replace_strings = []
-
-                while self.image_token in sample:
-                    image_height, image_width = next(image_sizes_iter)
-                    num_height_tokens = image_height // self.effective_patch_size
-                    num_width_tokens = image_width // self.effective_patch_size
-                    num_patches = num_height_tokens * num_width_tokens
-
-                    replace_str = self.image_token * num_patches
-                    replace_strings.append(replace_str)
-
-                    sample = sample.replace(self.image_token, "<placeholder>", 1)
-
-                while "<placeholder>" in sample:
-                    replace_str = replace_strings.pop(0)
-                    sample = sample.replace("<placeholder>", replace_str, 1)
-
-                prompt_strings.append(sample)
+            num_images = len(image_inputs["image_sizes"])
+            images_replacements = [self.replace_image_token(image_inputs, i) for i in range(num_images)]
+            prompt_strings, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
         else:
             prompt_strings = text
 

--- a/src/transformers/models/lighton_ocr/processing_lighton_ocr.py
+++ b/src/transformers/models/lighton_ocr/processing_lighton_ocr.py
@@ -129,6 +129,13 @@ class LightOnOcrProcessor(ProcessorMixin):
     def image_token_ids(self) -> list[int]:
         return [self.image_token_id, self.image_break_token_id, self.image_end_token_id]
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        image_height, image_width = image_inputs["image_sizes"][image_idx]
+        num_height_tokens = image_height // self.effective_patch_size
+        num_width_tokens = image_width // self.effective_patch_size
+        num_patches = num_height_tokens * num_width_tokens
+        return self.image_token * num_patches
+
     def __call__(
         self,
         images: ImageInput | None = None,
@@ -154,28 +161,9 @@ class LightOnOcrProcessor(ProcessorMixin):
             raise TypeError("Invalid input text. Please provide a string, or a list of strings")
 
         if image_inputs.get("pixel_values") is not None:
-            image_sizes_iter = iter(image_inputs["image_sizes"])
-            prompt_strings = []
-
-            for sample in text:
-                replace_strings = []
-
-                while self.image_token in sample:
-                    image_height, image_width = next(image_sizes_iter)
-                    num_height_tokens = image_height // self.effective_patch_size
-                    num_width_tokens = image_width // self.effective_patch_size
-                    num_patches = num_height_tokens * num_width_tokens
-
-                    replace_str = self.image_token * num_patches
-                    replace_strings.append(replace_str)
-
-                    sample = sample.replace(self.image_token, "<placeholder>", 1)
-
-                while "<placeholder>" in sample:
-                    replace_str = replace_strings.pop(0)
-                    sample = sample.replace("<placeholder>", replace_str, 1)
-
-                prompt_strings.append(sample)
+            num_images = len(image_inputs["image_sizes"])
+            images_replacements = [self.replace_image_token(image_inputs, i) for i in range(num_images)]
+            prompt_strings, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
         else:
             prompt_strings = text
 

--- a/src/transformers/models/llava_next/processing_llava_next.py
+++ b/src/transformers/models/llava_next/processing_llava_next.py
@@ -15,6 +15,8 @@
 Processor class for LLaVa-NeXT.
 """
 
+import re
+
 from ...feature_extraction_utils import BatchFeature
 from ...image_processing_utils import select_best_resolution
 from ...image_utils import ImageInput, SizeDict, get_image_size, to_numpy_array
@@ -118,20 +120,20 @@ class LlavaNextProcessor(ProcessorMixin):
         if image_inputs:
             image_sizes = iter(image_inputs["image_sizes"])
             height, width = get_image_size(to_numpy_array(image_inputs["pixel_values"][0][0]))
-            prompt_strings = []
-            for sample in text:
-                while self.image_token in sample:
-                    image_size = next(image_sizes)
-                    if not isinstance(image_size, (list, tuple)):
-                        # cast to list to avoid numerical precision errors when calculating unpadding
-                        image_size = image_size.tolist()
-                    orig_height, orig_width = image_size
-                    num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
-                    if self.vision_feature_select_strategy == "default":
-                        num_image_tokens -= 1
-                    sample = sample.replace(self.image_token, "<placeholder>" * num_image_tokens, 1)
-                prompt_strings.append(sample)
-            prompt_strings = [sample.replace("<placeholder>", self.image_token) for sample in prompt_strings]
+
+            def expand(_match):
+                image_size = next(image_sizes)
+                if not isinstance(image_size, (list, tuple)):
+                    # cast to list to avoid numerical precision errors when calculating unpadding
+                    image_size = image_size.tolist()
+                orig_height, orig_width = image_size
+                num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
+                if self.vision_feature_select_strategy == "default":
+                    num_image_tokens -= 1
+                return self.image_token * num_image_tokens
+
+            pattern = re.escape(self.image_token)
+            prompt_strings = [re.sub(pattern, expand, sample) for sample in text]
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", None)

--- a/src/transformers/models/llava_next/processing_llava_next.py
+++ b/src/transformers/models/llava_next/processing_llava_next.py
@@ -15,8 +15,6 @@
 Processor class for LLaVa-NeXT.
 """
 
-import re
-
 from ...feature_extraction_utils import BatchFeature
 from ...image_processing_utils import select_best_resolution
 from ...image_utils import ImageInput, SizeDict, get_image_size, to_numpy_array
@@ -81,6 +79,18 @@ class LlavaNextProcessor(ProcessorMixin):
         )
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        height, width = get_image_size(to_numpy_array(image_inputs["pixel_values"][0][0]))
+        image_size = image_inputs["image_sizes"][image_idx]
+        if not isinstance(image_size, (list, tuple)):
+            # cast to list to avoid numerical precision errors when calculating unpadding
+            image_size = image_size.tolist()
+        orig_height, orig_width = image_size
+        num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
+        if self.vision_feature_select_strategy == "default":
+            num_image_tokens -= 1
+        return self.image_token * num_image_tokens
+
     @auto_docstring
     def __call__(
         self,
@@ -118,22 +128,11 @@ class LlavaNextProcessor(ProcessorMixin):
 
         prompt_strings = text
         if image_inputs:
-            image_sizes = iter(image_inputs["image_sizes"])
-            height, width = get_image_size(to_numpy_array(image_inputs["pixel_values"][0][0]))
-
-            def expand(_match):
-                image_size = next(image_sizes)
-                if not isinstance(image_size, (list, tuple)):
-                    # cast to list to avoid numerical precision errors when calculating unpadding
-                    image_size = image_size.tolist()
-                orig_height, orig_width = image_size
-                num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
-                if self.vision_feature_select_strategy == "default":
-                    num_image_tokens -= 1
-                return self.image_token * num_image_tokens
-
-            pattern = re.escape(self.image_token)
-            prompt_strings = [re.sub(pattern, expand, sample) for sample in text]
+            images_replacements = [
+                self.replace_image_token(image_inputs, i) for i in range(len(image_inputs["image_sizes"]))
+            ]
+            # `get_text_with_replacements` mutates the list in place, so copy to avoid editing the caller's input
+            prompt_strings, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", None)

--- a/src/transformers/models/llava_onevision/processing_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/processing_llava_onevision.py
@@ -16,7 +16,6 @@ Processor class for LLaVa-Onevision.
 """
 
 import math
-import re
 from collections.abc import Iterable
 
 import numpy as np
@@ -169,18 +168,14 @@ class LlavaOnevisionProcessor(ProcessorMixin):
         special_token: str,
         batch_num_images: Iterable[int],
     ):
-        prompt_strings = []
+        images_replacements = []
         max_num_vision_tokens = 0
-        pattern = re.escape(special_token)
         for sample in text:
-            if special_token in sample:
-                num_images = next(batch_num_images)  # should consume iterable
-                is_multi_image = num_images != 1
-            else:
-                is_multi_image = False
-
-            def expand(_match, is_multi_image=is_multi_image):
-                nonlocal max_num_vision_tokens
+            if special_token not in sample:
+                continue
+            num_images = next(batch_num_images)  # should consume iterable
+            is_multi_image = num_images != 1
+            for _ in range(sample.count(special_token)):
                 original_size = next(image_sizes)  # should consume iterable
                 if is_multi_image:
                     num_image_tokens = self.num_image_tokens + 1  # one for image_newline
@@ -193,10 +188,9 @@ class LlavaOnevisionProcessor(ProcessorMixin):
                 max_num_vision_tokens = max(max_num_vision_tokens, num_image_tokens)
                 if self.vision_feature_select_strategy == "default":
                     num_image_tokens -= 1
-                return special_token * num_image_tokens
-
-            prompt_strings.append(re.sub(pattern, expand, sample))
-        text = prompt_strings
+                images_replacements.append(special_token * num_image_tokens)
+        # `get_text_with_replacements` mutates the list in place, so copy to avoid editing the caller's input
+        text, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
         return text, max_num_vision_tokens
 
     def _get_number_of_features(self, orig_height: int, orig_width: int, height: int, width: int) -> int:

--- a/src/transformers/models/llava_onevision/processing_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/processing_llava_onevision.py
@@ -16,6 +16,7 @@ Processor class for LLaVa-Onevision.
 """
 
 import math
+import re
 from collections.abc import Iterable
 
 import numpy as np
@@ -170,13 +171,16 @@ class LlavaOnevisionProcessor(ProcessorMixin):
     ):
         prompt_strings = []
         max_num_vision_tokens = 0
+        pattern = re.escape(special_token)
         for sample in text:
             if special_token in sample:
                 num_images = next(batch_num_images)  # should consume iterable
                 is_multi_image = num_images != 1
             else:
                 is_multi_image = False
-            while special_token in sample:
+
+            def expand(_match, is_multi_image=is_multi_image):
+                nonlocal max_num_vision_tokens
                 original_size = next(image_sizes)  # should consume iterable
                 if is_multi_image:
                     num_image_tokens = self.num_image_tokens + 1  # one for image_newline
@@ -189,9 +193,10 @@ class LlavaOnevisionProcessor(ProcessorMixin):
                 max_num_vision_tokens = max(max_num_vision_tokens, num_image_tokens)
                 if self.vision_feature_select_strategy == "default":
                     num_image_tokens -= 1
-                sample = sample.replace(special_token, "<placeholder>" * num_image_tokens, 1)
-            prompt_strings.append(sample)
-        text = [sample.replace("<placeholder>", special_token) for sample in prompt_strings]
+                return special_token * num_image_tokens
+
+            prompt_strings.append(re.sub(pattern, expand, sample))
+        text = prompt_strings
         return text, max_num_vision_tokens
 
     def _get_number_of_features(self, orig_height: int, orig_width: int, height: int, width: int) -> int:

--- a/src/transformers/models/minicpmv4_6/processing_minicpmv4_6.py
+++ b/src/transformers/models/minicpmv4_6/processing_minicpmv4_6.py
@@ -57,6 +57,79 @@ class MiniCPMV4_6Processor(ProcessorMixin):
         self.image_id_start_token = tokenizer.image_id_start_token
         self.image_id_end_token = tokenizer.image_id_end_token
 
+    def replace_image_token(self, image_inputs, image_idx):
+        """
+        Build the full structured placeholder block for the `image_idx`-th image, using
+        `self.image_token` directly as the inner repeated token. Per-item data (number of
+        patches, target sizes, grid rows/cols) is pulled from the processed `image_inputs`,
+        indexed by `image_idx`.
+        """
+        num_patches_per_image = image_inputs["num_patches_per_image"]
+        target_sizes = image_inputs["target_sizes"]
+        image_grids = image_inputs["grids"]
+        image_token_divisor = image_inputs["image_token_divisor"]
+
+        flat_index = int(sum(num_patches_per_image[:image_idx]))
+        n_patches = num_patches_per_image[image_idx]
+        img_target_sizes = target_sizes[flat_index : flat_index + n_patches]
+        num_tokens_per_patch = img_target_sizes.prod(-1) // image_token_divisor
+        num_rows, num_cols = image_grids[image_idx]
+
+        image_placeholder = (
+            self.image_start_token + self.image_token * int(num_tokens_per_patch[0]) + self.image_end_token
+        )
+
+        if self.slice_mode and num_rows > 0 and num_cols > 0:
+            per_slice_tokens = int(num_tokens_per_patch[1]) if len(num_tokens_per_patch) > 1 else 0
+            slice_placeholder = self.slice_start_token + self.image_token * per_slice_tokens + self.slice_end_token
+            slices = [slice_placeholder * num_cols for _ in range(num_rows)]
+            image_placeholder += "\n".join(slices)
+
+        return image_placeholder
+
+    def replace_video_token(self, video_inputs, video_idx):
+        """
+        Build the full structured placeholder block for the `video_idx`-th video, using
+        `self.video_token` directly as the inner repeated token. The original code repeated a
+        `<|placeholder|>` sentinel inside the image-style scaffolding and converted it back to
+        `self.video_token`, so the body is made of video tokens. Per-item data (frame counts,
+        per-frame patches, target sizes, grids) is pulled from the processed `video_inputs`,
+        indexed by `video_idx`.
+        """
+        video_target_sizes = video_inputs["target_sizes_videos"]
+        num_frames_per_video = video_inputs["num_frames_per_video"]
+        video_grids = video_inputs["grids_videos"]
+        num_patches_per_frame = video_inputs["num_patches_per_frame"]
+        video_token_divisor = video_inputs["video_token_divisor"]
+
+        frame_offset = int(sum(num_frames_per_video[:video_idx]))
+        flat_index = int(sum(num_patches_per_frame[:frame_offset]))
+        num_frames = num_frames_per_video[video_idx]
+
+        video_placeholder = ""
+        for f in range(num_frames):
+            gf = frame_offset + f
+            n_patches = num_patches_per_frame[gf]
+            frame_ts = video_target_sizes[flat_index : flat_index + n_patches]
+            frame_tokens = frame_ts.prod(-1) // video_token_divisor
+            grid_rows, grid_cols = video_grids[gf]
+
+            if len(frame_tokens) == 0:
+                flat_index += n_patches
+                continue
+
+            frame_placeholder = self.image_start_token + self.video_token * int(frame_tokens[0]) + self.image_end_token
+            if self.slice_mode and grid_rows > 0 and grid_cols > 0:
+                per_slice_tokens = int(frame_tokens[1]) if len(frame_tokens) > 1 else 0
+                slice_placeholder = self.slice_start_token + self.video_token * per_slice_tokens + self.slice_end_token
+                slices = [slice_placeholder * grid_cols for _ in range(grid_rows)]
+                frame_placeholder += "\n".join(slices)
+
+            video_placeholder += frame_placeholder
+            flat_index += n_patches
+
+        return video_placeholder
+
     @auto_docstring
     def __call__(
         self,
@@ -94,105 +167,71 @@ class MiniCPMV4_6Processor(ProcessorMixin):
         image_token_divisor = 4 if img_downsample == "4x" else 16
 
         image_inputs = {}
+        images_replacements = []
         if images is not None:
             image_inputs = self.image_processor(images, **output_kwargs["images_kwargs"])
+            # Stash the runtime divisor so `replace_image_token` can index everything by image idx.
+            image_inputs["image_token_divisor"] = image_token_divisor
 
-            image_grids = image_inputs.pop("grids")
-            num_patches_per_image = image_inputs.pop("num_patches_per_image")
-            target_sizes = image_inputs["target_sizes"]
-
-            flat_index = 0
+            # Build replacements in the order the placeholder tokens appear across the batch, so they
+            # are consumed in-order by `get_text_with_replacements`. The `use_image_id` prefix uses a
+            # per-sample (local) index, so it is assembled here where we iterate the text samples.
             global_image_index = 0
-            for i in range(len(text)):
+            for sample in text:
                 local_image_index = 0
-                while self.image_token in text[i]:
-                    n_patches = num_patches_per_image[global_image_index]
-                    img_target_sizes = target_sizes[flat_index : flat_index + n_patches]
-                    num_tokens_per_patch = img_target_sizes.prod(-1) // image_token_divisor
-                    num_rows, num_cols = image_grids[global_image_index]
-
-                    image_placeholder = (
-                        self.image_start_token
-                        + "<|placeholder|>" * int(num_tokens_per_patch[0])
-                        + self.image_end_token
-                    )
+                num_image_tokens = sample.count(self.image_token)
+                for _ in range(num_image_tokens):
+                    image_placeholder = self.replace_image_token(image_inputs, global_image_index)
                     if use_image_id:
                         image_placeholder = (
                             f"{self.image_id_start_token}{local_image_index}{self.image_id_end_token}"
                             + image_placeholder
                         )
-
-                    if self.slice_mode and num_rows > 0 and num_cols > 0:
-                        per_slice_tokens = int(num_tokens_per_patch[1]) if len(num_tokens_per_patch) > 1 else 0
-                        slice_placeholder = (
-                            self.slice_start_token + "<|placeholder|>" * per_slice_tokens + self.slice_end_token
-                        )
-                        slices = [slice_placeholder * num_cols for _ in range(num_rows)]
-                        image_placeholder += "\n".join(slices)
-
-                    text[i] = text[i].replace(self.image_token, image_placeholder, 1)
-                    flat_index += n_patches
+                    images_replacements.append(image_placeholder)
                     global_image_index += 1
                     local_image_index += 1
-                text[i] = text[i].replace("<|placeholder|>", self.image_token)
+
+            image_inputs.pop("image_token_divisor")
+            image_inputs.pop("grids")
+            image_inputs.pop("num_patches_per_image")
 
         vid_downsample = output_kwargs["videos_kwargs"].get("downsample_mode", self.video_processor.downsample_mode)
         video_token_divisor = 4 if vid_downsample == "4x" else 16
 
         video_inputs = {}
+        videos_replacements = []
         if videos is not None:
             video_inputs = self.video_processor(videos, **output_kwargs["videos_kwargs"])
+            # Stash the runtime divisor so `replace_video_token` can index everything by video idx.
+            video_inputs["video_token_divisor"] = video_token_divisor
 
-            video_target_sizes = video_inputs["target_sizes_videos"]
-            num_frames_per_video = video_inputs.pop("num_frames_per_video")
-            video_grids = video_inputs.pop("grids_videos")
-            num_patches_per_frame = video_inputs.pop("num_patches_per_frame")
-
-            flat_index = 0
-            frame_offset = 0
             global_video_index = 0
-            for i in range(len(text)):
+            for sample in text:
                 local_video_index = 0
-                while self.video_token in text[i]:
-                    num_frames = num_frames_per_video[global_video_index]
-                    video_placeholder = ""
-                    for f in range(num_frames):
-                        gf = frame_offset + f
-                        n_patches = num_patches_per_frame[gf]
-                        frame_ts = video_target_sizes[flat_index : flat_index + n_patches]
-                        frame_tokens = frame_ts.prod(-1) // video_token_divisor
-                        grid_rows, grid_cols = video_grids[gf]
-
-                        if len(frame_tokens) == 0:
-                            flat_index += n_patches
-                            continue
-
-                        frame_placeholder = (
-                            self.image_start_token + "<|placeholder|>" * int(frame_tokens[0]) + self.image_end_token
-                        )
-                        if self.slice_mode and grid_rows > 0 and grid_cols > 0:
-                            per_slice_tokens = int(frame_tokens[1]) if len(frame_tokens) > 1 else 0
-                            slice_placeholder = (
-                                self.slice_start_token + "<|placeholder|>" * per_slice_tokens + self.slice_end_token
-                            )
-                            slices = [slice_placeholder * grid_cols for _ in range(grid_rows)]
-                            frame_placeholder += "\n".join(slices)
-
-                        video_placeholder += frame_placeholder
-                        flat_index += n_patches
-
-                    frame_offset += num_frames
-
+                num_video_tokens = sample.count(self.video_token)
+                for _ in range(num_video_tokens):
+                    video_placeholder = self.replace_video_token(video_inputs, global_video_index)
                     if use_image_id:
                         video_placeholder = (
                             f"{self.image_id_start_token}{local_video_index}{self.image_id_end_token}"
                             + video_placeholder
                         )
-
-                    text[i] = text[i].replace(self.video_token, video_placeholder, 1)
+                    videos_replacements.append(video_placeholder)
                     global_video_index += 1
                     local_video_index += 1
-                text[i] = text[i].replace("<|placeholder|>", self.video_token)
+
+            video_inputs.pop("video_token_divisor")
+            video_inputs.pop("num_frames_per_video")
+            video_inputs.pop("grids_videos")
+            video_inputs.pop("num_patches_per_frame")
+
+        replacements_kwargs = {}
+        if images is not None:
+            replacements_kwargs["images_replacements"] = images_replacements
+        if videos is not None:
+            replacements_kwargs["videos_replacements"] = videos_replacements
+        if replacements_kwargs:
+            text, _ = self.get_text_with_replacements(list(text), **replacements_kwargs)
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)

--- a/src/transformers/models/paddleocr_vl/modular_paddleocr_vl.py
+++ b/src/transformers/models/paddleocr_vl/modular_paddleocr_vl.py
@@ -388,6 +388,13 @@ class PaddleOCRVLProcessor(ProcessorMixin):
         self.image_token_id = tokenizer.image_token_id
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
 
+    def replace_image_token(self, image_inputs, image_idx: int) -> str:
+        image_grid_thw = image_inputs["image_grid_thw"]
+        num_image_tokens = (
+            image_grid_thw[image_idx].prod() // self.image_processor.merge_size // self.image_processor.merge_size
+        )
+        return self.image_token * num_image_tokens
+
     def __call__(
         self,
         images: ImageInput = None,
@@ -440,21 +447,10 @@ class PaddleOCRVLProcessor(ProcessorMixin):
         text = text.copy()
 
         if image_grid_thw is not None:
-            index = 0
-            for i in range(len(text)):
-                while self.image_token in text[i]:
-                    text[i] = text[i].replace(
-                        self.image_token,
-                        "<|placeholder|>"
-                        * (
-                            image_grid_thw[index].prod()
-                            // self.image_processor.merge_size
-                            // self.image_processor.merge_size
-                        ),
-                        1,
-                    )
-                    index += 1
-                text[i] = text[i].replace("<|placeholder|>", self.image_token)
+            images_replacements = [
+                self.replace_image_token(image_inputs, image_idx=idx) for idx in range(len(image_grid_thw))
+            ]
+            text, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)

--- a/src/transformers/models/paddleocr_vl/processing_paddleocr_vl.py
+++ b/src/transformers/models/paddleocr_vl/processing_paddleocr_vl.py
@@ -59,6 +59,13 @@ class PaddleOCRVLProcessor(ProcessorMixin):
         self.image_token_id = tokenizer.image_token_id
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
 
+    def replace_image_token(self, image_inputs, image_idx: int) -> str:
+        image_grid_thw = image_inputs["image_grid_thw"]
+        num_image_tokens = (
+            image_grid_thw[image_idx].prod() // self.image_processor.merge_size // self.image_processor.merge_size
+        )
+        return self.image_token * num_image_tokens
+
     def __call__(
         self,
         images: ImageInput = None,
@@ -111,21 +118,10 @@ class PaddleOCRVLProcessor(ProcessorMixin):
         text = text.copy()
 
         if image_grid_thw is not None:
-            index = 0
-            for i in range(len(text)):
-                while self.image_token in text[i]:
-                    text[i] = text[i].replace(
-                        self.image_token,
-                        "<|placeholder|>"
-                        * (
-                            image_grid_thw[index].prod()
-                            // self.image_processor.merge_size
-                            // self.image_processor.merge_size
-                        ),
-                        1,
-                    )
-                    index += 1
-                text[i] = text[i].replace("<|placeholder|>", self.image_token)
+            images_replacements = [
+                self.replace_image_token(image_inputs, image_idx=idx) for idx in range(len(image_grid_thw))
+            ]
+            text, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)

--- a/src/transformers/models/phi4_multimodal/processing_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/processing_phi4_multimodal.py
@@ -16,8 +16,6 @@
 Processor class for Phi4Multimodal
 """
 
-import re
-
 from ...audio_utils import AudioInput
 from ...image_processing_utils import BatchFeature
 from ...image_utils import ImageInput
@@ -106,15 +104,19 @@ class Phi4MultimodalProcessor(ProcessorMixin):
                 f"Input contains {concatenated_prompt.count(audio_token)} tokens != {len(audio_embed_sizes)} audios"
             )
 
-        # Add appropriate number of image/audio tokens (note that the count of replacement is dynamic)
-        image_count_iter = iter(num_img_tokens)
-        audio_count_iter = iter(audio_embed_sizes)
-        processed_text = [
-            re.sub(re.escape(image_token), lambda _: image_token * next(image_count_iter), t) for t in text
+        # Add appropriate number of image/audio tokens (note that the count of replacement is dynamic) through
+        # the shared `get_text_with_replacements` helper (see #45493).
+        images_replacements = [
+            self.replace_image_token(num_img_tokens, image_idx=idx) for idx in range(len(num_img_tokens))
         ]
-        processed_text = [
-            re.sub(re.escape(audio_token), lambda _: audio_token * next(audio_count_iter), t) for t in processed_text
+        audio_replacements = [
+            self.replace_audio_token(audio_embed_sizes, audio_idx=idx) for idx in range(len(audio_embed_sizes))
         ]
+        processed_text, _ = self.get_text_with_replacements(
+            list(text),
+            images_replacements=images_replacements,
+            audio_replacements=audio_replacements,
+        )
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         text_inputs = self.tokenizer(processed_text, **output_kwargs["text_kwargs"])
@@ -128,6 +130,14 @@ class Phi4MultimodalProcessor(ProcessorMixin):
         }
 
         return BatchFeature(data=data, tensor_type=return_tensors)
+
+    def replace_image_token(self, image_inputs, image_idx: int) -> str:
+        """Return the per-image expansion of the image placeholder token, see #45493."""
+        return self.image_token * image_inputs[image_idx]
+
+    def replace_audio_token(self, audio_inputs, audio_idx: int) -> str:
+        """Return the per-audio expansion of the audio placeholder token, see #45493."""
+        return self.audio_token * audio_inputs[audio_idx]
 
 
 __all__ = ["Phi4MultimodalProcessor"]

--- a/src/transformers/models/pixtral/processing_pixtral.py
+++ b/src/transformers/models/pixtral/processing_pixtral.py
@@ -102,6 +102,17 @@ class PixtralProcessor(ProcessorMixin):
     def image_token_ids(self) -> list[int]:
         return [self.image_token_id, self.image_break_token_id, self.image_end_token_id]
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        patch_size = self.patch_size * self.spatial_merge_size
+        height, width = image_inputs["image_sizes"][image_idx]
+        num_height_tokens = height // patch_size
+        num_width_tokens = width // patch_size
+        replace_tokens = [[self.image_token] * num_width_tokens + [self.image_break_token]] * num_height_tokens
+        # Flatten list
+        replace_tokens = [item for sublist in replace_tokens for item in sublist]
+        replace_tokens[-1] = self.image_end_token
+        return "".join(replace_tokens)
+
     @auto_docstring
     def __call__(
         self,
@@ -140,32 +151,15 @@ class PixtralProcessor(ProcessorMixin):
             raise TypeError("Invalid input text. Please provide a string, or a list of strings")
 
         # try to expand inputs in processing if we have the necessary parts
-        prompt_strings = text
+        prompt_strings = list(text)
         if image_inputs.get("pixel_values") is not None:
             # Replace the image token with the expanded image token sequence
-            image_sizes = iter(image_inputs["image_sizes"])
-            prompt_strings = []
-            replace_strings = []
-
-            for sample in text:
-                while self.image_token in sample:
-                    height, width = next(image_sizes)
-                    num_height_tokens = height // patch_size
-                    num_width_tokens = width // patch_size
-                    replace_tokens = [
-                        [self.image_token] * num_width_tokens + [self.image_break_token]
-                    ] * num_height_tokens
-                    # Flatten list
-                    replace_tokens = [item for sublist in replace_tokens for item in sublist]
-                    replace_tokens[-1] = self.image_end_token
-                    replace_str = "".join(replace_tokens)
-                    replace_strings.append(replace_str)
-                    sample = sample.replace(self.image_token, "<placeholder>", 1)
-
-                while "<placeholder>" in sample:
-                    replace_str = replace_strings.pop(0)
-                    sample = sample.replace("<placeholder>", replace_str, 1)
-                prompt_strings.append(sample)
+            images_replacements = [
+                self.replace_image_token(image_inputs, i) for i in range(len(image_inputs["image_sizes"]))
+            ]
+            prompt_strings, _ = self.get_text_with_replacements(
+                prompt_strings, images_replacements=images_replacements
+            )
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)

--- a/src/transformers/models/qianfan_ocr/modular_qianfan_ocr.py
+++ b/src/transformers/models/qianfan_ocr/modular_qianfan_ocr.py
@@ -335,25 +335,26 @@ class QianfanOCRProcessor(InternVLProcessor):
         Processes interleaved text with <image> placeholders, replacing them with appropriate image tokens.
         """
         image_index = 0
-        processed_text = []
         image_patches = []
-        replace_strings = []
-        for prompt in text:
-            new_prompt = prompt
-            while self.image_placeholder_token in new_prompt:
+        images_replacements = []
+        text = list(text)
+        # Traverse prompts in document order: for each `<image>` placeholder, record the patches it
+        # consumes and the expanded replacement string, then map the placeholder to `self.image_token`
+        # so the shared `get_text_with_replacements` helper can expand it.
+        for batch_idx, prompt in enumerate(text):
+            while self.image_placeholder_token in prompt:
                 start_index = image_num_patches_indices[image_index - 1] if image_index > 0 else 0
                 end_index = image_num_patches_indices[image_index]
                 image_patches.append(image_pixel_values[start_index:end_index])
-                new_prompt = new_prompt.replace(self.image_placeholder_token, "<placeholder>", 1)
-                replace_strings.append(
+                images_replacements.append(
                     f"{self.start_image_token}{self.image_token * self.image_seq_length * image_num_patches[image_index]}{self.end_image_token}"
                 )
+                prompt = prompt.replace(self.image_placeholder_token, self.image_token, 1)
                 image_index += 1
-            while "<placeholder>" in new_prompt:
-                replace_str = replace_strings.pop(0)
-                new_prompt = new_prompt.replace("<placeholder>", replace_str, 1)
-            processed_text.append(new_prompt)
-        return processed_text, image_patches, image_index, 0
+            text[batch_idx] = prompt
+
+        text, _ = self.get_text_with_replacements(text, images_replacements=images_replacements)
+        return text, image_patches, image_index, 0
 
     def __call__(
         self,

--- a/src/transformers/models/qianfan_ocr/processing_qianfan_ocr.py
+++ b/src/transformers/models/qianfan_ocr/processing_qianfan_ocr.py
@@ -92,25 +92,26 @@ class QianfanOCRProcessor(ProcessorMixin):
         Processes interleaved text with <image> placeholders, replacing them with appropriate image tokens.
         """
         image_index = 0
-        processed_text = []
         image_patches = []
-        replace_strings = []
-        for prompt in text:
-            new_prompt = prompt
-            while self.image_placeholder_token in new_prompt:
+        images_replacements = []
+        text = list(text)
+        # Traverse prompts in document order: for each `<image>` placeholder, record the patches it
+        # consumes and the expanded replacement string, then map the placeholder to `self.image_token`
+        # so the shared `get_text_with_replacements` helper can expand it.
+        for batch_idx, prompt in enumerate(text):
+            while self.image_placeholder_token in prompt:
                 start_index = image_num_patches_indices[image_index - 1] if image_index > 0 else 0
                 end_index = image_num_patches_indices[image_index]
                 image_patches.append(image_pixel_values[start_index:end_index])
-                new_prompt = new_prompt.replace(self.image_placeholder_token, "<placeholder>", 1)
-                replace_strings.append(
+                images_replacements.append(
                     f"{self.start_image_token}{self.image_token * self.image_seq_length * image_num_patches[image_index]}{self.end_image_token}"
                 )
+                prompt = prompt.replace(self.image_placeholder_token, self.image_token, 1)
                 image_index += 1
-            while "<placeholder>" in new_prompt:
-                replace_str = replace_strings.pop(0)
-                new_prompt = new_prompt.replace("<placeholder>", replace_str, 1)
-            processed_text.append(new_prompt)
-        return processed_text, image_patches, image_index, 0
+            text[batch_idx] = prompt
+
+        text, _ = self.get_text_with_replacements(text, images_replacements=images_replacements)
+        return text, image_patches, image_index, 0
 
     @auto_docstring
     def __call__(

--- a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
@@ -110,8 +110,6 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
         self.image_token = self.tokenizer.image_token
         self.audio_token = self.tokenizer.audio_token
         self.video_token = self.tokenizer.video_token
-        self.vision_bos_token = self.tokenizer.vision_bos_token
-        self.vision_eos_token = self.tokenizer.vision_eos_token
         self.audio_bos_token = self.tokenizer.audio_bos_token
         self.audio_eos_token = self.tokenizer.audio_eos_token
 
@@ -178,7 +176,7 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
             text = [text]
 
         if images is not None or videos is not None or audio is not None:
-            text = self.replace_multimodal_special_tokens(
+            images_replacements, videos_replacements, audio_replacements = self._build_multimodal_replacements(
                 text,
                 audio_lengths,
                 image_grid_thw,
@@ -188,6 +186,12 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
                 position_id_per_seconds=position_id_per_seconds,
                 seconds_per_chunk=seconds_per_chunk,
             )
+            text, _ = self.get_text_with_replacements(
+                list(text),
+                images_replacements=images_replacements,
+                videos_replacements=videos_replacements,
+                audio_replacements=audio_replacements,
+            )
 
         texts_inputs = self.tokenizer(text, **output_kwargs["text_kwargs"])
 
@@ -196,7 +200,55 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
             tensor_type=kwargs.get("return_tensors"),
         )
 
-    def replace_multimodal_special_tokens(
+    def replace_image_token(self, image_grid_thw) -> str:
+        merge_length = self.image_processor.merge_size**2
+        num_image_tokens = image_grid_thw.prod() // merge_length
+        return self.image_token * num_image_tokens
+
+    def replace_audio_token(self, audio_length) -> str:
+        return self.audio_token * audio_length
+
+    def replace_video_token(
+        self,
+        video_grid_thw,
+        audio_length=None,
+        video_second_per_grid=None,
+        use_audio_in_video=False,
+        position_id_per_seconds=25,
+        seconds_per_chunk=2.0,
+    ) -> str:
+        if not use_audio_in_video:
+            merge_length = self.video_processor.merge_size**2
+            num_video_tokens = video_grid_thw.prod() // merge_length
+            return self.video_token * num_video_tokens
+
+        # Audio interleaved with video. The surrounding `vision_bos`/`vision_eos` tokens stay in the
+        # text, so only the inner `audio_bos` + interleaved chunks + `audio_eos` are produced here.
+        audio_token_indices = np.arange(audio_length)
+        height = video_grid_thw[1] // self.video_processor.merge_size
+        width = video_grid_thw[2] // self.video_processor.merge_size
+        video_token_indices = np.arange(video_grid_thw[0]).reshape(-1, 1, 1)
+        video_token_indices = np.broadcast_to(
+            video_token_indices, (video_token_indices.shape[0], height, width)
+        ).reshape(-1)
+        video_token_indices = video_token_indices * video_second_per_grid * position_id_per_seconds
+
+        tokens_per_chunk = int(position_id_per_seconds * seconds_per_chunk)
+        video_chunk_indexes = self.get_chunked_index(video_token_indices, tokens_per_chunk)
+        audio_chunk_indexes = self.get_chunked_index(audio_token_indices, tokens_per_chunk)
+
+        replacement_string = self.audio_bos_token
+        for j in range(max(len(video_chunk_indexes), len(audio_chunk_indexes))):
+            if j < len(video_chunk_indexes):
+                video_seq_length = video_chunk_indexes[j][1] - video_chunk_indexes[j][0]
+                replacement_string += self.video_token * video_seq_length
+            if j < len(audio_chunk_indexes):
+                audio_seq_length = audio_chunk_indexes[j][1] - audio_chunk_indexes[j][0]
+                replacement_string += self.audio_token * audio_seq_length
+        replacement_string += self.audio_eos_token
+        return replacement_string
+
+    def _build_multimodal_replacements(
         self,
         text,
         audio_lengths,
@@ -207,13 +259,16 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
         position_id_per_seconds,
         seconds_per_chunk,
     ):
-        # Extend mm token length
-        merge_length_image = self.image_processor.merge_size**2
-        merge_length_video = self.video_processor.merge_size**2
-
-        processed_text = []
+        """
+        Build the per-modality replacement strings in document order. The `audio_lengths` iterator is
+        shared between standalone audio tokens and audio interleaved inside videos (when
+        `use_audio_in_video=True`), so replacements must be produced in a single in-order pass over the
+        batch rather than via independent per-modality index maps.
+        """
+        images_replacements = []
+        videos_replacements = []
+        audio_replacements = []
         for sample in text:
-            positions = []
             special_tokens = [re.escape(tok) for tok in [self.audio_token, self.image_token, self.video_token]]
             pattern = "|".join(special_tokens)
             positions = sorted([(match.start(), match.group()) for match in re.finditer(pattern, sample)])
@@ -221,51 +276,24 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
 
             for _, special_token in positions:
                 if special_token == self.audio_token:
-                    sample = sample.replace(self.audio_token, "<|audio_placeholder|>" * next(audio_lengths), 1)
+                    audio_replacements.append(self.replace_audio_token(next(audio_lengths)))
                 elif special_token == self.image_token:
-                    image_seq_length = next(image_grid_thw).prod() // merge_length_image
-                    sample = sample.replace(self.image_token, "<|image_placeholder|>" * image_seq_length, 1)
+                    images_replacements.append(self.replace_image_token(next(image_grid_thw)))
                 elif special_token == self.video_token:
                     if not use_audio_in_video:
-                        video_seq_length = next(video_grid_thw).prod() // merge_length_video
-                        sample = sample.replace(self.video_token, "<|video_placeholder|>" * video_seq_length, 1)
+                        videos_replacements.append(self.replace_video_token(next(video_grid_thw)))
                     else:
-                        audio_token_indices = np.arange(next(audio_lengths))
-                        curr_video_grid_thw = next(video_grid_thw)
-                        height = curr_video_grid_thw[1] // self.video_processor.merge_size
-                        width = curr_video_grid_thw[2] // self.video_processor.merge_size
-                        video_token_indices = np.arange(curr_video_grid_thw[0]).reshape(-1, 1, 1)
-                        video_token_indices = np.broadcast_to(
-                            video_token_indices, (video_token_indices.shape[0], height, width)
-                        ).reshape(-1)
-                        video_token_indices = (
-                            video_token_indices * next(video_second_per_grid) * position_id_per_seconds
+                        videos_replacements.append(
+                            self.replace_video_token(
+                                next(video_grid_thw),
+                                audio_length=next(audio_lengths),
+                                video_second_per_grid=next(video_second_per_grid),
+                                use_audio_in_video=True,
+                                position_id_per_seconds=position_id_per_seconds,
+                                seconds_per_chunk=seconds_per_chunk,
+                            )
                         )
-
-                        tokens_per_chunk = int(position_id_per_seconds * seconds_per_chunk)
-                        video_chunk_indexes = self.get_chunked_index(video_token_indices, tokens_per_chunk)
-                        audio_chunk_indexes = self.get_chunked_index(audio_token_indices, tokens_per_chunk)
-
-                        placeholder_string = self.vision_bos_token + self.audio_bos_token
-                        for j in range(max(len(video_chunk_indexes), len(audio_chunk_indexes))):
-                            if j < len(video_chunk_indexes):
-                                video_seq_length = video_chunk_indexes[j][1] - video_chunk_indexes[j][0]
-                                placeholder_string += "<|video_placeholder|>" * video_seq_length
-                            if j < len(audio_chunk_indexes):
-                                audio_seq_length = audio_chunk_indexes[j][1] - audio_chunk_indexes[j][0]
-                                placeholder_string += "<|audio_placeholder|>" * audio_seq_length
-                        placeholder_string += self.audio_eos_token + self.vision_eos_token
-                        sample = sample.replace(
-                            self.vision_bos_token + self.video_token + self.vision_eos_token,
-                            placeholder_string,
-                            1,
-                        )
-
-            sample = sample.replace("<|audio_placeholder|>", self.audio_token)
-            sample = sample.replace("<|image_placeholder|>", self.image_token)
-            sample = sample.replace("<|video_placeholder|>", self.video_token)
-            processed_text.append(sample)
-        return processed_text
+        return images_replacements, videos_replacements, audio_replacements
 
     def get_chunked_index(self, token_indices: np.ndarray, tokens_per_chunk: int) -> list[tuple[int, int]]:
         """

--- a/src/transformers/models/qwen2_audio/processing_qwen2_audio.py
+++ b/src/transformers/models/qwen2_audio/processing_qwen2_audio.py
@@ -96,19 +96,21 @@ class Qwen2AudioProcessor(ProcessorMixin):
             # rename attention_mask to prevent conflicts later on
             audio_inputs["feature_attention_mask"] = audio_inputs.pop("attention_mask")
 
-            expanded_text = []
             audio_lengths = audio_inputs["feature_attention_mask"].sum(-1).tolist()
 
+            # Build the per-audio replacement strings in document order. The replacement for each
+            # audio token depends on the surrounding text (whether it is already wrapped in
+            # bos/eos), so it must be computed inline here rather than via `replace_audio_token`.
+            audio_replacements = []
             for sample in text:
-                replace_str = []
-                while self.audio_token in sample:
+                search_idx = 0
+                while (audio_token_start_idx := sample.find(self.audio_token, search_idx)) != -1:
                     audio_length = audio_lengths.pop(0)
                     input_length = (audio_length - 1) // 2 + 1
                     num_audio_tokens = (input_length - 2) // 2 + 1
 
                     expanded_audio_token = self.audio_token * num_audio_tokens
 
-                    audio_token_start_idx = sample.find(self.audio_token)
                     audio_token_end_idx = audio_token_start_idx + len(self.audio_token)
 
                     has_bos = (
@@ -124,13 +126,10 @@ class Qwen2AudioProcessor(ProcessorMixin):
                     if not has_bos and not has_eos:
                         expanded_audio_token = self.audio_bos_token + expanded_audio_token + self.audio_eos_token
 
-                    replace_str.append(expanded_audio_token)
-                    sample = sample.replace(self.audio_token, "<placeholder>", 1)
+                    audio_replacements.append(expanded_audio_token)
+                    search_idx = audio_token_end_idx
 
-                while "<placeholder>" in sample:
-                    sample = sample.replace("<placeholder>", replace_str.pop(0), 1)
-                expanded_text.append(sample)
-            text = expanded_text
+            text, _ = self.get_text_with_replacements(list(text), audio_replacements=audio_replacements)
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
         inputs = self.tokenizer(text, **output_kwargs["text_kwargs"])

--- a/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
@@ -2538,83 +2538,54 @@ class Qwen3OmniMoeProcessorKwargs(Qwen2_5OmniProcessorKwargs):
 
 
 class Qwen3OmniMoeProcessor(Qwen2_5OmniProcessor, ProcessorMixin):
-    def replace_multimodal_special_tokens(
-        self,
-        text,
-        audio_lengths,
-        image_grid_thw,
-        video_grid_thw,
-        video_second_per_grid,
-        use_audio_in_video,
-        position_id_per_seconds,
-        seconds_per_chunk,
-    ):
-        # Extend mm token length
+    def replace_audio_token(self, audio_length: int) -> str:
+        return self.audio_token * audio_length
+
+    def replace_image_token(self, image_grid_thw) -> str:
         merge_length_image = self.image_processor.merge_size**2
-        merge_length_video = self.video_processor.merge_size**2
+        image_seq_length = image_grid_thw.prod() // merge_length_image
+        return self.image_token * image_seq_length
 
-        processed_text = []
-        for sample in text:
-            positions = []
-            special_tokens = [re.escape(tok) for tok in [self.audio_token, self.image_token, self.video_token]]
-            pattern = "|".join(special_tokens)
-            positions = sorted([(match.start(), match.group()) for match in re.finditer(pattern, sample)])
-            positions.sort(key=lambda x: x[0])
+    def replace_video_token(
+        self,
+        video_grid_thw,
+        audio_length: int | None = None,
+        video_second_per_grid: float | None = None,
+        position_id_per_seconds: float | None = None,
+    ) -> str:
+        # Plain video: just repeat the video token `grid // merge_length` times.
+        if audio_length is None:
+            merge_length_video = self.video_processor.merge_size**2
+            video_seq_length = video_grid_thw.prod() // merge_length_video
+            return self.video_token * video_seq_length
 
-            for _, special_token in positions:
-                if special_token == self.audio_token:
-                    sample = sample.replace(self.audio_token, "<|audio_placeholder|>" * next(audio_lengths), 1)
-                elif special_token == self.image_token:
-                    image_seq_length = next(image_grid_thw).prod() // merge_length_image
-                    sample = sample.replace(self.image_token, "<|image_placeholder|>" * image_seq_length, 1)
-                elif special_token == self.video_token:
-                    if not use_audio_in_video:
-                        video_seq_length = next(video_grid_thw).prod() // merge_length_video
-                        sample = sample.replace(self.video_token, "<|video_placeholder|>" * video_seq_length, 1)
-                    else:
-                        audio_token_indices = np.arange(next(audio_lengths))
-                        curr_video_grid_thw = next(video_grid_thw)
-                        height = curr_video_grid_thw[1] // self.video_processor.merge_size
-                        width = curr_video_grid_thw[2] // self.video_processor.merge_size
-                        video_token_indices = np.arange(curr_video_grid_thw[0]).reshape(-1, 1, 1)
-                        video_token_indices = np.broadcast_to(
-                            video_token_indices, (video_token_indices.shape[0], height, width)
-                        ).reshape(-1)
-                        video_token_indices = (
-                            video_token_indices * next(video_second_per_grid) * position_id_per_seconds
-                        )
+        # `use_audio_in_video`: interleave video and audio placeholders by their temporal position.
+        # The outer `vision_bos`/`vision_eos` tokens stay in the text (they wrap the matched
+        # `video_token`), so the replacement only adds the inner `audio_bos ... audio_eos`.
+        audio_token_indices = np.arange(audio_length)
+        height = video_grid_thw[1] // self.video_processor.merge_size
+        width = video_grid_thw[2] // self.video_processor.merge_size
+        video_token_indices = np.arange(video_grid_thw[0]).reshape(-1, 1, 1)
+        video_token_indices = np.broadcast_to(
+            video_token_indices, (video_token_indices.shape[0], height, width)
+        ).reshape(-1)
+        video_token_indices = video_token_indices * video_second_per_grid * position_id_per_seconds
 
-                        video_data_index, audio_data_index = 0, 0
-                        placeholder_string = self.vision_bos_token + self.audio_bos_token
-                        while video_data_index < len(video_token_indices) and audio_data_index < len(
-                            audio_token_indices
-                        ):
-                            if video_token_indices[video_data_index] <= audio_token_indices[audio_data_index]:
-                                placeholder_string += "<|video_placeholder|>"
-                                video_data_index += 1
-                            else:
-                                placeholder_string += "<|audio_placeholder|>"
-                                audio_data_index += 1
-                        if video_data_index < len(video_token_indices):
-                            placeholder_string += "<|video_placeholder|>" * (
-                                len(video_token_indices) - video_data_index
-                            )
-                        if audio_data_index < len(audio_token_indices):
-                            placeholder_string += "<|audio_placeholder|>" * (
-                                len(audio_token_indices) - audio_data_index
-                            )
-                        placeholder_string += self.audio_eos_token + self.vision_eos_token
-                        sample = sample.replace(
-                            self.vision_bos_token + self.video_token + self.vision_eos_token,
-                            placeholder_string,
-                            1,
-                        )
-
-            sample = sample.replace("<|audio_placeholder|>", self.audio_token)
-            sample = sample.replace("<|image_placeholder|>", self.image_token)
-            sample = sample.replace("<|video_placeholder|>", self.video_token)
-            processed_text.append(sample)
-        return processed_text
+        video_data_index, audio_data_index = 0, 0
+        placeholder_string = self.audio_bos_token
+        while video_data_index < len(video_token_indices) and audio_data_index < len(audio_token_indices):
+            if video_token_indices[video_data_index] <= audio_token_indices[audio_data_index]:
+                placeholder_string += self.video_token
+                video_data_index += 1
+            else:
+                placeholder_string += self.audio_token
+                audio_data_index += 1
+        if video_data_index < len(video_token_indices):
+            placeholder_string += self.video_token * (len(video_token_indices) - video_data_index)
+        if audio_data_index < len(audio_token_indices):
+            placeholder_string += self.audio_token * (len(audio_token_indices) - audio_data_index)
+        placeholder_string += self.audio_eos_token
+        return placeholder_string
 
     def __call__(
         self,
@@ -2633,7 +2604,7 @@ class Qwen3OmniMoeProcessor(Qwen2_5OmniProcessor, ProcessorMixin):
             **kwargs,
         )
 
-        seconds_per_chunk = output_kwargs["videos_kwargs"].pop("seconds_per_chunk")
+        output_kwargs["videos_kwargs"].pop("seconds_per_chunk")  # popped to avoid leaking into the video processor
         position_id_per_seconds = output_kwargs["videos_kwargs"].pop("position_id_per_seconds")
         use_audio_in_video = output_kwargs["videos_kwargs"].pop("use_audio_in_video")
         fps = output_kwargs["videos_kwargs"].get("fps", 1.0)
@@ -2675,15 +2646,38 @@ class Qwen3OmniMoeProcessor(Qwen2_5OmniProcessor, ProcessorMixin):
         if not isinstance(text, list):
             text = [text]
 
-        text = self.replace_multimodal_special_tokens(
-            text,
-            audio_lengths,
-            image_grid_thw,
-            video_grid_thw,
-            video_second_per_grid=video_second_per_grid,
-            use_audio_in_video=use_audio_in_video,
-            position_id_per_seconds=position_id_per_seconds,
-            seconds_per_chunk=seconds_per_chunk,
+        # Build per-occurrence replacement strings in document order, scanning each sample for
+        # audio/image/video tokens sorted by position. The audio iterator is shared: in
+        # `use_audio_in_video` mode a video token also consumes one audio length (interleaved
+        # inside the video replacement) instead of being expanded as a standalone audio token.
+        images_replacements, videos_replacements, audio_replacements = [], [], []
+        special_tokens = [re.escape(tok) for tok in [self.audio_token, self.image_token, self.video_token]]
+        pattern = "|".join(special_tokens)
+        for sample in text:
+            positions = sorted((match.start(), match.group()) for match in re.finditer(pattern, sample))
+            for _, special_token in positions:
+                if special_token == self.audio_token:
+                    audio_replacements.append(self.replace_audio_token(next(audio_lengths)))
+                elif special_token == self.image_token:
+                    images_replacements.append(self.replace_image_token(next(image_grid_thw)))
+                elif special_token == self.video_token:
+                    if not use_audio_in_video:
+                        videos_replacements.append(self.replace_video_token(next(video_grid_thw)))
+                    else:
+                        videos_replacements.append(
+                            self.replace_video_token(
+                                next(video_grid_thw),
+                                audio_length=next(audio_lengths),
+                                video_second_per_grid=next(video_second_per_grid),
+                                position_id_per_seconds=position_id_per_seconds,
+                            )
+                        )
+
+        text, _ = self.get_text_with_replacements(
+            list(text),
+            images_replacements=images_replacements,
+            videos_replacements=videos_replacements,
+            audio_replacements=audio_replacements,
         )
 
         texts_inputs = self.tokenizer(text, **output_kwargs["text_kwargs"])

--- a/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
@@ -124,8 +124,6 @@ class Qwen3OmniMoeProcessor(ProcessorMixin):
         self.image_token = self.tokenizer.image_token
         self.audio_token = self.tokenizer.audio_token
         self.video_token = self.tokenizer.video_token
-        self.vision_bos_token = self.tokenizer.vision_bos_token
-        self.vision_eos_token = self.tokenizer.vision_eos_token
         self.audio_bos_token = self.tokenizer.audio_bos_token
         self.audio_eos_token = self.tokenizer.audio_eos_token
 
@@ -147,7 +145,7 @@ class Qwen3OmniMoeProcessor(ProcessorMixin):
             **kwargs,
         )
 
-        seconds_per_chunk = output_kwargs["videos_kwargs"].pop("seconds_per_chunk")
+        output_kwargs["videos_kwargs"].pop("seconds_per_chunk")  # popped to avoid leaking into the video processor
         position_id_per_seconds = output_kwargs["videos_kwargs"].pop("position_id_per_seconds")
         use_audio_in_video = output_kwargs["videos_kwargs"].pop("use_audio_in_video")
         fps = output_kwargs["videos_kwargs"].get("fps", 1.0)
@@ -189,15 +187,38 @@ class Qwen3OmniMoeProcessor(ProcessorMixin):
         if not isinstance(text, list):
             text = [text]
 
-        text = self.replace_multimodal_special_tokens(
-            text,
-            audio_lengths,
-            image_grid_thw,
-            video_grid_thw,
-            video_second_per_grid=video_second_per_grid,
-            use_audio_in_video=use_audio_in_video,
-            position_id_per_seconds=position_id_per_seconds,
-            seconds_per_chunk=seconds_per_chunk,
+        # Build per-occurrence replacement strings in document order, scanning each sample for
+        # audio/image/video tokens sorted by position. The audio iterator is shared: in
+        # `use_audio_in_video` mode a video token also consumes one audio length (interleaved
+        # inside the video replacement) instead of being expanded as a standalone audio token.
+        images_replacements, videos_replacements, audio_replacements = [], [], []
+        special_tokens = [re.escape(tok) for tok in [self.audio_token, self.image_token, self.video_token]]
+        pattern = "|".join(special_tokens)
+        for sample in text:
+            positions = sorted((match.start(), match.group()) for match in re.finditer(pattern, sample))
+            for _, special_token in positions:
+                if special_token == self.audio_token:
+                    audio_replacements.append(self.replace_audio_token(next(audio_lengths)))
+                elif special_token == self.image_token:
+                    images_replacements.append(self.replace_image_token(next(image_grid_thw)))
+                elif special_token == self.video_token:
+                    if not use_audio_in_video:
+                        videos_replacements.append(self.replace_video_token(next(video_grid_thw)))
+                    else:
+                        videos_replacements.append(
+                            self.replace_video_token(
+                                next(video_grid_thw),
+                                audio_length=next(audio_lengths),
+                                video_second_per_grid=next(video_second_per_grid),
+                                position_id_per_seconds=position_id_per_seconds,
+                            )
+                        )
+
+        text, _ = self.get_text_with_replacements(
+            list(text),
+            images_replacements=images_replacements,
+            videos_replacements=videos_replacements,
+            audio_replacements=audio_replacements,
         )
 
         texts_inputs = self.tokenizer(text, **output_kwargs["text_kwargs"])
@@ -207,7 +228,56 @@ class Qwen3OmniMoeProcessor(ProcessorMixin):
             tensor_type=kwargs.get("return_tensors"),
         )
 
-    def replace_multimodal_special_tokens(
+    def replace_image_token(self, image_grid_thw) -> str:
+        merge_length_image = self.image_processor.merge_size**2
+        image_seq_length = image_grid_thw.prod() // merge_length_image
+        return self.image_token * image_seq_length
+
+    def replace_audio_token(self, audio_length: int) -> str:
+        return self.audio_token * audio_length
+
+    def replace_video_token(
+        self,
+        video_grid_thw,
+        audio_length: int | None = None,
+        video_second_per_grid: float | None = None,
+        position_id_per_seconds: float | None = None,
+    ) -> str:
+        # Plain video: just repeat the video token `grid // merge_length` times.
+        if audio_length is None:
+            merge_length_video = self.video_processor.merge_size**2
+            video_seq_length = video_grid_thw.prod() // merge_length_video
+            return self.video_token * video_seq_length
+
+        # `use_audio_in_video`: interleave video and audio placeholders by their temporal position.
+        # The outer `vision_bos`/`vision_eos` tokens stay in the text (they wrap the matched
+        # `video_token`), so the replacement only adds the inner `audio_bos ... audio_eos`.
+        audio_token_indices = np.arange(audio_length)
+        height = video_grid_thw[1] // self.video_processor.merge_size
+        width = video_grid_thw[2] // self.video_processor.merge_size
+        video_token_indices = np.arange(video_grid_thw[0]).reshape(-1, 1, 1)
+        video_token_indices = np.broadcast_to(
+            video_token_indices, (video_token_indices.shape[0], height, width)
+        ).reshape(-1)
+        video_token_indices = video_token_indices * video_second_per_grid * position_id_per_seconds
+
+        video_data_index, audio_data_index = 0, 0
+        placeholder_string = self.audio_bos_token
+        while video_data_index < len(video_token_indices) and audio_data_index < len(audio_token_indices):
+            if video_token_indices[video_data_index] <= audio_token_indices[audio_data_index]:
+                placeholder_string += self.video_token
+                video_data_index += 1
+            else:
+                placeholder_string += self.audio_token
+                audio_data_index += 1
+        if video_data_index < len(video_token_indices):
+            placeholder_string += self.video_token * (len(video_token_indices) - video_data_index)
+        if audio_data_index < len(audio_token_indices):
+            placeholder_string += self.audio_token * (len(audio_token_indices) - audio_data_index)
+        placeholder_string += self.audio_eos_token
+        return placeholder_string
+
+    def _build_multimodal_replacements(
         self,
         text,
         audio_lengths,
@@ -218,13 +288,16 @@ class Qwen3OmniMoeProcessor(ProcessorMixin):
         position_id_per_seconds,
         seconds_per_chunk,
     ):
-        # Extend mm token length
-        merge_length_image = self.image_processor.merge_size**2
-        merge_length_video = self.video_processor.merge_size**2
-
-        processed_text = []
+        """
+        Build the per-modality replacement strings in document order. The `audio_lengths` iterator is
+        shared between standalone audio tokens and audio interleaved inside videos (when
+        `use_audio_in_video=True`), so replacements must be produced in a single in-order pass over the
+        batch rather than via independent per-modality index maps.
+        """
+        images_replacements = []
+        videos_replacements = []
+        audio_replacements = []
         for sample in text:
-            positions = []
             special_tokens = [re.escape(tok) for tok in [self.audio_token, self.image_token, self.video_token]]
             pattern = "|".join(special_tokens)
             positions = sorted([(match.start(), match.group()) for match in re.finditer(pattern, sample)])
@@ -232,58 +305,24 @@ class Qwen3OmniMoeProcessor(ProcessorMixin):
 
             for _, special_token in positions:
                 if special_token == self.audio_token:
-                    sample = sample.replace(self.audio_token, "<|audio_placeholder|>" * next(audio_lengths), 1)
+                    audio_replacements.append(self.replace_audio_token(next(audio_lengths)))
                 elif special_token == self.image_token:
-                    image_seq_length = next(image_grid_thw).prod() // merge_length_image
-                    sample = sample.replace(self.image_token, "<|image_placeholder|>" * image_seq_length, 1)
+                    images_replacements.append(self.replace_image_token(next(image_grid_thw)))
                 elif special_token == self.video_token:
                     if not use_audio_in_video:
-                        video_seq_length = next(video_grid_thw).prod() // merge_length_video
-                        sample = sample.replace(self.video_token, "<|video_placeholder|>" * video_seq_length, 1)
+                        videos_replacements.append(self.replace_video_token(next(video_grid_thw)))
                     else:
-                        audio_token_indices = np.arange(next(audio_lengths))
-                        curr_video_grid_thw = next(video_grid_thw)
-                        height = curr_video_grid_thw[1] // self.video_processor.merge_size
-                        width = curr_video_grid_thw[2] // self.video_processor.merge_size
-                        video_token_indices = np.arange(curr_video_grid_thw[0]).reshape(-1, 1, 1)
-                        video_token_indices = np.broadcast_to(
-                            video_token_indices, (video_token_indices.shape[0], height, width)
-                        ).reshape(-1)
-                        video_token_indices = (
-                            video_token_indices * next(video_second_per_grid) * position_id_per_seconds
-                        )
-
-                        video_data_index, audio_data_index = 0, 0
-                        placeholder_string = self.vision_bos_token + self.audio_bos_token
-                        while video_data_index < len(video_token_indices) and audio_data_index < len(
-                            audio_token_indices
-                        ):
-                            if video_token_indices[video_data_index] <= audio_token_indices[audio_data_index]:
-                                placeholder_string += "<|video_placeholder|>"
-                                video_data_index += 1
-                            else:
-                                placeholder_string += "<|audio_placeholder|>"
-                                audio_data_index += 1
-                        if video_data_index < len(video_token_indices):
-                            placeholder_string += "<|video_placeholder|>" * (
-                                len(video_token_indices) - video_data_index
+                        videos_replacements.append(
+                            self.replace_video_token(
+                                next(video_grid_thw),
+                                audio_length=next(audio_lengths),
+                                video_second_per_grid=next(video_second_per_grid),
+                                use_audio_in_video=True,
+                                position_id_per_seconds=position_id_per_seconds,
+                                seconds_per_chunk=seconds_per_chunk,
                             )
-                        if audio_data_index < len(audio_token_indices):
-                            placeholder_string += "<|audio_placeholder|>" * (
-                                len(audio_token_indices) - audio_data_index
-                            )
-                        placeholder_string += self.audio_eos_token + self.vision_eos_token
-                        sample = sample.replace(
-                            self.vision_bos_token + self.video_token + self.vision_eos_token,
-                            placeholder_string,
-                            1,
                         )
-
-            sample = sample.replace("<|audio_placeholder|>", self.audio_token)
-            sample = sample.replace("<|image_placeholder|>", self.image_token)
-            sample = sample.replace("<|video_placeholder|>", self.video_token)
-            processed_text.append(sample)
-        return processed_text
+        return images_replacements, videos_replacements, audio_replacements
 
     def get_chunked_index(self, token_indices: np.ndarray, tokens_per_chunk: int) -> list[tuple[int, int]]:
         """

--- a/src/transformers/models/smolvlm/processing_smolvlm.py
+++ b/src/transformers/models/smolvlm/processing_smolvlm.py
@@ -145,33 +145,17 @@ class SmolVLMProcessor(ProcessorMixin):
 
         super().__init__(image_processor, tokenizer, video_processor, chat_template=chat_template, **kwargs)
 
-    def expand_text_with_image_tokens(self, text, image_rows, image_cols):
-        prompt_strings = []
-        for sample, sample_rows, sample_cols in zip(text, image_rows, image_cols):
-            # Replace the image token with fake tokens around the expanded image token sequence of length `image_seq_len`
-            image_prompt_strings = []
-            for n_rows, n_cols in zip(sample_rows, sample_cols):
-                image_prompt_string = get_image_prompt_string(
-                    n_rows,
-                    n_cols,
-                    self.image_seq_len,
-                    image_token=self.image_token,
-                    fake_token_around_image=self.fake_image_token,
-                    global_image_token=self.global_image_token,
-                )
-                image_prompt_strings.append(image_prompt_string)
-
-            split_sample = sample.split(self.image_token)
-            if len(split_sample) == 0:
-                raise ValueError("The image token should be present in the text.")
-
-            # Place in the image prompt strings where the image tokens are
-            sample = split_sample[0]
-            for i, image_prompt_string in enumerate(image_prompt_strings):
-                sample += image_prompt_string + split_sample[i + 1]
-            prompt_strings.append(sample)
-
-        return prompt_strings
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        image_rows = [row for row_list in image_inputs["rows"] for row in row_list][image_idx]
+        image_cols = [col for col_list in image_inputs["cols"] for col in col_list][image_idx]
+        return get_image_prompt_string(
+            image_rows,
+            image_cols,
+            self.image_seq_len,
+            image_token=self.image_token,
+            fake_token_around_image=self.fake_image_token,
+            global_image_token=self.global_image_token,
+        )
 
     def expand_text_with_video_tokens(self, text, video_inputs):
         num_frames = video_inputs["pixel_values"].shape[1]
@@ -262,7 +246,10 @@ class SmolVLMProcessor(ProcessorMixin):
                     image_rows = [[0] * n_images for n_images in n_images_in_text]
                 if image_cols is None:
                     image_cols = [[0] * n_images for n_images in n_images_in_text]
-                text = self.expand_text_with_image_tokens(text, image_rows=image_rows, image_cols=image_cols)
+                image_inputs = {"rows": image_rows, "cols": image_cols}
+                num_images = sum(n_images_in_text)
+                images_replacements = [self.replace_image_token(image_inputs, i) for i in range(num_images)]
+                text, _ = self.get_text_with_replacements(list(text), images_replacements=images_replacements)
 
         elif videos is not None:
             vision_inputs = self.video_processor(videos, **output_kwargs["videos_kwargs"])

--- a/src/transformers/models/video_llava/processing_video_llava.py
+++ b/src/transformers/models/video_llava/processing_video_llava.py
@@ -65,6 +65,28 @@ class VideoLlavaProcessor(ProcessorMixin):
         self.video_token_id = tokenizer.convert_tokens_to_ids(self.video_token)
         super().__init__(image_processor, video_processor, tokenizer, chat_template=chat_template)
 
+    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
+        height, width = get_image_size(to_numpy_array(image_inputs.get("pixel_values_images")[image_idx]))
+        num_image_tokens = (height // self.patch_size) * (width // self.patch_size)
+        num_image_tokens += self.num_additional_image_tokens
+        if self.vision_feature_select_strategy == "default":
+            num_image_tokens -= 1
+        return self.image_token * num_image_tokens
+
+    def replace_video_token(self, video_inputs: dict, video_idx: int) -> str:
+        one_video = video_inputs.get("pixel_values_videos")[video_idx]
+        if isinstance(one_video, (list, tuple)):
+            one_video = np.array(one_video)
+        else:
+            one_video = to_numpy_array(one_video)
+        height, width = get_image_size(one_video[0])
+        num_frames = one_video.shape[0]  # frame dim is always after batch dim
+
+        num_image_tokens = (height // self.patch_size) * (width // self.patch_size)
+        num_image_tokens += self.num_additional_image_tokens
+        num_video_tokens = num_image_tokens * num_frames
+        return self.video_token * num_video_tokens
+
     @auto_docstring
     def __call__(
         self,
@@ -108,33 +130,26 @@ class VideoLlavaProcessor(ProcessorMixin):
             raise TypeError("Invalid input text. Please provide a string, or a list of strings")
 
         data = {}
+        encoded_images = encoded_videos = None
         if images is not None:
             encoded_images = self.image_processor(images=images, return_tensors=return_tensors)
             data.update(encoded_images)
-
-            height, width = get_image_size(to_numpy_array(encoded_images.get("pixel_values_images")[0]))
-            num_image_tokens = (height // self.patch_size) * (width // self.patch_size)
-            num_image_tokens += self.num_additional_image_tokens
-            if self.vision_feature_select_strategy == "default":
-                num_image_tokens -= 1
-            text = [sample.replace(self.image_token, self.image_token * num_image_tokens) for sample in text]
 
         if videos is not None:
             encoded_videos = self.video_processor(videos=videos, return_tensors=return_tensors)
             data.update(encoded_videos)
 
-            one_video = encoded_videos.get("pixel_values_videos")[0]
-            if isinstance(encoded_videos.get("pixel_values_videos")[0], (list, tuple)):
-                one_video = np.array(one_video)
-            else:
-                one_video = to_numpy_array(one_video)
-            height, width = get_image_size(one_video[0])
-            num_frames = one_video.shape[0]  # frame dim is always after batch dim
-
-            num_image_tokens = (height // self.patch_size) * (width // self.patch_size)
-            num_image_tokens += self.num_additional_image_tokens
-            num_video_tokens = num_image_tokens * num_frames
-            text = [sample.replace(self.video_token, self.video_token * num_video_tokens) for sample in text]
+        images_replacements = videos_replacements = []
+        if encoded_images is not None:
+            num_images = len(encoded_images.get("pixel_values_images"))
+            images_replacements = [self.replace_image_token(encoded_images, i) for i in range(num_images)]
+        if encoded_videos is not None:
+            num_videos = len(encoded_videos.get("pixel_values_videos"))
+            videos_replacements = [self.replace_video_token(encoded_videos, i) for i in range(num_videos)]
+        if encoded_images is not None or encoded_videos is not None:
+            text, _ = self.get_text_with_replacements(
+                list(text), images_replacements=images_replacements, videos_replacements=videos_replacements
+            )
 
         text_inputs = self.tokenizer(
             text,

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -682,6 +682,7 @@ class ProcessorMixin(PushToHubMixin):
                 images_replacements,
                 videos_replacements,
                 audio_replacements,
+                return_replacement_offsets=return_text_replacement_offsets,
             )
             text_inputs = self.tokenizer(text, **merged_kwargs["text_kwargs"])
             self._check_special_mm_tokens(text, text_inputs, modalities=["image", "video", "audio"])
@@ -805,6 +806,7 @@ class ProcessorMixin(PushToHubMixin):
         images_replacements: list[str] = [],
         videos_replacements: list[str] = [],
         audio_replacements: list[str] = [],
+        return_replacement_offsets: bool = False,
     ) -> tuple[list[str], list[dict[str, Any]]]:
         """
         Replace multimodal placeholder tokens in a batch of text strings with their
@@ -836,12 +838,16 @@ class ProcessorMixin(PushToHubMixin):
             audio_replacements (`list[str]`, *optional*, defaults to `[]`):
                 Expanded replacement strings for each audio input. Produced by
                 `self._process_audio`.
+            return_replacement_offsets (`bool`, *optional*, defaults to `False`):
+                Whether to compute and return `batch_replacement_offsets`. Building the offset
+                metadata is skipped when `False` (the returned offset lists are then empty), as it
+                is only needed by callers that pass `return_text_replacement_offsets=True`.
 
         Returns:
             `tuple[list[str], list[dict[str, Any]]]`: A tuple of:
                 - The modified `text` batch with all placeholder tokens expanded.
                 - `batch_replacement_offsets`: one entry per batch item, each being a
-                list of dicts with keys:
+                list of dicts (empty unless `return_replacement_offsets=True`) with keys:
                     - `"type"` (`str`): modality name — `"image"`, `"video"`, or `"audio"`
                     - `"span"` (`tuple[int, int]`): original `(start, end)` char offsets of the placeholder token
                     - `"new_span"` (`tuple[int, int]`): `(start, end)` offsets of placeholder in the expanded string
@@ -881,15 +887,16 @@ class ProcessorMixin(PushToHubMixin):
 
                 mm_type = m.lastgroup
                 replacement_text = next(replacements_iters[mm_type])
-                replacement_offsets.append(
-                    {
-                        "type": mm_type,
-                        "span": (start, end),
-                        "new_span": (start, start + len(replacement_text)),
-                        "text": m.group(),
-                        "replacement": replacement_text,
-                    }
-                )
+                if return_replacement_offsets:
+                    replacement_offsets.append(
+                        {
+                            "type": mm_type,
+                            "span": (start, end),
+                            "new_span": (start, start + len(replacement_text)),
+                            "text": m.group(),
+                            "replacement": replacement_text,
+                        }
+                    )
                 expanded_sample.append(replacement_text)
                 last = end
 

--- a/tests/models/colmodernvbert/test_processing_colmodernvbert.py
+++ b/tests/models/colmodernvbert/test_processing_colmodernvbert.py
@@ -283,6 +283,10 @@ class ColModernVBertProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         pass
 
     @unittest.skip("ColModernVBert can't process text+image inputs at the same time")
+    def test_processor_does_not_mutate_text_input(self):
+        pass
+
+    @unittest.skip("ColModernVBert can't process text+image inputs at the same time")
     def test_flat_kwarg_applied_when_modality_dict_lacks_it(self):
         pass
 

--- a/tests/models/colmodernvbert/test_processing_colmodernvbert.py
+++ b/tests/models/colmodernvbert/test_processing_colmodernvbert.py
@@ -283,7 +283,7 @@ class ColModernVBertProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         pass
 
     @unittest.skip("ColModernVBert can't process text+image inputs at the same time")
-    def test_processor_does_not_mutate_text_input(self):
+    def test_processor_expands_tokens_via_get_text_with_replacements(self):
         pass
 
     @unittest.skip("ColModernVBert can't process text+image inputs at the same time")

--- a/tests/models/colqwen2/test_processing_colqwen2.py
+++ b/tests/models/colqwen2/test_processing_colqwen2.py
@@ -293,5 +293,5 @@ class ColQwen2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         pass
 
     @unittest.skip("ColQwen2Processor can't process text+image inputs at the same time")
-    def test_processor_does_not_mutate_text_input(self):
+    def test_processor_expands_tokens_via_get_text_with_replacements(self):
         pass

--- a/tests/models/colqwen2/test_processing_colqwen2.py
+++ b/tests/models/colqwen2/test_processing_colqwen2.py
@@ -291,3 +291,7 @@ class ColQwen2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     @unittest.skip("ColQwen2Processor can't process text+image inputs at the same time")
     def test_flat_kwarg_applied_when_modality_dict_lacks_it(self):
         pass
+
+    @unittest.skip("ColQwen2Processor can't process text+image inputs at the same time")
+    def test_processor_does_not_mutate_text_input(self):
+        pass

--- a/tests/models/deepseek_ocr2/test_processing_deepseek_ocr2.py
+++ b/tests/models/deepseek_ocr2/test_processing_deepseek_ocr2.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from itertools import groupby
 
 import torch
 
@@ -88,3 +89,26 @@ class DeepseekOcr2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertEqual(num_local_patches, 6)
         self.assertEqual(num_image_tokens, 1121)
         self.assertIn("pixel_values_local", inputs)
+
+    def test_image_token_expansion_multiple_images(self):
+        """Several `<image>` placeholders in one prompt are each expanded, in encounter order."""
+        processor = self.get_processor()
+        processor.image_processor.size = {"height": 1024, "width": 1024}
+        processor.image_processor.tile_size = 768
+
+        small = torch.randint(0, 256, (3, 300, 200), dtype=torch.uint8)  # 0 local patches -> 257 tokens
+        large = torch.randint(0, 256, (3, 3264, 2448), dtype=torch.uint8)  # 6 local patches -> 1121 tokens
+        prompt = "<image>\n<image>\nFree OCR."
+
+        inputs = processor(images=[small, large], text=prompt, return_tensors="pt")
+
+        image_token_id = processor.image_token_id
+        ids = inputs["input_ids"][0].tolist()
+        # contiguous run lengths of image tokens, in order of appearance
+        runs = [sum(1 for _ in group) for token, group in groupby(ids) if token == image_token_id]
+
+        # patches are consumed in encounter order: small (0 local) then large (6 local)
+        self.assertEqual([int(n) for n in inputs["num_local_patches"]], [0, 6])
+        # the single-pass expansion must map the 1st placeholder -> 257 and the 2nd -> 1121, in order
+        self.assertEqual(runs, [257, 1121])
+        self.assertEqual((inputs["input_ids"] == image_token_id).sum().item(), 257 + 1121)

--- a/tests/models/mllama/test_processing_mllama.py
+++ b/tests/models/mllama/test_processing_mllama.py
@@ -56,6 +56,10 @@ class MllamaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def test_tokenizer_defaults(self):
         pass
 
+    @unittest.skip("Mllama uses one image token per image + cross-attention; no token expansion to centralize")
+    def test_processor_expands_tokens_via_get_text_with_replacements(self):
+        pass
+
     # Override as Mllama needs images to be an explicitly nested batch
     def prepare_image_inputs(self, batch_size: int | None = None):
         """This function prepares a list of PIL images for testing"""

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -785,6 +785,32 @@ class ProcessorTesterMixin:
         with self.assertRaises((TypeError, ValueError)):
             processor()
 
+    def test_processor_does_not_mutate_text_input(self):
+        """
+        Calling a processor must not modify the user-provided `text` list in place. The shared
+        `get_text_with_replacements` helper expands placeholder tokens in place, so a processor must
+        run it on a copy (the default `__call__` does this via `prepare_inputs_layout`). This guards
+        against regressions where a custom `__call__` forwards the user's list directly.
+        """
+        processor = self.get_processor()
+        call_signature = inspect.signature(processor.__call__)
+        input_args = [param.name for param in call_signature.parameters.values() if param.annotation != param.empty]
+
+        if "text" not in input_args or "images" not in input_args:
+            self.skipTest(f"{self.processor_class} doesn't support image+text inputs.")
+
+        if processor.tokenizer.pad_token_id is None:
+            processor.tokenizer.pad_token_id = processor.tokenizer.eos_token_id
+
+        text = self.prepare_text_inputs(batch_size=2, modalities=["image"])
+        image_inputs = self.prepare_image_inputs(batch_size=2)
+        # nested input type is the format supported by all multimodal processors
+        image_inputs = [[image] if not isinstance(image, list) else image for image in image_inputs]
+
+        text_snapshot = list(text)
+        processor(text=text, images=image_inputs, padding=True, return_tensors="pt")
+        self.assertEqual(text, text_snapshot, "`__call__` must not modify the input `text` list in place")
+
     def test_processor_text_has_no_visual(self):
         """
         Tests that multimodal models can process batch of inputs where samples can

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -21,6 +21,7 @@ import shutil
 import sys
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 from huggingface_hub import hf_hub_download
@@ -785,12 +786,12 @@ class ProcessorTesterMixin:
         with self.assertRaises((TypeError, ValueError)):
             processor()
 
-    def test_processor_does_not_mutate_text_input(self):
+    def test_processor_expands_tokens_via_get_text_with_replacements(self):
         """
-        Calling a processor must not modify the user-provided `text` list in place. The shared
-        `get_text_with_replacements` helper expands placeholder tokens in place, so a processor must
-        run it on a copy (the default `__call__` does this via `prepare_inputs_layout`). This guards
-        against regressions where a custom `__call__` forwards the user's list directly.
+        Multimodal placeholder expansion must go through the shared `get_text_with_replacements`
+        helper (see #45493) instead of bespoke per-processor `.replace`/`re.sub` logic, so that
+        placeholder handling, replacement offsets and `mm_token_type_ids` stay consistent across
+        models. This asserts the processor actually calls the helper when expanding image tokens.
         """
         processor = self.get_processor()
         call_signature = inspect.signature(processor.__call__)
@@ -807,9 +808,14 @@ class ProcessorTesterMixin:
         # nested input type is the format supported by all multimodal processors
         image_inputs = [[image] if not isinstance(image, list) else image for image in image_inputs]
 
-        text_snapshot = list(text)
-        processor(text=text, images=image_inputs, padding=True, return_tensors="pt")
-        self.assertEqual(text, text_snapshot, "`__call__` must not modify the input `text` list in place")
+        with patch.object(processor, "get_text_with_replacements", wraps=processor.get_text_with_replacements) as spy:
+            processor(text=text, images=image_inputs, padding=True, return_tensors="pt")
+
+        self.assertTrue(
+            spy.called,
+            f"{self.processor_class.__name__} must expand multimodal tokens via "
+            "`get_text_with_replacements` rather than bespoke logic.",
+        )
 
     def test_processor_text_has_no_visual(self):
         """


### PR DESCRIPTION
Routes image/video/audio placeholder expansion through the shared `ProcessorMixin.get_text_with_replacements` helper (#45493) for ~25 processors that still rolled their own `.replace`/`re.sub`/sentinel logic. Each now defines `replace_image_token`/`replace_video_token`/`replace_audio_token` (or builds the replacement list inline where expansion is context-dependent). Output is byte-for-byte identical.

### Also
- **Perf:** `get_text_with_replacements` now skips building `batch_replacement_offsets` unless `return_text_replacement_offsets=True` (~40% faster on the text step; feature unchanged when requested).
- **Test:** new `ProcessorTesterMixin.test_processor_expands_tokens_via_get_text_with_replacements` enforces the contract; skip-listed for ColQwen2/ColModernVBert (text XOR images) and Mllama (one token/image + cross-attention).

### Notes
- Validated against each model's existing token-count tests; byte-equivalence harnesses where tests are gated (torchaudio / unreleased checkpoints). CI runs the rest.
- `gemma3n` deferred (its Hub template emits soft tokens → needs a soft-token-anchored migration, not boi/eoi).
- AI assistance was used; every migrated `replace_*_token` should be reviewed. Suggest squash-on-merge (history evolved in place).