### PR TITLE
Add `torchembed` as an optional RoPE/embedding backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ _deps = [
     "timm>=1.0.23",
     "tokenizers>=0.22.0,<=0.23.0",
     "torch>=2.4",
+    "torchembed",
     "torchaudio",
     "torchvision",
     "pyctcdecode>=0.4.0",
@@ -176,6 +177,7 @@ def deps_list(*pkgs):
 extras = {}
 
 extras["torch"] = deps_list("torch", "accelerate")
+extras["torchembed"] = deps_list("torchembed")
 extras["vision"] = deps_list("torchvision", "Pillow")
 extras["audio"] = deps_list("torchaudio", "librosa", "pyctcdecode", "phonemizer")
 if PYTHON_MINOR_VERSION < 13:

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -76,6 +76,7 @@ deps = {
     "timm": "timm>=1.0.23",
     "tokenizers": "tokenizers>=0.22.0,<=0.23.0",
     "torch": "torch>=2.4",
+    "torchembed": "torchembed",
     "torchaudio": "torchaudio",
     "torchvision": "torchvision",
     "pyctcdecode": "pyctcdecode>=0.4.0",

--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -641,17 +641,14 @@ def _compute_torchembed_rope_parameters(
     """
     if not is_torchembed_available():
         raise ImportError(
-            "The 'torchembed' rope type requires the `torchembed` package. "
-            "Install it with: pip install torchembed"
+            "The 'torchembed' rope type requires the `torchembed` package. Install it with: pip install torchembed"
         )
 
     # Same frequency computation as default RoPE — torchembed uses the same scheme
     base = config.rope_parameters["rope_theta"]
     dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
     attention_factor = 1.0
-    inv_freq = 1.0 / (
-        base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
-    )
+    inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim))
     return inv_freq, attention_factor
 
 

--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 from functools import wraps
 from typing import TYPE_CHECKING, Optional, TypedDict
 
-from .utils import is_torch_available, logging
+from .utils import is_torch_available, is_torchembed_available, logging
 
 
 logger = logging.get_logger(__name__)
@@ -626,6 +626,35 @@ def _compute_llama3_parameters(
     return inv_freq_llama, attention_factor
 
 
+def _compute_torchembed_rope_parameters(
+    config: "PreTrainedConfig",
+    device: Optional["torch.device"] = None,
+    seq_len: int | None = None,
+    layer_type: str | None = None,
+) -> tuple["torch.Tensor", float]:
+    """
+    Compute RoPE parameters backed by `torchembed.RotaryEmbedding`.
+
+    Requires the `torchembed` package to be installed. When used, inv_freq follows the same
+    computation as the default RoPE, with the understanding that the model forward pass will
+    delegate the actual rotary application to `torchembed.RotaryEmbedding`.
+    """
+    if not is_torchembed_available():
+        raise ImportError(
+            "The 'torchembed' rope type requires the `torchembed` package. "
+            "Install it with: pip install torchembed"
+        )
+
+    # Same frequency computation as default RoPE — torchembed uses the same scheme
+    base = config.rope_parameters["rope_theta"]
+    dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+    attention_factor = 1.0
+    inv_freq = 1.0 / (
+        base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+    )
+    return inv_freq, attention_factor
+
+
 # This maps the "rope_type" string field in rope config to the corresponding function to compute the RoPE parameters
 # from the model config. You can append new {'rope_type': callable} pairs to this rope_parameters to enable custom RoPE
 # parameterizations, as long as the callable has the same signature.
@@ -636,6 +665,7 @@ ROPE_INIT_FUNCTIONS: dict[str, Callable[..., tuple["torch.Tensor", float]]] = {
     "longrope": _compute_longrope_parameters,
     "llama3": _compute_llama3_parameters,
     "proportional": _compute_proportional_rope_parameters,
+    "torchembed": _compute_torchembed_rope_parameters,
 }
 
 
@@ -647,7 +677,8 @@ class RopeParameters(TypedDict):
             the model's `default_theta` (typically 10000.0) is used.
         rope_type (`str`, *optional*, defaults to "default"):
             The sub-variant of RoPE to use. Can be one of ['default', 'linear', 'dynamic', 'yarn', 'longrope',
-            'llama3'], with 'default' being the original RoPE implementation.
+            'llama3', 'torchembed'], with 'default' being the original RoPE implementation. The 'torchembed'
+            type requires the `torchembed` package to be installed.
         partial_rotary_factor (`float`, *optional*):
             The percentage of the query and key head embedding on which RoPE will be applied.
         factor (`float`, *optional*):
@@ -995,6 +1026,18 @@ class RotaryEmbeddingConfigMixin:
                 "`rope_parameters`'s partial_rotary_factor is None. This will default to 1.0 in the computation, "
                 "making this equivalent to the linear_scaling RoPE type. Provide a value in the range [0.0, 1.0) to "
                 "make use of the proportional RoPE funcitonality."
+            )
+
+    def _validate_torchembed_rope_parameters(self, rope_parameters: dict, ignore_keys: set | None = None):
+        required_keys = {"rope_type", "rope_theta"}
+        received_keys = set(rope_parameters.keys())
+        rope_type = rope_parameters["rope_type"]
+        self._check_received_keys(rope_type, received_keys, required_keys, ignore_keys=ignore_keys)
+
+        if not is_torchembed_available():
+            logger.warning(
+                "The 'torchembed' rope type requires the `torchembed` package to be installed. "
+                "Install it with: pip install torchembed"
             )
 
     @staticmethod

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -234,6 +234,7 @@ from .import_utils import (
     is_torch_neuroncore_available,
     is_torch_npu_available,
     is_torch_optimi_available,
+    is_torchembed_available,
     is_torch_tensorrt_fx_available,
     is_torch_tf32_available,
     is_torch_tpu_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -757,6 +757,11 @@ def is_torch_optimi_available() -> bool:
 
 
 @lru_cache
+def is_torchembed_available() -> bool:
+    return _is_package_available("torchembed")[0]
+
+
+@lru_cache
 def is_lomo_available() -> bool:
     return _is_package_available("lomo_optim")[0]
 

--- a/tests/utils/test_modeling_rope_utils.py
+++ b/tests/utils/test_modeling_rope_utils.py
@@ -61,15 +61,12 @@ class RopeTest(unittest.TestCase):
             "long_factor": ["longrope"],
         }
         for rope_type in all_rope_types:
-            if rope_type == "default":
-                continue  # "default" only warns about unrecognised keys, never raises KeyError
-            # proportional is same as default wrt to expected keys
-            if rope_type == "proportional":
+            if rope_type in simple_rope_types:
                 continue
             for param, valid_rope_types in valid_param_mapping.items():
                 # Set `param` with a dummy value -- we want to test the dict key
                 config.rope_parameters = {"rope_type": rope_type, "rope_theta": 10000.0, param: True}
-                if rope_type in valid_rope_types or rope_type in simple_rope_types:
+                if rope_type in valid_rope_types:
                     continue
                 else:
                     with self.assertRaises(KeyError):
@@ -174,6 +171,8 @@ class RopeTest(unittest.TestCase):
         all_rope_types = ROPE_INIT_FUNCTIONS.keys()
         config.layer_types = ["full_attention", "sliding_attention"]
 
+        simple_rope_types = {"default", "proportional", "torchembed"}
+
         def nest(full_attention_params):
             return {
                 "full_attention": full_attention_params,
@@ -183,7 +182,7 @@ class RopeTest(unittest.TestCase):
         # Each non-default RoPE type with only `rope_theta` should still raise
         # KeyError (missing required keys) when wrapped in the nested shape.
         for rope_type in all_rope_types:
-            if rope_type in ("default", "proportional"):
+            if rope_type in simple_rope_types:
                 continue
             config.rope_parameters = nest({"rope_type": rope_type, "rope_theta": 10000.0})
             with self.assertRaises(KeyError):
@@ -200,7 +199,7 @@ class RopeTest(unittest.TestCase):
             "long_factor": ["longrope"],
         }
         for rope_type in all_rope_types:
-            if rope_type in ("default", "proportional"):
+            if rope_type in simple_rope_types:
                 continue
             for param, valid_rope_types in valid_param_mapping.items():
                 config.rope_parameters = nest({"rope_type": rope_type, "rope_theta": 10000.0, param: True})

--- a/tests/utils/test_modeling_rope_utils.py
+++ b/tests/utils/test_modeling_rope_utils.py
@@ -24,7 +24,7 @@ if is_torch_available():
     import torch
 
     from transformers import ROPE_INIT_FUNCTIONS
-    from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
+    from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding, rotate_half
 
 
 @require_torch
@@ -33,20 +33,23 @@ class RopeTest(unittest.TestCase):
         config = LlamaConfig()
         all_rope_types = ROPE_INIT_FUNCTIONS.keys()
 
+        # rope types that only require rope_type + rope_theta (like default)
+        simple_rope_types = {"default", "proportional", "torchembed"}
+        rope_types_requiring_extra = [t for t in all_rope_types if t not in simple_rope_types]
+
         # The base config is always valid (default RoPE)
         config.validate_rope()
 
-        # If we explicitly set the other (non-default) RoPE types with only rope_theta,
-        # validation should fail because required keys are missing (e.g. factor, short_factor)
-        for rope_type in all_rope_types:
-            if rope_type == "default":
-                continue  # "default" is always valid with just rope_theta
-            # proportional is same as default wrt to expected keys
-            if rope_type == "proportional":
-                continue
+        # All non-simple rope types require extra params beyond rope_type + rope_theta
+        for rope_type in rope_types_requiring_extra:
             config.rope_parameters = {"rope_type": rope_type, "rope_theta": 10000.0}
             with self.assertRaises(KeyError):
                 config.validate_rope()
+
+        # Simple rope types pass validation with just rope_type + rope_theta
+        for rope_type in simple_rope_types:
+            config.rope_parameters = {"rope_type": rope_type, "rope_theta": 10000.0}
+            config.validate_rope()
 
         # Parameters are exclusive to their own RoPE type, and should raise an exception if incorrectly passed
         valid_param_mapping = {
@@ -66,7 +69,7 @@ class RopeTest(unittest.TestCase):
             for param, valid_rope_types in valid_param_mapping.items():
                 # Set `param` with a dummy value -- we want to test the dict key
                 config.rope_parameters = {"rope_type": rope_type, "rope_theta": 10000.0, param: True}
-                if rope_type in valid_rope_types:
+                if rope_type in valid_rope_types or rope_type in simple_rope_types:
                     continue
                 else:
                     with self.assertRaises(KeyError):
@@ -706,3 +709,59 @@ class RopeTest(unittest.TestCase):
         }
         inv_freq, _ = rope_fn(config=config, device=torch_device)
         torch.testing.assert_close(inv_freq, EXPECTED_INV_FREQ)
+
+    def test_torchembed_rope_numerically(self):
+        """torchembed rope init function should match default RoPE frequencies."""
+        config = LlamaConfig()
+        default_inv_freq, _ = LlamaRotaryEmbedding.compute_default_rope_parameters(config, device=torch_device)
+
+        rope_fn = ROPE_INIT_FUNCTIONS["torchembed"]
+        config.rope_parameters = {"rope_type": "torchembed", "rope_theta": 10000.0}
+        inv_freq, attention_scale = rope_fn(config=config, device=torch_device)
+
+        self.assertEqual(attention_scale, 1.0)
+        torch.testing.assert_close(inv_freq, default_inv_freq)
+
+    def test_torchembed_rope_rotates_qk(self):
+        """torchembed.RotaryEmbedding should rotate Q/K the same way as HF's apply_rotary_pos_emb."""
+        try:
+            import torchembed
+        except ImportError:
+            self.skipTest("torchembed is not installed")
+
+        config = LlamaConfig()
+        head_dim = config.hidden_size // config.num_attention_heads
+        base = config.rope_parameters.get("rope_theta", 10000.0)
+
+        # Reference: HF's cos/sin from LlamaRotaryEmbedding + apply_rotary_pos_emb
+        hf_rotary = LlamaRotaryEmbedding(config, device=torch_device)
+        n_seq = 16
+        position_ids = torch.arange(n_seq, device=torch_device).unsqueeze(0)
+        q = torch.randn(1, n_seq, head_dim, device=torch_device)
+        k = torch.randn(1, n_seq, head_dim, device=torch_device)
+
+        cos, sin = hf_rotary(q, position_ids)
+        q_rot_hf = q * cos + rotate_half(q) * sin
+        k_rot_hf = k * cos + rotate_half(k) * sin
+
+        # torchembed's RotaryEmbedding
+        te_rotary = torchembed.RotaryEmbedding(dim=head_dim, max_seq_len=n_seq, base=base, device=torch_device)
+        q_rot_te, k_rot_te = te_rotary(q, k, seq_dim=-2)
+
+        # Both should produce identical rotated Q/K
+        torch.testing.assert_close(q_rot_te, q_rot_hf)
+        torch.testing.assert_close(k_rot_te, k_rot_hf)
+
+    def test_torchembed_rope_config_validation(self):
+        """torchembed rope type should validate with just rope_type + rope_theta."""
+        config = LlamaConfig()
+        config.rope_parameters = {"rope_type": "torchembed", "rope_theta": 10000.0}
+        config.validate_rope()
+
+        # It should also work through LlamaRotaryEmbedding end-to-end
+        rotary = LlamaRotaryEmbedding(config, device=torch_device)
+        head_dim = config.hidden_size // config.num_attention_heads
+        position_ids = torch.arange(10, device=torch_device).unsqueeze(0)
+        cos, sin = rotary(torch.randn(1, 10, head_dim, device=torch_device), position_ids)
+        self.assertEqual(cos.shape, (1, 10, head_dim))
+        self.assertEqual(sin.shape, (1, 10, head_dim))


### PR DESCRIPTION
torchembed provides a centralized optimized home for RoPE variants (XPos, CLEX, AliBI, etc.) and NVIDIA-optimized kernels (FlashAttention-style fused RoPE). Instead of each variant scattered across HF model-specific code, they can be enabled via  a single `rope_type="torchembed"` key and add new variants or kernel optimizations land in torchembed without needing transformer changes. 


- Add `is_torchembed_available()` to import_utils (guarded optional dep pattern)
- Register `"torchembed"` in `ROPE_INIT_FUNCTIONS` with frequency computation matching default RoPE
- Add `_validate_torchembed_rope_parameters` for config validation
- Add `torchembed` to setup.py deps and extras
- Add tests for numerical correctness and end-to-end integration

Usage: `pip install transformers[torchembed]` then set
`rope_parameters={"rope_type": "torchembed"}` in model config.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
