### PR TITLE
Fix InternVL models

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -364,7 +364,6 @@ MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS: set[str] = {
     "h2ovl_chat",
     "hyperclovax_vlm",
     "internlm2",
-    "internvl_chat",
     "jamba",
     "janus",
     "llava",


### PR DESCRIPTION
Since https://github.com/huggingface/transformers/pull/45078 (first released in v5.6.0), the fallback from `TokenizersBackend` to ` tokenizer_config.tokenizer_class` has been removed.

`internvl_chat` had been added to `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS` so that it would explicitly use `TokenizersBackend` instead of the class specified in its `tokenizer_config`. However, it appears that `internvl_chat` was actually using this fallback and therefore was actually loading the class specified by `tokenizer_config`.

This PR removes `internvl_chat` from `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS` so that the model can be loaded again with the same behaviour as in <v5.6.0.