### PR TITLE
docs: clarify distributed launch for semantic segmentation

### DIFF
--- a/examples/pytorch/semantic-segmentation/README.md
+++ b/examples/pytorch/semantic-segmentation/README.md
@@ -101,6 +101,10 @@ In order to use `segments/sidewalk-semantic`:
  - Log in to Hugging Face with `hf auth login` (token can be accessed [here](https://huggingface.co/settings/tokens)).
  - Accept terms of use for `sidewalk-semantic` on [dataset page](https://huggingface.co/datasets/segments/sidewalk-semantic).
 
+> [!TIP]
+> For distributed training with the Trainer, launch this script with a distributed launcher such as
+> `accelerate launch` or `torchrun` instead of plain `python`.
+
 ```bash
 python run_semantic_segmentation.py \
     --model_name_or_path nvidia/mit-b0 \


### PR DESCRIPTION
# What does this PR do?

Adds a note to the semantic segmentation PyTorch example clarifying that distributed Trainer runs should be launched with a distributed launcher such as `accelerate launch` or `torchrun`, instead of plain `python`.

Fixes #35667


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. Discussed in #35667.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests? N/A, documentation-only change. Ran `git diff --check`.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
