### PR TITLE
[Modular Converter] Strip @use_kernelized_func(fn) when fn lacks @use_kernel_func_from_hub

### DIFF
--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -1863,6 +1863,59 @@ def get_class_node_and_dependencies(
     return nodes_to_add, file_type, new_imports
 
 
+def strip_orphaned_kernelized_func_decorators(body: dict) -> dict:
+    """Remove @use_kernelized_func(fn) from class decorators when fn is defined at module
+    level in the same generated file without @use_kernel_func_from_hub.
+
+    Root cause: replace_class_node() falls back to the parent class decorators when the
+    modular subclass declares none. A parent may have @use_kernelized_func(fn) wired to a
+    kernel-decorated fn, but if the generated file redefines fn locally (e.g. a partial-RoPE
+    variant) without @use_kernel_func_from_hub, kernelize() crashes: attach_hidden_kernels()
+    expects an nn.Module in _hidden_kernels but finds a plain function instead.
+
+    Calling this before get_needed_imports lets the existing scope analysis also drop the
+    now-unused use_kernelized_func import automatically.
+    """
+    kernel_decorated: set[str] = set()
+    all_local_funcs: set[str] = set()
+
+    for key, item in body.items():
+        node = item["node"]
+        if not m.matches(node, m.FunctionDef()):
+            continue
+        all_local_funcs.add(key)
+        for dec in node.decorators:
+            if m.matches(dec.decorator, m.Call(func=m.Name("use_kernel_func_from_hub"))):
+                kernel_decorated.add(key)
+                break
+
+    undecorated_local_funcs = all_local_funcs - kernel_decorated
+    if not undecorated_local_funcs:
+        return body
+
+    new_body = {}
+    for key, item in body.items():
+        node = item["node"]
+        if m.matches(node, m.ClassDef()):
+            new_decs, changed = [], False
+            for dec in node.decorators:
+                if m.matches(dec.decorator, m.Call(func=m.Name("use_kernelized_func"))):
+                    args = dec.decorator.args
+                    if (
+                        len(args) == 1
+                        and m.matches(args[0].value, m.Name())
+                        and args[0].value.value in undecorated_local_funcs
+                    ):
+                        changed = True
+                        continue
+                new_decs.append(dec)
+            if changed:
+                item = {**item, "node": node.with_changes(decorators=new_decs)}
+        new_body[key] = item
+
+    return new_body
+
+
 def create_modules(
     modular_mapper: ModularFileMapper,
     file_path: str | None = None,
@@ -1930,6 +1983,7 @@ def create_modules(
 
     # Find the correct imports, and write the new modules
     for file, body in files.items():
+        body = strip_orphaned_kernelized_func_decorators(body)
         new_body = [k[1]["node"] for k in sorted(body.items(), key=lambda x: x[1]["insert_idx"])]
         needed_imports = get_needed_imports(body, all_imports)
 


### PR DESCRIPTION
## What this PR does

Fixes the root cause of the `use_kernels=True` crash on `Qwen3Next` and `Qwen3.5` (issue #46399).

### Root cause

`replace_class_node()` falls back to the parent class decorators when a modular subclass declares none. For `Qwen3NextAttention(Qwen3MoeAttention)` and `Qwen3_5Attention`, this means `@use_kernelized_func(apply_rotary_pos_emb)` is inherited from `Qwen3MoeAttention` — but the generated file defines `apply_rotary_pos_emb` as a partial-RoPE variant **without** `@use_kernel_func_from_hub`. When `kernelize()` runs, `attach_hidden_kernels()` tries to register that plain function as an `nn.Module` and raises:

```
ValueError: Attempted to register a kernel for apply_rotary_pos_emb,
but it was not a torch.nn.Module.
```

### Fix

Add `strip_orphaned_kernelized_func_decorators()`, called in `create_modules()` **before** `get_needed_imports()`.

For each generated file's `body` dict it:
1. Collects all module-level function names and identifies which have `@use_kernel_func_from_hub`
2. For any class with `@use_kernelized_func(fn)` where `fn` is defined locally **without** `@use_kernel_func_from_hub`, drops that decorator

Calling it before `get_needed_imports` means the existing LibCST scope analysis also removes the now-unused `use_kernelized_func` import automatically — no separate cleanup needed.

### What is NOT changed

- No model files are touched here. The regeneration of `modeling_qwen3_next.py` and `modeling_qwen3_5.py` (using this fixed converter) is in a follow-up PR to keep the diff reviewable.
- No kernel is added for partial RoPE. That belongs in a future PR once [kernels-community#919](https://github.com/huggingface/kernels-community/pull/919) ships.

## PR series for #46399

| PR | Status | Description |
|---|---|---|
| #46435 | Open | Regression tests (currently failing — will pass after this) |
| **This PR** | Open | Converter fix |
| PR 3 | Pending | Regenerate `modeling_qwen3_next.py` and `modeling_qwen3_5.py` |

cc @vasqu @ArthurZucker @MekkCyber @drbh

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests)?
- [x] Was this discussed/approved via a Github issue or the forum? Yes — #46399
- [ ] Did you update the documentation with your relevant changes?
- [x] Did you write any new necessary tests? Regression tests in #46435; unit tests for this function in PR 3.