### PR TITLE
Require `trust_remote_code` to run a local-directory `custom_generate`

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -471,8 +471,12 @@ class GenerationMixin(ContinuousMixin):
                 "`generate.py` file, can't load the custom generate function."
             )
 
-        # Handle opt-in `trust_remote_code` and related exceptions
-        is_local_code = os.path.exists(pretrained_model_name_or_path)
+        # Loading a custom generate function executes the repository's `custom_generate/generate.py`
+        # (via `get_class_in_module` below), so it is remote code and must be gated by
+        # `trust_remote_code` -- including when it is loaded from a local directory. `from_pretrained`
+        # likewise requires `trust_remote_code` for custom modeling code that lives in a local repo;
+        # treating a local path as trusted here previously let `custom_generate/generate.py` run with
+        # no opt-in.
         error_message = (
             f"The repository `{pretrained_model_name_or_path}` contains custom generation code that will override "
             "the default `generate` method."
@@ -480,8 +484,8 @@ class GenerationMixin(ContinuousMixin):
         resolve_trust_remote_code(
             trust_remote_code,
             pretrained_model_name_or_path,
-            has_local_code=is_local_code,
-            has_remote_code=not is_local_code,
+            has_local_code=False,
+            has_remote_code=True,
             error_message=error_message,
         )
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -4672,6 +4672,28 @@ class GenerationIntegrationTests(unittest.TestCase):
             )
             assert value == "success"
 
+    def test_custom_generate_local_directory_requires_trust_remote_code(self):
+        """Tests that `trust_remote_code` is required for a local-directory `custom_generate` too (not
+        just for Hub repos): otherwise a repository's `custom_generate/generate.py` would execute on
+        load without any opt-in."""
+        model = AutoModelForCausalLM.from_pretrained(
+            "hf-internal-testing/tiny-random-MistralForCausalLM", device_map="auto"
+        )
+        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-MistralForCausalLM")
+        model_inputs = tokenizer("Hello, world!", return_tensors="pt").to(model.device)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            custom_generate_dir = Path(tmp_dir) / "custom_generate"
+            custom_generate_dir.mkdir()
+            with open(custom_generate_dir / "generate.py", "w") as f:
+                f.write("def generate(*args, **kwargs):\n    return 'should_not_run'\n")
+            with self.assertRaises(ValueError):
+                model.generate(
+                    **model_inputs,
+                    max_new_tokens=10,
+                    trust_remote_code=False,
+                    custom_generate=str(tmp_dir),
+                )
+
     def test_custom_generate_callable(self):
         """Tests that passing a callable to `custom_generate` executes the callable decoding loop"""
         model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
`GenerationMixin.load_custom_generate` runs a repository's `custom_generate/generate.py` (`get_class_in_module` → `exec_module`). This is gated by `trust_remote_code` for Hub repos, but a **local directory** was treated as trusted: `is_local_code = os.path.exists(pretrained_model_name_or_path)` is passed as `has_local_code`, so `resolve_trust_remote_code` never raises and the code runs. As a result `model.generate(custom_generate="<local dir>")` imports and executes the repo's `generate.py` with no `trust_remote_code` opt-in.

This is inconsistent with the rest of the library: `from_pretrained` requires `trust_remote_code` for custom modeling code even when that code lives in a *local* repository directory. An application that loads generation recipes from a local path (e.g. a downloaded/uploaded model directory) while relying on `trust_remote_code=False` to keep code from running is therefore exposed to code execution.

The fix treats `custom_generate` code as remote regardless of where it is loaded from (`has_local_code=False`, `has_remote_code=True`), so the existing `trust_remote_code` gate applies to local directories too. The execution sink (`get_class_in_module`) runs after this check, so untrusted code no longer runs. The existing `test_custom_generate_local_directory` already passes `trust_remote_code=True`, so it is unaffected; a regression test is added for the local-directory-without-opt-in case.

AI assistance was used while drafting this change; I reviewed every line and ran the tests below.

# What does this PR do?

Requires `trust_remote_code=True` to load and run a `custom_generate` function from a local directory, matching the existing behaviour for Hub repos and for custom modeling code in `from_pretrained`.

**Tests run** (`torch==2.12.0`):

```
pytest tests/generation/test_utils.py -k \
  "test_custom_generate_local_directory or test_custom_generate_requires_trust_remote_code"
# 3 passed (existing local-dir test with trust_remote_code=True still passes;
#           new test asserts a local dir without it is rejected)
ruff format --check   # clean
```

Fixes # (security hardening; reported privately rather than via a public issue to avoid disclosing the vector)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

- generate: @gante @zucchini-nlp
- model loading (from pretrained): @CyrilVallez
