### PR TITLE
Guard PEFT adapter loading against arbitrary `megatron_core` module import

### DIFF
--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -440,6 +440,7 @@ class PeftAdapterMixin:
         local_files_only: bool = False,
         adapter_kwargs: dict[str, Any] | None = None,
         load_config: Optional["LoadStateDictConfig"] = None,
+        trust_remote_code: bool | None = None,
         **kwargs,
     ) -> "LoadStateDictInfo":
         """
@@ -456,6 +457,9 @@ class PeftAdapterMixin:
                 The adapter name to use. If not set, will use the name "default".
             load_config (`LoadStateDictConfig`, *optional*):
                 A load configuration to reuse when pulling adapter weights, typically from `from_pretrained`.
+            trust_remote_code (`bool`, *optional*):
+                Whether to allow the adapter config to trigger code execution (e.g. importing a custom
+                `megatron_core` module). Defaults to `False`; required to be `True` to load such adapters.
             kwargs (`dict[str, Any]`, *optional*):
                 Additional `LoadStateDictConfig` fields passed as keyword arguments.
             peft_config (`dict[str, Any]`, *optional*):
@@ -578,6 +582,21 @@ class PeftAdapterMixin:
         peft_weight_conversions = build_peft_weight_mapping(weight_conversions, adapter_name, peft_config=peft_config)
 
         patch_moe_parameter_targeting(model=self, peft_config=peft_config)
+
+        # Security: a malicious `adapter_config.json` from an untrusted repository can set
+        # `megatron_config`, which makes PEFT import the module named in `megatron_core` during
+        # `inject_adapter_in_model` (`importlib.import_module(config.megatron_core)` in
+        # `peft.tuners.lora.tp_layer.dispatch_megatron`). Adapters are auto-loaded by
+        # `from_pretrained` with no code-execution opt-in, so restrict this import to the real
+        # Megatron-Core package unless the caller explicitly passes `trust_remote_code=True`.
+        if getattr(peft_config, "megatron_config", None) is not None and not trust_remote_code:
+            megatron_core = getattr(peft_config, "megatron_core", "megatron.core")
+            if megatron_core not in ("megatron.core", "megatron"):
+                raise ValueError(
+                    f"This adapter's config requests importing `{megatron_core}` via `megatron_core`, "
+                    "which would execute code from the adapter repository when the adapter is injected. "
+                    "If you trust this repository, reload it with `trust_remote_code=True`."
+                )
 
         if not hotswap:
             # Create and add fresh new adapters into the model, unless the weights are hotswapped

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4341,6 +4341,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 adapter_name=adapter_name,
                 load_config=load_config,
                 adapter_kwargs=adapter_kwargs,
+                trust_remote_code=trust_remote_code,
             )
 
         if output_loading_info:

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -111,6 +111,46 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                 # dummy generation
                 _ = peft_model.generate(input_ids=torch.LongTensor([[0, 1, 2, 3, 4, 5, 6, 7]]).to(torch_device))
 
+    def test_peft_adapter_megatron_core_import_requires_trust_remote_code(self):
+        """
+        Security regression: an auto-loaded `adapter_config.json` can set `megatron_config`, which
+        makes PEFT import the module named in `megatron_core` during `inject_adapter_in_model`
+        (`importlib.import_module(config.megatron_core)`). Loading such an adapter must not import an
+        arbitrary module without `trust_remote_code=True`.
+        """
+        from peft import LoraConfig
+
+        model_id = self.transformers_test_model_ids[0]
+        model = AutoModelForCausalLM.from_pretrained(model_id).to(torch_device)
+        model.add_adapter(LoraConfig(init_lora_weights=False))
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            model.save_pretrained(tmpdirname)
+
+            # Tamper the saved adapter config to request importing an arbitrary module.
+            adapter_config_path = os.path.join(tmpdirname, ADAPTER_CONFIG_NAME)
+            with open(adapter_config_path) as f:
+                adapter_config = json.load(f)
+            adapter_config["megatron_config"] = {"hidden_size": 8}
+            adapter_config["megatron_core"] = "os"
+            with open(adapter_config_path, "w") as f:
+                json.dump(adapter_config, f)
+
+            # Without trust_remote_code the loader must refuse instead of importing the module.
+            with self.assertRaises(ValueError) as ctx:
+                AutoModelForCausalLM.from_pretrained(tmpdirname)
+            self.assertIn("trust_remote_code", str(ctx.exception))
+
+            # The legitimate Megatron-Core module name is allowed through the guard (any later error
+            # is only because megatron is not installed in the test environment, never the guard).
+            adapter_config["megatron_core"] = "megatron.core"
+            with open(adapter_config_path, "w") as f:
+                json.dump(adapter_config, f)
+            try:
+                AutoModelForCausalLM.from_pretrained(tmpdirname)
+            except Exception as e:
+                self.assertNotIn("trust_remote_code", str(e))
+
     def test_peft_state_dict(self):
         """
         Simple test that checks if the returned state dict of `get_adapter_state_dict()` method contains


### PR DESCRIPTION
A model repository's `adapter_config.json` is fully untrusted, and `from_pretrained` auto-loads it whenever PEFT is installed and the repo contains one (`maybe_load_adapters` → `load_adapter` → `inject_adapter_in_model`), with no `trust_remote_code` opt-in. If that config sets `megatron_config`, PEFT's LoRA Megatron dispatcher runs `importlib.import_module(config.megatron_core)` (`peft/tuners/lora/tp_layer.py`, `dispatch_megatron`). So a saved repo can make `from_pretrained` import an attacker-named module — code execution from an untrusted repo without any consent gate. With the repo on `sys.path` (e.g. the usual clone-and-load-from-`.` flow) the imported module can be a `.py` shipped in the repo itself.

This is the same trust-boundary class as the kernel-loading bypass (CVE-2026-4372): an attacker-controlled config field reaching an import/exec sink through a plain `from_pretrained`, no `trust_remote_code`. The import sink lives in PEFT, but transformers is what reaches it automatically; the fix here keeps the auto-load from importing arbitrary modules.

The fix threads `trust_remote_code` into `load_adapter` and, before injection, restricts the `megatron_core` import to the real Megatron-Core package (`megatron.core` / `megatron`) unless the caller passes `trust_remote_code=True`. Legitimate Megatron + PEFT loads are unaffected; only adapter configs that ask to import some other module now require the explicit opt-in. Adds a regression test.

AI assistance was used while drafting this change; I reviewed every line and ran the tests below.

# What does this PR do?

Prevents a saved PEFT adapter config from importing an arbitrary module during `from_pretrained` adapter auto-load (via PEFT's `megatron_core`) unless `trust_remote_code=True`.

**Tests run** (`peft==0.19.1`, `torch==2.12.0`):

```
RUN_SLOW=1 pytest tests/peft_integration/test_peft_integration.py -k \
  "megatron_core_import_requires_trust_remote_code or test_peft_from_pretrained or test_peft_add_adapter or test_peft_save_pretrained"
# 4 passed
ruff check / ruff format --check   # clean
```

Fixes # (security hardening; reported privately rather than via a public issue to avoid disclosing the vector)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

- model loading (from pretrained): @CyrilVallez
- peft: @BenjaminBossan @githubnemo
