### PR TITLE
Bound image-processor resize/crop output to prevent unbounded allocation

### DIFF
--- a/src/transformers/image_processing_backends.py
+++ b/src/transformers/image_processing_backends.py
@@ -30,6 +30,7 @@ from .image_transforms import (
     get_size_with_aspect_ratio,
     group_images_by_shape,
     reorder_images,
+    validate_image_output_size,
 )
 from .image_transforms import (
     normalize as np_normalize,
@@ -263,6 +264,7 @@ class TorchvisionBackend(BaseImageProcessor):
                 f" {size}."
             )
 
+        validate_image_output_size(*new_size)
         # Workaround for torch.compile issue with uint8 on AMD GPUs
         if is_torchdynamo_compiling() and is_rocm_platform():
             return self._compile_friendly_resize(image, new_size, interpolation, antialias)

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -310,6 +310,21 @@ def get_resize_output_image_size(
     return (new_long, new_short) if width <= height else (new_short, new_long)
 
 
+# A resized or center-cropped image larger than this many pixels almost certainly indicates a
+# malformed or malicious `size`/`crop_size` in the image-processor config rather than a real target,
+# and materializing it would exhaust memory. Refuse it instead of allocating (DoS guard).
+MAX_IMAGE_OUTPUT_PIXELS = 1 << 27
+
+
+def validate_image_output_size(height: int, width: int) -> None:
+    if height * width > MAX_IMAGE_OUTPUT_PIXELS:
+        raise ValueError(
+            f"Refusing to allocate an image of {height}x{width} ({height * width} pixels), which exceeds "
+            f"the maximum of {MAX_IMAGE_OUTPUT_PIXELS}; this likely indicates an invalid `size`/`crop_size` "
+            f"in the image processor config."
+        )
+
+
 def resize(
     image: np.ndarray,
     size: tuple[int, int],
@@ -363,6 +378,7 @@ def resize(
         do_rescale = _rescale_for_pil_conversion(image)
         image = to_pil_image(image, do_rescale=do_rescale, input_data_format=input_data_format)
     height, width = size
+    validate_image_output_size(height, width)
     # PIL images are in the format (width, height)
     resized_image = image.resize((width, height), resample=resample, reducing_gap=reducing_gap)
 
@@ -488,6 +504,7 @@ def center_crop(
     orig_height, orig_width = get_image_size(image, ChannelDimension.FIRST)
     crop_height, crop_width = size
     crop_height, crop_width = int(crop_height), int(crop_width)
+    validate_image_output_size(crop_height, crop_width)
 
     # In case size is odd, (image_shape[0] + size[0]) // 2 won't give the proper result.
     top = (orig_height - crop_height) // 2

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -310,6 +310,20 @@ class ImageTransformsTester(unittest.TestCase):
         self.assertEqual(normalized_image.dtype, np.float32)
         self.assertTrue(np.allclose(normalized_image, expected_image, atol=1e-6))
 
+    def test_resize_and_crop_reject_oversized_allocation(self):
+        # Regression: resize/center_crop must reject an oversized target (an untrusted config can set
+        # `size`/`crop_size` arbitrarily) instead of allocating it and OOM-ing at preprocess time.
+        from transformers.image_transforms import MAX_IMAGE_OUTPUT_PIXELS
+
+        big = int(MAX_IMAGE_OUTPUT_PIXELS**0.5) + 1  # big * big > MAX_IMAGE_OUTPUT_PIXELS
+        image = np.random.randint(0, 256, (3, 32, 32))
+        with self.assertRaises(ValueError):
+            resize(image, (big, big))
+        with self.assertRaises(ValueError):
+            center_crop(image, (big, big))
+        # a reasonable size still works
+        self.assertEqual(resize(image, (64, 64)).shape, (3, 64, 64))
+
     def test_center_crop(self):
         image = np.random.randint(0, 256, (3, 224, 224))
 


### PR DESCRIPTION
Image processors resize and center-crop every input image to the `size`/`crop_size` read from `preprocessor_config.json`, with no upper bound. `image_transforms.resize` does `image.resize((width, height))` and `center_crop` pads/crops to `(crop_height, crop_width)`, where those targets come straight from config. A model repo whose `preprocessor_config.json` sets an oversized value (e.g. `size=15000` or `crop_size=50000`) therefore makes any `processor(image)` call materialize a huge `(height × width × channels)` array — for *any* input image, a 32×32 one suffices — exhausting memory and OOM-killing the worker.

I verified this against the real library: `CLIPImageProcessor(size={"shortest_edge":15000}, crop_size=15000)(Image.new("RGB",(32,32)))` produces a `(1,3,15000,15000)` = 2.70 GB array (≈12 s), and under a hard 128 MB limit `size=15000` is OOM-killed. This is the same allocation class as the mel/chroma filter-bank guard and the positional-embedding guards.

Add a shared output-size guard `validate_image_output_size` in `image_transforms` and call it before the allocation in `resize`, `center_crop`, and the Torchvision backend `resize` (the PIL backend resizes through `image_transforms.resize`, so it is covered too). The limit (`1 << 27` pixels) is far above any real model input. Adds a regression test.

AI assistance was used while drafting this change; I reviewed every line and ran the tests below.

# What does this PR do?

Bounds the image-processor resize/center-crop output so an oversized `size`/`crop_size` in an untrusted config cannot OOM the process at preprocess time.

**Tests run** (`torch==2.12.0`):
```
pytest tests/test_image_transforms.py -k "resize or center_crop"   # 4 passed
python utils/check_copies.py    # clean
ruff check / ruff format --check # clean
# benign still works: CLIPImageProcessor(size=224)(Image.new("RGB",(32,32)))
```

Fixes # (security hardening; reported privately rather than via a public issue to avoid disclosing the vector)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

- vision models / image processing: @yonigozlan @molbap
