### PR TITLE
Fix static cache max length config

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1918,6 +1918,8 @@ class GenerationMixin(ContinuousMixin):
                     f"and will be removed in v5.13. Please only use one of {STATIC_CACHE_IMPLEMENTATIONS}, "
                     "and the layer structure will be inferred automatically."
                 )
+            cache_config = generation_config.cache_config or {}
+            max_cache_length = max(max_cache_length, cache_config.get("max_cache_len", max_cache_length))
             model_kwargs[cache_name] = self._prepare_static_cache(
                 cache_implementation=generation_config.cache_implementation,
                 batch_size=max(generation_config.num_beams, generation_config.num_return_sequences) * batch_size,

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -108,6 +108,34 @@ class CacheTest(unittest.TestCase):
         self.assertTrue(cached_keys.shape == (1, 1, 10, 128))
         self.assertTrue(cached_values.shape == (1, 1, 10, 128))
 
+    def test_generate_static_cache_uses_cache_config_max_cache_len(self):
+        config = LlamaConfig(
+            vocab_size=16,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            pad_token_id=0,
+            bos_token_id=1,
+            eos_token_id=2,
+        )
+        model = AutoModelForCausalLM.from_config(config).to(torch_device).eval()
+        input_ids = torch.tensor([[1, 3, 4]], device=torch_device)
+
+        outputs = model.generate(
+            input_ids=input_ids,
+            max_new_tokens=2,
+            do_sample=False,
+            return_dict_in_generate=True,
+            cache_implementation="static",
+            cache_config={"max_cache_len": 32},
+            disable_compile=True,
+        )
+
+        self.assertIsInstance(outputs.past_key_values, StaticCache)
+        self.assertEqual(outputs.past_key_values.max_cache_len, 32)
+
 
 def _skip_on_failed_cache_prerequisites(test, cache_implementation):
     """Function to skip tests on failed cache prerequisites, given a cache implementation"""


### PR DESCRIPTION
## Summary

`cache_config` was only consulted by the quantized cache branch in `generate()`. For static caches, `cache_config={"max_cache_len": ...}` was ignored and the auto-allocated `StaticCache` was still sized from `max_length - 1`.

This keeps the normal generated-length floor, but lets a larger `cache_config["max_cache_len"]` pre-size the static cache so repeated calls can reuse it instead of reallocating when `max_new_tokens` grows.

## To verify

- `python -m py_compile src\transformers\generation\utils.py tests\utils\test_cache_utils.py`
- `python -m ruff check src\transformers\generation\utils.py tests\utils\test_cache_utils.py`
- `python -m ruff format --check src\transformers\generation\utils.py tests\utils\test_cache_utils.py`
- `git diff --check upstream/main..HEAD`
- Direct local-source regression script with `PYTHONPATH=src` and a tiny `LlamaConfig`: verified `StaticCache.max_cache_len == 32` when `cache_config={"max_cache_len": 32}`.

I also tried the targeted pytest:

```powershell
$env:PYTHONPATH='src'; python -m pytest tests\utils\test_cache_utils.py -q -k "static_cache_uses_cache_config_max_cache_len"
```

but this Windows environment fails while importing `conftest.py` before collecting the test because the globally installed `kernels` package raises `ValueError: Either a revision or a version must be specified.` from `kernels.layer.layer.LayerRepository`. That is the same local kernels import blocker I saw before touching this patch.

Fixes #46424