### PR TITLE
Fix missing _auto_class for trust_remote_code models using local config

### DIFF
--- a/.github/workflows/pr_build_doc_with_comment.yml
+++ b/.github/workflows/pr_build_doc_with_comment.yml
@@ -8,7 +8,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number }}-${{ startsWith(github.event.comment.body, 'build-doc') }}
   cancel-in-progress: true
-permissions: {}
+permissions:
+  contents: read
 
 
 jobs:

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -231,7 +231,7 @@ class _BaseAutoModelClass:
             # mappings in this case, or all future loads of that model will be the remote code model.
             if not has_local_code:
                 cls.register(config.__class__, model_class, exist_ok=True)
-                model_class.register_for_auto_class(auto_class=cls)
+            model_class.register_for_auto_class(auto_class=cls)
             _ = kwargs.pop("code_revision", None)
             model_class = add_generation_mixin_to_remote_model(model_class)
             return model_class._from_config(config, **kwargs)
@@ -384,7 +384,7 @@ class _BaseAutoModelClass:
             # mappings in this case, or all future loads of that model will be the remote code model.
             if not has_local_code:
                 cls.register(config.__class__, model_class, exist_ok=True)
-                model_class.register_for_auto_class(auto_class=cls)
+            model_class.register_for_auto_class(auto_class=cls)
             model_class = add_generation_mixin_to_remote_model(model_class)
             return model_class.from_pretrained(
                 pretrained_model_name_or_path, *model_args, config=config, **hub_kwargs, **kwargs


### PR DESCRIPTION
Fixes #46165

### Description
This fixes an issue where custom dynamic modules failed to copy their Python scripts (like `modeling_*.py`) to the checkpoint directory during `save_pretrained` or `Trainer` checkpoints. 

When a custom model reused a local configuration layout, `auto_factory.py` skipped assigning `_auto_class`, preventing the custom code from persisting and causing an `OSError` on resume. This PR moves `register_for_auto_class` outside of the nested `if` block so that the class is properly tagged without mutating the global model mapping.