### PR TITLE
Fix the offsets in processing

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -873,11 +873,15 @@ class ProcessorMixin(PushToHubMixin):
         batch_replacement_offsets = []
         for batch_idx in range(len(text)):
             last = 0
+            offset = 0
             replacement_offsets = []
             expanded_sample = []
             for m in re.finditer(regex_special_mm_tokens, text[batch_idx]):
                 start, end = m.span()
                 expanded_sample.append(text[batch_idx][last:start])
+
+                # adjust spans using running offset if one sample has several MM data associated
+                start_with_offset = start + offset
 
                 mm_type = m.lastgroup
                 replacement_text = next(replacements_iters[mm_type])
@@ -885,12 +889,14 @@ class ProcessorMixin(PushToHubMixin):
                     {
                         "type": mm_type,
                         "span": (start, end),
-                        "new_span": (start, start + len(replacement_text)),
+                        "new_span": (start_with_offset, start_with_offset + len(replacement_text)),
                         "text": m.group(),
                         "replacement": replacement_text,
                     }
                 )
                 expanded_sample.append(replacement_text)
+                # update the offsets and the last position
+                offset += len(replacement_text) - (end - start)
                 last = end
 
             expanded_sample.append(text[batch_idx][last:])

--- a/tests/models/florence2/test_processing_florence2.py
+++ b/tests/models/florence2/test_processing_florence2.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 import unittest
 
+import numpy as np
+
 from transformers import Florence2Processor
 from transformers.testing_utils import require_torch, require_vision
 from transformers.utils import is_torch_available
@@ -233,3 +235,41 @@ class Florence2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "<OCR_WITH_REGION>": {"quad_boxes": [[100, 100, 200, 100, 200, 200, 100, 200]], "labels": ["Hello"]}
         }
         self.assertEqual(ocr_result, EXPECTED_OCR_RESULT)
+
+    def test_get_num_multimodal_tokens_matches_processor_call(self):
+        "Tests that the helper used internally in vLLM works correctly"
+
+        # Overridden -> model needs nested image structure
+        processor = self.get_processor()
+
+        if processor.tokenizer.pad_token_id is None:
+            processor.tokenizer.pad_token_id = processor.tokenizer.eos_token_id
+
+        image_sizes = [(100, 100), (300, 100), (500, 30), (213, 167)]
+        image_inputs = []
+        for h, w in image_sizes:
+            image_inputs.append(np.random.randint(255, size=(h, w, 3), dtype=np.uint8))
+
+        image_token = getattr(self, "image_token", "")
+        text = [f"This is an image {image_token}"] * len(image_inputs)
+        inputs = processor(
+            text=text, images=image_inputs, padding=True, return_mm_token_type_ids=True, return_tensors="pt"
+        )
+
+        num_image_tokens_from_call = inputs.mm_token_type_ids.sum(-1).tolist()
+        num_image_tokens_from_helper = processor._get_num_multimodal_tokens(image_sizes=image_sizes)
+        self.assertListEqual(num_image_tokens_from_call, num_image_tokens_from_helper["num_image_tokens"])
+
+        # Test with two images per single text
+        text = [f"These are two images {image_token}{image_token}"] * len(image_inputs)
+        inputs = processor(
+            text=text,
+            images=[[image, image] for image in image_inputs],
+            padding=True,
+            return_mm_token_type_ids=True,
+            return_tensors="pt",
+        )
+
+        num_image_tokens_from_call = inputs.mm_token_type_ids.sum(-1).tolist()
+        num_image_tokens_from_helper = processor._get_num_multimodal_tokens(image_sizes=image_sizes * 2)
+        self.assertEqual(sum(num_image_tokens_from_call), sum(num_image_tokens_from_helper["num_image_tokens"]))

--- a/tests/models/fuyu/test_processing_fuyu.py
+++ b/tests/models/fuyu/test_processing_fuyu.py
@@ -1,4 +1,20 @@
+# Copyright 2023 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
+
+import numpy as np
 
 from transformers import (
     FuyuImageProcessor,
@@ -342,6 +358,30 @@ class FuyuProcessingTest(ProcessorTesterMixin, unittest.TestCase):
         inputs_dict_no_vision = {"text": text, "images": image_inputs_nested}
         inputs_nested = processor(**inputs_dict_no_vision, **processing_kwargs)
         self.assertTrue(self.text_input_name in inputs_nested)
+
+    def test_get_num_multimodal_tokens_matches_processor_call(self):
+        "Tests that the helper used internally in vLLM works correctly"
+
+        # Override -> model siltently ignores multiimage and processes one image per sample
+        processor = self.get_processor()
+
+        if processor.tokenizer.pad_token_id is None:
+            processor.tokenizer.pad_token_id = processor.tokenizer.eos_token_id
+
+        image_sizes = [(100, 100), (300, 100), (500, 30), (213, 167)]
+        image_inputs = []
+        for h, w in image_sizes:
+            image_inputs.append(np.random.randint(255, size=(h, w, 3), dtype=np.uint8))
+
+        image_token = getattr(self, "image_token", "")
+        text = [f"This is an image {image_token}"] * len(image_inputs)
+        inputs = processor(
+            text=text, images=image_inputs, padding=True, return_mm_token_type_ids=True, return_tensors="pt"
+        )
+
+        num_image_tokens_from_call = inputs.mm_token_type_ids.sum(-1).tolist()
+        num_image_tokens_from_helper = processor._get_num_multimodal_tokens(image_sizes=image_sizes)
+        self.assertListEqual(num_image_tokens_from_call, num_image_tokens_from_helper["num_image_tokens"])
 
 
 @require_torch

--- a/tests/models/idefics3/test_processing_idefics3.py
+++ b/tests/models/idefics3/test_processing_idefics3.py
@@ -97,6 +97,22 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                 num_image_tokens_from_helper = processor._get_num_multimodal_tokens(image_sizes=image_sizes)
                 self.assertListEqual(num_image_tokens_from_call, num_image_tokens_from_helper["num_image_tokens"])
 
+                # Test with two images per single text
+                text = [f"These are two images {processor.image_token}{processor.image_token}"] * len(image_inputs)
+                inputs = processor(
+                    text=text,
+                    images=image_inputs * 2,
+                    padding=True,
+                    return_mm_token_type_ids=True,
+                    return_tensors="pt",
+                )
+
+                num_image_tokens_from_call = inputs.mm_token_type_ids.sum(-1).tolist()
+                num_image_tokens_from_helper = processor._get_num_multimodal_tokens(image_sizes=image_sizes * 2)
+                self.assertEqual(
+                    sum(num_image_tokens_from_call), sum(num_image_tokens_from_helper["num_image_tokens"])
+                )
+
     def get_split_image_expected_tokens(self, processor, image_rows, image_cols):
         text_split_images = []
         for n_h in range(image_rows):

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -2081,7 +2081,8 @@ class ProcessorTesterMixin:
         for h, w in image_sizes:
             image_inputs.append(np.random.randint(255, size=(h, w, 3), dtype=np.uint8))
 
-        text = [f"This is an image {getattr(self, 'image_token', '')}"] * len(image_inputs)
+        image_token = getattr(self, "image_token", "")
+        text = [f"This is an image {image_token}"] * len(image_inputs)
         inputs = processor(
             text=text, images=image_inputs, padding=True, return_mm_token_type_ids=True, return_tensors="pt"
         )
@@ -2092,3 +2093,17 @@ class ProcessorTesterMixin:
         num_image_tokens_from_call = inputs.mm_token_type_ids.sum(-1).tolist()
         num_image_tokens_from_helper = processor._get_num_multimodal_tokens(image_sizes=image_sizes)
         self.assertListEqual(num_image_tokens_from_call, num_image_tokens_from_helper["num_image_tokens"])
+
+        # Test with two images per single text
+        text = [f"These are two images {image_token}{image_token}"] * len(image_inputs)
+        inputs = processor(
+            text=text,
+            images=image_inputs * 2,
+            padding=True,
+            return_mm_token_type_ids=True,
+            return_tensors="pt",
+        )
+
+        num_image_tokens_from_call = inputs.mm_token_type_ids.sum(-1).tolist()
+        num_image_tokens_from_helper = processor._get_num_multimodal_tokens(image_sizes=image_sizes * 2)
+        self.assertEqual(sum(num_image_tokens_from_call), sum(num_image_tokens_from_helper["num_image_tokens"]))


### PR DESCRIPTION
# What does this PR do?

Helps vllm to bump v5.10

Before: spans were computed only from the original regex positions, so after the first replacement every image after it became misaligned and `new_span` was wrong.

Now: we track a running `offset` that accumulates length changes from each replacement, and use it to adjust spans so every match is mapped correctly into the expanded text
