### PR TITLE
Fix Moonshine streaming right window boundary

### DIFF
--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1915,7 +1915,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask

--- a/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
@@ -355,7 +355,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask

--- a/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
@@ -269,7 +269,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask

--- a/tests/models/moonshine_streaming/test_modeling_moonshine_streaming.py
+++ b/tests/models/moonshine_streaming/test_modeling_moonshine_streaming.py
@@ -36,6 +36,7 @@ if is_torch_available():
         MoonshineStreamingForConditionalGeneration,
         MoonshineStreamingModel,
     )
+    from transformers.models.moonshine_streaming.modeling_moonshine_streaming import sliding_window_mask_function
 
 from datasets import load_dataset
 
@@ -155,6 +156,13 @@ class MoonshineStreamingModelTest(ModelTesterMixin, PipelineTesterMixin, unittes
 
     def test_config(self):
         self.config_tester.run_common_tests()
+
+    def test_sliding_window_right_context_includes_boundary_frame(self):
+        mask = sliding_window_mask_function((16, 4))
+
+        future = [kv_idx for kv_idx in range(11, 16) if mask(0, 0, 10, kv_idx)]
+
+        self.assertEqual(future, [11, 12, 13, 14])
 
     def test_can_init_all_missing_weights(self):
         self.skipTest("MoonshineStreaming uses special parameter initialization that conflicts with this test")


### PR DESCRIPTION
## What does this PR do?

Fixes the Moonshine streaming right-window mask so `right_window_size=4` includes four future frames instead of three.

The left window already uses a strict comparison because the current query frame is included on the left side. The right side excludes the query frame with `dist < 0`, so the boundary frame should use `<= right_window_size`.

Fixes #46305

## Tests

- `PYTHONPATH=src python -c "import sys; sys.modules['kernels']=None; from transformers.models.moonshine_streaming.modeling_moonshine_streaming import sliding_window_mask_function; mask=sliding_window_mask_function((16,4)); future=[i for i in range(11,16) if mask(0,0,10,i)]; print(future); assert future == [11,12,13,14]; assert not mask(0,0,10,15)"`
- `python -m py_compile src\transformers\models\moonshine_streaming\modular_moonshine_streaming.py src\transformers\models\moonshine_streaming\modeling_moonshine_streaming.py tests\models\moonshine_streaming\test_modeling_moonshine_streaming.py`
- `python -m ruff check src\transformers\models\moonshine_streaming\modular_moonshine_streaming.py src\transformers\models\moonshine_streaming\modeling_moonshine_streaming.py tests\models\moonshine_streaming\test_modeling_moonshine_streaming.py`
- `python utils\check_copies.py --fix_and_overwrite`
- `git diff --check`

`pytest tests\models\moonshine_streaming\test_modeling_moonshine_streaming.py::MoonshineStreamingModelTest::test_sliding_window_right_context_includes_boundary_frame -q` was blocked in my local Windows environment by an unrelated global `kernels` package import error: `ValueError: Either a revision or a version must be specified.`
