### PR TITLE
Bound sinusoidal positional embedding table to prevent unbounded allocation

### DIFF
--- a/src/transformers/models/fsmt/modeling_fsmt.py
+++ b/src/transformers/models/fsmt/modeling_fsmt.py
@@ -1091,6 +1091,15 @@ class SinusoidalPositionalEmbedding(nn.Embedding):
         This matches the implementation in tensor2tensor, but differs slightly from the description in Section 3.5 of
         "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/kosmos2/modeling_kosmos2.py
+++ b/src/transformers/models/kosmos2/modeling_kosmos2.py
@@ -595,6 +595,15 @@ class Kosmos2TextSinusoidalPositionalEmbedding(nn.Module):
         This matches the implementation in tensor2tensor, but differs slightly from the description in Section 3.5 of
         "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -667,6 +667,15 @@ class Kosmos2_5TextSinusoidalPositionalEmbedding(nn.Module):
         This matches the implementation in tensor2tensor, but differs slightly from the description in Section 3.5 of
         "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/m2m_100/modeling_m2m_100.py
+++ b/src/transformers/models/m2m_100/modeling_m2m_100.py
@@ -104,6 +104,15 @@ class M2M100SinusoidalPositionalEmbedding(nn.Module):
         This matches the implementation in tensor2tensor, but differs slightly from the description in Section 3.5 of
         "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/musicgen/modeling_musicgen.py
+++ b/src/transformers/models/musicgen/modeling_musicgen.py
@@ -126,6 +126,15 @@ class MusicgenSinusoidalPositionalEmbedding(nn.Module):
         Build sinusoidal embeddings. This matches the implementation in tensor2tensor, but differs slightly from the
         description in Section 3.5 of "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/musicgen_melody/modeling_musicgen_melody.py
+++ b/src/transformers/models/musicgen_melody/modeling_musicgen_melody.py
@@ -132,6 +132,15 @@ class MusicgenMelodySinusoidalPositionalEmbedding(nn.Module):
         Build sinusoidal embeddings. This matches the implementation in tensor2tensor, but differs slightly from the
         description in Section 3.5 of "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/nllb_moe/modeling_nllb_moe.py
+++ b/src/transformers/models/nllb_moe/modeling_nllb_moe.py
@@ -87,6 +87,15 @@ class NllbMoeSinusoidalPositionalEmbedding(nn.Module):
         This matches the implementation in tensor2tensor, but differs slightly from the description in Section 3.5 of
         "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/seamless_m4t/modeling_seamless_m4t.py
+++ b/src/transformers/models/seamless_m4t/modeling_seamless_m4t.py
@@ -909,6 +909,15 @@ class SeamlessM4TSinusoidalPositionalEmbedding(nn.Module):
         This matches the implementation in tensor2tensor, but differs slightly from the description in Section 3.5 of
         "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/seamless_m4t_v2/modeling_seamless_m4t_v2.py
+++ b/src/transformers/models/seamless_m4t_v2/modeling_seamless_m4t_v2.py
@@ -784,6 +784,15 @@ class SeamlessM4Tv2SinusoidalPositionalEmbedding(nn.Module):
         This matches the implementation in tensor2tensor, but differs slightly from the description in Section 3.5 of
         "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/speech_to_text/modeling_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/modeling_speech_to_text.py
@@ -125,6 +125,15 @@ class Speech2TextSinusoidalPositionalEmbedding(nn.Module):
         Build sinusoidal embeddings. This matches the implementation in tensor2tensor, but differs slightly from the
         description in Section 3.5 of "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/speecht5/modeling_speecht5.py
+++ b/src/transformers/models/speecht5/modeling_speecht5.py
@@ -307,6 +307,15 @@ class SpeechT5SinusoidalPositionalEmbedding(nn.Module):
         Build sinusoidal embeddings. This matches the implementation in tensor2tensor, but differs slightly from the
         description in Section 3.5 of "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -91,6 +91,15 @@ class TrOCRSinusoidalPositionalEmbedding(nn.Module):
         Build sinusoidal embeddings. This matches the implementation in tensor2tensor, but differs slightly from the
         description in Section 3.5 of "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/src/transformers/models/xglm/modeling_xglm.py
+++ b/src/transformers/models/xglm/modeling_xglm.py
@@ -77,6 +77,15 @@ class XGLMSinusoidalPositionalEmbedding(nn.Module):
         This matches the implementation in tensor2tensor, but differs slightly from the description in Section 3.5 of
         "Attention Is All You Need".
         """
+        # Guard against unbounded memory allocation: this table has
+        # `num_embeddings * embedding_dim` elements and is built eagerly from
+        # `config.max_position_embeddings`, so reject pathologically large sizes
+        # (2**30 elements is far above any real model and would already be ~4GB).
+        if num_embeddings * embedding_dim > 2**30:
+            raise ValueError(
+                f"Cannot create a sinusoidal positional embedding table of {num_embeddings} x "
+                f"{embedding_dim} elements; check the model config (e.g. `max_position_embeddings`)."
+            )
         half_dim = embedding_dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.int64).float() * -emb)

--- a/tests/models/m2m_100/test_modeling_m2m_100.py
+++ b/tests/models/m2m_100/test_modeling_m2m_100.py
@@ -243,6 +243,18 @@ class M2M100ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     def test_config(self):
         self.config_tester.run_common_tests()
 
+    def test_sinusoidal_embedding_rejects_oversized_allocation(self):
+        # Regression: the sinusoidal table is (num_positions x embedding_dim) and is built eagerly
+        # from config.max_position_embeddings, so an oversized value must be rejected instead of
+        # OOM-ing the process at model construction.
+        from transformers.models.m2m_100.modeling_m2m_100 import M2M100SinusoidalPositionalEmbedding
+
+        # a reasonable table still builds
+        M2M100SinusoidalPositionalEmbedding(num_positions=2048, embedding_dim=16, padding_idx=1)
+        # a pathologically large one is refused, not allocated
+        with self.assertRaises(ValueError):
+            M2M100SinusoidalPositionalEmbedding(num_positions=10**9, embedding_dim=1024, padding_idx=1)
+
     def test_save_load_strict(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs()
         for model_class in self.all_model_classes:


### PR DESCRIPTION
`SinusoidalPositionalEmbedding.get_embedding` builds a `(num_embeddings × embedding_dim)` float table, where `num_embeddings` comes from `config.max_position_embeddings`. The table is computed eagerly in `__init__` (via `make_weights`) and stored as `register_buffer(..., persistent=False)`, so it is recomputed at construction and is *not* part of the checkpoint. A model repo whose `config.json` sets an oversized `max_position_embeddings` (e.g. `50_000_000`) therefore makes plain `from_pretrained(...)` allocate hundreds of GB at model construction — before any weights are loaded, with no input — and the process is OOM-killed.

I verified this under a hard 128 MB limit: a benign config loads, while `max_position_embeddings=50_000_000` (≈205 GB) is OOM-killed; the real class builds a 4.1 GB buffer for `1_000_000` (taking ~2 min, so it is also a CPU sink). This is the same allocation class as the mel/chroma filter-bank guard.

Reject pathologically large tables (`num_embeddings * embedding_dim > 2**30`, far above any real model and already ~4 GB at float32) in `get_embedding`, which is the single point both `__init__` and the forward-time resize go through. The class is copied across the models that use sinusoidal positions, so the same guard is added to all of them (`make fix-repo`/`check_copies` keeps the copies in sync). Adds a regression test.

AI assistance was used while drafting this change; I reviewed every line and ran the tests below.

# What does this PR do?

Bounds the eager sinusoidal positional-embedding table so an oversized `max_position_embeddings` in an untrusted config cannot OOM the process at `from_pretrained`.

**Tests run** (`torch==2.12.0`):
```
pytest tests/models/m2m_100/test_modeling_m2m_100.py -k sinusoidal_embedding_rejects_oversized_allocation   # passed
python utils/check_copies.py    # clean (all copies in sync)
ruff check / ruff format --check # clean
# benign load still works: AutoModel.from_pretrained("hf-internal-testing/tiny-random-m2m_100")
```

Fixes # (security hardening; reported privately rather than via a public issue to avoid disclosing the vector)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

- text models / model loading: @ArthurZucker @CyrilVallez
