### PR TITLE
Bound causal-attention mask to prevent unbounded allocation

### DIFF
--- a/src/transformers/models/bark/modeling_bark.py
+++ b/src/transformers/models/bark/modeling_bark.py
@@ -94,6 +94,10 @@ class BarkSelfAttention(nn.Module):
         self.layer_idx = layer_idx
         if is_causal:
             block_size = config.block_size
+            # Guard against unbounded memory allocation: this causal mask is O(block_size**2)
+            # and is built eagerly from the model config, so reject pathologically large values.
+            if block_size * block_size > 2**30:
+                raise ValueError(f"Refusing to build a {block_size}x{block_size} causal mask; check `block_size`.")
             bias = torch.tril(torch.ones((block_size, block_size), dtype=bool)).view(1, 1, block_size, block_size)
             self.register_buffer("bias", bias)
 

--- a/src/transformers/models/clvp/modeling_clvp.py
+++ b/src/transformers/models/clvp/modeling_clvp.py
@@ -289,6 +289,13 @@ class ClvpSelfAttention(nn.Module):
 
         if hasattr(config, "max_position_embeddings"):
             max_positions = config.max_position_embeddings
+            # Guard against unbounded memory allocation: this causal mask is O(max_positions**2)
+            # and is built eagerly from the model config, so reject pathologically large values.
+            if max_positions * max_positions > 2**30:
+                raise ValueError(
+                    f"Refusing to build a {max_positions}x{max_positions} causal mask; check "
+                    f"`max_position_embeddings` in the model config."
+                )
             bias = torch.tril(torch.ones((max_positions, max_positions), dtype=torch.bool))
             bias = bias.view(1, 1, max_positions, max_positions)
             self.register_buffer("bias", bias, persistent=False)

--- a/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -380,6 +380,13 @@ class GPTBigCodeModel(GPTBigCodePreTrainedModel):
         self.ln_f = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_epsilon)
 
         max_positions = config.max_position_embeddings
+        # Guard against unbounded memory allocation: this causal mask is O(max_positions**2)
+        # and is built eagerly from the model config, so reject pathologically large values.
+        if max_positions * max_positions > 2**30:
+            raise ValueError(
+                f"Refusing to build a {max_positions}x{max_positions} causal mask; check "
+                f"`max_position_embeddings` in the model config."
+            )
         self.register_buffer(
             "bias", torch.tril(torch.ones((max_positions, max_positions), dtype=torch.bool)), persistent=False
         )

--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -54,6 +54,13 @@ class GPTNeoSelfAttention(nn.Module):
         self.config = config
 
         max_positions = config.max_position_embeddings
+        # Guard against unbounded memory allocation: this causal mask is O(max_positions**2)
+        # and is built eagerly from the model config, so reject pathologically large values.
+        if max_positions * max_positions > 2**30:
+            raise ValueError(
+                f"Refusing to build a {max_positions}x{max_positions} causal mask; check "
+                f"`max_position_embeddings` in the model config."
+            )
         bias = torch.tril(torch.ones((max_positions, max_positions), dtype=bool)).view(
             1, 1, max_positions, max_positions
         )

--- a/src/transformers/models/imagegpt/modeling_imagegpt.py
+++ b/src/transformers/models/imagegpt/modeling_imagegpt.py
@@ -63,6 +63,13 @@ class ImageGPTAttention(nn.Module):
         super().__init__()
         self.config = config
         max_positions = config.max_position_embeddings
+        # Guard against unbounded memory allocation: this causal mask is O(max_positions**2)
+        # and is built eagerly from the model config, so reject pathologically large values.
+        if max_positions * max_positions > 2**30:
+            raise ValueError(
+                f"Refusing to build a {max_positions}x{max_positions} causal mask; check "
+                f"`max_position_embeddings` in the model config."
+            )
         self.register_buffer(
             "bias",
             torch.tril(torch.ones((max_positions, max_positions), dtype=torch.bool)).view(

--- a/src/transformers/models/openai/modeling_openai.py
+++ b/src/transformers/models/openai/modeling_openai.py
@@ -50,6 +50,10 @@ class Attention(nn.Module):
         n_state = nx  # in Attention: n_state=768 (nx=n_embd)
         if n_state % config.n_head != 0:
             raise ValueError(f"Attention n_state shape: {n_state} must be divisible by config.n_head {config.n_head}")
+        # Guard against unbounded memory allocation: this causal mask is O(n_positions**2)
+        # and is built eagerly from the model config, so reject pathologically large values.
+        if n_positions * n_positions > 2**30:
+            raise ValueError(f"Refusing to build a {n_positions}x{n_positions} causal mask; check `n_positions`.")
         self.register_buffer(
             "bias",
             torch.tril(torch.ones(n_positions, n_positions)).view(1, 1, n_positions, n_positions),

--- a/tests/models/gpt_neo/test_modeling_gpt_neo.py
+++ b/tests/models/gpt_neo/test_modeling_gpt_neo.py
@@ -388,6 +388,17 @@ class GPTNeoModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     def test_config(self):
         self.config_tester.run_common_tests()
 
+    def test_causal_mask_rejects_oversized_allocation(self):
+        # Regression: the causal-mask buffer is (max_position_embeddings x max_position_embeddings)
+        # and is built eagerly at construction, so an oversized value must be rejected instead of
+        # OOM-ing the process.
+        from transformers.models.gpt_neo.modeling_gpt_neo import GPTNeoSelfAttention
+
+        config = self.model_tester.get_config()
+        config.max_position_embeddings = 100000  # 100k x 100k bool mask = 10 GB
+        with self.assertRaises(ValueError):
+            GPTNeoSelfAttention(config, attention_type="global", layer_id=0)
+
     def test_gpt_neo_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_gpt_neo_model(*config_and_inputs)


### PR DESCRIPTION
Several models build a `(max_positions × max_positions)` causal-mask buffer eagerly in attention `__init__`, via `torch.tril(torch.ones((max_positions, max_positions)))`, where `max_positions` comes straight from the model config (`max_position_embeddings`, `n_positions`, or `block_size`). The buffer is `register_buffer(..., persistent=False)`, so it is recomputed at construction and is *not* part of the checkpoint. A model repo whose `config.json` sets an oversized value (e.g. `max_position_embeddings=100000`) therefore makes plain `from_pretrained(...)` allocate `O(n²)` memory (≈10 GB per layer) at construction — before any weights load, with no input — and the process is OOM-killed. Because the size is quadratic, even moderate values (≈12 000) already exceed a small worker.

I verified under a hard 128 MB limit: a benign config loads, while `max_position_embeddings=100000` is OOM-killed; the real `GPTNeoSelfAttention` builds a 0.9 GB buffer for `30000`. This is the same allocation class as the mel/chroma filter-bank guard and the sinusoidal positional-embedding guard.

Reject pathologically large masks (`max_positions * max_positions > 2**30`, far above any real model) before the allocation in `gpt_neo`, `gpt_bigcode`, `imagegpt`, `openai-gpt`, `clvp` and `bark`. Adds a regression test.

AI assistance was used while drafting this change; I reviewed every line and ran the tests below.

# What does this PR do?

Bounds the eager `(n × n)` causal-mask buffer so an oversized `max_position_embeddings`/`n_positions`/`block_size` in an untrusted config cannot OOM the process at `from_pretrained`.

**Tests run** (`torch==2.12.0`):
```
pytest tests/models/gpt_neo/test_modeling_gpt_neo.py -k causal_mask_rejects_oversized_allocation   # passed
python utils/check_copies.py    # clean
ruff check / ruff format --check # clean
# benign load still works: AutoModel.from_pretrained("hf-internal-testing/tiny-random-GPTNeoModel")
```

Fixes # (security hardening; reported privately rather than via a public issue to avoid disclosing the vector)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

- text models / model loading: @ArthurZucker @CyrilVallez
