### PR TITLE
fix: propagate dtype to text sub-config for composite models in Auto classes

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -247,6 +247,9 @@ class _BaseAutoModelClass:
                 parent_quant = getattr(parent_config, "quantization_config", None)
                 if parent_quant is not None:
                     config.quantization_config = parent_quant
+                parent_dtype = getattr(parent_config, "dtype", None)
+                if parent_dtype is not None and getattr(config, "dtype", None) is None:
+                    config.dtype = parent_dtype
             return model_class._from_config(config, **kwargs)
 
         raise ValueError(
@@ -401,6 +404,9 @@ class _BaseAutoModelClass:
                 parent_quant = getattr(parent_config, "quantization_config", None)
                 if parent_quant is not None:
                     config.quantization_config = parent_quant
+                parent_dtype = getattr(parent_config, "dtype", None)
+                if parent_dtype is not None and getattr(config, "dtype", None) is None:
+                    config.dtype = parent_dtype
             return model_class.from_pretrained(
                 pretrained_model_name_or_path, *model_args, config=config, **hub_kwargs, **kwargs
             )

--- a/tests/models/qwen3_5/test_modeling_qwen3_5.py
+++ b/tests/models/qwen3_5/test_modeling_qwen3_5.py
@@ -421,6 +421,16 @@ class Qwen3_5ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCas
         self.assertIsInstance(model, Qwen3_5ForCausalLM)
         self.assertIsInstance(model.config, Qwen3_5TextConfig)
 
+    def test_automodelforcausallm_propagates_dtype(self):
+        config = self.model_tester.get_config()
+        config.dtype = torch.float32  # set on composite config
+        full_model = Qwen3_5ForConditionalGeneration(config)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            full_model.save_pretrained(tmp_dir)
+            model = AutoModelForCausalLM.from_pretrained(tmp_dir)  # no dtype kwarg
+        for name, param in model.named_parameters():
+            self.assertEqual(param.dtype, torch.float32, msg=f"{name} has dtype {param.dtype}")
+
     @unittest.skip(
         "Conversion only for the `CausalLM` loading from saved `ConditionalLM`, doesn't apply to simple VLM"
     )


### PR DESCRIPTION
Fixes #46459

**Problem**
dtype passed to AutoModelForCausalLM.from_pretrained is silently ignored for composite (multimodal) checkpoints like Qwen3.5. AutoConfig.from_pretrained absorbs it into the top-level composite config, which is then swapped to the text sub-config via get_text_config() — dropping the user's value. The model falls back to the checkpoint default (bfloat16) with no warning.

**Fix**
Propagate parent_config.dtype to the extracted text sub-config at both get_text_config() call sites in auto_factory.py, mirroring the existing quantization_config propagation from #45494.

**Coordination**
Coordinated on issue #46459 before opening this PR. Issue author (@qflen) acknowledged with approval.

**Duplicate check**
gh pr list --repo huggingface/transformers --state open --search "46459 in:body" returned no results. No overlapping open PRs exist.

**Tests run**
pytest tests/models/qwen3_5/test_modeling_qwen3_5.py::Qwen3_5ModelTest::test_automodelforcausallm_propagates_dtype
PASSED

AutoModelForCausalLM.from_pretrained("Qwen/Qwen3.5-0.8B", dtype=torch.float32)
Output: torch.float32 

**AI assistance disclosure**
AI assistance (Claude) was used for codebase fix verification. All changed lines were reviewed and understood by personally , and the fix was validated locally end-to-end.

The tests_generate failure is a pre-existing flaky test — Kosmos2_5ModelTest::test_generate_with_cache_matches_no_cache — marked FLAKY by CircleCI. It tests cache consistency in Kosmos2.5 generation and has no relation to this change.

@Cyrilvallez @zucchini-nlp