### PR TITLE
Fix: skip caching_allocator_warmup for non-CUDA/XPU accelerator devices

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5026,45 +5026,40 @@ def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: dict, 
 
     # This will kick off the caching allocator to avoid having to Malloc afterwards
     for device, byte_count in total_byte_count.items():
-        if device.type in ["cuda", "xpu"]:
-            accelerator_module = getattr(torch, device.type)
-            index = device.index if device.index is not None else accelerator_module.current_device()
-            free_device_memory, total_device_memory = accelerator_module.mem_get_info(index)
-            unused_memory = accelerator_module.memory_reserved(index) - accelerator_module.memory_allocated(index)
-            # If we have reserved but unused memory, we can lower the allocation we want to make, but only if it's still
-            # higher than the unused memory. This is because otherwise torch will use that unused memory when performing
-            # our own allocation, thus not allocating any new memory from the GPU. For example if byte_count=6 GiB,
-            # unused_memory=4 GiB, then we cannot allocate only 2 GiB as this would *likely* (may not be exact, due to
-            # fragmentation issues) simply use the pool of 4 GiB unused memory that is available. In those cases, it's better
-            # to allocate more than the technically only 2 GiB required
-            if byte_count - unused_memory > unused_memory:
-                byte_count = byte_count - unused_memory
-            # Minimum amount that will trigger new gpu allocation, even if it's technically "too much" compared to what we need
-            elif byte_count - unused_memory > 1.5 * 1024**3:
-                # Nothing we can do here, the memory will need to fill itself as we load params, but we cannot reallocate
-                # from gpu until the unused memory is not filled
-                if unused_memory + 1 > free_device_memory:
-                    byte_count = 0
-                # We allocate the minimum amount that will force new gpu allocation, even if it's technically "too much"
-                else:
-                    byte_count = unused_memory + 1
-            # If we only need to reallocate less than 1.5 GiB of what is already allocated, then don't allocate more
-            else:
+        if device.type not in ["cuda", "xpu"]:
+            continue  # No caching allocator to warm up on non-CUDA/XPU devices
+        accelerator_module = getattr(torch, device.type)
+        index = device.index if device.index is not None else accelerator_module.current_device()
+        free_device_memory, total_device_memory = accelerator_module.mem_get_info(index)
+        unused_memory = accelerator_module.memory_reserved(index) - accelerator_module.memory_allocated(index)
+        # If we have reserved but unused memory, we can lower the allocation we want to make, but only if it's still
+        # higher than the unused memory. This is because otherwise torch will use that unused memory when performing
+        # our own allocation, thus not allocating any new memory from the GPU. For example if byte_count=6 GiB,
+        # unused_memory=4 GiB, then we cannot allocate only 2 GiB as this would *likely* (may not be exact, due to
+        # fragmentation issues) simply use the pool of 4 GiB unused memory that is available. In those cases, it's better
+        # to allocate more than the technically only 2 GiB required
+        if byte_count - unused_memory > unused_memory:
+            byte_count = byte_count - unused_memory
+        # Minimum amount that will trigger new gpu allocation, even if it's technically "too much" compared to what we need
+        elif byte_count - unused_memory > 1.5 * 1024**3:
+            # Nothing we can do here, the memory will need to fill itself as we load params, but we cannot reallocate
+            # from gpu until the unused memory is not filled
+            if unused_memory + 1 > free_device_memory:
                 byte_count = 0
-            # Allow up to (max device memory - 1.2 GiB) in resource-constrained hardware configurations. Trying to reserve more
-            # than that amount might sometimes lead to unnecessary cuda/xpu OOM, if the last parameter to be loaded on the device is large,
-            # and the remaining reserved memory portion is smaller than the param size -> torch will then try to fully re-allocate all
-            # the param size, instead of using the remaining reserved part, and allocating only the difference, which can lead
-            # to OOM. See https://github.com/huggingface/transformers/issues/37436#issuecomment-2808982161 for more details.
-            # Note that we use an absolute value instead of device proportion here, as a 8GiB device could still allocate too much
-            # if using e.g. 90% of device size, while a 140GiB device would allocate too little
-            byte_count = min(byte_count, total_device_memory - 1.2 * 1024**3)
-        elif device.type == "mps":
-            # Skip warmup on MPS: there is a limit of the maximum size a single buffer can have on MPS,
-            # which from testing seems to be about 2/3 of the total device memory (tested on apple silicon).
-            # This causes the warmup function to return a `RuntimeError: Invalid buffer size: XX.XX GiB`.
-            # NOTE: not tested on intel macs
-            continue
+            # We allocate the minimum amount that will force new gpu allocation, even if it's technically "too much"
+            else:
+                byte_count = unused_memory + 1
+        # If we only need to reallocate less than 1.5 GiB of what is already allocated, then don't allocate more
+        else:
+            byte_count = 0
+        # Allow up to (max device memory - 1.2 GiB) in resource-constrained hardware configurations. Trying to reserve more
+        # than that amount might sometimes lead to unnecessary cuda/xpu OOM, if the last parameter to be loaded on the device is large,
+        # and the remaining reserved memory portion is smaller than the param size -> torch will then try to fully re-allocate all
+        # the param size, instead of using the remaining reserved part, and allocating only the difference, which can lead
+        # to OOM. See https://github.com/huggingface/transformers/issues/37436#issuecomment-2808982161 for more details.
+        # Note that we use an absolute value instead of device proportion here, as a 8GiB device could still allocate too much
+        # if using e.g. 90% of device size, while a 140GiB device would allocate too little
+        byte_count = min(byte_count, total_device_memory - 1.2 * 1024**3)
         # We divide by 2 here as we allocate in fp16
         _ = torch.empty(int(byte_count // 2), dtype=torch.float16, device=device, requires_grad=False)
 


### PR DESCRIPTION
## What this fixes

`caching_allocator_warmup()` hardcodes `dtype=torch.float16` and allocates a full-model-size tensor for **every** accelerator device. Non-CUDA backends (Vulkan, MPS, privateuseone, etc.) do not have a CUDA-style caching allocator to warm up, and attempting fp16 tensor allocation on these backends causes crashes:

- **Vulkan on AMD RADV**: fp16 tensor creation crashes outright (fp16 support is incomplete on Vulkan).
- **Even with fp16 support** (e.g., if PyTorch adds Vulkan fp16), large allocations would still fail because Vulkan Memory Allocator image size caps (~1.3 GB) are far below full model sizes for models > 2.6B params on integrated GPUs.
- Performance impact of skipping: **zero** — there is no caching allocator to benefit from pre-allocation on these backends.

## The fix (3 effective lines)

Add an early-exit guard at the top of the warmup loop body. If `device.type` is neither `cuda` nor `xpu`, skip warmup entirely with `continue`. This replaces the previous MPS-specific skip and generalizes it to all non-CUDA/XPU accelerator backends.

```python
if device.type not in ["cuda", "xpu"]:
    continue  # No caching allocator to warm up on non-CUDA/XPU devices
```

This is upstream-correct: ROCm uses the `"cuda"` device type, so AMD GPUs via ROCm are **unaffected**. Only truly non-CUDA backends (Vulkan, MPS, privateuseone, etc.) skip — which is correct because none have a `cudaMalloc`-equivalent caching allocator.

## Testing

- CUDA path is structurally unchanged — the existing memory accounting and fp16 warmup execute exactly as before for CUDA/XPU devices.
- MPS was previously handled by its own `elif device.type == "mps": continue` — now caught by the generalized early guard (same behavior, cleaner code).
- Vulkan and other non-CUDA backends now safely skip the warmup instead of crashing on `torch.empty(..., dtype=torch.float16)`.

## AI assistance disclosure

This PR was drafted with AI assistance. The human submitter has reviewed every changed line and understands the change end-to-end.