### PR TITLE
Fix missing labels warning in Trainer evaluation loop (#28530)

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2820,6 +2820,13 @@ class Trainer:
             metrics = self.compute_metrics(
                 EvalPrediction(predictions=all_preds, label_ids=all_labels, **eval_set_kwargs)
             )
+        elif self.compute_metrics is not None and all_labels is None:
+            logger.warning(
+                "The `compute_metrics` function is provided, but no labels were found in the evaluation dataset. "
+                "As a result, metrics will not be computed. Please ensure your dataset contains a column named 'labels' "
+                "or explicitly set `label_names` in your `TrainingArguments`."
+            )
+            metrics = {} if metrics is None else metrics
         elif metrics is None:
             metrics = {}
 


### PR DESCRIPTION
### Summary
Fixes #28530. 

As discussed in the issue, if a user provides a custom dataset where label columns are not automatically detected (and `label_names` is not explicitly set), `Trainer` silently skips the `compute_metrics` function. This causes downstream callbacks like `EarlyStoppingCallback` to fail cryptically due to missing metric keys.

###  Changes
- Added a `logger.warning` in `trainer.py`'s `evaluation_loop` to explicitly alert the user when `compute_metrics` is provided but no labels are found, preventing silent failures and guiding them to configure `label_names`.

@muellerzr @amyeroberts