### PR TITLE
[docs] torchvision lanczos

### DIFF
--- a/docs/source/en/image_processors.md
+++ b/docs/source/en/image_processors.md
@@ -60,7 +60,8 @@ The [AutoClass](./model_doc/auto) API provides a convenient method to load an im
 
 Use [`~AutoImageProcessor.from_pretrained`] with the `backend` argument to select the backend. When `backend` is omitted (the default), torchvision is picked when it is installed and PIL is used otherwise. Note that `backend="pil"` is only supported for older models; newer models only expose the torchvision backend.
 
-> **Note:** a small set of older models (Chameleon, Flava, Idefics3, SmolVLM) use Lanczos interpolation that torchvision does not support, so they always default to the PIL backend regardless of torchvision availability. Pass `backend="torchvision"` explicitly to override this.
+> [!NOTE]
+> A small set of older models (Chameleon, Flava, Idefics3, SmolVLM) use Lanczos interpolation. Their default backend depends on your torchvision version. With torchvision > 0.27, Lanczos is supported natively and these models default to torchvision. Older torchvision version falls back to BICUBIC, so the default is PIL to preserve the original outputs. Pass `backend="torchvision"` explicitly to override the default.
 
 ```py
 from transformers import AutoImageProcessor

--- a/docs/source/en/main_classes/image_processor.md
+++ b/docs/source/en/main_classes/image_processor.md
@@ -26,7 +26,7 @@ Image processors use a backend-based architecture. The class hierarchy is:
 
 Both backends expose the same API. Use the `backend` attribute to inspect which backend a loaded processor uses (e.g. `processor.backend == "torchvision"`).
 
-Pass `backend` to [`AutoImageProcessor.from_pretrained`] to select a backend. When `backend` is omitted (the default), torchvision is picked if it's installed, otherwise PIL is used. A few models that use Lanczos interpolation (Chameleon, Flava, Idefics3, SmolVLM) are an exception, and they default to PIL when torchvision < 0.27. Pass an explicit string to override that choice.
+Pass `backend` to [`AutoImageProcessor.from_pretrained`] to select a backend. When `backend` is omitted (the default), torchvision is picked if it's installed, otherwise PIL is used. A few models that use Lanczos interpolation (Chameleon, Flava, Idefics3, SmolVLM) are an exception, and they default to PIL when torchvision < 0.27. Forcing `backend="torchvision"` for these models on torchvision < 0.27 falls back to BICUBIC interpolation, since torchvision supports Lanczos for tensors only from 0.27 onward.
 
 ```python
 from transformers import AutoImageProcessor

--- a/docs/source/en/main_classes/image_processor.md
+++ b/docs/source/en/main_classes/image_processor.md
@@ -26,7 +26,7 @@ Image processors use a backend-based architecture. The class hierarchy is:
 
 Both backends expose the same API. Use the `backend` attribute to inspect which backend a loaded processor uses (e.g. `processor.backend == "torchvision"`).
 
-Use [`AutoImageProcessor.from_pretrained`] with the `backend` argument to select a backend. When `backend` is omitted (the default), torchvision is picked when it is installed and PIL is used otherwise. Pass an explicit string to override that choice:
+Pass `backend` to [`AutoImageProcessor.from_pretrained`] to select a backend. When `backend` is omitted (the default), torchvision is picked if it's installed, otherwise PIL is used. A few models that use Lanczos interpolation (Chameleon, Flava, Idefics3, SmolVLM) are an exception, and they default to PIL when torchvision < 0.27. Pass an explicit string to override that choice.
 
 ```python
 from transformers import AutoImageProcessor


### PR DESCRIPTION
adds docs for #46496

updates a stale note about models that always default to PIL because torchvision doesn't support lanczos and update backend auto-selection behavior docs