### PR TITLE
Guard mel/chroma filter banks against unbounded memory allocation

### DIFF
--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -57,6 +57,12 @@ if is_torchcodec_available():
 
 AudioInput = Union[np.ndarray, "torch.Tensor", Sequence[np.ndarray], Sequence["torch.Tensor"]]
 
+# Upper bound on the number of elements of a filter bank (mel: `num_frequency_bins * num_mel_filters`; chroma:
+# `num_frequency_bins * num_chroma`). Used to reject config-driven values that would allocate an excessive amount of
+# memory (see `mel_filter_bank` / `chroma_filter_bank`). The largest filter bank produced by any model in this
+# repository is on the order of 10**5 elements, so this leaves a wide margin.
+MAX_FILTER_BANK_SIZE = 2_000_000
+
 
 @retry(exceptions=(httpx.HTTPError,))
 def _fetch_audio_bytes(url: str, timeout: float | None = 10.0) -> bytes:
@@ -429,6 +435,21 @@ def chroma_filter_bank(
     Returns:
         `np.ndarray` of shape `(num_frequency_bins, num_chroma)`
     """
+    if num_frequency_bins < 1 or num_chroma < 1:
+        raise ValueError(
+            f"Require num_frequency_bins >= 1 and num_chroma >= 1, got ({num_frequency_bins}, {num_chroma})"
+        )
+
+    # Like `mel_filter_bank`, this builds a dense matrix whose size (`num_frequency_bins * num_chroma`) is derived from
+    # config fields (e.g. `n_fft` / `num_chroma`); bound it so a malformed config cannot exhaust memory.
+    if num_frequency_bins * num_chroma > MAX_FILTER_BANK_SIZE:
+        raise ValueError(
+            f"Refusing to create a chroma filter bank of shape ({num_frequency_bins}, {num_chroma}): "
+            f"{num_frequency_bins * num_chroma} elements exceeds the maximum of {MAX_FILTER_BANK_SIZE}. "
+            "This is far larger than any real audio configuration and would consume an excessive amount of memory; "
+            "check `num_frequency_bins`/`num_chroma` (e.g. the `n_fft` and `num_chroma` in your config)."
+        )
+
     # Get the FFT bins, not counting the DC component
     frequencies = np.linspace(0, sampling_rate, num_frequency_bins, endpoint=False)[1:]
 
@@ -529,6 +550,21 @@ def mel_filter_bank(
 
     if num_frequency_bins < 2:
         raise ValueError(f"Require num_frequency_bins: {num_frequency_bins} >= 2")
+
+    if num_mel_filters < 1:
+        raise ValueError(f"Require num_mel_filters: {num_mel_filters} >= 1")
+
+    # The filter bank is a dense `(num_frequency_bins, num_mel_filters)` matrix allocated eagerly (often in a feature
+    # extractor's `__init__`). Both dimensions ultimately come from config fields (e.g. `n_fft` / `feature_size`), so
+    # an unvalidated config could request an arbitrarily large matrix and exhaust memory. The largest filter bank used
+    # by any model in this repository is well under 10**5 elements, so this bound leaves a very wide safety margin.
+    if num_frequency_bins * num_mel_filters > MAX_FILTER_BANK_SIZE:
+        raise ValueError(
+            f"Refusing to create a mel filter bank of shape ({num_frequency_bins}, {num_mel_filters}): "
+            f"{num_frequency_bins * num_mel_filters} elements exceeds the maximum of {MAX_FILTER_BANK_SIZE}. "
+            "This is far larger than any real audio configuration and would consume an excessive amount of memory; "
+            "check `num_frequency_bins`/`num_mel_filters` (e.g. the `n_fft` and `feature_size` in your config)."
+        )
 
     if min_frequency > max_frequency:
         raise ValueError(f"Require min_frequency: {min_frequency} <= max_frequency: {max_frequency}")

--- a/tests/utils/test_audio_utils.py
+++ b/tests/utils/test_audio_utils.py
@@ -120,6 +120,30 @@ class AudioUtilsFunctionTester(unittest.TestCase):
         )
         self.assertEqual(mel_filters.shape, (513, 13))
 
+    def test_mel_filter_bank_rejects_oversized_allocation(self):
+        # A malformed/malicious config (e.g. a huge `n_fft` or `feature_size`) must not be able to request an
+        # arbitrarily large filter bank and exhaust memory. Both an oversized `num_frequency_bins` and an oversized
+        # `num_mel_filters` (and their product) must be rejected before any allocation happens.
+        common = {"min_frequency": 0.0, "max_frequency": 8000.0, "sampling_rate": 16000}
+        for num_frequency_bins, num_mel_filters in ((10001, 8000), (3_000_000, 2), (2, 3_000_000)):
+            with self.assertRaises(ValueError):
+                mel_filter_bank(num_frequency_bins=num_frequency_bins, num_mel_filters=num_mel_filters, **common)
+
+        # A realistically-sized filter bank (well within the limit) still works.
+        mel_filters = mel_filter_bank(num_frequency_bins=513, num_mel_filters=128, **common)
+        self.assertEqual(mel_filters.shape, (513, 128))
+
+    def test_chroma_filter_bank_rejects_oversized_allocation(self):
+        # Same guard as the mel filter bank: a malicious `n_fft` / `num_chroma` (e.g. via
+        # MusicgenMelodyFeatureExtractor) must not be able to allocate an arbitrarily large matrix.
+        for num_frequency_bins, num_chroma in ((6_000_000, 24), (3_000_000, 1), (0, 12)):
+            with self.assertRaises(ValueError):
+                chroma_filter_bank(num_frequency_bins=num_frequency_bins, num_chroma=num_chroma, sampling_rate=16000)
+
+        # A realistically-sized chroma filter bank still works.
+        chroma_filters = chroma_filter_bank(num_frequency_bins=16384, num_chroma=12, sampling_rate=32000)
+        self.assertEqual(chroma_filters.shape, (12, 1 + 16384 // 2))
+
     def test_mel_filter_bank_htk(self):
         mel_filters = mel_filter_bank(
             num_frequency_bins=16,


### PR DESCRIPTION
## What

`mel_filter_bank()` and `chroma_filter_bank()` build a dense filter-bank matrix **eagerly in the `__init__`** of audio feature extractors, with the dimensions taken straight from config fields:

- **mel** — `(num_frequency_bins, num_mel_filters)` from `n_fft` / `fft_length` / `window_size` and `feature_size` / `num_mel_filters` / `num_mel_bins` (whisper, clap, phi4_multimodal, gemma4, voxtral_realtime, pop2piano, clvp, speecht5, seamless_m4t, audio_spectrogram_transformer, univnet, …);
- **chroma** — `(num_chroma, num_frequency_bins)` from `n_fft` / `num_chroma` (musicgen_melody).

`mel_filter_bank` only validated `num_frequency_bins >= 2` and `chroma_filter_bank` had no size validation at all. So a malformed or malicious `preprocessor_config.json` can request an enormous matrix and exhaust memory (OOM-kill) **at load time** — before any audio input, any inference, and without `trust_remote_code`. Loading such a repo (`AutoFeatureExtractor`/`AutoProcessor.from_pretrained`, `pipeline(...)`, or a model served by `transformers serve`) kills the worker.

This PR rejects pathological dimensions early in both shared choke points: it bounds the number of filter-bank elements and requires the dimensions to be positive, raising a clear `ValueError` instead of allocating gigabytes. The limit (`MAX_FILTER_BANK_SIZE = 2_000_000` elements) is more than an order of magnitude above the largest filter bank produced by any model in the repo (the biggest is ~4×10⁴ elements: clvp `513 × 80`; musicgen_melody chroma default is `12 × 8193`), so it cannot affect legitimate configs.

## Reproducer (before this PR)

```python
from transformers import WhisperFeatureExtractor, MusicgenMelodyFeatureExtractor
# each call is equivalent to AutoFeatureExtractor.from_pretrained(<repo with a malicious preprocessor_config.json>)
WhisperFeatureExtractor(feature_size=8000, n_fft=20000, sampling_rate=16000)   # ~640 MB mel matrix
MusicgenMelodyFeatureExtractor(n_fft=6_000_000, num_chroma=24)                 # multi-GB chroma matrix
# main: OOM-kill on a constrained worker
# this PR: ValueError("Refusing to create a mel/chroma filter bank of shape (...): ... exceeds the maximum ...")
```

Verified end-to-end under a hard 256 MB limit (`docker run --memory=256m`): on `main` a malicious config OOM-kills the process (exit 137); with this patch it raises `ValueError`, while normal feature extractors still load fine. Measured `tracemalloc` peaks for a ~180-byte config: mel `n_fft=60000, feature_size=5000` → 6.0 GB; chroma `n_fft=6000000, num_chroma=24` → 3.6 GB.

## Type

CWE-789 (Memory Allocation with Excessive Size Value) / CWE-400 — a few-hundred-byte config triggers a multi-GB allocation at load time across the audio feature-extractor family.

## Tests

Added `test_mel_filter_bank_rejects_oversized_allocation` and `test_chroma_filter_bank_rejects_oversized_allocation` (oversized product, oversized single dimension, and a realistic in-bounds case for each).

```
python -m unittest tests.utils.test_audio_utils.AudioUtilsFunctionTester -v
# test_mel_filter_bank_rejects_oversized_allocation ... ok
# test_chroma_filter_bank_rejects_oversized_allocation ... ok
# test_mel_filter_bank_shape / _slaney / _htk ... ok
```

`ruff check` and `ruff format --check` pass on both changed files.

## Notes

No open or merged PR/issue addresses filter-bank memory / `n_fft` allocation (checked PRs, issues, and the pip advisory DB for this repo); the existing audio CVEs are all ReDoS / pickle deserialization, a different class.

This patch was prepared with AI-assisted tooling; the change has been reviewed and is owned by the submitter (per the repository's contribution policy requiring disclosure of AI assistance).
