### PR TITLE
Fix buggy action sha pin

### DIFF
--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -385,7 +385,7 @@ jobs:
 
       - name: Send processed report
         if: ${{ !endsWith(env.REPORT_TEXT, '{}') }}
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001
         with:
           # Slack channel id, channel name, or user id to post message.
           # See also: https://api.slack.com/methods/chat.postMessage#channels


### PR DESCRIPTION
# What does this PR do?

I am very disappointed by the 🤖 in #46414.

After that change, we got the following error:

(see [this run](https://github.com/huggingface/transformers/actions/runs/27251020256/job/80510403808))
(a run that works with this PR: [here](https://github.com/huggingface/transformers/actions/runs/27266364066/job/80526057768))


```bash
Error: Missing input! Either a method or webhook is required to take action.
SlackError: Missing input! Either a method or webhook is required to take action.
    at Config.validate (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/src/config.js:210:1)
    at new Config (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/src/config.js:126:1)

file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/src/config.js:210
        throw new SlackError(
^
SlackError: Missing input! Either a method or webhook is required to take action.
    at Config.validate (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/src/config.js:210:1)
    at new Config (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/src/config.js:126:1)
    at send (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/src/send.js:12:1)
    at file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/src/index.js:9:1
    at __nccwpck_require__.a (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/webpack/runtime/async module:49:1)
    at Object.9722 (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/dist/index.js:47275:21)
    at __nccwpck_require__ (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/webpack/bootstrap:21:1)
    at file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/webpack/startup:4:1
    at ModuleJob.run (node:internal/modules/esm/module_job:437:25)
    at node:internal/modules/esm/loader:639:26
    at send (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/src/send.js:12:1)
    at file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/src/index.js:9:1
    at __nccwpck_require__.a (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/webpack/runtime/async module:49:1)
    at Object.9722 (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/dist/index.js:47275:21)
    at __nccwpck_require__ (file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/webpack/bootstrap:21:1)
    at file:///__w/_actions/slackapi/slack-github-action/45a88b9581bfab2566dc881e2cd66d334e621e2c/webpack/startup:4:1
    at ModuleJob.run (node:internal/modules/esm/module_job:437:25)
    at node:internal/modules/esm/loader:639:26
Error: Error: failed to run script step: command terminated with non-zero exit code: error executing command [sh -e /__w/_temp/fac99330-64a2-11f1-9510-a1f9b93a9593.sh], exit code 1
Error: Process completed with exit code 1.
Error: Executing the custom container implementation failed. Please contact your self hosted runner administrator.
```