### PR TITLE
docs: Update NeMo Automodel getting-started docs for updated user API

### DIFF
--- a/docs/source/en/community_integrations/nemo_automodel_finetuning.md
+++ b/docs/source/en/community_integrations/nemo_automodel_finetuning.md
@@ -21,6 +21,9 @@ rendered properly in your Markdown viewer.
 Define your training run in a YAML config file (see full [config file](https://github.com/NVIDIA-NeMo/Automodel/blob/0d05e245e0bbc9128b869b21a3908512affc6cae/examples/llm_finetune/nemotron/nemotron_nano_v3_hellaswag_peft.yaml)).
 
 ```yaml
+# Recipe class the `automodel` CLI instantiates from this config
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
 # Instantiate a Nemotron V3 Nano model
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
@@ -51,10 +54,10 @@ distributed:
 # ... other parameters
 ```
 
-Launch training with `torchrun` using the command below.
+Launch training with the `automodel` CLI using the command below.
 
 ```bash
-torchrun -–nproc-per-node=4 examples/llm_finetune/finetune.py -c /path/to/yaml
+automodel /path/to/yaml --nproc-per-node 4
 ```
 
 ## Transformers integration

--- a/docs/source/en/community_integrations/nemo_automodel_pretraining.md
+++ b/docs/source/en/community_integrations/nemo_automodel_pretraining.md
@@ -26,31 +26,29 @@ import torch
 import torch.distributed as dist
 
 from nemo_automodel import NeMoAutoModelForCausalLM
-from nemo_automodel.recipes._dist_setup import setup_distributed
+from nemo_automodel.components.distributed.config import DistributedSetup
+from nemo_automodel.components.distributed.mesh import ParallelismSizes
 
 dist.init_process_group(backend="nccl")
 torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 torch.manual_seed(1111)
 
-dist_setup = setup_distributed(
-    {
-        "strategy": "fsdp2",
-        "dp_size": None,  # will be inferred from world_size and other parallelism sizes
-        "dp_replicate_size": None,
-        "tp_size": 1,
-        "pp_size": 1,
-        "cp_size": 1,
-        "ep_size": 8,
-    },
+# Build the resolved distributed topology (device mesh + MoE mesh + strategy/MoE configs).
+# dp_size is inferred from world_size and the other parallelism sizes.
+distributed_setup = DistributedSetup.build(
+    strategy="fsdp2",
+    parallelism_sizes=ParallelismSizes(
+        tp_size=1,
+        pp_size=1,
+        cp_size=1,
+        ep_size=8,
+    ),
     world_size=dist.get_world_size(),
 )
-kwargs = {
-    "device_mesh": dist_setup.device_mesh,
-    "moe_mesh": dist_setup.moe_mesh,
-    "distributed_config": dist_setup.strategy_config,
-    "moe_config": dist_setup.moe_config,
-}
-model = NeMoAutoModelForCausalLM.from_pretrained("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", **kwargs)
+model = NeMoAutoModelForCausalLM.from_pretrained(
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+    distributed_setup=distributed_setup,
+)
 print(model)
 dist.destroy_process_group()
 ```


### PR DESCRIPTION
## What
Updates the two NeMo AutoModel getting-started pages to match the current NeMo AutoModel user API. Both code samples are currently broken against recent releases.

## Why
Fixes [NVIDIA-NeMo/Automodel#2507](https://github.com/NVIDIA-NeMo/Automodel/issues/2507).

**Pretraining page** — the Python sample:
- imported `nemo_automodel.recipes._dist_setup.setup_distributed`, which no longer exists; and
- passed `device_mesh`/`moe_mesh`/`distributed_config`/`moe_config` to `from_pretrained`, which now raises `TypeError` — distributed settings must be passed through a single `distributed_setup` object.

  It now builds a `DistributedSetup` with `DistributedSetup.build(...)` and passes it as `distributed_setup=`.

**Finetuning page** — the launch command used the deprecated `torchrun ... examples/llm_finetune/finetune.py -c <yaml>` path (that script now emits a `DeprecationWarning`). It now uses the `automodel <config.yaml> --nproc-per-node N` CLI, and the YAML snippet gains the top-level `recipe:` key that the CLI requires.

## Notes
Opened as a **draft**. The YAML `_target_` paths were verified against the live `examples/llm_finetune/nemotron/nemotron_nano_v3_hellaswag_peft.yaml` and are unchanged.
