### PR TITLE
[Tests] Add regression tests for use_kernels=True crash on Qwen3Next and Qwen3.5

### DIFF
--- a/tests/models/qwen3_5/test_modeling_qwen3_5.py
+++ b/tests/models/qwen3_5/test_modeling_qwen3_5.py
@@ -24,6 +24,7 @@ from transformers.testing_utils import (
     cleanup,
     require_causal_conv1d,
     require_flash_linear_attention,
+    require_kernels,
     require_torch,
     require_torch_gpu,
     slow,
@@ -96,6 +97,14 @@ class Qwen3_5TextModelTest(CausalLMModelTest, unittest.TestCase):
         head_v_dim = config.linear_value_head_dim
 
         return (batch_size, num_v_heads, head_k_dim, head_v_dim)
+
+    @require_kernels
+    def test_kernelize_does_not_crash(self):
+        """Regression for #46399: use_kernels=True raised ValueError because @use_kernelized_func
+        referenced apply_rotary_pos_emb which lacked @use_kernel_func_from_hub."""
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        model = Qwen3_5TextModel(config).to(device=torch_device)
+        model.use_kernels = True
 
     def test_attention_outputs(self):
         "Needs to be overwritten as Qwen3.5 alternates between attention layers and gated deltanet layers."

--- a/tests/models/qwen3_next/test_modeling_qwen3_next.py
+++ b/tests/models/qwen3_next/test_modeling_qwen3_next.py
@@ -21,6 +21,7 @@ from transformers import DataCollatorWithFlattening, is_torch_available
 from transformers.testing_utils import (
     require_causal_conv1d,
     require_flash_linear_attention,
+    require_kernels,
     require_torch,
     require_torch_gpu,
     require_torch_multi_gpu,
@@ -84,6 +85,14 @@ class Qwen3NextModelTest(CausalLMModelTest, unittest.TestCase):
         head_v_dim = config.linear_value_head_dim
 
         return (batch_size, num_v_heads, head_k_dim, head_v_dim)
+
+    @require_kernels
+    def test_kernelize_does_not_crash(self):
+        """Regression for #46399: use_kernels=True raised ValueError because @use_kernelized_func
+        referenced apply_rotary_pos_emb which lacked @use_kernel_func_from_hub."""
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        model = Qwen3NextModel(config).to(device=torch_device)
+        model.use_kernels = True
 
     @unittest.skip("Qwen3-Next hybrid linear-attention cache is not compatible with quantized cache yet.")
     def test_generate_with_quant_cache(self):


### PR DESCRIPTION
## What this PR does

Adds `test_kernelize_does_not_crash` to `Qwen3NextModelTest` and `Qwen3_5TextModelTest`.

### Root cause (from issue #46399)

Setting `model.use_kernels = True` on either model raises:
```
ValueError: Attempted to register a kernel for apply_rotary_pos_emb,
but it was not a torch.nn.Module.
This means the underlying function needs to be decorated with
@use_kernel_func_from_hub.
```

The generated modeling files for `Qwen3Next` and `Qwen3.5` define a local
`apply_rotary_pos_emb` (partial-RoPE variant) **without**
`@use_kernel_func_from_hub`, but the attention class still inherits
`@use_kernelized_func(apply_rotary_pos_emb)` from the parent class via the
modular converter's decorator fallback. When `kernelize()` tries to register
the plain function as an `nn.Module`, it crashes.

### This PR

- Adds two `@require_kernels`-gated tests, one per model.
- Tests currently **fail** (they reproduce the crash).  They will pass once the
  modular converter fix lands in the follow-up PR.

### Follow-up PRs (tracked in #46399)

- **PR 2**: Fix `utils/modular_model_converter.py` — strip `@use_kernelized_func(fn)` from generated classes when `fn` is defined locally without `@use_kernel_func_from_hub`.
- **PR 3**: Regenerate `modeling_qwen3_next.py` and `modeling_qwen3_5.py` using the fixed converter.
- **Future**: Wire `@use_kernel_func_from_hub("rotary_pos_emb_partial")` once [kernels-community#919](https://github.com/huggingface/kernels-community/pull/919) ships.

Closes #46399 (partial — regression test step)

cc @MekkCyber @vasqu @ArthurZucker @drbh

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests)?
- [ ] Did you discuss your PR/implementation with the related model author(s) in the issue?
- [x] Did you update the [documentation](https://github.com/huggingface/transformers/tree/main/docs) with the relevant changes?
- [x] Did you write any new necessary tests?