### PR TITLE
[CI] Implement real security check in PR CI security gate

### DIFF
--- a/.github/workflows/pr-ci-security-gate.yml
+++ b/.github/workflows/pr-ci-security-gate.yml
@@ -14,38 +14,45 @@ jobs:
     if: "!contains(fromJSON('[\"MEMBER\",\"OWNER\",\"COLLABORATOR\"]'), github.event.pull_request.author_association)"
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout PR code for static analysis
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Deny changes to CI and build infrastructure files
+      - name: Get changed files
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          changed=$(gh pr diff "$PR_NUMBER" --name-only --repo "$REPO")
+          gh pr diff "$PR_NUMBER" --name-only --repo "$REPO" > /tmp/changed_files.txt
           echo "Changed files:"
-          echo "$changed"
-          if echo "$changed" | grep -qE '^\.github/|^Dockerfile|^docker-compose|^Makefile|^setup\.py$|^pyproject\.toml$|^setup\.cfg$|^requirements'; then
+          cat /tmp/changed_files.txt
+          grep '\.py$' /tmp/changed_files.txt > /tmp/py_files.txt || true
+
+      - name: Deny changes to CI and build infrastructure files
+        run: |
+          if grep -qE '^\.github/|^Dockerfile|^docker-compose|^Makefile|^setup\.py$|^pyproject\.toml$|^setup\.cfg$|^requirements' /tmp/changed_files.txt; then
             echo "::error::PR modifies CI or build infrastructure — manual review required"
             exit 1
           fi
 
-      - name: Run Bandit on changed Python files
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
+      - name: Check if Python files changed
+        id: py-check
         run: |
-          py_files=$(gh pr diff "$PR_NUMBER" --name-only --repo "$REPO" | grep '\.py$' || true)
-          if [ -z "$py_files" ]; then
+          if [ -s /tmp/py_files.txt ]; then
+            echo "has_py=true" >> "$GITHUB_OUTPUT"
+          else
             echo "No Python files changed — skipping Bandit"
-            exit 0
+            echo "has_py=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Checkout PR code for static analysis
+        if: steps.py-check.outputs.has_py == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run Bandit on changed Python files
+        if: steps.py-check.outputs.has_py == 'true'
+        run: |
           pip install bandit --quiet
-          echo "$py_files" | xargs bandit --severity-level high --confidence-level medium -q
+          xargs bandit --severity-level high --confidence-level medium -q < /tmp/py_files.txt
 
   approve-pr-ci:
     needs: security-check

--- a/.github/workflows/pr-ci-security-gate.yml
+++ b/.github/workflows/pr-ci-security-gate.yml
@@ -13,15 +13,39 @@ jobs:
     # Members/collaborators/owners trigger PR CI directly — gate only needed for forks
     if: "!contains(fromJSON('[\"MEMBER\",\"OWNER\",\"COLLABORATOR\"]'), github.event.pull_request.author_association)"
     runs-on: ubuntu-22.04
-    outputs:
-      result: ${{ steps.check.outputs.result }}
     steps:
-      - name: Security check
-        id: check
+      - name: Checkout PR code for static analysis
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Deny changes to CI and build infrastructure files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          # TODO: add real checks (e.g. no workflow file changes, no CI infra changes)
-          sleep 60
-          echo "result=pass" >> "$GITHUB_OUTPUT"
+          changed=$(gh pr diff "$PR_NUMBER" --name-only --repo "$REPO")
+          echo "Changed files:"
+          echo "$changed"
+          if echo "$changed" | grep -qE '^\.github/|^Dockerfile|^docker-compose|^Makefile|^setup\.py$|^pyproject\.toml$|^setup\.cfg$|^requirements'; then
+            echo "::error::PR modifies CI or build infrastructure — manual review required"
+            exit 1
+          fi
+
+      - name: Run Bandit on changed Python files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          py_files=$(gh pr diff "$PR_NUMBER" --name-only --repo "$REPO" | grep '\.py$' || true)
+          if [ -z "$py_files" ]; then
+            echo "No Python files changed — skipping Bandit"
+            exit 0
+          fi
+          pip install bandit --quiet
+          echo "$py_files" | xargs bandit --severity-level high --confidence-level medium -q
 
   approve-pr-ci:
     needs: security-check


### PR DESCRIPTION
## Summary

Replace the stub security check with a real two-layer gate:

- **Layer 1 — file path deny-list**: immediately blocks PRs that touch `.github/`, `Dockerfile`, `Makefile`, `pyproject.toml`, `setup.cfg`, `setup.py`, or `requirements*` — no tool needed, requires manual review
- **Layer 2 — Bandit**: runs static analysis on changed `.py` files only (not the full repo), at high severity + medium confidence to avoid false positives from normal ML code patterns

The PR code is checked out at its head SHA for read-only static analysis — safe in `pull_request_target` context since we never execute the fork code.