### PR TITLE
(Draft) [CB] Change padding from interval to pow2

### DIFF
--- a/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
+++ b/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
@@ -25,6 +25,7 @@ from lighteval.tasks.requests import Doc
 from tabulate import tabulate
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, ContinuousBatchingConfig, GenerationConfig
+from transformers.utils.logging import disable_progress_bar
 
 
 # Defaults
@@ -176,6 +177,7 @@ class BenchmarkResults:
         self.local_rank = int(os.environ.get("LOCAL_RANK", 0))
         # Pin this worker to its own GPU and open a process group to gather results later
         if self.dp_size > 1:
+            disable_progress_bar()
             torch.cuda.set_device(self.local_rank)
             if not torch.distributed.is_initialized():  # type: ignore
                 torch.distributed.init_process_group(backend="gloo")  # type: ignore
@@ -229,8 +231,9 @@ class BenchmarkResults:
             return None
 
         # Tag lines with the rank and disable the per-token bar so DP stdout stays readable.
-        tag = f"[rank {self.global_rank}] " if self.dp_size > 1 else ""
-        print(f"\n{tag}[{entry.label}] samples={entry.num_samples} avg_in={avg_input:.1f} max_new={max_new_tokens}")
+        tag = f"[rank {self.global_rank}]" if self.dp_size > 1 else ""
+        details = f"samples={entry.num_samples} avg_in={avg_input:.1f} max_new={max_new_tokens}"
+        print(f"\n{tag} [{entry.label}] Starting with {details}")
 
         model = self._get_model()
         self.cleanup()
@@ -249,18 +252,17 @@ class BenchmarkResults:
 
             entry.time_seconds = gen_time
             entry.num_tokens = num_tokens
-            entry.throughput_tok_per_sec = num_tokens / gen_time if gen_time > 0 else 0.0
+            tps = num_tokens / gen_time if gen_time > 0 else 0.0
+            entry.throughput_tok_per_sec = tps
             entry.peak_memory_gb = torch.cuda.max_memory_allocated() / (1024**3)
             if score_fn is not None:
                 entry.accuracy = score_fn(outputs)
-            print(
-                f"   {gen_time:.2f}s, {num_tokens} tokens, "
-                f"{entry.throughput_tok_per_sec:.2f} tok/s, peak {entry.peak_memory_gb:.2f} GB"
-                + (f", acc {entry.accuracy:.3f}" if entry.accuracy is not None else "")
-            )
+            details = f"time={gen_time:.2f}s tokens={num_tokens} tok/s={tps:.2f} GB={entry.peak_memory_gb:.2f}"
+            details += f", acc={entry.accuracy:.3f}" if entry.accuracy is not None else ""
+            print(f"\n{tag} [{entry.label}] Finished with {details}")
         except Exception as e:
             entry.error = str(e)
-            print(f"   ERROR: {e}")
+            print(f"{tag} [{entry.label}] ERROR: {e}")
 
         self.entries.append(entry)
         model = None

--- a/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
+++ b/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
@@ -169,6 +169,7 @@ class BenchmarkResults:
         self.attn_impl = attn_impl
         self.tp_size = tp_size
         self.dp_size = dp_size
+        self._start_time = time.perf_counter()
         # For now, TP and DP are mutually exclusive
         if self.tp_size > 1 and self.dp_size > 1:
             raise ValueError("TP and DP cannot be used together")
@@ -306,6 +307,9 @@ class BenchmarkResults:
 
     # Display
     def print_summary(self) -> None:
+        print("-" * 80)
+        print(f"Total time: {time.perf_counter() - self._start_time:.2f}s")
+        print("-" * 80)
         rows = [
             {
                 "label": e.label,

--- a/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
+++ b/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
@@ -292,18 +292,17 @@ class BenchmarkResults:
 
     @classmethod
     def load_most_recent(cls, name: str) -> "BenchmarkResults":
-        """Load the most recent JSON file matching name."""
-        candidates = sorted(RESULTS_DIR.glob(f"{name}__*.json"))
-        if not candidates:
-            raise FileNotFoundError(f"No baseline with name '{name}' in {RESULTS_DIR}")
-        data = json.loads(candidates[-1].read_text())
-        instance = cls(
-            model_id=data.get("model_id"),
-            attn_impl=data.get("attn_impl"),
-        )
-        instance.entries = [BenchmarkEntry(**e) for e in data["entries"]]
-        print(f"Loaded baseline from {candidates[-1]}")
-        return instance
+        """Load the most recent run matching name, skipping files in an incompatible legacy format."""
+        candidates = sorted(RESULTS_DIR.glob(f"{name}__*.json"), reverse=True)
+        for path in candidates:
+            data = json.loads(path.read_text())
+            if not (isinstance(data, dict) and "entries" in data):
+                continue
+            instance = cls(model_id=data.get("model_id"), attn_impl=data.get("attn_impl"))
+            instance.entries = [BenchmarkEntry(**e) for e in data["entries"]]
+            print(f"Loaded baseline from {path}")
+            return instance
+        raise FileNotFoundError(f"No compatible baseline with name '{name}' in {RESULTS_DIR}")
 
     # Display
     def print_summary(self) -> None:
@@ -481,8 +480,8 @@ if __name__ == "__main__":
 
     if write_results:
         results.print_summary()
+        if args.name:
+            results.save(args.name)
         if args.compare_to:
             baseline = BenchmarkResults.load_most_recent(args.compare_to)
             results.compare_to(baseline=baseline)
-        if args.name:
-            results.save(args.name)

--- a/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
+++ b/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
@@ -171,12 +171,14 @@ class BenchmarkResults:
         # For now, TP and DP are mutually exclusive
         if self.tp_size > 1 and self.dp_size > 1:
             raise ValueError("TP and DP cannot be used together")
-        # torchrun sets these per worker; the work is independent so no process group is needed.
+        # torchrun sets these per worker
         self.global_rank = int(os.environ.get("RANK", 0))
         self.local_rank = int(os.environ.get("LOCAL_RANK", 0))
-        # Pin this worker to its own GPU so all torch.cuda calls (memory stats, cleanup) target it.
+        # Pin this worker to its own GPU and open a process group to gather results later
         if self.dp_size > 1:
             torch.cuda.set_device(self.local_rank)
+            if not torch.distributed.is_initialized():  # type: ignore
+                torch.distributed.init_process_group(backend="gloo")  # type: ignore
         # Entries accumulator
         self.entries: list[BenchmarkEntry] = []
 
@@ -262,6 +264,12 @@ class BenchmarkResults:
         self.entries.append(entry)
         self.cleanup()
 
+    def gather_entries(self) -> None:
+        """In DP, merge each rank's owned entries onto all ranks (entry i is owned by rank i % dp_size)."""
+        gathered: list[Any] = [None] * self.dp_size
+        torch.distributed.all_gather_object(gathered, self.entries)  # type: ignore
+        self.entries = [gathered[i % self.dp_size][i] for i in range(len(self.entries))]
+
     # Persistence
     def save(self, name: str) -> Path:
         """Save all entries to a timestamped JSON file keyed by name."""
@@ -294,8 +302,6 @@ class BenchmarkResults:
 
     # Display
     def print_summary(self) -> None:
-        if self.dp_size > 1:
-            print("-" * 80, f"RANK {self.global_rank}", "-" * 80, sep="\n")
         rows = [
             {
                 "label": e.label,
@@ -458,12 +464,17 @@ if __name__ == "__main__":
             label=f"rollouts_{length}",
         )
 
-    # Post processing and display. Only on rank 0 in TP runs to avoid duplicate output / file writes.
-    is_rank_zero = not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
-    if is_rank_zero:
+    # In DP, gather every rank's entries
+    if args.dp_size > 1:
+        results.gather_entries()
+
+    # Post processing and display, only for rank 0
+    write_results = results.global_rank == 0 if (args.dp_size > 1 or args.tp_size > 1) else True
+
+    if write_results:
         results.print_summary()
-        if cli_args.compare_to:
-            baseline = BenchmarkResults.load_most_recent(cli_args.compare_to)
+        if args.compare_to:
+            baseline = BenchmarkResults.load_most_recent(args.compare_to)
             results.compare_to(baseline=baseline)
-        if cli_args.name:
-            results.save(cli_args.name)
+        if args.name:
+            results.save(args.name)

--- a/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
+++ b/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
@@ -222,14 +222,15 @@ class BenchmarkResults:
             cb_config=_config_summary(cb_config),
             gen_config=_config_summary(gen_config),
         )
-        print(f"\n[{entry.label}] samples={entry.num_samples} avg_in={avg_input:.1f} max_new={max_new_tokens}")
-
         # In DP, entries are sharded round-robin across ranks: entry i runs on rank i % dp_size.
         if self.dp_size > 1 and len(self.entries) % self.dp_size != self.global_rank:
             entry.error = f"Rank {self.global_rank} is not in charge of this entry"
-            print(f"SKIPPED: {entry.error}")
             self.entries.append(entry)
             return None
+
+        # Tag lines with the rank and disable the per-token bar so DP stdout stays readable.
+        tag = f"[rank {self.global_rank}] " if self.dp_size > 1 else ""
+        print(f"\n{tag}[{entry.label}] samples={entry.num_samples} avg_in={avg_input:.1f} max_new={max_new_tokens}")
 
         model = self._get_model()
         self.cleanup()
@@ -239,7 +240,7 @@ class BenchmarkResults:
                 inputs=data,
                 generation_config=gen_config,
                 continuous_batching_config=cb_config,
-                progress_bar=True,
+                progress_bar=self.dp_size == 1,
             )
             gen_start = min(out.created_time for out in outputs.values())
             gen_end = max(out.lifespan[1] for out in outputs.values())
@@ -262,6 +263,7 @@ class BenchmarkResults:
             print(f"   ERROR: {e}")
 
         self.entries.append(entry)
+        model = None
         self.cleanup()
 
     def gather_entries(self) -> None:

--- a/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
+++ b/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
@@ -8,6 +8,7 @@ data) and can compare throughput against a previously-saved run.
 import argparse
 import gc
 import json
+import os
 import time
 import types
 from collections.abc import Callable
@@ -30,11 +31,19 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, ContinuousBatching
 RESULTS_DIR = Path(__file__).parent.parent / "benchmark_results/cb_overall/"
 
 
+# Auxiliary functions
 def _fmt(val: Any, spec: str = "", missing: str = "X") -> str:
     """Format `val` per `spec`, or return `missing` if val is None."""
     return format(val, spec) if val is not None else missing
 
 
+def _config_summary(cfg: Any) -> dict[str, Any]:
+    """Extract a JSON-friendly summary of a dataclass/config object."""
+    raw = cfg.to_dict() if hasattr(cfg, "to_dict") else cfg.__dict__
+    return {k: v for k, v in raw.items() if isinstance(v, (int, float, str, bool, type(None)))}
+
+
+# Data-related functions
 def _build_gsm8k_platinum_module() -> types.ModuleType:
     """Define the gsm8k_platinum custom task inline so lighteval's Registry can pick it up via `custom_tasks=`."""
 
@@ -49,7 +58,7 @@ def _build_gsm8k_platinum_module() -> types.ModuleType:
     metrics = list(Registry().load_all_task_configs()["gsm8k"].metrics)
 
     mod = types.ModuleType("_gsm8k_platinum_inline")
-    mod.TASKS_TABLE = [
+    mod.TASKS_TABLE = [  # type: ignore
         LightevalTaskConfig(
             name="gsm8k_platinum",
             prompt_function=gsm8k_platinum_prompt,
@@ -90,7 +99,7 @@ def _build_lighteval_inputs_scorer(
     def score(outputs) -> float:
         scores = []
         for doc, (_, out) in zip(docs, outputs.items()):
-            text = tokenizer.decode(out.generated_tokens, skip_special_tokens=True)
+            text = tokenizer.decode(out.generated_tokens, skip_special_tokens=True)  # type: ignore
             for s in stop_sequences:
                 text = text.split(s, 1)[0]
             value = metric.sample_level_fn.compute(doc, ModelResponse(text=[text]))
@@ -101,7 +110,6 @@ def _build_lighteval_inputs_scorer(
     return inputs, score
 
 
-# Data helpers
 def get_tokenized_gsm8k(
     tokenizer: AutoTokenizer, n_fewshot: int = 8
 ) -> tuple[list[list[int]], Callable[[Any], float]]:
@@ -152,19 +160,24 @@ class BenchmarkEntry:
     error: str | None = None
 
 
-def _config_summary(cfg: Any) -> dict[str, Any]:
-    """Extract a JSON-friendly summary of a dataclass/config object."""
-    raw = cfg.to_dict() if hasattr(cfg, "to_dict") else cfg.__dict__
-    return {k: v for k, v in raw.items() if isinstance(v, (int, float, str, bool, type(None)))}
-
-
 class BenchmarkResults:
     """Holds all CB benchmark runs and the shared model they execute against."""
 
-    def __init__(self, model_id: str, attn_impl: str, tp_size: int = 1):
+    def __init__(self, model_id: str, attn_impl: str, tp_size: int = 1, dp_size: int = 1):
         self.model_id = model_id
         self.attn_impl = attn_impl
         self.tp_size = tp_size
+        self.dp_size = dp_size
+        # For now, TP and DP are mutually exclusive
+        if self.tp_size > 1 and self.dp_size > 1:
+            raise ValueError("TP and DP cannot be used together")
+        # torchrun sets these per worker; the work is independent so no process group is needed.
+        self.global_rank = int(os.environ.get("RANK", 0))
+        self.local_rank = int(os.environ.get("LOCAL_RANK", 0))
+        # Pin this worker to its own GPU so all torch.cuda calls (memory stats, cleanup) target it.
+        if self.dp_size > 1:
+            torch.cuda.set_device(self.local_rank)
+        # Entries accumulator
         self.entries: list[BenchmarkEntry] = []
 
     def cleanup(self) -> None:
@@ -175,7 +188,12 @@ class BenchmarkResults:
     def _get_model(self) -> Any:
         self.cleanup()
         # tp_plan and device_map are mutually exclusive — TP uses its own placement.
-        placement = {"tp_plan": "auto"} if self.tp_size > 1 else {"device_map": 0}
+        if self.tp_size > 1:
+            placement = {"tp_plan": "auto"}
+        elif self.dp_size > 1:
+            placement = {"device_map": self.local_rank}
+        else:
+            placement = {"device_map": 0}
         model = AutoModelForCausalLM.from_pretrained(self.model_id, attn_implementation=self.attn_impl, **placement)
         return model.eval()
 
@@ -187,13 +205,11 @@ class BenchmarkResults:
         gen_config: GenerationConfig | None = None,
         label: str | None = None,
         score_fn: Callable[[Any], float] | None = None,
-    ) -> BenchmarkEntry:
+    ) -> None:
         """Run one CB benchmark and record time, tokens, and peak memory."""
 
         gen_config = GenerationConfig() if gen_config is None else gen_config
         gen_config.max_new_tokens = max_new_tokens
-
-        model = self._get_model()
 
         avg_input = sum(len(x) for x in data) / max(len(data), 1)
         entry = BenchmarkEntry(
@@ -204,9 +220,16 @@ class BenchmarkResults:
             cb_config=_config_summary(cb_config),
             gen_config=_config_summary(gen_config),
         )
-
         print(f"\n[{entry.label}] samples={entry.num_samples} avg_in={avg_input:.1f} max_new={max_new_tokens}")
 
+        # In DP, entries are sharded round-robin across ranks: entry i runs on rank i % dp_size.
+        if self.dp_size > 1 and len(self.entries) % self.dp_size != self.global_rank:
+            entry.error = f"Rank {self.global_rank} is not in charge of this entry"
+            print(f"SKIPPED: {entry.error}")
+            self.entries.append(entry)
+            return None
+
+        model = self._get_model()
         self.cleanup()
 
         try:
@@ -238,7 +261,6 @@ class BenchmarkResults:
 
         self.entries.append(entry)
         self.cleanup()
-        return entry
 
     # Persistence
     def save(self, name: str) -> Path:
@@ -250,7 +272,8 @@ class BenchmarkResults:
             "attn_impl": self.attn_impl,
             "entries": [asdict(e) for e in self.entries],
         }
-        filename.write_text(json.dumps(payload, indent=2))
+        with open(filename, "a") as f:
+            json.dump(payload, f, indent=2)
         print(f"\nResults saved to {filename}")
         return filename
 
@@ -271,6 +294,8 @@ class BenchmarkResults:
 
     # Display
     def print_summary(self) -> None:
+        if self.dp_size > 1:
+            print("-" * 80, f"RANK {self.global_rank}", "-" * 80, sep="\n")
         rows = [
             {
                 "label": e.label,
@@ -317,6 +342,7 @@ if __name__ == "__main__":
     parser.add_argument("--model-id", type=str, default="meta-llama/Llama-3.1-8B-Instruct")
     parser.add_argument("--attn", type=str, default="kernels-community/flash-attn3")
     parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size (1 = no TP).")
+    parser.add_argument("--dp-size", type=int, default=1, help="Data parallel size (1 = no DP).")
     parser.add_argument(
         "--rollouts-lengths",
         "-rl",
@@ -324,14 +350,14 @@ if __name__ == "__main__":
         nargs="+",
         help="If this is specified, only the rollouts benchmarks run, with the given sizes (in tokens).",
     )
-    cli_args = parser.parse_args()
+    args = parser.parse_args()
 
-    results = BenchmarkResults(model_id=cli_args.model_id, attn_impl=cli_args.attn, tp_size=cli_args.tp_size)
-    tokenizer = AutoTokenizer.from_pretrained(cli_args.model_id, padding_side="left")
+    results = BenchmarkResults(model_id=args.model_id, attn_impl=args.attn, tp_size=args.tp_size, dp_size=args.dp_size)
+    tokenizer = AutoTokenizer.from_pretrained(args.model_id, padding_side="left")
 
-    if cli_args.rollouts_lengths is not None:
+    if args.rollouts_lengths is not None:
         rollouts_only = True
-        rollout_sizes = cli_args.rollouts_lengths
+        rollout_sizes = args.rollouts_lengths
     else:
         rollouts_only = False
         rollout_sizes = [1024, 2048, 4096, 8192, 16384]

--- a/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
+++ b/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
@@ -284,7 +284,7 @@ class BenchmarkResults:
             "attn_impl": self.attn_impl,
             "entries": [asdict(e) for e in self.entries],
         }
-        with open(filename, "a") as f:
+        with open(filename, "w") as f:
             json.dump(payload, f, indent=2)
         print(f"\nResults saved to {filename}")
         return filename

--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -256,7 +256,7 @@ When active, the manager pads query and KV lengths to the next power of 2 so sha
 ```py
 cb_config = ContinuousBatchingConfig(
     use_cuda_graph=True,
-    max_cached_graphs=32,
+    max_cached_graphs=128,
 )
 ```
 

--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -251,13 +251,11 @@ CUDA graphs eliminate CPU dispatch overhead by recording the GPU execution graph
 cb_config = ContinuousBatchingConfig(use_cuda_graph=True)
 ```
 
-When active, the manager pads query and KV lengths to fixed intervals so shapes repeat and graphs reuse. Smaller values of `q_padding_interval_size` and `kv_padding_interval_size` reduce wasted compute on padding, but this means there are more unique shapes the graph has to record and store which costs more memory.
+When active, the manager pads query and KV lengths to the next power of 2 so shapes repeat and graphs reuse.
 
 ```py
 cb_config = ContinuousBatchingConfig(
     use_cuda_graph=True,
-    q_padding_interval_size=64,
-    kv_padding_interval_size=16384,
     max_cached_graphs=32,
 )
 ```

--- a/docs/source/en/continuous_batching_architecture.md
+++ b/docs/source/en/continuous_batching_architecture.md
@@ -138,11 +138,10 @@ When the cache has space again, the request resumes from where it left off with 
 
 Every generation step involves CPU overhead, from assembling the batch to dispatching GPU kernels and reading the results. CUDA graphs eliminate the overhead by recording the full GPU execution sequence once and replaying it for batches with matching shapes.
 
-Because the batch shapes change every step, the continuous batching system handles this with padding and caching.
+Because the batch shapes change every step, the continuous batching system handles this with padding and caching:
 
-1. Query lengths are padded to the nearest multiple of `q_padding_interval_size`.
-2. KV lengths are padded to the nearest multiple of `kv_padding_interval_size`.
-3. Recorded graphs are stored in an LRU cache of up to `max_cached_graphs` entries.
+- Query and KV lengths are padded to the nearest multiple of 2.
+- Recorded graphs are stored in an LRU cache of up to `max_cached_graphs` entries.
 
 When a batch's padded shape matches a cached graph, the graph replays without any CPU dispatch. New shapes trigger a new graph capture.
 

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1771,7 +1771,9 @@ class ContinuousBatchingConfig:
 
     def __post_init__(self):
         # Only turn off graph mixing support if TP is on
-        if self.disable_nccl_graph_mixing and int(os.environ.get("WORLD_SIZE", "1")) > 1:
+        graph_mixing_supported = os.environ.get("NCCL_GRAPH_MIXING_SUPPORT", "1") == "1"
+        distributed = int(os.environ.get("WORLD_SIZE", "1")) > 1
+        if self.disable_nccl_graph_mixing and graph_mixing_supported and distributed:
             logger.warning(
                 "Setting NCCL_GRAPH_MIXING_SUPPORT = 0 because disable_nccl_graph_mixing is True and WORLD_SIZE > 1."
             )

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1634,12 +1634,6 @@ class ContinuousBatchingConfig:
             Whether to enable CUDA graphs. This can be a tuple of booleans (one for the varlen path and one for the
             decode fast path), a boolean which will apply to both paths, or None (automatically inferred). After calling
             `decide_use_cuda_graphs`, the attribute will be a tuple of booleans. Default is None (automatically inferred).
-        q_padding_interval_size (`int`, *optional*, defaults to 0):
-            Query padding granularity in tokens for CUDA graphs. Uses a preset from `continuous_api.py` when
-            set to 0.
-        kv_padding_interval_size (`int`, *optional*, defaults to 0):
-            KV padding granularity in tokens for CUDA graphs. Uses a preset from `continuous_api.py` when
-            set to 0.
         max_cached_graphs (`int`, *optional*, defaults to 0):
             Maximum number of cached CUDA graphs. Uses a preset from `continuous_api.py` when set to 0.
         varlen_compile_config (`CompileConfig`, *optional*):
@@ -1676,6 +1670,12 @@ class ContinuousBatchingConfig:
         cpu_group_timeout (`float`, *optional*, defaults to 300.0):
             The time (in seconds) after which a CPU communication will timeout and the process will crash. Leave to None
             for no timeout. Default is 300 seconds.
+
+    Deprecated arguments:
+        q_padding_interval_size (`int`, *optional*, defaults to 0):
+            Used to control the padding granularity for query lengths in CUDA graphs.
+        kv_padding_interval_size (`int`, *optional*, defaults to 0):
+            Used to control the padding granularity for KV lengths in CUDA graphs.
     """
 
     # Size of each KV cache block
@@ -1711,11 +1711,8 @@ class ContinuousBatchingConfig:
     # the attribute will ALWAYS be a tuple of booleans.
     use_cuda_graph: bool | tuple[bool, bool] | None = None
 
-    # If any of these parameters are set to a non-default, CUDA graphs will be used. Otherwise we automatically infer
-    # if they should be turned on. Padding interval sizes are in tokens and further explained in the docstring at the
-    # top of the continuous_batching/continuous_api.py file.
-    q_padding_interval_size: int = 0
-    kv_padding_interval_size: int = 0
+    # Controls how much graphs can be cached at the same time. If set to something other than 0, CUDA graphs will be
+    # used.
     max_cached_graphs: int = 0
 
     # Compile configs for the two execution paths. If None, uses the compile_config from generation_config as fallback.
@@ -1769,6 +1766,10 @@ class ContinuousBatchingConfig:
     # long for almost all use cases.
     cpu_group_timeout: float | None = 300.0
 
+    # ! Deprecated arguments
+    q_padding_interval_size: int = 0
+    kv_padding_interval_size: int = 0
+
     def __post_init__(self):
         # Only turn off graph mixing support if TP is on
         graph_mixing_supported = os.environ.get("NCCL_GRAPH_MIXING_SUPPORT", "1") == "1"
@@ -1778,6 +1779,12 @@ class ContinuousBatchingConfig:
                 "Setting NCCL_GRAPH_MIXING_SUPPORT = 0 because disable_nccl_graph_mixing is True and WORLD_SIZE > 1."
             )
             os.environ.setdefault("NCCL_GRAPH_MIXING_SUPPORT", "0")
+        # Warn about deprecated arguments
+        if self.q_padding_interval_size != 0 or self.kv_padding_interval_size != 0:  # Deprecated in 5.11
+            logger.warning(
+                "q_padding_interval_size and kv_padding_interval_size are deprecated: padding is now done to the "
+                "nearest power of 2. Ignoring these values."
+            )
 
     @property
     def cuda_graph_booleans(self) -> tuple[bool, bool]:

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -49,11 +49,11 @@ generation goes on, there are two dimensions that change:
 - the number of queries tokens (Q), which can vary from batch to batch
 - the number of keys/values tokens (KV), which grows as the cache does
 
-To solve this, we pad along those dimensions to the nearest power of 2. Since graphs memory and time to create, we use
-an LRU cache with a fixed size to limit memory usage.
+To solve this, we pad along those dimensions to the nearest power of 2. Since graphs take memory and time to create, we
+use an LRU cache with a fixed size to limit memory usage.
 
 The maximum number of cached graphs is controlled by max_cached_graphs (default 128), which uses LRU eviction.
-All defaults are stored in ContinuousBatchingConfig.resolve_sentinel_values().
+All defaults are stored in initialization.py.
 """
 
 

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -49,18 +49,10 @@ generation goes on, there are two dimensions that change:
 - the number of queries tokens (Q), which can vary from batch to batch
 - the number of keys/values tokens (KV), which grows as the cache does
 
-To solve this, we slice along those dimensions to fixed lengths. The size of the slices is controlled by interval sizes:
-- q_padding_interval_size: the padding granularity for queries (in tokens)
-- kv_padding_interval_size: the padding granularity for KV cache (in tokens)
+To solve this, we pad along those dimensions to the nearest power of 2. Since graphs memory and time to create, we use
+an LRU cache with a fixed size to limit memory usage.
 
-For example, with q_padding_interval_size=64 and an actual query length of 100, we pad to 128 tokens.
-
-Smaller intervals mean finer granularity and thus less padding, but more unique graph signatures. Since graphs take
-memory and time to create, we use an LRU cache with a fixed size to limit memory usage. Good defaults:
-- Q: 64 tokens gives ~4 graphs for max_batch_tokens=256, which is a good balance
-- KV: 8192 tokens (256 blocks at block_size=32) gives reasonable granularity for large caches
-
-The maximum number of cached graphs is controlled by max_cached_graphs (default 32), which uses LRU eviction.
+The maximum number of cached graphs is controlled by max_cached_graphs (default 128), which uses LRU eviction.
 All defaults are stored in ContinuousBatchingConfig.resolve_sentinel_values().
 """
 

--- a/src/transformers/generation/continuous_batching/initialization.py
+++ b/src/transformers/generation/continuous_batching/initialization.py
@@ -31,8 +31,6 @@ from .utils import WorkloadHints
 FALLBACK_DEFAULTS = {
     "max_requests_per_batch": 1024,
     "max_blocks_per_request": 32,
-    "q_padding_interval_size": 64,
-    "kv_padding_interval_size": 64 * 256,  # 64 blocks of 256 tokens ie. 16384 tokens
     "max_cached_graphs": 128,
 }
 

--- a/src/transformers/generation/continuous_batching/initialization.py
+++ b/src/transformers/generation/continuous_batching/initialization.py
@@ -48,10 +48,8 @@ def resolve_continuous_batching_config(
 
     # Look at whether the user explicitly asked for the decode fast path before we assign a default value
     user_requested_decode_path = cb_config.max_blocks_per_request is not None
-    # Same for cuda graphs, if the user signals they want CUDA graphs via any padding/cached-graph parameter
-    cuda_graph_requested = any(
-        [cb_config.q_padding_interval_size, cb_config.kv_padding_interval_size, cb_config.max_cached_graphs]
-    )
+    # Same for cuda graphs, if the user signals they want CUDA graphs via the max_cached_graphs parameter
+    cuda_graph_requested = cb_config.max_cached_graphs > 0
 
     # Resolve missing attributes for which we have hints. Must happen before no-hints resolve.
     resolve_using_hints(cb_config, workload_hints)
@@ -108,10 +106,6 @@ def resolve_without_hints(cb_config: ContinuousBatchingConfig) -> None:
         cb_config.max_requests_per_batch = FALLBACK_DEFAULTS["max_requests_per_batch"]
     if cb_config.max_blocks_per_request is None:
         cb_config.max_blocks_per_request = FALLBACK_DEFAULTS["max_blocks_per_request"]
-    if cb_config.q_padding_interval_size == 0:
-        cb_config.q_padding_interval_size = FALLBACK_DEFAULTS["q_padding_interval_size"]
-    if cb_config.kv_padding_interval_size == 0:
-        cb_config.kv_padding_interval_size = FALLBACK_DEFAULTS["kv_padding_interval_size"]
     if cb_config.max_cached_graphs == 0:
         cb_config.max_cached_graphs = FALLBACK_DEFAULTS["max_cached_graphs"]
 

--- a/src/transformers/generation/continuous_batching/initialization.py
+++ b/src/transformers/generation/continuous_batching/initialization.py
@@ -33,7 +33,7 @@ FALLBACK_DEFAULTS = {
     "max_blocks_per_request": 32,
     "q_padding_interval_size": 64,
     "kv_padding_interval_size": 64 * 256,  # 64 blocks of 256 tokens ie. 16384 tokens
-    "max_cached_graphs": 32,
+    "max_cached_graphs": 128,
 }
 
 

--- a/src/transformers/generation/continuous_batching/model_runner.py
+++ b/src/transformers/generation/continuous_batching/model_runner.py
@@ -23,7 +23,7 @@ from .cache import PagedAttentionCache
 from .cb_logits_processors import ContinuousBatchingLogitsProcessorList
 from .input_outputs import ContinuousBatchingAsyncIOs, ContinuousBatchingIOs
 from .requests import RequestStatus, logger
-from .utils import create_warmup_future_states, get_cuda_pools, mem_pool_ctx, pad_to_interval, pad_to_pow2
+from .utils import create_warmup_future_states, get_cuda_pools, mem_pool_ctx, pad_to_pow2
 
 
 class ModelRunner:
@@ -79,11 +79,10 @@ class ModelRunner:
         if not self.pad_inputs:
             return num_q_tokens, max_kv_read
         max_batch_tokens = self.cache.max_batch_tokens
-        # For varlen batches, we pad using interval sizes
+        # Padding differs for varlen and decode fast path (upper bound for Q, Kv not used in decode fast path)
         if not use_decode_fast_path:
             num_q_tokens = pad_to_pow2(num_q_tokens, max_batch_tokens)
             max_kv_read = pad_to_pow2(max_kv_read, self.cache.num_pages)
-        # For decode fast path batches, we pad using powers of 2 and use no KV
         else:
             num_q_tokens = pad_to_pow2(num_q_tokens, self.cb_config.max_requests_per_batch)
             max_kv_read = 0

--- a/src/transformers/generation/continuous_batching/model_runner.py
+++ b/src/transformers/generation/continuous_batching/model_runner.py
@@ -81,8 +81,8 @@ class ModelRunner:
         max_batch_tokens = self.cache.max_batch_tokens
         # For varlen batches, we pad using interval sizes
         if not use_decode_fast_path:
-            num_q_tokens = pad_to_interval(num_q_tokens, self.cb_config.q_padding_interval_size, max_batch_tokens)
-            max_kv_read = pad_to_interval(max_kv_read, self.cb_config.kv_padding_interval_size, self.cache.num_pages)
+            num_q_tokens = pad_to_pow2(num_q_tokens, max_batch_tokens)
+            max_kv_read = pad_to_pow2(max_kv_read, self.cache.num_pages)
         # For decode fast path batches, we pad using powers of 2 and use no KV
         else:
             num_q_tokens = pad_to_pow2(num_q_tokens, self.cb_config.max_requests_per_batch)

--- a/src/transformers/generation/continuous_batching/requests.py
+++ b/src/transformers/generation/continuous_batching/requests.py
@@ -208,21 +208,11 @@ class RequestState:
             self.lifespan = (time.perf_counter(), -1)
         elif value == RequestStatus.FINISHED:
             self.lifespan = (self.lifespan[0], time.perf_counter())
-            self.log_end_of_request()
         self._status = value
 
     @property
     def timestamps(self) -> list[float] | None:
         return self._timestamps if self.record_timestamps else None
-
-    def log_end_of_request(self):
-        prefill_len = len(self.initial_tokens)
-        decode_len = self.generated_len()
-        start_time = self.lifespan[0] - self.created_time
-        end_time = self.lifespan[1] - self.created_time
-        logger.info(
-            f"Request {self.request_id} finished: {prefill_len = } {decode_len = } {start_time = } {end_time = }"
-        )
 
     def current_len(self) -> int:
         """Get the current length of the sequence (prompt + generated tokens)."""

--- a/src/transformers/generation/continuous_batching/scheduler.py
+++ b/src/transformers/generation/continuous_batching/scheduler.py
@@ -230,7 +230,7 @@ class Scheduler(ABC):
             # If we are out the safety margin, we only accept decoding requests or the first prefill request
             outside_safety_margin = num_free_blocks < safety_margins
             if outside_safety_margin and scheduled_requests and state.status != RequestStatus.DECODING:
-                logger.info(
+                logger.debug(
                     f"Outside safety margin, breaking out of scheduling loop. {num_free_blocks = } {safety_margins = }"
                 )
                 break

--- a/src/transformers/generation/continuous_batching/utils.py
+++ b/src/transformers/generation/continuous_batching/utils.py
@@ -74,14 +74,6 @@ def attn_mask_is_needed(config: PretrainedConfig) -> bool:
     return config._attn_implementation in ["paged|eager", "paged|sdpa"]
 
 
-def pad_to_interval(size: int, interval_size: int, max_value: int) -> int:
-    """Return the smallest multiple of (interval_size) >= (size), capped at (max_value)."""
-    if interval_size <= 0:
-        return max_value
-    padded = ceil(size / interval_size) * interval_size if size > 0 else interval_size
-    return min(padded, max_value)
-
-
 def pad_to_pow2(value: int, max_value: int, min_value: int = 0) -> int:
     """Return the smallest power of 2 >= (value), capped at (max_value). If a minimum value is provided, the value is at
     least padded to that value."""

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -1240,7 +1240,6 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             use_async_batching=use_async_batching,
             per_request_processors=True,
             return_logprobs=True,
-            q_padding_interval_size=16,  # allows for exact comparison between CB and regular generation
         )
         manager = model.init_continuous_batching(
             generation_config=generation_config,


### PR DESCRIPTION
Draft until we have a full picture of the performance improvements.

<!-- 
# Summary

This PR makes some small changes to how CUDA graphs are bucketed in continuous batching. It used to be that they were bucketted based on intervals, now they are bucketed based on powers of 2. This means less buckets, less parameters in the config, and better performance.

Hinges on https://github.com/huggingface/transformers/pull/46490 to be merged.

## Performance

For Llama 8B

| label | main acc | with PR acc | main (tok/s) | with PR (tok/s) | diff |
|---|---|---|---|---|---|
| gsm8k_default | 0.822 | 0.825 | 2448.09 | 2431.56 | -0.7% |
| gsm8k_sampling | 0.796 | 0.781 | 1947.00 | 1946.53 | -0.0% |
| gsm8k_compile | 0.822 | 0.825 | 2454.80 | 2450.69 | -0.2% |
| gsm8k_no_fast_decode | 0.822 | 0.825 | 2349.59 | 2348.36 | -0.1% |
| gsm8k_bare_bones | 0.821 | 0.825 | 1862.95 | 1871.58 | +0.5% |
| ifeval_default | 0.447 | 0.457 | 8293.33 | 8940.09 | +7.8% |
| few_blocks | - | - | 691.24 | 682.46 | -1.3% |
| multi_return_seq | - | - | 1630.70 | 1630.93 | +0.0% |
| rollouts_1024 | - | - | 3285.90 | 3573.25 | +8.7% |
| rollouts_2048 | - | - | 3130.02 | 3413.55 | +9.1% |
| rollouts_4096 | - | - | 2789.79 | 2702.67 | -3.1% |
| rollouts_8192 | - | - | 2259.52 | 2393.42 | +5.9% |
| rollouts_16384 | - | - | 1397.03 | 1569.22 | +12.3% |

## Tests

TBD

## Review

Reviewed the PR using claude and compound engineering plugin.

-->