### PR TITLE
[CI] Add 60s delay in security gate for flow observation

### DIFF
--- a/.github/workflows/pr-ci-security-gate.yml
+++ b/.github/workflows/pr-ci-security-gate.yml
@@ -20,6 +20,7 @@ jobs:
         id: check
         run: |
           # TODO: add real checks (e.g. no workflow file changes, no CI infra changes)
+          sleep 60
           echo "result=pass" >> "$GITHUB_OUTPUT"
 
   approve-pr-ci:


### PR DESCRIPTION
Temporary: adds a `sleep 60` in the security check job so there is time to observe the full flow before the approval API call fires.

To be reverted before the real security checks are added.