### PR TITLE
Add workflow to post CI Grafana dashboard link to PR

### DIFF
--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -1,0 +1,39 @@
+name: Post CI Dashboard Link
+
+on:
+  workflow_run:
+    workflows: ["PR CI"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  post-link:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const headSha = context.payload.workflow_run.head_sha;
+
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+
+            const pr = prs.find(pr => pr.head.sha === headSha);
+            if (!pr) {
+              console.log(`No open PR found for SHA ${headSha}, skipping`);
+              return;
+            }
+
+            const url = `https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=${pr.number}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: `**CI Observability Dashboard:** [View test results in Grafana](${url})`,
+            });


### PR DESCRIPTION
## Summary
- Adds `pr-ci-post-dashboard-link.yml` workflow that triggers via `workflow_run` on completion of "PR CI"
- Uses `actions/github-script` to find the PR by head SHA and post a comment with the Grafana observability dashboard link
- Works for both same-repo and fork PRs since `workflow_run` always runs in the base repo context

## Notes
- The `workflow_run` approach is required because `GITHUB_TOKEN` is read-only for fork-triggered `pull_request` workflows
- PR is looked up via `pulls.list` filtered by `head.sha` — no search API indexing delays, no rate limit concerns
