### PR TITLE
Fix T5 decoder input validation error messages

### DIFF
--- a/src/transformers/models/mt5/modeling_mt5.py
+++ b/src/transformers/models/mt5/modeling_mt5.py
@@ -654,7 +654,7 @@ class MT5Stack(MT5PreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.return_dict
 
         if input_ids is not None and inputs_embeds is not None:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder " if self.is_decoder else ""
             raise ValueError(
                 f"You cannot specify both {err_msg_prefix}input_ids and {err_msg_prefix}inputs_embeds at the same time"
             )
@@ -664,7 +664,7 @@ class MT5Stack(MT5PreTrainedModel):
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder " if self.is_decoder else ""
             raise ValueError(f"You have to specify either {err_msg_prefix}input_ids or {err_msg_prefix}inputs_embeds")
 
         if self.gradient_checkpointing and self.training:

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -643,7 +643,7 @@ class T5Stack(T5PreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.return_dict
 
         if input_ids is not None and inputs_embeds is not None:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder " if self.is_decoder else ""
             raise ValueError(
                 f"You cannot specify both {err_msg_prefix}input_ids and {err_msg_prefix}inputs_embeds at the same time"
             )
@@ -653,7 +653,7 @@ class T5Stack(T5PreTrainedModel):
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder " if self.is_decoder else ""
             raise ValueError(f"You have to specify either {err_msg_prefix}input_ids or {err_msg_prefix}inputs_embeds")
 
         if self.gradient_checkpointing and self.training:

--- a/src/transformers/models/umt5/modeling_umt5.py
+++ b/src/transformers/models/umt5/modeling_umt5.py
@@ -612,7 +612,7 @@ class UMT5Stack(UMT5PreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.return_dict
 
         if input_ids is not None and inputs_embeds is not None:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder " if self.is_decoder else ""
             raise ValueError(
                 f"You cannot specify both {err_msg_prefix}input_ids and {err_msg_prefix}inputs_embeds at the same time"
             )
@@ -622,7 +622,7 @@ class UMT5Stack(UMT5PreTrainedModel):
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder " if self.is_decoder else ""
             raise ValueError(f"You have to specify either {err_msg_prefix}input_ids or {err_msg_prefix}inputs_embeds")
 
         if self.gradient_checkpointing and self.training:

--- a/tests/models/mt5/test_modeling_mt5.py
+++ b/tests/models/mt5/test_modeling_mt5.py
@@ -538,6 +538,20 @@ class MT5ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
             self.assertTrue(config_and_inputs[0].scale_decoder_outputs)
         self.model_tester.create_and_check_model(*config_and_inputs)
 
+    def test_decoder_input_validation_errors_name_forward_args(self):
+        config, _, decoder_input_ids, *_ = self.model_tester.prepare_config_and_inputs()
+        model = MT5Model(config).to(torch_device)
+        model.eval()
+
+        decoder_input_ids = decoder_input_ids.to(torch_device)
+        inputs_embeds = model.decoder.embed_tokens(decoder_input_ids)
+
+        with self.assertRaisesRegex(ValueError, "both decoder input_ids and decoder inputs_embeds"):
+            model.decoder(input_ids=decoder_input_ids, inputs_embeds=inputs_embeds)
+
+        with self.assertRaisesRegex(ValueError, "either decoder input_ids or decoder inputs_embeds"):
+            model.decoder()
+
     # MT5ForSequenceClassification does not support inputs_embeds
     def test_inputs_embeds(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -579,6 +579,20 @@ class T5ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, 
         self.assertTrue(config_and_inputs[0].scale_decoder_outputs)
         self.model_tester.create_and_check_model(*config_and_inputs)
 
+    def test_decoder_input_validation_errors_name_forward_args(self):
+        config, _, decoder_input_ids, *_ = self.model_tester.prepare_config_and_inputs()
+        model = T5Model(config).to(torch_device)
+        model.eval()
+
+        decoder_input_ids = decoder_input_ids.to(torch_device)
+        inputs_embeds = model.decoder.embed_tokens(decoder_input_ids)
+
+        with self.assertRaisesRegex(ValueError, "both decoder input_ids and decoder inputs_embeds"):
+            model.decoder(input_ids=decoder_input_ids, inputs_embeds=inputs_embeds)
+
+        with self.assertRaisesRegex(ValueError, "either decoder input_ids or decoder inputs_embeds"):
+            model.decoder()
+
     def test_model_v1_1(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         config_v1 = self.model_tester.get_config_v1_1()

--- a/tests/models/umt5/test_modeling_umt5.py
+++ b/tests/models/umt5/test_modeling_umt5.py
@@ -295,6 +295,20 @@ class UMT5ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
             with torch.no_grad():
                 model(**inputs)[0]
 
+    def test_decoder_input_validation_errors_name_forward_args(self):
+        config, input_dict = self.model_tester.prepare_config_and_inputs()
+        model = UMT5Model(config).to(torch_device)
+        model.eval()
+
+        decoder_input_ids = input_dict["decoder_input_ids"].to(torch_device)
+        inputs_embeds = model.decoder.embed_tokens(decoder_input_ids)
+
+        with self.assertRaisesRegex(ValueError, "both decoder input_ids and decoder inputs_embeds"):
+            model.decoder(input_ids=decoder_input_ids, inputs_embeds=inputs_embeds)
+
+        with self.assertRaisesRegex(ValueError, "either decoder input_ids or decoder inputs_embeds"):
+            model.decoder()
+
     # overwrite because T5 doesn't accept position ids as input and expects `decoder_input_ids`
     def test_custom_4d_attention_mask(self):
         for model_class in self.all_generative_model_classes:


### PR DESCRIPTION
## What does this PR do?

Fixes #46463.

Direct calls to the T5-family decoder stacks accept `input_ids` and `inputs_embeds`, but the validation errors used `decoder_input_ids` / `decoder_inputs_embeds` when `self.is_decoder` was true. That made the message look like the caller had passed the seq2seq wrapper arguments, even when they were calling `model.decoder(...)` directly.

This keeps the decoder context in the message while naming the actual stack forward arguments:

- `decoder input_ids`
- `decoder inputs_embeds`

The same fix is applied to T5, mT5, and UMT5 so the copied family stays consistent.

## Tests

- Selected T5 / mT5 / UMT5 regression tests for the new decoder validation case: passed
- Direct reproduction script for both "both inputs" and "neither input" cases across T5 / mT5 / UMT5: passed
- `python -m py_compile` on touched model and test files
- `python -m ruff check` on touched files
- `python -m ruff format --check` on touched files
- `python utils/check_copies.py --file ...` for touched model files

My local conda environment has a third-party `utils` package that shadows this repository's top-level `utils/` directory during pytest collection, so I forced the repo `utils/` module path for the selected pytest run.
