### PR TITLE
Fix chat !save custom filename parsing

### DIFF
--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -419,13 +419,7 @@ class Chat:
         elif user_input == "!help":
             interface.print_help()
 
-        elif user_input.startswith("!save") and len(user_input.split()) < 2:
-            split_input = user_input.split()
-            filename = (
-                split_input[1]
-                if len(split_input) == 2
-                else os.path.join(self.save_folder, self.model_id, f"chat_{time.strftime('%Y-%m-%d_%H-%M-%S')}.json")
-            )
+        elif (filename := get_chat_save_filename(user_input, self.save_folder, self.model_id)) is not None:
             save_chat(filename=filename, chat=chat, settings=self.settings)
             interface.print_color(text=f"Chat saved to {filename}!", color="green")
 
@@ -507,15 +501,7 @@ class Chat:
                         interface.print_help()
                         continue
 
-                    elif user_input.startswith("!save") and len(user_input.split()) < 2:
-                        split_input = user_input.split()
-                        filename = (
-                            split_input[1]
-                            if len(split_input) == 2
-                            else os.path.join(
-                                self.save_folder, self.model_id, f"chat_{time.strftime('%Y-%m-%d_%H-%M-%S')}.json"
-                            )
-                        )
+                    elif (filename := get_chat_save_filename(user_input, self.save_folder, self.model_id)) is not None:
                         save_chat(filename=filename, chat=chat, settings=self.settings)
                         interface.print_color(text=f"Chat saved to {filename}!", color="green")
                         continue
@@ -662,9 +648,23 @@ def new_chat_history(system_prompt: str | None = None) -> list[dict]:
     return [{"role": "system", "content": system_prompt}] if system_prompt else []
 
 
+def get_chat_save_filename(user_input: str, save_folder: str, model_id: str) -> str | None:
+    """Returns the filename for a valid !save command, or None if the command is invalid."""
+    split_input = user_input.split()
+    if not split_input or split_input[0] != "!save" or len(split_input) > 2:
+        return None
+
+    if len(split_input) == 2:
+        return split_input[1]
+
+    return os.path.join(save_folder, model_id, f"chat_{time.strftime('%Y-%m-%d_%H-%M-%S')}.json")
+
+
 def save_chat(filename: str, chat: list[dict], settings: dict) -> str:
     """Saves the chat history to a file."""
-    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    dirname = os.path.dirname(filename)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
     with open(filename, "w") as f:
         json.dump({"settings": settings, "chat_history": chat}, f, indent=4)
     return os.path.abspath(filename)

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -15,12 +15,22 @@ import json
 import os
 import tempfile
 
+from transformers import GenerationConfig
 from transformers.cli.chat import (
+    Chat,
     get_service_root_url,
     new_chat_history,
     parse_generate_flags,
     save_chat,
 )
+
+
+class DummyInterface:
+    def __init__(self):
+        self.messages = []
+
+    def print_color(self, text: str, color: str):
+        self.messages.append((text, color))
 
 
 def test_help(cli):
@@ -38,6 +48,38 @@ def test_save_and_clear_chat():
             data = json.load(f)
             assert data["chat_history"] == [{"role": "user", "content": "hi"}]
             assert data["settings"] == {"foo": "bar"}
+
+
+def test_save_chat_supports_bare_filename(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    saved_path = save_chat("chat.json", [{"role": "user", "content": "hi"}], {"foo": "bar"})
+
+    assert saved_path == os.path.abspath("chat.json")
+    assert os.path.isfile(saved_path)
+
+
+def test_save_chat_command_supports_custom_filename(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    chat = Chat.__new__(Chat)
+    chat.save_folder = "chat_history"
+    chat.model_id = "org/model"
+    chat.settings = {"foo": "bar"}
+    chat.system_prompt = None
+    interface = DummyInterface()
+
+    chat_history, valid_command, _ = chat.handle_non_exit_user_commands(
+        "!save custom-chat.json",
+        interface,
+        {},
+        GenerationConfig(),
+        [{"role": "user", "content": "hi"}],
+    )
+
+    assert valid_command is True
+    assert chat_history == [{"role": "user", "content": "hi"}]
+    assert os.path.isfile("custom-chat.json")
+    assert interface.messages == [("Chat saved to custom-chat.json!", "green")]
 
 
 def test_new_chat_history():


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46567)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46567)
<!-- ci-dashboard-badge:end -->

## Summary
- fix the chat CLI `!save NAME` command so the advertised custom filename is accepted
- keep malformed save commands invalid by parsing the command token explicitly
- allow `save_chat("chat.json", ...)` to write into the current directory without calling `os.makedirs("")`

## Validation
- `PYTHONPATH=src .\.venv\Scripts\python.exe -m pytest tests\cli\test_chat.py -q`
- `.\.venv\Scripts\python.exe -m ruff check src\transformers\cli\chat.py tests\cli\test_chat.py`
- `.\.venv\Scripts\python.exe -m py_compile src\transformers\cli\chat.py tests\cli\test_chat.py`
- `git diff --check`

## Duplicate check
- Searched GitHub issues and PRs for `save_chat`, chat custom filename, `chat_history` save filename, and `!save` / `SAVE_NAME`; no matching existing issue or PR found.