### PR TITLE
docs: fix grammar in llm_tutorial.md (A LLM -> An LLM)

### DIFF
--- a/docs/source/en/llm_tutorial.md
+++ b/docs/source/en/llm_tutorial.md
@@ -18,7 +18,7 @@ rendered properly in your Markdown viewer.
 
 [[open-in-colab]]
 
-Text generation is the most popular application for large language models (LLMs). A LLM is trained to generate the next word (token) given some initial text (prompt) along with its own generated outputs up to a predefined length or when it reaches an end-of-sequence (`EOS`) token.
+Text generation is the most popular application for large language models (LLMs). An LLM is trained to generate the next word (token) given some initial text (prompt) along with its own generated outputs up to a predefined length or when it reaches an end-of-sequence (`EOS`) token.
 
 In Transformers, the [`~GenerationMixin.generate`] API handles text generation, and it is available for all models with generative capabilities. This guide will show you the basics of text generation with [`~GenerationMixin.generate`] and some common pitfalls to avoid.
 


### PR DESCRIPTION
## What does this PR do?

Fixes a grammatical error in `docs/source/en/llm_tutorial.md`.

Changed "A LLM is trained" to "An LLM is trained." 
The indefinite article "an" is correct before LLM since it begins 
with a vowel sound ("el").

## Motivation

Small grammar fix to improve the quality and professionalism 
of the LLM tutorial documentation, which is one of the most 
frequently read guides in the Transformers library.

## Changes
 Fixed: `A LLM`→`` in llm_tutorial.md line 23

No dependencies required for this change.




