### PR TITLE
ci: mention code quality failure in CI dashboard comment

### DIFF
--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           script: |
             const headSha = context.payload.workflow_run.head_sha;
+            const runId = context.payload.workflow_run.id;
 
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
@@ -29,6 +30,16 @@ jobs:
               console.log(`No open PR found for SHA ${headSha}, skipping`);
               return;
             }
+
+            // Check if the code quality job failed (causes all test jobs to be skipped)
+            const { data: jobsData } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+              per_page: 100,
+            });
+            const qualityJob = jobsData.jobs.find(j => j.name.includes('Check code quality'));
+            const qualityFailed = qualityJob && qualityJob.conclusion === 'failure';
 
             // Delete any existing dashboard comment before posting a fresh one
             const { data: comments } = await github.rest.issues.listComments({
@@ -48,9 +59,13 @@ jobs:
             }
 
             const url = `https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=${pr.number}`;
+            let body = `**CI Dashboard:** [View test results in Grafana](${url})`;
+            if (qualityFailed) {
+              body += `\n\n> ⚠️ **Code quality check failed** — all test jobs were skipped. Fix the code quality issues and push again to run tests.`;
+            }
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              body: `**CI Dashboard:** [View test results in Grafana](${url})`,
+              body,
             });


### PR DESCRIPTION
## Summary

- When `check_code_quality` fails, the CI dashboard comment posted to the PR now includes a warning explaining that all test jobs were skipped
- The Grafana link is always posted regardless, so partial OTEL data is still accessible

## How it works

After the "PR CI" workflow completes, `listJobsForWorkflowRun` is called to find the `Check code quality` job. If its conclusion is `failure`, a blockquote warning is appended to the comment:

> ⚠️ **Code quality check failed** — all test jobs were skipped. Fix the code quality issues and push again to run tests.

## Related

Follows up on #46410 and #46412.
