### PR TITLE
Fix generate masks for unknown layer types

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -1410,8 +1410,12 @@ def create_masks_for_generate(
 
     # If the attribute exist, we need several masks
     if hasattr(effective_config, "layer_types"):
+        layer_patterns = set(effective_config.layer_types)
+        if not layer_patterns <= LAYER_PATTERN_TO_MASK_FUNCTION_MAPPING.keys():
+            return attention_mask
+
         causal_masks = {}
-        for layer_pattern in set(effective_config.layer_types):
+        for layer_pattern in layer_patterns:
             causal_masks[layer_pattern] = LAYER_PATTERN_TO_MASK_FUNCTION_MAPPING[layer_pattern](**mask_kwargs)
         return causal_masks
     # In this case, all layers are sliding

--- a/tests/utils/test_masking_utils.py
+++ b/tests/utils/test_masking_utils.py
@@ -32,6 +32,7 @@ if is_torch_available():
         create_bidirectional_mask,
         create_causal_mask,
         create_chunked_causal_mask,
+        create_masks_for_generate,
         find_packed_sequence_indices,
     )
 
@@ -147,6 +148,22 @@ class MaskTest(unittest.TestCase):
 
         # We compatre the str representations, as the BlockMask objects themselves cannot easily be compared
         self.assertEqual(causal_mask.to_string(), EXPECTED_BLOCK_MASK.to_string())
+
+
+    def test_create_masks_for_generate_unknown_layer_type_returns_attention_mask(self):
+        config = LlamaConfig()
+        config.layer_types = ["full_attention", "linear_attention"]
+        attention_mask = torch.ones((1, 4), dtype=torch.long)
+
+        mask = create_masks_for_generate(
+            config=config,
+            inputs_embeds=torch.empty((1, 4), dtype=torch.float32),
+            attention_mask=attention_mask,
+            cache_position=torch.arange(4),
+            past_key_values=None,
+        )
+
+        self.assertIs(mask, attention_mask)
 
     def test_find_packed_sequence_indices(self):
         position_ids = torch.tensor([[0, 1, 2, 3, 0, 1, 0, 1, 2, 3], [0, 1, 2, 3, 4, 5, 0, 1, 2, 3]])


### PR DESCRIPTION
# What does this PR do?

Fixes #46441

`create_masks_for_generate` currently assumes every configured `layer_types` value has a pre-build mask function. Hybrid linear-attention models include `linear_attention`, which is intentionally handled inside the model forward, so this path raises a `KeyError` before generation reaches the model.

This PR returns the original 2D attention mask when any layer type has no registered pre-generation mask function, allowing the model forward to build the appropriate per-layer masks itself.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. Issue: #46441
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation). N/A — bug fix with no docs/API change.
- [x] Did you write any new necessary tests?


## Who can review?

@ArthurZucker @Cyrilvallez
