### PR TITLE
fix: honor static cache max len config

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1929,10 +1929,13 @@ class GenerationMixin(ContinuousMixin):
                     f"and will be removed in v5.13. Please only use one of {STATIC_CACHE_IMPLEMENTATIONS}, "
                     "and the layer structure will be inferred automatically."
                 )
+            cache_config = generation_config.cache_config if generation_config.cache_config is not None else {}
+            max_static_cache_len = cache_config.get("max_cache_len", max_cache_length)
+            max_static_cache_len = max(max_cache_length, max_static_cache_len)
             model_kwargs[cache_name] = self._prepare_static_cache(
                 cache_implementation=generation_config.cache_implementation,
                 batch_size=max(generation_config.num_beams, generation_config.num_return_sequences) * batch_size,
-                max_cache_len=max_cache_length,
+                max_cache_len=max_static_cache_len,
                 model_kwargs=model_kwargs,
             )
         elif generation_config.cache_implementation == "quantized":

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -72,6 +72,7 @@ if is_torch_available():
         BartForConditionalGeneration,
         BartTokenizer,
         DataCollatorWithFlattening,
+        GPT2Config,
         GPT2LMHeadModel,
         GPT2Tokenizer,
         ImageGPTForCausalImageModeling,
@@ -2888,6 +2889,29 @@ class GenerationIntegrationTests(unittest.TestCase):
         # so the output is on CPU; the generated tokens must still match the on-device run.
         self.assertEqual(on_cpu.device.type, "cpu")
         self.assertTrue(torch.equal(on_cpu, on_device.cpu()))
+
+    def test_static_cache_uses_max_cache_len_from_cache_config(self):
+        config = GPT2Config(
+            vocab_size=32,
+            n_embd=16,
+            n_layer=2,
+            n_head=2,
+            bos_token_id=0,
+            eos_token_id=-1,
+            pad_token_id=0,
+        )
+        model = GPT2LMHeadModel(config).to(torch_device).eval()
+        input_ids = torch.tensor([[0, 1, 2]], device=torch_device)
+
+        model.generate(
+            input_ids,
+            max_new_tokens=2,
+            cache_implementation="static",
+            cache_config={"max_cache_len": 32},
+        )
+
+        self.assertIsInstance(model._cache, StaticCache)
+        self.assertEqual(model._cache.max_cache_len, 32)
 
     def test_generation_config_deprecation(self):
         import logging as pylogging


### PR DESCRIPTION
## Summary

- honor `generation_config.cache_config["max_cache_len"]` when auto-preparing static caches
- keep the cache length at least as large as the current generation requires
- add a tiny GPT-2 regression test that checks the prepared `StaticCache` size

Fixes #46424.

## To verify

- `PYTHONPATH=src python -m pytest tests\generation\test_utils.py::GenerationIntegrationTests::test_static_cache_uses_max_cache_len_from_cache_config -q`
- `python -m py_compile src\transformers\generation\utils.py tests\generation\test_utils.py`
- `git diff --check`
