### PR TITLE
fix(rt-detr): use float32 on MPS in build_2d_sinusoidal_position_embedding

### DIFF
--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -847,7 +847,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype; frequency arithmetic uses float64 internally (float32 on MPS).
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -856,11 +856,12 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    compute_dtype = torch.float64 if str(device) != "mps" else torch.float32
+    omega = torch.arange(pos_dim, dtype=compute_dtype, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=compute_dtype, device=device)
+    grid_w = torch.arange(width, dtype=compute_dtype, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -869,7 +870,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=compute_dtype, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -976,7 +976,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype; frequency arithmetic uses float64 internally (float32 on MPS).
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -985,11 +985,12 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    compute_dtype = torch.float64 if str(device) != "mps" else torch.float32
+    omega = torch.arange(pos_dim, dtype=compute_dtype, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=compute_dtype, device=device)
+    grid_w = torch.arange(width, dtype=compute_dtype, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -998,7 +999,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=compute_dtype, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #46159

`build_2d_sinusoidal_position_embedding` in both RT-DETR and RT-DETRv2 
hardcodes `dtype=torch.float64` for internal sinusoidal arithmetic. 
MPS (Apple Silicon) does not support float64, causing a TypeError when 
running inference on Apple Silicon devices.

This PR uses `float64` on CUDA/CPU for precision, and falls back to 
`float32` on MPS devices only.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a Github issue? Fixes #46159
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@yonigozlan @molbap