### PR TITLE
Remove unused shared_expert_combination_strategy from cohere2_moe

### DIFF
--- a/src/transformers/models/cohere2_moe/configuration_cohere2_moe.py
+++ b/src/transformers/models/cohere2_moe/configuration_cohere2_moe.py
@@ -35,8 +35,6 @@ class Cohere2MoeConfig(PreTrainedConfig):
         Number of routed experts.
     num_shared_experts (`int`, *optional*, defaults to 0):
         The number of shared experts.
-    shared_expert_combination_strategy (`str`, *optional*, defaults to `"average"`):
-        The combination strategy of shared expert, must be one of ['average', 'sum'].
     expert_selection_fn (`str`, *optional*, defaults to `"softmax"`):
         Expert selection function of router.
     layer_types (`list`, *optional*):
@@ -110,7 +108,6 @@ class Cohere2MoeConfig(PreTrainedConfig):
     num_experts_per_tok: int = 2
     num_experts: int = 8
     num_shared_experts: int = 0
-    shared_expert_combination_strategy: str = "average"
     expert_selection_fn: str = "softmax"
     layer_types: list[str] | None = None
     mlp_layer_types: list | None = None

--- a/src/transformers/models/cohere2_moe/modeling_cohere2_moe.py
+++ b/src/transformers/models/cohere2_moe/modeling_cohere2_moe.py
@@ -168,7 +168,6 @@ class Cohere2MoeSparseMoeBlock(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.num_shared_experts = config.num_shared_experts
-        self.shared_expert_combination_strategy = config.shared_expert_combination_strategy
 
         self.gate = Cohere2MoeTopKRouter(config)
         self.experts = Cohere2MoeExperts(config)
@@ -186,12 +185,7 @@ class Cohere2MoeSparseMoeBlock(nn.Module):
 
         if self.num_shared_experts > 0:
             shared_expert_output = self.shared_experts(hidden_states_flat)
-            if self.shared_expert_combination_strategy == "sum":
-                final_hidden_states = final_hidden_states + shared_expert_output
-            elif self.shared_expert_combination_strategy == "average":
-                final_hidden_states = (final_hidden_states + shared_expert_output) / 2
-            else:
-                raise ValueError("`shared_expert_combination_strategy` can only be `sum` or `average`")
+            final_hidden_states = (final_hidden_states + shared_expert_output) / 2
 
         return final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
 

--- a/src/transformers/models/cohere2_moe/modular_cohere2_moe.py
+++ b/src/transformers/models/cohere2_moe/modular_cohere2_moe.py
@@ -95,7 +95,6 @@ class Cohere2MoeSparseMoeBlock(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.num_shared_experts = config.num_shared_experts
-        self.shared_expert_combination_strategy = config.shared_expert_combination_strategy
 
         self.gate = Cohere2MoeTopKRouter(config)
         self.experts = Cohere2MoeExperts(config)
@@ -113,12 +112,7 @@ class Cohere2MoeSparseMoeBlock(nn.Module):
 
         if self.num_shared_experts > 0:
             shared_expert_output = self.shared_experts(hidden_states_flat)
-            if self.shared_expert_combination_strategy == "sum":
-                final_hidden_states = final_hidden_states + shared_expert_output
-            elif self.shared_expert_combination_strategy == "average":
-                final_hidden_states = (final_hidden_states + shared_expert_output) / 2
-            else:
-                raise ValueError("`shared_expert_combination_strategy` can only be `sum` or `average`")
+            final_hidden_states = (final_hidden_states + shared_expert_output) / 2
 
         return final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
 


### PR DESCRIPTION
The `sum` branch of `shared_expert_combination_strategy` is dead: every published `cohere2_moe` checkpoint (the `command-a-plus-05-2026` family + its derivatives) uses `average`. Drop the config field and always average the shared-expert output.

Existing configs that still carry the key load unchanged (it's ignored). Tests: `tests/models/cohere2_moe` pass (TP tests need multi-GPU). AI-assisted, human-reviewed.