### PR TITLE
feat: update GGUF model configuration parameters for Gemma 4

### DIFF
--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -704,6 +704,15 @@ def load_gguf_checkpoint(gguf_checkpoint_path, return_tensors=False, model_to_lo
         # EOG tokens to match generation_config.json: <eos>(1),
         # <|tool_response>(50), <turn|>(106).
         parsed_parameters["config"]["eos_token_id"] = [1, 106, 50]
+        parsed_parameters["config"]["attention_k_eq_v"] = True
+        parsed_parameters["config"]["hidden_size_per_layer_input"] = 0
+        parsed_parameters["config"]["vocab_size_per_layer_input"] = 0
+        
+        gguf_num_key_value_heads = parsed_parameters["config"].get("num_key_value_heads")
+        if isinstance(gguf_num_key_value_heads, list):
+            parsed_parameters["config"]["num_key_value_heads"] = gguf_num_key_value_heads[0]
+            if len(set(gguf_num_key_value_heads)) > 1:
+                parsed_parameters["config"]["num_global_key_value_heads"] = min(gguf_num_key_value_heads)
 
     # MiniMax-M2: convert expert_gating_func integer to scoring_func string
     if parsed_parameters["config"].get("model_type") == "minimax_m2":


### PR DESCRIPTION
# What does this PR do?

This PR implements full GGUF loading support for the Gemma 4 architecture. It fixes multiple issues preventing Gemma 4 GGUF files from loading in `transformers`:

1. **KV Heads Array Parsing:** Handled the `num_key_value_heads` parsing for `gemma4`. Because Gemma 4 uses hybrid attention, GGUF stores `num_key_value_heads` as a list per layer (e.g., `[16, 16, 16, 16, 16, 4, ...]`). This caused a `TypeError: expected int, got list`. The PR extracts `num_key_value_heads` and `num_global_key_value_heads` directly from this list.
2. **KV Sharing Configuration (`attention_k_eq_v`):** Gemma 4 uses shared KV projections for full attention layers, meaning `v_proj.weight` is missing in the GGUF checkpoint and `k_proj` shape is smaller (`[2048, 5376]`). Set `attention_k_eq_v = True` for Gemma 4 to match this structural expectation and prevent size mismatches.
3. **Disabled Per-Layer Embeddings (PLE):** GGUF checkpoints currently strip out or do not support PLE weights (`per_layer_input_gate`, `post_per_layer_input_norm`, etc.). Set `hidden_size_per_layer_input = 0` to prevent `transformers` from randomly initializing these missing weights.

**Coordination / Issue link:** 
-

**Test commands run and results:**
Tested locally with `lm_eval`:
`python -m lm_eval --model hf --model_args pretrained=.\models,gguf_file=gemma-4-31B-it-Q4_K_M.gguf --tasks gsm8k --device cuda:0`
Result: The model initialized successfully without size mismatches, and successfully mapped sliding vs full attention layers and disabled PLE.

**AI Assistance:**
This patch was developed and debugged with the assistance of an AI coding agent. As the submitting human, I have reviewed every changed line, validated the logic for hybrid attention configuration, and verified the fix end-to-end on my local machine.