### PR TITLE
Fix `{image/video/audio}_token_ids` in `ProcessorMixin`

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -941,15 +941,33 @@ class ProcessorMixin(PushToHubMixin):
     # These values are used to build `mm_token_type_ids`
     @property
     def image_token_ids(self) -> list[int | None]:
+        if _image_token_ids := getattr(self, "_image_token_ids", None):
+            return _image_token_ids
         return [getattr(self, "image_token_id", None)]
+
+    @image_token_ids.setter
+    def image_token_ids(self, value: list[int | None]):
+        setattr(self, "_image_token_ids", value)
 
     @property
     def video_token_ids(self) -> list[int | None]:
+        if _video_token_ids := getattr(self, "_video_token_ids", None):
+            return _video_token_ids
         return [getattr(self, "video_token_id", None)]
+
+    @video_token_ids.setter
+    def video_token_ids(self, value: list[int | None]):
+        setattr(self, "_video_token_ids", value)
 
     @property
     def audio_token_ids(self) -> list[int | None]:
+        if _audio_token_ids := getattr(self, "_audio_token_ids", None):
+            return _audio_token_ids
         return [getattr(self, "audio_token_id", None)]
+
+    @audio_token_ids.setter
+    def audio_token_ids(self, value: list[int | None]):
+        setattr(self, "_audio_token_ids", value)
 
     def check_argument_for_proper_class(self, argument_name, argument):
         """


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/45493 converted these attributes to properties. This breaks custom models which set `{image/video/audio}_token_ids` directly because:

- There is no setter, so these properties are read-only
- The getter will only ever read from `image_token_id`

This PR maintains BC by:

- Adding a setter for these properties
- Updating the getter to to first check if `{image/video/audio}_token_ids` has been explicitly set