### PR TITLE
Use torchvision's native LANCZOS interpolation instead of PIL fallback

### DIFF
--- a/src/transformers/image_processing_backends.py
+++ b/src/transformers/image_processing_backends.py
@@ -61,7 +61,7 @@ from .utils import (
     is_vision_available,
     logging,
 )
-from .utils.import_utils import is_rocm_platform, is_torchdynamo_compiling, requires
+from .utils.import_utils import is_rocm_platform, is_torchdynamo_compiling, is_torchvision_greater_or_equal, requires
 
 
 if is_vision_available():
@@ -232,10 +232,11 @@ class TorchvisionBackend(BaseImageProcessor):
                 interpolation = resample
         else:
             interpolation = tvF.InterpolationMode.BILINEAR
-        if interpolation == tvF.InterpolationMode.LANCZOS:
+        if interpolation == tvF.InterpolationMode.LANCZOS and not is_torchvision_greater_or_equal("0.27"):
             logger.warning_once(
-                "You have used a torchvision backend image processor with LANCZOS resample which not yet supported for torch.Tensor. "
-                "BICUBIC resample will be used as an alternative. Please fall back to a pil backend image processor if you "
+                "You have used a torchvision backend image processor with LANCZOS resample which is not supported "
+                "for torch.Tensor with torchvision < 0.27. BICUBIC resample will be used as an alternative. "
+                "Please upgrade torchvision to 0.27+ or fall back to a pil backend image processor if you "
                 "want full consistency with the original model."
             )
             interpolation = tvF.InterpolationMode.BICUBIC

--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -33,7 +33,7 @@ from ...utils import (
     logging,
     safe_load_json_file,
 )
-from ...utils.import_utils import requires
+from ...utils.import_utils import is_torchvision_greater_or_equal, requires
 from .auto_factory import _LazyAutoMapping
 from .auto_mappings import IMAGE_PROCESSOR_MAPPING_NAMES
 from .configuration_auto import (
@@ -46,14 +46,18 @@ from .configuration_auto import (
 
 logger = logging.get_logger(__name__)
 
-# These image processors use Lanczos interpolation, which is not supported by fast image processors.
-# To avoid important differences in outputs, we default to using the PIL backend for these processors.
-DEFAULT_TO_PIL_BACKEND_IMAGE_PROCESSORS = [
+# These image processors use Lanczos interpolation, which is not supported by torchvision < 0.27.
+# To avoid important differences in outputs, we default to using the PIL backend for these processors
+# when running on older torchvision versions. With torchvision >= 0.27, Lanczos is natively supported
+# and these processors can use the torchvision backend directly.
+_LANCZOS_IMAGE_PROCESSORS = [
     "ChameleonImageProcessor",
     "FlavaImageProcessor",
     "Idefics3ImageProcessor",
     "SmolVLMImageProcessor",
 ]
+
+DEFAULT_TO_PIL_BACKEND_IMAGE_PROCESSORS = [] if is_torchvision_greater_or_equal("0.27") else _LANCZOS_IMAGE_PROCESSORS
 
 
 if TYPE_CHECKING:
@@ -317,8 +321,8 @@ def _resolve_backend(backend: str | None, use_fast: bool | None, base_class_name
       explicit backend is given.
     - Explicit backend string: returned as-is.
     - None resolution: forces 'pil' for processors in DEFAULT_TO_PIL_BACKEND_IMAGE_PROCESSORS
-      (Lanczos interpolation, unsupported by torchvision); otherwise picks 'torchvision' when
-      available, falling back to 'pil'.
+      (Lanczos interpolation, unsupported by torchvision < 0.27); otherwise picks 'torchvision'
+      when available, falling back to 'pil'.
     """
     if use_fast is not None:
         logger.warning_once(

--- a/src/transformers/models/chameleon/image_processing_chameleon.py
+++ b/src/transformers/models/chameleon/image_processing_chameleon.py
@@ -15,14 +15,11 @@
 
 import numpy as np
 import PIL.Image
-import torch
-from torchvision.transforms.v2 import functional as tvF
 
 from ...image_processing_backends import TorchvisionBackend
 from ...image_utils import (
     ImageInput,
     PILImageResampling,
-    SizeDict,
 )
 from ...processing_utils import ImagesKwargs, Unpack
 from ...utils import auto_docstring, logging
@@ -71,34 +68,6 @@ class ChameleonImageProcessor(TorchvisionBackend):
         alpha = img_rgba[:, :, 3] / 255.0
         img_rgb = (1 - alpha[:, :, np.newaxis]) * 255 + alpha[:, :, np.newaxis] * img_rgba[:, :, :3]
         return PIL.Image.fromarray(img_rgb.astype("uint8"), "RGB")
-
-    def resize(
-        self,
-        image: "torch.Tensor",
-        size: "SizeDict",
-        resample: "PILImageResampling | tvF.InterpolationMode | int | None",
-        **kwargs,
-    ) -> "torch.Tensor":
-        """Resize with LANCZOS fallback to BICUBIC."""
-        interpolation = (
-            resample if isinstance(resample, (tvF.InterpolationMode, int)) else tvF.InterpolationMode.BILINEAR
-        )
-        if resample is None:
-            interpolation = tvF.InterpolationMode.BILINEAR
-        elif isinstance(resample, PILImageResampling):
-            if resample == PILImageResampling.LANCZOS:
-                logger.warning_once(
-                    "You have used fast image processor with LANCZOS resample which not yet supported for torch.Tensor. "
-                    "BICUBIC resample will be used as an alternative. Please fall back to slow image processor if you "
-                    "want full consistency with the original model."
-                )
-                interpolation = tvF.InterpolationMode.BICUBIC
-            else:
-                from ...image_utils import pil_torch_interpolation_mapping
-
-                interpolation = pil_torch_interpolation_mapping[resample]
-
-        return super().resize(image=image, size=size, resample=interpolation, **kwargs)
 
 
 __all__ = ["ChameleonImageProcessor"]

--- a/src/transformers/models/flava/image_processing_flava.py
+++ b/src/transformers/models/flava/image_processing_flava.py
@@ -78,10 +78,9 @@ class FlavaImageProcessorKwargs(ImagesKwargs, total=False):
     codebook_size (`dict[str, int]`, *optional*, defaults to `{"height": 224, "width": 224}`):
         Resize the input for codebook to the given size. Can be overridden by the `codebook_size` parameter in
         `preprocess`.
-    codebook_resample (`PILImageResampling`, *optional*, defaults to `PILImageResampling.LANCZOS` for PIL backend,
-        `PILImageResampling.BICUBIC` for torchvision backend):
-        Resampling filter to use if resizing the codebook image. LANCZOS is not supported for torch Tensors;
-        BICUBIC is used as the closest alternative for the torchvision backend. Can be overridden by the
+    codebook_resample (`PILImageResampling`, *optional*, defaults to `PILImageResampling.LANCZOS`):
+        Resampling filter to use if resizing the codebook image. With torchvision < 0.27, LANCZOS is not
+        supported for torch Tensors and BICUBIC is used as the closest alternative. Can be overridden by the
         `codebook_resample` parameter in `preprocess`.
     codebook_do_center_crop (`bool`, *optional*, defaults to `True`):
         Whether to crop the input for codebook at the center. If the input size is smaller than
@@ -235,9 +234,10 @@ class FlavaImageProcessor(TorchvisionBackend):
     return_codebook_pixels = False
     codebook_do_resize = True
     codebook_size = {"height": 112, "width": 112}
-    # LANCZOS resampling is not supported for torch Tensors; BICUBIC is the closest alternative.
-    # Note: the PIL backend defaults to LANCZOS for this parameter.
-    codebook_resample = PILImageResampling.BICUBIC
+    # LANCZOS resampling is not supported for torch Tensors with torchvision < 0.27; BICUBIC is the closest
+    # alternative. With torchvision >= 0.27, LANCZOS is natively supported.
+    # Note: the PIL backend always defaults to LANCZOS for this parameter.
+    codebook_resample = PILImageResampling.LANCZOS
     codebook_do_center_crop = True
     codebook_crop_size = {"height": 112, "width": 112}
     codebook_do_rescale = True

--- a/src/transformers/models/flava/image_processing_flava.py
+++ b/src/transformers/models/flava/image_processing_flava.py
@@ -234,9 +234,6 @@ class FlavaImageProcessor(TorchvisionBackend):
     return_codebook_pixels = False
     codebook_do_resize = True
     codebook_size = {"height": 112, "width": 112}
-    # LANCZOS resampling is not supported for torch Tensors with torchvision < 0.27; BICUBIC is the closest
-    # alternative. With torchvision >= 0.27, LANCZOS is natively supported.
-    # Note: the PIL backend always defaults to LANCZOS for this parameter.
     codebook_resample = PILImageResampling.LANCZOS
     codebook_do_center_crop = True
     codebook_crop_size = {"height": 112, "width": 112}

--- a/src/transformers/models/flava/image_processing_pil_flava.py
+++ b/src/transformers/models/flava/image_processing_pil_flava.py
@@ -91,10 +91,9 @@ class FlavaImageProcessorKwargs(ImagesKwargs, total=False):
     codebook_size (`dict[str, int]`, *optional*, defaults to `{"height": 224, "width": 224}`):
         Resize the input for codebook to the given size. Can be overridden by the `codebook_size` parameter in
         `preprocess`.
-    codebook_resample (`PILImageResampling`, *optional*, defaults to `PILImageResampling.LANCZOS` for PIL backend,
-        `PILImageResampling.BICUBIC` for torchvision backend):
-        Resampling filter to use if resizing the codebook image. LANCZOS is not supported for torch Tensors;
-        BICUBIC is used as the closest alternative for the torchvision backend. Can be overridden by the
+    codebook_resample (`PILImageResampling`, *optional*, defaults to `PILImageResampling.LANCZOS`):
+        Resampling filter to use if resizing the codebook image. With torchvision < 0.27, LANCZOS is not
+        supported for torch Tensors and BICUBIC is used as the closest alternative. Can be overridden by the
         `codebook_resample` parameter in `preprocess`.
     codebook_do_center_crop (`bool`, *optional*, defaults to `True`):
         Whether to crop the input for codebook at the center. If the input size is smaller than

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -246,6 +246,7 @@ from .import_utils import (
     is_torchdynamo_compiling,
     is_torchdynamo_exporting,
     is_torchvision_available,
+    is_torchvision_greater_or_equal,
     is_torchvision_v2_available,
     is_tracing,
     is_training_run_on_sagemaker,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -742,6 +742,14 @@ def is_torchvision_v2_available() -> bool:
 
 
 @lru_cache
+def is_torchvision_greater_or_equal(library_version: str) -> bool:
+    if not is_torchvision_available():
+        return False
+    _, torchvision_version = _is_package_available("torchvision", return_version=True)
+    return version.parse(torchvision_version) >= version.parse(library_version)
+
+
+@lru_cache
 def is_galore_torch_available() -> bool:
     return _is_package_available("galore_torch")[0]
 

--- a/tests/models/auto/test_image_processing_auto.py
+++ b/tests/models/auto/test_image_processing_auto.py
@@ -302,15 +302,20 @@ class AutoImageProcessorTest(unittest.TestCase):
 
     @require_torchvision
     def test_default_to_pil_backend_for_lanczos_processors(self):
-        # Even when torchvision is available, processors that rely on Lanczos interpolation
-        # (listed in DEFAULT_TO_PIL_BACKEND_IMAGE_PROCESSORS) must default to the PIL backend
-        # when backend='auto'.
+        # Processors that rely on Lanczos interpolation (listed in _LANCZOS_IMAGE_PROCESSORS)
+        # must default to the PIL backend when torchvision < 0.27, but can use the torchvision
+        # backend directly when torchvision >= 0.27 (which natively supports Lanczos).
+        from transformers.utils.import_utils import is_torchvision_greater_or_equal
+
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor_tmpfile = Path(tmpdirname) / "preprocessor_config.json"
             json.dump({"image_processor_type": "FlavaImageProcessor"}, open(processor_tmpfile, "w"))
 
             image_processor = AutoImageProcessor.from_pretrained(tmpdirname)
-            self.assertEqual(type(image_processor).__name__, "FlavaImageProcessorPil")
+            if is_torchvision_greater_or_equal("0.27"):
+                self.assertEqual(type(image_processor).__name__, "FlavaImageProcessor")
+            else:
+                self.assertEqual(type(image_processor).__name__, "FlavaImageProcessorPil")
 
     @require_torchvision
     def test_explicit_backend_overrides_lanczos_default(self):

--- a/tests/models/auto/test_image_processing_auto.py
+++ b/tests/models/auto/test_image_processing_auto.py
@@ -305,16 +305,25 @@ class AutoImageProcessorTest(unittest.TestCase):
         # Processors that rely on Lanczos interpolation (listed in _LANCZOS_IMAGE_PROCESSORS)
         # must default to the PIL backend when torchvision < 0.27, but can use the torchvision
         # backend directly when torchvision >= 0.27 (which natively supports Lanczos).
-        from transformers.utils.import_utils import is_torchvision_greater_or_equal
+        from unittest.mock import patch
+
+        from transformers.models.auto.image_processing_auto import _LANCZOS_IMAGE_PROCESSORS
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor_tmpfile = Path(tmpdirname) / "preprocessor_config.json"
             json.dump({"image_processor_type": "FlavaImageProcessor"}, open(processor_tmpfile, "w"))
 
-            image_processor = AutoImageProcessor.from_pretrained(tmpdirname)
-            if is_torchvision_greater_or_equal("0.27"):
+            # Simulate torchvision >= 0.27: list is empty, so torchvision backend is used
+            with patch("transformers.models.auto.image_processing_auto.DEFAULT_TO_PIL_BACKEND_IMAGE_PROCESSORS", []):
+                image_processor = AutoImageProcessor.from_pretrained(tmpdirname)
                 self.assertEqual(type(image_processor).__name__, "FlavaImageProcessor")
-            else:
+
+            # Simulate torchvision < 0.27: list is populated, so PIL backend is forced
+            with patch(
+                "transformers.models.auto.image_processing_auto.DEFAULT_TO_PIL_BACKEND_IMAGE_PROCESSORS",
+                _LANCZOS_IMAGE_PROCESSORS,
+            ):
+                image_processor = AutoImageProcessor.from_pretrained(tmpdirname)
                 self.assertEqual(type(image_processor).__name__, "FlavaImageProcessorPil")
 
     @require_torchvision

--- a/tests/models/flava/test_image_processing_flava.py
+++ b/tests/models/flava/test_image_processing_flava.py
@@ -105,8 +105,9 @@ class FlavaImageProcessingTester:
 
         self.codebook_do_resize = codebook_do_resize
         self.codebook_size = codebook_size
-        # LANCZOS resample does not support torch Tensor. Use BICUBIC as closest alternative
-        self.codebook_resample = codebook_resample if codebook_resample is not None else PILImageResampling.BICUBIC
+        # LANCZOS resample is natively supported with torchvision >= 0.27.
+        # On older versions, the base class falls back to BICUBIC automatically.
+        self.codebook_resample = codebook_resample if codebook_resample is not None else PILImageResampling.LANCZOS
         self.codebook_do_center_crop = codebook_do_center_crop
         self.codebook_crop_size = codebook_crop_size
         self.codebook_do_map_pixels = codebook_do_map_pixels


### PR DESCRIPTION
# What does this PR do?

This is sort of a follow-up to https://github.com/huggingface/transformers/pull/45195, and the proposed changes were discussed on the PyTorch slack channel with @yonigozlan .

[Torchvision 0.27](https://github.com/pytorch/vision/releases/tag/v0.27.0) added native support for LANCZOS interpolation. Previously, `transformers` needed two workarounds:

- the torchvision backend had to fall back to BICUBIC when LANCZOS was requested
-  some entire model pipelines had to fallback to PIL.

This PR removes both workarounds when torchvision >= 0.27 is installed. TorchVision is faster than PIL because it natively supports AVX2 and NEON paths for x86 and aarch64, and outputs are bitwise equivalent to PIL-SIMD.

### Benchmarks

```
~/dev/transformers (use_torchvision_lanczos*) » python benchmark_lanczos.py                                                                                                                                                                nicolashug@nicolashug-fedora-PW0H326Y
Scenario                                        PIL (ms)    TV (ms)    Speedup
------------------------------------------------------------------------------
Chameleon  (800x600 -> 682x512)                     6.63       1.88       3.5x
Idefics3   (1920x1080 -> 819x1456)                 26.40      11.02       2.4x
Flava CB   (224x224 -> 112x112)                     0.54       0.18       3.1x
```

Benchmark code:
<details> 

```py
"""Benchmark: torchvision LANCZOS resize vs PIL LANCZOS resize.

Requires torchvision >= 0.27 (which added LANCZOS support for tensors).
"""

import time

import PIL.Image
import numpy as np
import torch
from torchvision.transforms.v2.functional import resize as tv_resize
from torchvision.transforms import InterpolationMode


def bench_pil(pil_image, size, n=100):
    # Warmup
    for _ in range(10):
        pil_image.resize(size, PIL.Image.LANCZOS)

    t0 = time.perf_counter()
    for _ in range(n):
        pil_image.resize(size, PIL.Image.LANCZOS)
    return (time.perf_counter() - t0) / n * 1000  # ms


def bench_tv(tensor, size, n=100):
    # Warmup
    for _ in range(10):
        tv_resize(tensor, size, interpolation=InterpolationMode.LANCZOS, antialias=True)

    t0 = time.perf_counter()
    for _ in range(n):
        tv_resize(tensor, size, interpolation=InterpolationMode.LANCZOS, antialias=True)
    return (time.perf_counter() - t0) / n * 1000  # ms


# Typical sizes from the 4 affected models:
#   Chameleon:     shortest_edge=512 (we use 800x600 -> 682x512)
#   Idefics3/SmolVLM: longest_edge=1456 (we use 1920x1080 -> 1456x819)
#   Flava codebook:   112x112 (we use 224x224 -> 112x112)
scenarios = [
    ("Chameleon  (800x600 -> 682x512)", (800, 600), (512, 682)),
    ("Idefics3   (1920x1080 -> 819x1456)", (1920, 1080), (819, 1456)),
    ("Flava CB   (224x224 -> 112x112)", (224, 224), (112, 112)),
]

print(f"{'Scenario':<45} {'PIL (ms)':>10} {'TV (ms)':>10} {'Speedup':>10}")
print("-" * 78)

for label, (in_w, in_h), (out_h, out_w) in scenarios:
    rng = np.random.RandomState(0)
    arr = rng.randint(0, 256, (in_h, in_w, 3), dtype=np.uint8)

    pil_img = PIL.Image.fromarray(arr)
    tensor = torch.from_numpy(arr).permute(2, 0, 1).contiguous()  # CHW uint8

    pil_ms = bench_pil(pil_img, (out_w, out_h))
    tv_ms = bench_tv(tensor, (out_h, out_w))

    print(f"{label:<45} {pil_ms:>10.2f} {tv_ms:>10.2f} {pil_ms / tv_ms:>9.1f}x")

```

</details>


## Code Agent Policy

- [X] I confirm that this is not a pure code agent PR.

## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [X] Did you write any new necessary tests? _I think existing tests properly cover the codepaths already_


## Who can review?

@vasqu  @zucchini-nlp since your reviewed https://github.com/huggingface/transformers/pull/45195. Thanks!


<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
