### PR TITLE
Fix dtype mismatch in NemotronH/Zamba2 Mamba2 CUDA-kernel path (`out_proj`)

### DIFF
--- a/src/transformers/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modeling_nemotron_h.py
@@ -277,7 +277,10 @@ class NemotronHMamba2Mixer(nn.Module):
             )
             hidden_states = hidden_states.view(batch_size, self.num_heads * self.head_dim)
             hidden_states = self.norm(hidden_states, gate)
-            out = self.out_proj(hidden_states)[:, None, ...]
+            # The SSM kernels return fp32 regardless of the module dtype; cast back to the
+            # projection weight dtype so the matmul does not fail when out_proj.weight is a
+            # narrower dtype than the activations (e.g. fp32 activations with a bf16 out_proj).
+            out = self.out_proj(hidden_states.to(self.out_proj.weight.dtype))[:, None, ...]
         # if no cache is found, calling the kernel
         else:
             if attention_mask is not None and not torch.all(attention_mask == 1):
@@ -369,7 +372,10 @@ class NemotronHMamba2Mixer(nn.Module):
                 scan_output = scan_output.view(batch_size, seq_len, -1)
                 # Multiply "gate" branch and apply extra normalization layer
                 scan_output = self.norm(scan_output, gate)
-                out = self.out_proj(scan_output)
+                # The SSM kernels return fp32 regardless of the module dtype; cast back to the
+                # projection weight dtype so the matmul does not fail when out_proj.weight is a
+                # narrower dtype than the activations (e.g. fp32 activations with a bf16 out_proj).
+                out = self.out_proj(scan_output.to(self.out_proj.weight.dtype))
         return out
 
     # fmt: off

--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -565,7 +565,10 @@ class Zamba2MambaMixer(nn.Module):
             )
             hidden_states = hidden_states.view(batch_size, self.num_heads * self.head_dim)
             hidden_states = self.norm(hidden_states, gate)
-            out = self.out_proj(hidden_states)[:, None, ...]
+            # The SSM kernels return fp32 regardless of the module dtype; cast back to the
+            # projection weight dtype so the matmul does not fail when out_proj.weight is a
+            # narrower dtype than the activations (e.g. fp32 activations with a bf16 out_proj).
+            out = self.out_proj(hidden_states.to(self.out_proj.weight.dtype))[:, None, ...]
         # if no cache is found, calling the kernel
         else:
             if attention_mask is not None and not torch.all(attention_mask == 1):
@@ -657,7 +660,10 @@ class Zamba2MambaMixer(nn.Module):
                 scan_output = scan_output.view(batch_size, seq_len, -1)
                 # Multiply "gate" branch and apply extra normalization layer
                 scan_output = self.norm(scan_output, gate)
-                out = self.out_proj(scan_output)
+                # The SSM kernels return fp32 regardless of the module dtype; cast back to the
+                # projection weight dtype so the matmul does not fail when out_proj.weight is a
+                # narrower dtype than the activations (e.g. fp32 activations with a bf16 out_proj).
+                out = self.out_proj(scan_output.to(self.out_proj.weight.dtype))
         return out
 
     # fmt: off

--- a/src/transformers/models/zamba2/modular_zamba2.py
+++ b/src/transformers/models/zamba2/modular_zamba2.py
@@ -353,7 +353,10 @@ class Zamba2MambaMixer(nn.Module):
             )
             hidden_states = hidden_states.view(batch_size, self.num_heads * self.head_dim)
             hidden_states = self.norm(hidden_states, gate)
-            out = self.out_proj(hidden_states)[:, None, ...]
+            # The SSM kernels return fp32 regardless of the module dtype; cast back to the
+            # projection weight dtype so the matmul does not fail when out_proj.weight is a
+            # narrower dtype than the activations (e.g. fp32 activations with a bf16 out_proj).
+            out = self.out_proj(hidden_states.to(self.out_proj.weight.dtype))[:, None, ...]
         # if no cache is found, calling the kernel
         else:
             if attention_mask is not None and not torch.all(attention_mask == 1):
@@ -445,7 +448,10 @@ class Zamba2MambaMixer(nn.Module):
                 scan_output = scan_output.view(batch_size, seq_len, -1)
                 # Multiply "gate" branch and apply extra normalization layer
                 scan_output = self.norm(scan_output, gate)
-                out = self.out_proj(scan_output)
+                # The SSM kernels return fp32 regardless of the module dtype; cast back to the
+                # projection weight dtype so the matmul does not fail when out_proj.weight is a
+                # narrower dtype than the activations (e.g. fp32 activations with a bf16 out_proj).
+                out = self.out_proj(scan_output.to(self.out_proj.weight.dtype))
         return out
 
     # fmt: off


### PR DESCRIPTION


#### Summary

The Mamba2 SSM CUDA-kernel forward path (`cuda_kernels_forward`) projects the scan output
through `out_proj` **without casting it to the projection weight dtype**. Because the SSM kernels
(`mamba_chunk_scan_combined` / `selective_state_update`) return **fp32 regardless of the module
dtype**, the projection fails whenever `out_proj.weight` is a narrower dtype than the activations:

```
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: float != c10::BFloat16
```



#### Fix

Cast the projection input to the `out_proj` weight dtype before both explicit `out_proj` calls in
the CUDA-kernel path, so the matmul dtypes always agree (matching the slow path's intent, and
robust to mixed-dtype models):

```python
out = self.out_proj(scan_output.to(self.out_proj.weight.dtype))
```

`NemotronHMamba2Mixer` inherits this method from `Zamba2MambaMixer`, so the fix is applied in the
modular source `models/zamba2/modular_zamba2.py` and propagated to the generated
`modeling_zamba2.py` and `modeling_nemotron_h.py`.

