### PR TITLE
ci: less flaky test_assisted_decoding_matches_greedy_search_1_same

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -725,9 +725,10 @@ class GenerationTesterMixin:
             generation_kwargs.update({"assistant_model": assistant_model})
             output_assisted = model.generate(**generation_kwargs, **inputs_dict, **logits_processor_kwargs)
 
-            # `gpt_oss` seems to have larger differences on CPU every other generated tokens, sth. like
-            # 1e-9, 1e-5, 1e-9, 1e-5. While on GPU, they are all very small 1e-9.
-            if is_moe_model(config):
+            # some models requires larger tolerance
+            if model.config.model_type in ["vibevoice_asr"]:
+                atol = rtol = 5e-3
+            elif is_moe_model(config):
                 atol = rtol = 1e-3
             else:
                 atol = rtol = 1e-5


### PR DESCRIPTION
# What does this PR do?

We get 2.5e -3 for this model ... `vibevoice_asr`.

See https://app.circleci.com/pipelines/gh/huggingface/transformers/177026/workflows/5c539c52-535f-4dfa-885a-df90184480cb/jobs/2341894

> FAILED tests/models/vibevoice_asr/test_modeling_vibevoice_asr.py::VibeVoiceAsrForConditionalGenerationModelTest::test_assisted_decoding_matches_greedy_search_1_same - AssertionError: Generate outputs are not similar enough (atol=0.001, rtol=0.001).
  Sequence mismatch: 4/29 tokens differ (first at position 25).
  Batch index: 0
  Token at mismatch — output_1: 44, output_2: 64
  Score diff at first mismatch — max: 2.529049e-03, mean: 6.395052e-04

After this PR, running

>  python3 -m pytest -v -n 8 --flake-finder --flake-runs=3000 tests/models/vibevoice_asr/test_modeling_vibevoice_asr.py::VibeVoiceAsrForConditionalGenerationModelTest::test_assisted_decoding_matches_greedy_search_1_same

we get


>  3000 passed in 237.30s (0:03:57