### PR TITLE
[fix] regression introduced by #45534

### DIFF
--- a/src/transformers/models/audioflamingo3/configuration_audioflamingo3.py
+++ b/src/transformers/models/audioflamingo3/configuration_audioflamingo3.py
@@ -100,7 +100,6 @@ class AudioFlamingo3Config(PreTrainedConfig):
     audio_token_id: int = 151669
     projector_hidden_act: str = "gelu"
     projector_bias: bool = True
-    tie_word_embeddings: bool = False
 
     def __post_init__(self, **kwargs):
         if isinstance(self.audio_config, dict):

--- a/src/transformers/models/audioflamingo3/modeling_audioflamingo3.py
+++ b/src/transformers/models/audioflamingo3/modeling_audioflamingo3.py
@@ -567,7 +567,7 @@ class AudioFlamingo3Model(AudioFlamingo3PreTrainedModel):
 )
 class AudioFlamingo3ForConditionalGeneration(AudioFlamingo3PreTrainedModel, GenerationMixin):
     _keep_in_fp32_modules_strict = ["embed_positions"]
-    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
+    _tied_weights_keys = None
 
     def __init__(self, config):
         super().__init__(config)

--- a/src/transformers/models/audioflamingo3/modular_audioflamingo3.py
+++ b/src/transformers/models/audioflamingo3/modular_audioflamingo3.py
@@ -273,6 +273,8 @@ class AudioFlamingo3Model(VoxtralModel):
     """
 )
 class AudioFlamingo3ForConditionalGeneration(VoxtralForConditionalGeneration):
+    _tied_weights_keys = None
+
     def __init__(self, config):
         super().__init__(config)
         self.model = AudioFlamingo3Model(config)

--- a/src/transformers/models/glmasr/configuration_glmasr.py
+++ b/src/transformers/models/glmasr/configuration_glmasr.py
@@ -101,6 +101,7 @@ class GlmAsrConfig(PreTrainedConfig):
     text_config: dict | PreTrainedConfig | None = None
     audio_token_id: int = 59260
     projector_hidden_act: str = "gelu"
+    tie_word_embeddings: bool = True
 
     def __post_init__(self, **kwargs):
         if isinstance(self.audio_config, dict):

--- a/src/transformers/models/glmasr/configuration_glmasr.py
+++ b/src/transformers/models/glmasr/configuration_glmasr.py
@@ -101,7 +101,6 @@ class GlmAsrConfig(PreTrainedConfig):
     text_config: dict | PreTrainedConfig | None = None
     audio_token_id: int = 59260
     projector_hidden_act: str = "gelu"
-    tie_word_embeddings: bool = True
 
     def __post_init__(self, **kwargs):
         if isinstance(self.audio_config, dict):

--- a/src/transformers/models/glmasr/modular_glmasr.py
+++ b/src/transformers/models/glmasr/modular_glmasr.py
@@ -380,6 +380,8 @@ class GlmAsrModel(AudioFlamingo3Model):
     """
 )
 class GlmAsrForConditionalGeneration(AudioFlamingo3ForConditionalGeneration):
+    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
+
     def __init__(self, config):
         super().__init__(config)
         self.model = GlmAsrModel(config)

--- a/src/transformers/models/musicflamingo/configuration_musicflamingo.py
+++ b/src/transformers/models/musicflamingo/configuration_musicflamingo.py
@@ -66,7 +66,6 @@ class MusicFlamingoConfig(PreTrainedConfig):
     audio_token_id: int = 151669
     projector_hidden_act: str = "gelu"
     projector_bias: bool = True
-    tie_word_embeddings: bool = False
 
     audio_bos_token_id: int = 151670
     audio_eos_token_id: int = 151671

--- a/src/transformers/models/musicflamingo/modeling_musicflamingo.py
+++ b/src/transformers/models/musicflamingo/modeling_musicflamingo.py
@@ -409,7 +409,7 @@ class MusicFlamingoCausalLMOutputWithPast(ModelOutput):
 )
 class MusicFlamingoForConditionalGeneration(MusicFlamingoPreTrainedModel, GenerationMixin):
     _keep_in_fp32_modules_strict = ["embed_positions"]
-    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
+    _tied_weights_keys = None
 
     def __init__(self, config: MusicFlamingoConfig):
         super().__init__(config)

--- a/src/transformers/models/musicflamingo/modular_musicflamingo.py
+++ b/src/transformers/models/musicflamingo/modular_musicflamingo.py
@@ -78,7 +78,6 @@ class MusicFlamingoConfig(AudioFlamingo3Config):
     audio_eos_token_id: int = 151671
     audio_frame_step: float = 0.01
     rope_parameters: dict | None = None
-    tie_word_embeddings: bool = False
 
     def __post_init__(self, **kwargs):
         if self.rope_parameters is None:

--- a/src/transformers/models/qwen2_audio/configuration_qwen2_audio.py
+++ b/src/transformers/models/qwen2_audio/configuration_qwen2_audio.py
@@ -98,7 +98,6 @@ class Qwen2AudioConfig(PreTrainedConfig):
     audio_config: dict | PreTrainedConfig | None = None
     text_config: dict | PreTrainedConfig | None = None
     audio_token_index: int = 151646
-    tie_word_embeddings: bool = True
 
     def __post_init__(self, **kwargs):
         if isinstance(self.audio_config, dict):

--- a/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
+++ b/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
@@ -766,8 +766,6 @@ class Qwen2AudioModel(Qwen2AudioPreTrainedModel):
     """
 )
 class Qwen2AudioForConditionalGeneration(Qwen2AudioPreTrainedModel, GenerationMixin):
-    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
-
     def __init__(self, config: Qwen2AudioConfig):
         super().__init__(config)
         self.model = Qwen2AudioModel(config)

--- a/src/transformers/models/vibevoice_asr/configuration_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/configuration_vibevoice_asr.py
@@ -75,7 +75,6 @@ class VibeVoiceAsrConfig(PreTrainedConfig):
     audio_bos_token_id: int = 151646
     audio_eos_token_id: int = 151647
     acoustic_tokenizer_chunk_size: int = 1440000
-    tie_word_embeddings: bool = False
 
     def __post_init__(self, **kwargs):
         if isinstance(self.acoustic_tokenizer_encoder_config, dict):

--- a/src/transformers/models/vibevoice_asr/modeling_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/modeling_vibevoice_asr.py
@@ -444,8 +444,6 @@ class VibeVoiceAsrModel(VibeVoiceAsrPreTrainedModel):
     """
 )
 class VibeVoiceAsrForConditionalGeneration(VibeVoiceAsrPreTrainedModel, GenerationMixin):
-    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
-
     def __init__(self, config: VibeVoiceAsrConfig):
         super().__init__(config)
         self.model = VibeVoiceAsrModel(config)

--- a/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
@@ -88,7 +88,6 @@ class VibeVoiceAsrConfig(PreTrainedConfig):
     audio_bos_token_id: int = 151646
     audio_eos_token_id: int = 151647
     acoustic_tokenizer_chunk_size: int = 1440000
-    tie_word_embeddings: bool = False
 
     def __post_init__(self, **kwargs):
         if isinstance(self.acoustic_tokenizer_encoder_config, dict):

--- a/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
@@ -360,8 +360,6 @@ class VibeVoiceAsrModel(VibeVoiceAsrPreTrainedModel):
     """
 )
 class VibeVoiceAsrForConditionalGeneration(VibeVoiceAsrPreTrainedModel, GenerationMixin):
-    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
-
     def __init__(self, config: VibeVoiceAsrConfig):
         super().__init__(config)
         self.model = VibeVoiceAsrModel(config)

--- a/src/transformers/models/voxtral/configuration_voxtral.py
+++ b/src/transformers/models/voxtral/configuration_voxtral.py
@@ -110,7 +110,6 @@ class VoxtralConfig(PreTrainedConfig):
     text_config: dict | PreTrainedConfig | None = None
     audio_token_id: int | None = None
     projector_hidden_act: str = "gelu"
-    tie_word_embeddings: bool = True
 
     def __post_init__(self, **kwargs):
         if isinstance(self.audio_config, dict):

--- a/src/transformers/models/voxtral/modeling_voxtral.py
+++ b/src/transformers/models/voxtral/modeling_voxtral.py
@@ -487,7 +487,6 @@ class VoxtralModel(VoxtralPreTrainedModel):
 )
 class VoxtralForConditionalGeneration(VoxtralPreTrainedModel, GenerationMixin):
     _keep_in_fp32_modules_strict = ["embed_positions"]
-    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
 
     def __init__(self, config):
         super().__init__(config)

--- a/src/transformers/models/voxtral/modular_voxtral.py
+++ b/src/transformers/models/voxtral/modular_voxtral.py
@@ -257,7 +257,6 @@ class VoxtralModel(VoxtralPreTrainedModel):
 )
 class VoxtralForConditionalGeneration(VoxtralPreTrainedModel, GenerationMixin):
     _keep_in_fp32_modules_strict = ["embed_positions"]
-    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
 
     def __init__(self, config):
         super().__init__(config)

--- a/src/transformers/models/voxtral_realtime/configuration_voxtral_realtime.py
+++ b/src/transformers/models/voxtral_realtime/configuration_voxtral_realtime.py
@@ -56,7 +56,6 @@ class VoxtralRealtimeTextConfig(PreTrainedConfig):
     pad_token_id: int | None = None
     bos_token_id: int | None = 1
     eos_token_id: int | list[int] | None = 2
-    tie_word_embeddings: bool = False
     rope_parameters: RopeParameters | dict | None = None
     sliding_window: int | None = 4096
     attention_dropout: float | int = 0.0


### PR DESCRIPTION
# What does this PR do?

A continuation of #46400

Verified by running (on this branch) [this script](https://gist.github.com/eustlb/c1b12d46b4a4f2ae959555ce8aab52ae)

```
model                 lm_head   lm==embed   weights tied  config tie  match
---------------------------------------------------------------------------
qwen2_audio           yes       False       False         False       OK
voxtral               yes       False       False         False       OK
voxtral_realtime      no        n/a         True          True        OK
glmasr                yes       True        False         True        MISMATCH <<<
granite_speech        no        n/a         True          True        OK
granite_speech_plus   no        n/a         True          True        OK
audioflamingo3        yes       False       False         False       OK
musicflamingo         yes       False       False         False       OK
vibevoice_asr         yes       False       False         False       OK
```
  - lm_head — yes/no: whether the checkpoint has a separate lm_head.* tensor in its safetensors (has_lm_head).
  - lm==embed — True/False/n/a: when an lm_head exists, whether lm_head.weight is bitwise identical to embed_tokens.weight. n/a when there's no separate lm_head.
  - weights tied — True/False: what the actual checkpoint implies (not has_lm_head → no separate head means weights are tied).
  - config tie — True/False: what the config class resolves tie_word_embeddings to (fallback False).
  - match — OK if config tie == weights tied, else MISMATCH <<< (the regression check).

For `glmasr`, hub weights have a lm head but it's bitwise to embed tokens so we keep weight tying 