### PR TITLE
Fix remote cache position and serving imports

### DIFF
--- a/src/transformers/cli/serving/chat_completion.py
+++ b/src/transformers/cli/serving/chat_completion.py
@@ -17,10 +17,12 @@ Handler for the /v1/chat/completions endpoint.
 Supports streaming (SSE via DirectStreamer) and non-streaming (JSON) responses.
 """
 
+from __future__ import annotations
+
 import asyncio
 import time
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 from ...utils import logging
 from ...utils.import_utils import is_serve_available
@@ -56,6 +58,10 @@ if is_serve_available():
         """OpenAI ``ChoiceDelta`` extended with the ``reasoning_content`` field."""
 
         reasoning_content: str | None = None
+else:
+
+    class CompletionCreateParamsStreaming(TypedDict):
+        pass
 
 
 from .utils import (

--- a/src/transformers/cli/serving/completion.py
+++ b/src/transformers/cli/serving/completion.py
@@ -19,10 +19,12 @@ in choices[].text. Supports streaming and non-streaming modes, and suffix for
 fill-in-the-middle text insertion.
 """
 
+from __future__ import annotations
+
 import asyncio
 import time
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 from ...utils import logging
 from ...utils.import_utils import is_serve_available
@@ -33,6 +35,10 @@ if is_serve_available():
     from fastapi.responses import JSONResponse, StreamingResponse
     from openai.types import Completion, CompletionChoice, CompletionUsage
     from openai.types.completion_create_params import CompletionCreateParamsBase
+else:
+
+    class CompletionCreateParamsBase(TypedDict):
+        pass
 
 
 from .utils import BaseGenerateManager, BaseHandler, _StreamError

--- a/src/transformers/cli/serving/response.py
+++ b/src/transformers/cli/serving/response.py
@@ -17,10 +17,12 @@ Handler for the /v1/responses endpoint (OpenAI Responses API).
 Supports streaming (SSE) and non-streaming (JSON) responses.
 """
 
+from __future__ import annotations
+
 import asyncio
 import time
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 from ...utils import logging
 from ...utils.import_utils import is_serve_available
@@ -53,6 +55,10 @@ if is_serve_available():
     )
     from openai.types.responses.response_create_params import ResponseCreateParamsStreaming
     from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails, ResponseUsage
+else:
+
+    class ResponseCreateParamsStreaming(TypedDict):
+        pass
 
 
 from .utils import (

--- a/src/transformers/cli/serving/server.py
+++ b/src/transformers/cli/serving/server.py
@@ -15,6 +15,8 @@
 FastAPI app factory.
 """
 
+from __future__ import annotations
+
 import uuid
 from contextlib import asynccontextmanager
 

--- a/src/transformers/cli/serving/transcription.py
+++ b/src/transformers/cli/serving/transcription.py
@@ -15,8 +15,10 @@
 Handler for the /v1/audio/transcriptions endpoint.
 """
 
+from __future__ import annotations
+
 import io
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 from ...utils import logging
 from ...utils.import_utils import is_serve_available
@@ -26,6 +28,10 @@ if is_serve_available():
     from fastapi import HTTPException, Request
     from fastapi.responses import JSONResponse, StreamingResponse
     from openai.types.audio.transcription_create_params import TranscriptionCreateParamsBase
+else:
+
+    class TranscriptionCreateParamsBase(TypedDict):
+        pass
 
 from .model_manager import ModelManager
 from .utils import DirectStreamer, GenerateManager, GenerationState, _StreamError

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -601,6 +601,42 @@ class GenerationMixin(ContinuousMixin):
 
         return model_inputs
 
+    def _call_prepare_inputs_for_generation(
+        self: "GenerativePreTrainedModel", input_ids: torch.LongTensor, **model_kwargs
+    ):
+        """
+        Calls `prepare_inputs_for_generation`, temporarily adding `cache_position` for legacy remote code models.
+
+        This keeps `cache_position` out of the generation state while preserving compatibility with remote models that
+        still override `prepare_inputs_for_generation` and expect this argument to be passed by `generate`.
+        """
+        if (
+            "cache_position" not in model_kwargs
+            and self.is_remote_code()
+            and "cache_position" in set(inspect.signature(self.prepare_inputs_for_generation).parameters)
+        ):
+            logger.warning_once(
+                "The remote code model you are currently using seems to expect `cache_position`. This arg has been "
+                "removed from the Transformers library, and will stop being created in `generate` even for remote code models "
+                "in a future release. Please open a PR on the remote code hub repo to remove any usage of `cache_position`."
+            )
+            inputs_embeds = model_kwargs.get("inputs_embeds")
+            if (
+                not self.config.is_encoder_decoder
+                and inputs_embeds is not None
+                and model_kwargs.get("is_first_iteration")
+                and model_kwargs.get("next_sequence_length") is None
+            ):
+                sequence_length = inputs_embeds.shape[1]
+            else:
+                sequence_length = model_kwargs.get("next_sequence_length") or input_ids.shape[1]
+
+            past_key_values = model_kwargs.get("past_key_values")
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            model_kwargs["cache_position"] = torch.arange(sequence_length, device=input_ids.device) + past_seen_tokens
+
+        return self.prepare_inputs_for_generation(input_ids, **model_kwargs)
+
     def _prepare_model_inputs(
         self: "GenerativePreTrainedModel",
         inputs: torch.Tensor | None,
@@ -2789,7 +2825,7 @@ class GenerationMixin(ContinuousMixin):
         while self._has_unfinished_sequences(this_peer_finished, synced_gpus, device=input_ids.device):
             if prefill_consumed:
                 next_sequence_length = 1 if model_kwargs["use_cache"] else None
-                model_inputs = self.prepare_inputs_for_generation(
+                model_inputs = self._call_prepare_inputs_for_generation(
                     input_ids, next_sequence_length=next_sequence_length, **model_kwargs
                 )
                 with self._optimize_model_for_decode():
@@ -3279,7 +3315,7 @@ class GenerationMixin(ContinuousMixin):
                 # a. Forward current tokens, obtain the logits
                 flat_running_sequences = self._flatten_beam_dim(running_sequences[:, :, :cur_len])
                 next_sequence_length = 1 if model_kwargs["use_cache"] else None
-                model_inputs = self.prepare_inputs_for_generation(
+                model_inputs = self._call_prepare_inputs_for_generation(
                     flat_running_sequences, next_sequence_length=next_sequence_length, **model_kwargs
                 )
                 model_outputs = self(**model_inputs, return_dict=True)
@@ -3612,7 +3648,7 @@ class GenerationMixin(ContinuousMixin):
                 candidate_kwargs = _prepare_position_ids(candidate_kwargs, new_length, self.config.is_encoder_decoder)
 
             next_sequence_length = candidate_length + 1 if not is_first_iteration else None
-            model_inputs = self.prepare_inputs_for_generation(
+            model_inputs = self._call_prepare_inputs_for_generation(
                 candidate_input_ids,
                 next_sequence_length=next_sequence_length,
                 is_first_iteration=is_first_iteration,
@@ -3819,7 +3855,7 @@ class GenerationMixin(ContinuousMixin):
 
         # Usual prefill
         if generation_config.prefill_chunk_size is None:
-            model_inputs = self.prepare_inputs_for_generation(
+            model_inputs = self._call_prepare_inputs_for_generation(
                 input_ids,
                 next_sequence_length=next_sequence_length,
                 is_first_iteration=is_first_iteration,
@@ -3854,7 +3890,7 @@ class GenerationMixin(ContinuousMixin):
                     model_kwargs["attention_mask"] = attention_mask[:, :current_length]
                 if position_ids is not None:
                     model_kwargs["position_ids"] = position_ids[:, past_length:current_length]
-                model_inputs = self.prepare_inputs_for_generation(input_chunk, **model_kwargs)
+                model_inputs = self._call_prepare_inputs_for_generation(input_chunk, **model_kwargs)
 
                 outputs = model_forward(**model_inputs, return_dict=True)
 

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -17,11 +17,13 @@ Tests for the serving layer.
 """
 
 import asyncio
+import importlib
 import json
 import socket
+import sys
 import time
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import httpx
 
@@ -57,6 +59,39 @@ if is_serve_available():
     from fastapi import HTTPException
     from openai import OpenAI
     from openai.types.responses import Response, ResponseCreatedEvent
+
+
+def test_serving_modules_import_without_optional_deps():
+    modules = [
+        "transformers.cli.serving.chat_completion",
+        "transformers.cli.serving.completion",
+        "transformers.cli.serving.response",
+        "transformers.cli.serving.transcription",
+        "transformers.cli.serving.server",
+    ]
+    previous_modules = {module: sys.modules.pop(module, None) for module in modules}
+    parent_module = sys.modules.get("transformers.cli.serving")
+    previous_attrs = {
+        module.rsplit(".", 1)[1]: getattr(parent_module, module.rsplit(".", 1)[1], None)
+        for module in modules
+        if parent_module is not None
+    }
+
+    try:
+        with patch("transformers.utils.import_utils.is_serve_available", return_value=False):
+            for module in modules:
+                importlib.import_module(module)
+    finally:
+        for module in modules:
+            sys.modules.pop(module, None)
+            if previous_modules[module] is not None:
+                sys.modules[module] = previous_modules[module]
+        if parent_module is not None:
+            for attr, value in previous_attrs.items():
+                if value is not None:
+                    setattr(parent_module, attr, value)
+                elif hasattr(parent_module, attr):
+                    delattr(parent_module, attr)
 
 
 def _find_free_port() -> int:

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -72,6 +72,7 @@ if is_torch_available():
         BartForConditionalGeneration,
         BartTokenizer,
         DataCollatorWithFlattening,
+        GPT2Config,
         GPT2LMHeadModel,
         GPT2Tokenizer,
         ImageGPTForCausalImageModeling,
@@ -2825,6 +2826,49 @@ def floats_tensor(shape, scale=1.0, rng=None, name=None):
 @pytest.mark.generate
 @require_torch
 class GenerationIntegrationTests(unittest.TestCase):
+    def test_remote_prepare_inputs_gets_legacy_cache_position(self):
+        config = GPT2Config(
+            n_layer=1,
+            n_head=2,
+            n_embd=8,
+            vocab_size=32,
+            bos_token_id=0,
+            eos_token_id=30,
+            pad_token_id=31,
+        )
+        model = GPT2LMHeadModel(config).to(torch_device)
+        input_ids = torch.tensor([[1, 2, 3]], device=torch_device)
+
+        original_prepare_inputs = model.prepare_inputs_for_generation
+        cache_positions = []
+
+        def legacy_prepare_inputs_for_generation(
+            input_ids,
+            past_key_values=None,
+            attention_mask=None,
+            inputs_embeds=None,
+            cache_position=None,
+            **kwargs,
+        ):
+            self.assertIsNotNone(cache_position)
+            cache_positions.append(cache_position)
+            return original_prepare_inputs(
+                input_ids,
+                past_key_values=past_key_values,
+                attention_mask=attention_mask,
+                inputs_embeds=inputs_embeds,
+                **kwargs,
+            )
+
+        model.is_remote_code = lambda: True
+        model.prepare_inputs_for_generation = legacy_prepare_inputs_for_generation
+
+        model.generate(input_ids, do_sample=False, max_new_tokens=2)
+
+        self.assertGreaterEqual(len(cache_positions), 2)
+        self.assertListEqual(cache_positions[0].tolist(), [0, 1, 2])
+        self.assertListEqual(cache_positions[1].tolist(), [3])
+
     def test_generation_config_defaults(self):
         "Tests that we can set config value to a global default. See https://github.com/huggingface/transformers/issues/42762"
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)


### PR DESCRIPTION
Fixes two compatibility issues:

- Keeps serving modules importable when optional serving dependencies are not installed.
- Restores temporary `cache_position` compatibility for remote-code models that override `prepare_inputs_for_generation` and still explicitly accept `cache_position`.

## Root cause

Serving request schema classes inherited from OpenAI types that were imported only when `is_serve_available()` was true, making the modules fail to import in lean environments.

For generation, v5 creates `cache_position` inside the default `GenerationMixin.prepare_inputs_for_generation`, but remote-code models may override that method. Those overrides never received the compatibility value, causing failures like `TypeError: 'NoneType' object is not subscriptable`.

## Issue coordination

Fixes #46468.

Coordination/approval: (https://github.com/huggingface/transformers/issues/46468)

Duplicate-work check:
- `gh issue view <issue_number> --repo huggingface/transformers --comments`
- `gh pr list --repo huggingface/transformers --state open --search "<issue_number> in:body"`
- `gh pr list --repo huggingface/transformers --state open --search "cache_position CompletionCreateParamsStreaming serving"`

## Tests

- `git diff --check`
- `python -m pytest tests/cli/test_serve.py::test_serving_modules_import_without_optional_deps tests/generation/test_utils.py::GenerationIntegrationTests::test_remote_prepare_inputs_gets_legacy_cache_position -q`
- `make style`

## AI assistance

This patch was assisted with AI assistance. I reviewed the changed lines and understand the change end-to-end.