### PR TITLE
[TBC] [CI] Auto-approve PR CI for fork PRs via security gate

### DIFF
--- a/.github/workflows/pr-ci-security-gate.yml
+++ b/.github/workflows/pr-ci-security-gate.yml
@@ -1,0 +1,47 @@
+name: PR CI Security Gate
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  security-check:
+    # Members/collaborators/owners trigger PR CI directly — gate only needed for forks
+    if: "!contains(fromJSON('[\"MEMBER\",\"OWNER\",\"COLLABORATOR\"]'), github.event.pull_request.author_association)"
+    runs-on: ubuntu-22.04
+    outputs:
+      result: ${{ steps.check.outputs.result }}
+    steps:
+      - name: Security check
+        id: check
+        run: |
+          # TODO: add real checks (e.g. no workflow file changes, no CI infra changes)
+          echo "result=pass" >> "$GITHUB_OUTPUT"
+
+  approve-pr-ci:
+    needs: security-check
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Find and approve the pending PR CI workflow run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          for i in $(seq 1 12); do
+            run_id=$(gh api \
+              "repos/$REPO/actions/runs?event=pull_request&head_sha=$HEAD_SHA&status=action_required" \
+              --jq '.workflow_runs[] | select(.name == "PR CI") | .id' | head -1)
+            if [ -n "$run_id" ]; then
+              gh api --method POST "repos/$REPO/actions/runs/$run_id/approve"
+              echo "Approved run $run_id"
+              exit 0
+            fi
+            echo "Attempt $i: run not yet pending, retrying in 5s..."
+            sleep 5
+          done
+          echo "No pending PR CI run found after retries — skipping"


### PR DESCRIPTION
## Summary

- Add `pr-ci-security-gate.yml` triggered by `pull_request_target` to automatically approve the pending **PR CI** workflow run for fork PRs once a security check passes
- Security check is a stub (always passes) for now — real checks will be added after the flow is validated end-to-end
- `pr-ci-caller.yml` is unchanged; the `ydshieh2` allowlist remains in place for testing

## How it works

1. Fork PR opened → `pull_request_target` fires (no approval needed, runs in base repo context)
2. `security-check` job runs (currently a no-op pass)
3. `approve-pr-ci` job polls the Actions API for the pending **PR CI** run on that commit SHA and approves it
4. The unblocked `pull_request` workflow proceeds normally

## Test plan

- [ ] Open a PR from `ydshieh2` fork and verify the security gate triggers and approves the PR CI run automatically
- [ ] Confirm the security gate is skipped for member/collaborator PRs
- [ ] Once validated, replace the stub security check with real checks and open `pr-ci-caller.yml` to all fork PRs