### PR TITLE
ci: fix slack report job — use AWS runner and authenticated GitHub API calls

### DIFF
--- a/.github/workflows/slack-report.yml
+++ b/.github/workflows/slack-report.yml
@@ -41,7 +41,8 @@ permissions:
 jobs:
   send_results:
     name: Send results to webhook
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: aws-general-8-plus
     if: always() && !cancelled()
     steps:
       - name: Preliminary job status
@@ -51,6 +52,11 @@ jobs:
           setup_status: ${{ inputs.setup_status }}
         run: |
           echo "Setup status: $setup_status"
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.10'
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -88,6 +94,7 @@ jobs:
           CI_SLACK_CHANNEL_DUMMY_TESTS: ${{ secrets.CI_SLACK_CHANNEL_DUMMY_TESTS }}
           SLACK_REPORT_CHANNEL: ${{ inputs.slack_report_channel }}
           ACCESS_REPO_INFO_TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI_EVENT: ${{ inputs.ci_event }}
           # This `CI_TITLE` would be empty for `schedule` or `workflow_run` events.
           CI_TITLE: ${{ github.event.head_commit.message }}
@@ -97,6 +104,7 @@ jobs:
           REPORT_REPO_ID: ${{ inputs.report_repo_id }}
           quantization_matrix: ${{ inputs.quantization_matrix }}
           folder_slices: ${{ inputs.folder_slices }}
+          PYTHONUNBUFFERED: "1"
         # We pass `needs.setup.outputs.matrix` as the argument. A processing in `notification_service.py` to change
         # `models/bert` to `models_bert` is required, as the artifact names use `_` instead of `/`.
         # For a job that doesn't depend on (i.e. `needs`) `setup`, the value for `inputs.folder_slices` would be an
@@ -105,6 +113,7 @@ jobs:
           pip install huggingface_hub
           pip install slack_sdk
           pip show slack_sdk
+          pip install requests
           pip install .
           if [ "$quantization_matrix" != "" ]; then
             python utils/notification_service.py "$quantization_matrix"

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1076,9 +1076,13 @@ if __name__ == "__main__":
         ci_title = ci_title.strip().split("\n")[0].strip()
 
         # Retrieve the PR title and author login to complete the report
+        github_token = os.environ.get("GITHUB_TOKEN")
+        github_headers = {"Authorization": f"token {github_token}"} if github_token else {}
+
         commit_number = ci_url.split("/")[-1]
         ci_detail_url = f"https://api.github.com/repos/{repository_full_name}/commits/{commit_number}"
-        ci_details = requests.get(ci_detail_url).json()
+        ci_details = requests.get(ci_detail_url, headers=github_headers).json()
+
         ci_author = ci_details["author"]["login"]
 
         merged_by = None
@@ -1087,7 +1091,7 @@ if __name__ == "__main__":
         if len(numbers) > 0:
             pr_number = numbers[0]
             ci_detail_url = f"https://api.github.com/repos/{repository_full_name}/pulls/{pr_number}"
-            ci_details = requests.get(ci_detail_url).json()
+            ci_details = requests.get(ci_detail_url, headers=github_headers).json()
 
             ci_author = ci_details["user"]["login"]
             ci_url = f"https://github.com/{repository_full_name}/pull/{pr_number}"

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1083,7 +1083,11 @@ if __name__ == "__main__":
         ci_detail_url = f"https://api.github.com/repos/{repository_full_name}/commits/{commit_number}"
         ci_details = requests.get(ci_detail_url, headers=github_headers).json()
 
-        ci_author = ci_details["author"]["login"]
+        # We use `.get()` to avoid failures when the GitHub API returns an unexpected response (e.g. due to rate
+        # limiting, where the response won't contain the expected fields). It's preferred to continue the CI run
+        # without failing even if we can't retrieve the author info. That said, the GITHUB_TOKEN should always be
+        # set during CI runs to avoid hitting the rate limit in the first place.
+        ci_author = (ci_details.get("author") or {}).get("login")
 
         merged_by = None
         # Find the PR number (if any) and change the url to the actual PR page.
@@ -1093,10 +1097,11 @@ if __name__ == "__main__":
             ci_detail_url = f"https://api.github.com/repos/{repository_full_name}/pulls/{pr_number}"
             ci_details = requests.get(ci_detail_url, headers=github_headers).json()
 
-            ci_author = ci_details["user"]["login"]
+            ci_author = ci_details.get("user", {}).get("login") or ci_author
             ci_url = f"https://github.com/{repository_full_name}/pull/{pr_number}"
 
-            merged_by = ci_details["merged_by"]["login"]
+            merged_by_info = ci_details.get("merged_by")
+            merged_by = merged_by_info.get("login") if merged_by_info is not None else None
 
         if merged_by is None:
             ci_title = f"<{ci_url}|{ci_title}>\nAuthor: GH_{ci_author}"


### PR DESCRIPTION
## Summary

- Switch `slack-report` job from `ubuntu-22.04` to `aws-general-8-plus` runner to avoid GitHub Actions IPs being blocked by the WAF IP reputation list when uploading to HuggingFace Hub
- Add `actions/setup-python` step since AWS runners don't have Python pre-installed
- Pass `GITHUB_TOKEN` to the script and use it in GitHub API requests (`/commits`, `/pulls`) to avoid unauthenticated rate limiting (60 req/hr → 5000 req/hr)
- Use `.get()` for API response field access so a rate-limit error response doesn't crash the CI run
