### PR TITLE
Clarify Falcon-Mamba kernel fallback warning

### DIFF
--- a/src/transformers/models/falcon_mamba/modeling_falcon_mamba.py
+++ b/src/transformers/models/falcon_mamba/modeling_falcon_mamba.py
@@ -181,9 +181,9 @@ class FalconMambaMixer(nn.Module):
             if self.use_falcon_mambapy:
                 if is_mambapy_available():
                     logger.warning_once(
-                        "The fast path is not available because one of `(selective_state_update, selective_scan_fn, causal_conv1d_fn, causal_conv1d_update, mamba_inner_fn)`"
-                        " is None. Falling back to the mamba.py backend. To install follow https://github.com/state-spaces/mamba/#installation for mamba-ssm and"
-                        " https://github.com/Dao-AILab/causal-conv1d or `pip install kernels` for causal-conv1d"
+                        "The Falcon-Mamba fast path is not available because one of `(selective_state_update, selective_scan_fn, causal_conv1d_fn, causal_conv1d_update, falcon_mamba_inner_fn)`"
+                        " is None. Falling back to the mamba.py backend. Install `kernels` to use the Falcon-Mamba hub kernels;"
+                        " `mamba_ssm` and `causal_conv1d` alone do not provide every Falcon-Mamba fast-path kernel."
                     )
                 else:
                     raise ImportError(
@@ -191,9 +191,9 @@ class FalconMambaMixer(nn.Module):
                     )
             else:
                 logger.warning_once(
-                    "The fast path is not available because one of `(selective_state_update, selective_scan_fn, causal_conv1d_fn, causal_conv1d_update, mamba_inner_fn)`"
-                    " is None. Falling back to the sequential implementation of Mamba, as use_mambapy is set to False. To install follow https://github.com/state-spaces/mamba/#installation for mamba-ssm and"
-                    " https://github.com/Dao-AILab/causal-conv1d or `pip install kernels` for causal-conv1d. For the mamba.py backend, follow https://github.com/alxndrTL/mamba.py."
+                    "The Falcon-Mamba fast path is not available because one of `(selective_state_update, selective_scan_fn, causal_conv1d_fn, causal_conv1d_update, falcon_mamba_inner_fn)`"
+                    " is None. Falling back to the sequential implementation of Mamba, as use_mambapy is set to False. Install `kernels` to use the Falcon-Mamba hub kernels;"
+                    " `mamba_ssm` and `causal_conv1d` alone do not provide every Falcon-Mamba fast-path kernel. For the mamba.py backend, follow https://github.com/alxndrTL/mamba.py."
                 )
 
     def cuda_kernels_forward(

--- a/src/transformers/models/falcon_mamba/modular_falcon_mamba.py
+++ b/src/transformers/models/falcon_mamba/modular_falcon_mamba.py
@@ -134,9 +134,9 @@ class FalconMambaMixer(MambaMixer):
             if self.use_falcon_mambapy:
                 if is_mambapy_available():
                     logger.warning_once(
-                        "The fast path is not available because one of `(selective_state_update, selective_scan_fn, causal_conv1d_fn, causal_conv1d_update, mamba_inner_fn)`"
-                        " is None. Falling back to the mamba.py backend. To install follow https://github.com/state-spaces/mamba/#installation for mamba-ssm and"
-                        " https://github.com/Dao-AILab/causal-conv1d or `pip install kernels` for causal-conv1d"
+                        "The Falcon-Mamba fast path is not available because one of `(selective_state_update, selective_scan_fn, causal_conv1d_fn, causal_conv1d_update, falcon_mamba_inner_fn)`"
+                        " is None. Falling back to the mamba.py backend. Install `kernels` to use the Falcon-Mamba hub kernels;"
+                        " `mamba_ssm` and `causal_conv1d` alone do not provide every Falcon-Mamba fast-path kernel."
                     )
                 else:
                     raise ImportError(
@@ -144,9 +144,9 @@ class FalconMambaMixer(MambaMixer):
                     )
             else:
                 logger.warning_once(
-                    "The fast path is not available because one of `(selective_state_update, selective_scan_fn, causal_conv1d_fn, causal_conv1d_update, mamba_inner_fn)`"
-                    " is None. Falling back to the sequential implementation of Mamba, as use_mambapy is set to False. To install follow https://github.com/state-spaces/mamba/#installation for mamba-ssm and"
-                    " https://github.com/Dao-AILab/causal-conv1d or `pip install kernels` for causal-conv1d. For the mamba.py backend, follow https://github.com/alxndrTL/mamba.py."
+                    "The Falcon-Mamba fast path is not available because one of `(selective_state_update, selective_scan_fn, causal_conv1d_fn, causal_conv1d_update, falcon_mamba_inner_fn)`"
+                    " is None. Falling back to the sequential implementation of Mamba, as use_mambapy is set to False. Install `kernels` to use the Falcon-Mamba hub kernels;"
+                    " `mamba_ssm` and `causal_conv1d` alone do not provide every Falcon-Mamba fast-path kernel. For the mamba.py backend, follow https://github.com/alxndrTL/mamba.py."
                 )
 
     def __init__(self, config: FalconMambaConfig, layer_idx: int, initialize_mixer_weights: bool = True):

--- a/tests/models/falcon_mamba/test_modeling_falcon_mamba.py
+++ b/tests/models/falcon_mamba/test_modeling_falcon_mamba.py
@@ -20,6 +20,7 @@ import pytest
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig, FalconMambaConfig, is_torch_available
 from transformers.testing_utils import (
+    CaptureLogger,
     Expectations,
     cleanup,
     require_bitsandbytes,
@@ -42,6 +43,8 @@ if is_torch_available():
     import torch
 
     from transformers import DynamicCache, FalconMambaForCausalLM, FalconMambaModel
+    from transformers.models.falcon_mamba.modeling_falcon_mamba import FalconMambaMixer
+    from transformers.models.falcon_mamba.modeling_falcon_mamba import logger as falcon_mamba_logger
 
 
 # Copied from transformers.tests.models.mamba.MambaModelTester with Mamba->FalconMamba,mamba->falcon_mamba
@@ -318,6 +321,23 @@ class FalconMambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTest
     def test_falcon_mamba_lm_head_forward_and_backwards(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_falcon_mamba_lm_head_forward_and_backwards(*config_and_inputs)
+
+    def test_slow_path_warning_mentions_falcon_mamba_kernels(self):
+        falcon_mamba_logger.warning_once.cache_clear()
+        config = FalconMambaConfig(
+            hidden_size=32,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            use_falcon_mambapy=False,
+        )
+
+        with CaptureLogger(falcon_mamba_logger) as captured:
+            FalconMambaMixer(config, layer_idx=0, initialize_mixer_weights=False)
+
+        self.assertIn("The Falcon-Mamba fast path is not available", captured.out)
+        self.assertIn("falcon_mamba_inner_fn", captured.out)
+        self.assertIn("Install `kernels` to use the Falcon-Mamba hub kernels", captured.out)
+        self.assertIn("do not provide every Falcon-Mamba fast-path kernel", captured.out)
 
     @slow
     # Ignore copy


### PR DESCRIPTION
## Summary
- clarify the Falcon-Mamba slow-path warning so it points users to `kernels`
- mention `falcon_mamba_inner_fn`, matching the actual missing fast-path symbol
- cover the warning text without changing Falcon-Mamba runtime behavior

Fixes #46234.

## To verify
- `PYTHONPATH=src python -m py_compile src\transformers\models\falcon_mamba\modular_falcon_mamba.py src\transformers\models\falcon_mamba\modeling_falcon_mamba.py tests\models\falcon_mamba\test_modeling_falcon_mamba.py`
- `python -m ruff check src\transformers\models\falcon_mamba\modular_falcon_mamba.py src\transformers\models\falcon_mamba\modeling_falcon_mamba.py tests\models\falcon_mamba\test_modeling_falcon_mamba.py`
- `python -m ruff format --check src\transformers\models\falcon_mamba\modular_falcon_mamba.py src\transformers\models\falcon_mamba\modeling_falcon_mamba.py tests\models\falcon_mamba\test_modeling_falcon_mamba.py`
- `git diff --check`
- `git fsck --no-progress`

I also ran the focused Falcon-Mamba warning test through `pytest.main(...)` after injecting the repository-local `utils` namespace, because this local environment has a site-packages `utils` package that shadows the repo test helper package during direct pytest collection. The focused test passed.
