### PR TITLE
Make DiffusionGemma trainable

### DIFF
--- a/src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
@@ -104,6 +104,8 @@ class DiffusionGemmaGenerationConfig(GenerationConfig):
 
         > Special tokens that can be used at generation time
 
+        bos_token_id (`int`, *optional*):
+            The id of the *beginning-of-sequence* token.
         pad_token_id (`int`, *optional*):
             The id of the *padding* token.
         eos_token_id (`Union[int, list[int]]`, *optional*):
@@ -133,6 +135,7 @@ class DiffusionGemmaGenerationConfig(GenerationConfig):
         self.cache_config: dict[str, Any] | None = kwargs.pop("cache_config", None)
 
         # Special tokens that can be used at generation time
+        self.bos_token_id: int | None = kwargs.pop("bos_token_id", None)
         self.pad_token_id: int | None = kwargs.pop("pad_token_id", None)
         self.eos_token_id: list[int] | int | None = kwargs.pop("eos_token_id", None)
 

--- a/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
@@ -19,6 +19,7 @@
 # limitations under the License.
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Optional
 
 import torch
@@ -1215,6 +1216,7 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
         decoder_input_ids: torch.LongTensor,
         past_key_values: Cache | None = None,
         self_conditioning_logits: torch.FloatTensor | None = None,
+        self_conditioning_mask: torch.BoolTensor | None = None,
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
@@ -1225,6 +1227,10 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
         self_conditioning_logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, vocab_size)`, *optional*):
             Self-conditioning logits from the previous denoising step, used to compute the
             self-conditioning embeddings.
+        self_conditioning_mask (`torch.BoolTensor` of shape `(batch_size,)`, *optional*):
+            Per-example mask over `self_conditioning_logits`: examples set to `False` get a zeroed self-conditioning
+            signal, as if no logits were passed for them. Useful for training, where self-conditioning is enabled per
+            example with some probability.
         decoder_attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length+canvas_length)` or `dict`, *optional*):
             Attention mask for the decoder KV cache. Used to specify padded/unpopulated encoder KV cached entries.
         decoder_position_ids (`torch.LongTensor` of shape `(batch_size, canvas_length)`, *optional*):
@@ -1244,6 +1250,8 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
                 self_conditioning_logits.softmax(dim=-1, dtype=torch.float32).to(self.embed_tokens.weight.dtype),
                 self.embed_tokens.weight,
             ) * self.embed_tokens.embed_scale.to(inputs_embeds.dtype)
+            if self_conditioning_mask is not None:
+                soft_embeddings = soft_embeddings * self_conditioning_mask.to(soft_embeddings.dtype)[:, None, None]
         else:
             soft_embeddings = torch.zeros_like(inputs_embeds)
         inputs_embeds = self.self_conditioning(inputs_embeds, soft_embeddings)
@@ -1432,6 +1440,34 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
 
 
 @auto_docstring
+@dataclass
+class DiffusionGemmaModelOutputWithPast(BaseModelOutputWithPast):
+    r"""
+    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
+        provided, e.g. to compute an autoregressive loss on the encoder during training.
+    """
+
+    encoder_last_hidden_state: torch.FloatTensor | None = None
+
+
+@auto_docstring
+@dataclass
+class DiffusionGemmaBlockDiffusionOutputWithPast(CausalLMOutputWithPast):
+    r"""
+    loss (`torch.FloatTensor` of shape `(1,)`, *optional*):
+        Language modeling loss.
+    logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, config.text_config.vocab_size)`):
+        Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
+    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
+        provided, e.g. to compute an autoregressive loss on the encoder during training.
+    """
+
+    encoder_last_hidden_state: torch.FloatTensor | None = None
+
+
+@auto_docstring
 class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
     """
     DiffusionGemma model consisting of an auto-regressive encoder (DiffusionGemmaEncoderModel, very similar to a
@@ -1485,10 +1521,11 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
         position_ids: torch.LongTensor | None = None,
         decoder_input_ids: torch.LongTensor | None = None,
         self_conditioning_logits: torch.FloatTensor | None = None,
+        self_conditioning_mask: torch.BoolTensor | None = None,
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> BaseModelOutputWithPast:
+    ) -> DiffusionGemmaModelOutputWithPast:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1499,6 +1536,10 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
         self_conditioning_logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, vocab_size)`, *optional*):
             Self-conditioning logits from the previous denoising step, used to compute the
             self-conditioning embeddings.
+        self_conditioning_mask (`torch.BoolTensor` of shape `(batch_size,)`, *optional*):
+            Per-example mask over `self_conditioning_logits`: examples set to `False` get a zeroed self-conditioning
+            signal, as if no logits were passed for them. Useful for training, where self-conditioning is enabled per
+            example with some probability.
         decoder_attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length+canvas_length)` or `dict`, *optional*):
             Attention mask for the decoder KV cache. Used to specify padded/unpopulated encoder KV cached entries.
         decoder_position_ids (`torch.LongTensor` of shape `(batch_size, canvas_length)`, *optional*):
@@ -1506,6 +1547,7 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
         """
 
         # 1: Encode new prompt tokens into the KV cache
+        encoder_last_hidden_state = None
         if input_ids is not None:
             encoder_outputs = self.encoder(
                 input_ids=input_ids,
@@ -1515,6 +1557,7 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
                 **kwargs,
             )
             past_key_values = encoder_outputs.past_key_values
+            encoder_last_hidden_state = encoder_outputs.last_hidden_state
         elif past_key_values is None:
             raise ValueError("Either `input_ids` or `past_key_values` must be provided.")
 
@@ -1536,16 +1579,18 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
             decoder_input_ids=decoder_input_ids,
             past_key_values=past_key_values,
             self_conditioning_logits=self_conditioning_logits,
+            self_conditioning_mask=self_conditioning_mask,
             decoder_attention_mask=decoder_attention_mask,
             decoder_position_ids=decoder_position_ids,
             **kwargs,
         )
 
-        return BaseModelOutputWithPast(
+        return DiffusionGemmaModelOutputWithPast(
             last_hidden_state=decoder_outputs.last_hidden_state,
             hidden_states=decoder_outputs.hidden_states,
             attentions=decoder_outputs.attentions,
             past_key_values=past_key_values,
+            encoder_last_hidden_state=encoder_last_hidden_state,
         )
 
 
@@ -1587,10 +1632,11 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         position_ids: torch.LongTensor | None = None,
         decoder_input_ids: torch.LongTensor | None = None,
         self_conditioning_logits: torch.FloatTensor | None = None,
+        self_conditioning_mask: torch.BoolTensor | None = None,
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> CausalLMOutputWithPast:
+    ) -> DiffusionGemmaBlockDiffusionOutputWithPast:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1601,6 +1647,10 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         self_conditioning_logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, vocab_size)`, *optional*):
             Self-conditioning logits from the previous denoising step, used to compute the self-conditioning
             embeddings.
+        self_conditioning_mask (`torch.BoolTensor` of shape `(batch_size,)`, *optional*):
+            Per-example mask over `self_conditioning_logits`: examples set to `False` get a zeroed self-conditioning
+            signal, as if no logits were passed for them. Useful for training, where self-conditioning is enabled per
+            example with some probability.
         decoder_attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length+canvas_length)` or `dict`, *optional*):
             Attention mask for the decoder KV cache. Used to specify padded/unpopulated encoder KV cached entries.
         decoder_position_ids (`torch.LongTensor` of shape `(batch_size, canvas_length)`, *optional*):
@@ -1615,6 +1665,7 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
             position_ids=position_ids,
             decoder_input_ids=decoder_input_ids,
             self_conditioning_logits=self_conditioning_logits,
+            self_conditioning_mask=self_conditioning_mask,
             decoder_attention_mask=decoder_attention_mask,
             decoder_position_ids=decoder_position_ids,
             **kwargs,
@@ -1627,11 +1678,12 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         logits = torch.tanh(logits)
         logits = logits * self.final_logit_softcapping
 
-        return CausalLMOutputWithPast(
+        return DiffusionGemmaBlockDiffusionOutputWithPast(
             logits=logits,
             hidden_states=model_outputs.hidden_states,
             attentions=model_outputs.attentions,
             past_key_values=model_outputs.past_key_values,
+            encoder_last_hidden_state=model_outputs.encoder_last_hidden_state,
         )
 
 

--- a/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
@@ -798,7 +798,7 @@ class DiffusionGemmaSelfConditioning(nn.Module):
 class DiffusionGemmaPreTrainedModel(PreTrainedModel):
     config: DiffusionGemmaConfig
     base_model_prefix = "model"
-    supports_gradient_checkpointing = True
+    supports_gradient_checkpointing = False
     _no_split_modules = [
         "DiffusionGemmaDecoderTextLayer",
         "DiffusionGemmaEncoderTextLayer",

--- a/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
@@ -19,6 +19,7 @@
 # limitations under the License.
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Optional
 
 import torch
@@ -36,8 +37,7 @@ from ...modeling_outputs import (
     BaseModelOutput,
     BaseModelOutputWithPast,
     BaseModelOutputWithPooling,
-    Seq2SeqLMOutput,
-    Seq2SeqModelOutput,
+    CausalLMOutputWithPast,
 )
 from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
@@ -1440,6 +1440,34 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
 
 
 @auto_docstring
+@dataclass
+class DiffusionGemmaModelOutputWithPast(BaseModelOutputWithPast):
+    r"""
+    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
+        provided, e.g. to compute an autoregressive loss on the encoder during training.
+    """
+
+    encoder_last_hidden_state: torch.FloatTensor | None = None
+
+
+@auto_docstring
+@dataclass
+class DiffusionGemmaBlockDiffusionOutputWithPast(CausalLMOutputWithPast):
+    r"""
+    loss (`torch.FloatTensor` of shape `(1,)`, *optional*):
+        Language modeling loss.
+    logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, config.text_config.vocab_size)`):
+        Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
+    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
+        provided, e.g. to compute an autoregressive loss on the encoder during training.
+    """
+
+    encoder_last_hidden_state: torch.FloatTensor | None = None
+
+
+@auto_docstring
 class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
     """
     DiffusionGemma model consisting of an auto-regressive encoder (DiffusionGemmaEncoderModel, very similar to a
@@ -1497,7 +1525,7 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> Seq2SeqModelOutput:
+    ) -> DiffusionGemmaModelOutputWithPast:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1557,10 +1585,10 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
             **kwargs,
         )
 
-        return Seq2SeqModelOutput(
+        return DiffusionGemmaModelOutputWithPast(
             last_hidden_state=decoder_outputs.last_hidden_state,
-            decoder_hidden_states=decoder_outputs.hidden_states,
-            decoder_attentions=decoder_outputs.attentions,
+            hidden_states=decoder_outputs.hidden_states,
+            attentions=decoder_outputs.attentions,
             past_key_values=past_key_values,
             encoder_last_hidden_state=encoder_last_hidden_state,
         )
@@ -1608,7 +1636,7 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> Seq2SeqLMOutput:
+    ) -> DiffusionGemmaBlockDiffusionOutputWithPast:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1650,10 +1678,10 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         logits = torch.tanh(logits)
         logits = logits * self.final_logit_softcapping
 
-        return Seq2SeqLMOutput(
+        return DiffusionGemmaBlockDiffusionOutputWithPast(
             logits=logits,
-            decoder_hidden_states=model_outputs.decoder_hidden_states,
-            decoder_attentions=model_outputs.decoder_attentions,
+            hidden_states=model_outputs.hidden_states,
+            attentions=model_outputs.attentions,
             past_key_values=model_outputs.past_key_values,
             encoder_last_hidden_state=model_outputs.encoder_last_hidden_state,
         )

--- a/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
@@ -19,7 +19,6 @@
 # limitations under the License.
 
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Optional
 
 import torch
@@ -37,7 +36,8 @@ from ...modeling_outputs import (
     BaseModelOutput,
     BaseModelOutputWithPast,
     BaseModelOutputWithPooling,
-    CausalLMOutputWithPast,
+    Seq2SeqLMOutput,
+    Seq2SeqModelOutput,
 )
 from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
@@ -1440,34 +1440,6 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
 
 
 @auto_docstring
-@dataclass
-class DiffusionGemmaModelOutputWithPast(BaseModelOutputWithPast):
-    r"""
-    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
-        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
-        provided, e.g. to compute an autoregressive loss on the encoder during training.
-    """
-
-    encoder_last_hidden_state: torch.FloatTensor | None = None
-
-
-@auto_docstring
-@dataclass
-class DiffusionGemmaBlockDiffusionOutputWithPast(CausalLMOutputWithPast):
-    r"""
-    loss (`torch.FloatTensor` of shape `(1,)`, *optional*):
-        Language modeling loss.
-    logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, config.text_config.vocab_size)`):
-        Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
-    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
-        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
-        provided, e.g. to compute an autoregressive loss on the encoder during training.
-    """
-
-    encoder_last_hidden_state: torch.FloatTensor | None = None
-
-
-@auto_docstring
 class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
     """
     DiffusionGemma model consisting of an auto-regressive encoder (DiffusionGemmaEncoderModel, very similar to a
@@ -1525,7 +1497,7 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> DiffusionGemmaModelOutputWithPast:
+    ) -> Seq2SeqModelOutput:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1585,10 +1557,10 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel):
             **kwargs,
         )
 
-        return DiffusionGemmaModelOutputWithPast(
+        return Seq2SeqModelOutput(
             last_hidden_state=decoder_outputs.last_hidden_state,
-            hidden_states=decoder_outputs.hidden_states,
-            attentions=decoder_outputs.attentions,
+            decoder_hidden_states=decoder_outputs.hidden_states,
+            decoder_attentions=decoder_outputs.attentions,
             past_key_values=past_key_values,
             encoder_last_hidden_state=encoder_last_hidden_state,
         )
@@ -1636,7 +1608,7 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> DiffusionGemmaBlockDiffusionOutputWithPast:
+    ) -> Seq2SeqLMOutput:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1678,10 +1650,10 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         logits = torch.tanh(logits)
         logits = logits * self.final_logit_softcapping
 
-        return DiffusionGemmaBlockDiffusionOutputWithPast(
+        return Seq2SeqLMOutput(
             logits=logits,
-            hidden_states=model_outputs.hidden_states,
-            attentions=model_outputs.attentions,
+            decoder_hidden_states=model_outputs.decoder_hidden_states,
+            decoder_attentions=model_outputs.decoder_attentions,
             past_key_values=model_outputs.past_key_values,
             encoder_last_hidden_state=model_outputs.encoder_last_hidden_state,
         )

--- a/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -30,7 +31,7 @@ from ...masking_utils import (
 )
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import GradientCheckpointingLayer
-from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPast, Seq2SeqLMOutput, Seq2SeqModelOutput
+from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPast, CausalLMOutputWithPast
 from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
@@ -1246,6 +1247,34 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
         return {"full_attention": full_mask, "sliding_attention": sliding_mask}
 
 
+@auto_docstring
+@dataclass
+class DiffusionGemmaModelOutputWithPast(BaseModelOutputWithPast):
+    r"""
+    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
+        provided, e.g. to compute an autoregressive loss on the encoder during training.
+    """
+
+    encoder_last_hidden_state: torch.FloatTensor | None = None
+
+
+@auto_docstring
+@dataclass
+class DiffusionGemmaBlockDiffusionOutputWithPast(CausalLMOutputWithPast):
+    r"""
+    loss (`torch.FloatTensor` of shape `(1,)`, *optional*):
+        Language modeling loss.
+    logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, config.text_config.vocab_size)`):
+        Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
+    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
+        provided, e.g. to compute an autoregressive loss on the encoder during training.
+    """
+
+    encoder_last_hidden_state: torch.FloatTensor | None = None
+
+
 class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
     """
     DiffusionGemma model consisting of an auto-regressive encoder (DiffusionGemmaEncoderModel, very similar to a
@@ -1291,7 +1320,7 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> Seq2SeqModelOutput:
+    ) -> DiffusionGemmaModelOutputWithPast:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1351,10 +1380,10 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
             **kwargs,
         )
 
-        return Seq2SeqModelOutput(
+        return DiffusionGemmaModelOutputWithPast(
             last_hidden_state=decoder_outputs.last_hidden_state,
-            decoder_hidden_states=decoder_outputs.hidden_states,
-            decoder_attentions=decoder_outputs.attentions,
+            hidden_states=decoder_outputs.hidden_states,
+            attentions=decoder_outputs.attentions,
             past_key_values=past_key_values,
             encoder_last_hidden_state=encoder_last_hidden_state,
         )
@@ -1402,7 +1431,7 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> Seq2SeqLMOutput:
+    ) -> DiffusionGemmaBlockDiffusionOutputWithPast:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1444,10 +1473,10 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         logits = torch.tanh(logits)
         logits = logits * self.final_logit_softcapping
 
-        return Seq2SeqLMOutput(
+        return DiffusionGemmaBlockDiffusionOutputWithPast(
             logits=logits,
-            decoder_hidden_states=model_outputs.decoder_hidden_states,
-            decoder_attentions=model_outputs.decoder_attentions,
+            hidden_states=model_outputs.hidden_states,
+            attentions=model_outputs.attentions,
             past_key_values=model_outputs.past_key_values,
             encoder_last_hidden_state=model_outputs.encoder_last_hidden_state,
         )

--- a/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -1023,6 +1024,7 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
         decoder_input_ids: torch.LongTensor,
         past_key_values: Cache | None = None,
         self_conditioning_logits: torch.FloatTensor | None = None,
+        self_conditioning_mask: torch.BoolTensor | None = None,
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
@@ -1033,6 +1035,10 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
         self_conditioning_logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, vocab_size)`, *optional*):
             Self-conditioning logits from the previous denoising step, used to compute the
             self-conditioning embeddings.
+        self_conditioning_mask (`torch.BoolTensor` of shape `(batch_size,)`, *optional*):
+            Per-example mask over `self_conditioning_logits`: examples set to `False` get a zeroed self-conditioning
+            signal, as if no logits were passed for them. Useful for training, where self-conditioning is enabled per
+            example with some probability.
         decoder_attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length+canvas_length)` or `dict`, *optional*):
             Attention mask for the decoder KV cache. Used to specify padded/unpopulated encoder KV cached entries.
         decoder_position_ids (`torch.LongTensor` of shape `(batch_size, canvas_length)`, *optional*):
@@ -1052,6 +1058,8 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
                 self_conditioning_logits.softmax(dim=-1, dtype=torch.float32).to(self.embed_tokens.weight.dtype),
                 self.embed_tokens.weight,
             ) * self.embed_tokens.embed_scale.to(inputs_embeds.dtype)
+            if self_conditioning_mask is not None:
+                soft_embeddings = soft_embeddings * self_conditioning_mask.to(soft_embeddings.dtype)[:, None, None]
         else:
             soft_embeddings = torch.zeros_like(inputs_embeds)
         inputs_embeds = self.self_conditioning(inputs_embeds, soft_embeddings)
@@ -1239,6 +1247,34 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
         return {"full_attention": full_mask, "sliding_attention": sliding_mask}
 
 
+@auto_docstring
+@dataclass
+class DiffusionGemmaModelOutputWithPast(BaseModelOutputWithPast):
+    r"""
+    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
+        provided, e.g. to compute an autoregressive loss on the encoder during training.
+    """
+
+    encoder_last_hidden_state: torch.FloatTensor | None = None
+
+
+@auto_docstring
+@dataclass
+class DiffusionGemmaBlockDiffusionOutputWithPast(CausalLMOutputWithPast):
+    r"""
+    loss (`torch.FloatTensor` of shape `(1,)`, *optional*):
+        Language modeling loss.
+    logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, config.text_config.vocab_size)`):
+        Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
+    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
+        provided, e.g. to compute an autoregressive loss on the encoder during training.
+    """
+
+    encoder_last_hidden_state: torch.FloatTensor | None = None
+
+
 class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
     """
     DiffusionGemma model consisting of an auto-regressive encoder (DiffusionGemmaEncoderModel, very similar to a
@@ -1280,10 +1316,11 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
         position_ids: torch.LongTensor | None = None,
         decoder_input_ids: torch.LongTensor | None = None,
         self_conditioning_logits: torch.FloatTensor | None = None,
+        self_conditioning_mask: torch.BoolTensor | None = None,
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> BaseModelOutputWithPast:
+    ) -> DiffusionGemmaModelOutputWithPast:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1294,6 +1331,10 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
         self_conditioning_logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, vocab_size)`, *optional*):
             Self-conditioning logits from the previous denoising step, used to compute the
             self-conditioning embeddings.
+        self_conditioning_mask (`torch.BoolTensor` of shape `(batch_size,)`, *optional*):
+            Per-example mask over `self_conditioning_logits`: examples set to `False` get a zeroed self-conditioning
+            signal, as if no logits were passed for them. Useful for training, where self-conditioning is enabled per
+            example with some probability.
         decoder_attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length+canvas_length)` or `dict`, *optional*):
             Attention mask for the decoder KV cache. Used to specify padded/unpopulated encoder KV cached entries.
         decoder_position_ids (`torch.LongTensor` of shape `(batch_size, canvas_length)`, *optional*):
@@ -1301,6 +1342,7 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
         """
 
         # 1: Encode new prompt tokens into the KV cache
+        encoder_last_hidden_state = None
         if input_ids is not None:
             encoder_outputs = self.encoder(
                 input_ids=input_ids,
@@ -1310,6 +1352,7 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
                 **kwargs,
             )
             past_key_values = encoder_outputs.past_key_values
+            encoder_last_hidden_state = encoder_outputs.last_hidden_state
         elif past_key_values is None:
             raise ValueError("Either `input_ids` or `past_key_values` must be provided.")
 
@@ -1331,16 +1374,18 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
             decoder_input_ids=decoder_input_ids,
             past_key_values=past_key_values,
             self_conditioning_logits=self_conditioning_logits,
+            self_conditioning_mask=self_conditioning_mask,
             decoder_attention_mask=decoder_attention_mask,
             decoder_position_ids=decoder_position_ids,
             **kwargs,
         )
 
-        return BaseModelOutputWithPast(
+        return DiffusionGemmaModelOutputWithPast(
             last_hidden_state=decoder_outputs.last_hidden_state,
             hidden_states=decoder_outputs.hidden_states,
             attentions=decoder_outputs.attentions,
             past_key_values=past_key_values,
+            encoder_last_hidden_state=encoder_last_hidden_state,
         )
 
 
@@ -1382,10 +1427,11 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         position_ids: torch.LongTensor | None = None,
         decoder_input_ids: torch.LongTensor | None = None,
         self_conditioning_logits: torch.FloatTensor | None = None,
+        self_conditioning_mask: torch.BoolTensor | None = None,
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> CausalLMOutputWithPast:
+    ) -> DiffusionGemmaBlockDiffusionOutputWithPast:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1396,6 +1442,10 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         self_conditioning_logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, vocab_size)`, *optional*):
             Self-conditioning logits from the previous denoising step, used to compute the self-conditioning
             embeddings.
+        self_conditioning_mask (`torch.BoolTensor` of shape `(batch_size,)`, *optional*):
+            Per-example mask over `self_conditioning_logits`: examples set to `False` get a zeroed self-conditioning
+            signal, as if no logits were passed for them. Useful for training, where self-conditioning is enabled per
+            example with some probability.
         decoder_attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length+canvas_length)` or `dict`, *optional*):
             Attention mask for the decoder KV cache. Used to specify padded/unpopulated encoder KV cached entries.
         decoder_position_ids (`torch.LongTensor` of shape `(batch_size, canvas_length)`, *optional*):
@@ -1410,6 +1460,7 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
             position_ids=position_ids,
             decoder_input_ids=decoder_input_ids,
             self_conditioning_logits=self_conditioning_logits,
+            self_conditioning_mask=self_conditioning_mask,
             decoder_attention_mask=decoder_attention_mask,
             decoder_position_ids=decoder_position_ids,
             **kwargs,
@@ -1422,11 +1473,12 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         logits = torch.tanh(logits)
         logits = logits * self.final_logit_softcapping
 
-        return CausalLMOutputWithPast(
+        return DiffusionGemmaBlockDiffusionOutputWithPast(
             logits=logits,
             hidden_states=model_outputs.hidden_states,
             attentions=model_outputs.attentions,
             past_key_values=model_outputs.past_key_values,
+            encoder_last_hidden_state=model_outputs.encoder_last_hidden_state,
         )
 
 

--- a/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -31,7 +30,7 @@ from ...masking_utils import (
 )
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import GradientCheckpointingLayer
-from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPast, CausalLMOutputWithPast
+from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPast, Seq2SeqLMOutput, Seq2SeqModelOutput
 from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
@@ -1247,34 +1246,6 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
         return {"full_attention": full_mask, "sliding_attention": sliding_mask}
 
 
-@auto_docstring
-@dataclass
-class DiffusionGemmaModelOutputWithPast(BaseModelOutputWithPast):
-    r"""
-    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
-        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
-        provided, e.g. to compute an autoregressive loss on the encoder during training.
-    """
-
-    encoder_last_hidden_state: torch.FloatTensor | None = None
-
-
-@auto_docstring
-@dataclass
-class DiffusionGemmaBlockDiffusionOutputWithPast(CausalLMOutputWithPast):
-    r"""
-    loss (`torch.FloatTensor` of shape `(1,)`, *optional*):
-        Language modeling loss.
-    logits (`torch.FloatTensor` of shape `(batch_size, canvas_length, config.text_config.vocab_size)`):
-        Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
-    encoder_last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
-        Sequence of hidden states at the output of the last layer of the encoder. Only set when `input_ids` is
-        provided, e.g. to compute an autoregressive loss on the encoder during training.
-    """
-
-    encoder_last_hidden_state: torch.FloatTensor | None = None
-
-
 class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
     """
     DiffusionGemma model consisting of an auto-regressive encoder (DiffusionGemmaEncoderModel, very similar to a
@@ -1320,7 +1291,7 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> DiffusionGemmaModelOutputWithPast:
+    ) -> Seq2SeqModelOutput:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1380,10 +1351,10 @@ class DiffusionGemmaModel(DiffusionGemmaPreTrainedModel, T5Gemma2Model):
             **kwargs,
         )
 
-        return DiffusionGemmaModelOutputWithPast(
+        return Seq2SeqModelOutput(
             last_hidden_state=decoder_outputs.last_hidden_state,
-            hidden_states=decoder_outputs.hidden_states,
-            attentions=decoder_outputs.attentions,
+            decoder_hidden_states=decoder_outputs.hidden_states,
+            decoder_attentions=decoder_outputs.attentions,
             past_key_values=past_key_values,
             encoder_last_hidden_state=encoder_last_hidden_state,
         )
@@ -1431,7 +1402,7 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         decoder_attention_mask: torch.Tensor | dict | None = None,
         decoder_position_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> DiffusionGemmaBlockDiffusionOutputWithPast:
+    ) -> Seq2SeqLMOutput:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Uncached token IDs for the prompt to be encoded as context for the canvas.
@@ -1473,10 +1444,10 @@ class DiffusionGemmaForBlockDiffusion(DiffusionGemmaPreTrainedModel, DiffusionGe
         logits = torch.tanh(logits)
         logits = logits * self.final_logit_softcapping
 
-        return DiffusionGemmaBlockDiffusionOutputWithPast(
+        return Seq2SeqLMOutput(
             logits=logits,
-            hidden_states=model_outputs.hidden_states,
-            attentions=model_outputs.attentions,
+            decoder_hidden_states=model_outputs.decoder_hidden_states,
+            decoder_attentions=model_outputs.decoder_attentions,
             past_key_values=model_outputs.past_key_values,
             encoder_last_hidden_state=model_outputs.encoder_last_hidden_state,
         )

--- a/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
@@ -644,7 +644,7 @@ class DiffusionGemmaSelfConditioning(nn.Module):
 class DiffusionGemmaPreTrainedModel(PreTrainedModel):
     config: DiffusionGemmaConfig
     base_model_prefix = "model"
-    supports_gradient_checkpointing = True
+    supports_gradient_checkpointing = False
     _no_split_modules = [
         "DiffusionGemmaDecoderTextLayer",
         "DiffusionGemmaEncoderTextLayer",

--- a/tests/models/diffusion_gemma/test_modeling_diffusion_gemma.py
+++ b/tests/models/diffusion_gemma/test_modeling_diffusion_gemma.py
@@ -248,35 +248,6 @@ class DiffusionGemmaVisionText2TextModelTest(ModelTesterMixin, unittest.TestCase
     def test_disk_offload_safetensors(self):
         pass
 
-    def test_retain_grad_hidden_states_attentions(self):
-        # The base test keys the output fields on `config.is_encoder_decoder`. This model returns `Seq2SeqModelOutput`
-        # with `is_encoder_decoder=False`, and only the decoder's hidden states and attentions are populated (the
-        # encoder feeds the decoder through its KV cache).
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        config.output_hidden_states = True
-        config.output_attentions = self.has_attentions
-        config._attn_implementation = "eager"
-
-        model_class = self.all_model_classes[0]
-        model = model_class._from_config(config, attn_implementation="eager")
-        model.to(torch_device)
-
-        inputs = self._prepare_for_class(inputs_dict, model_class)
-        outputs = model(**inputs)
-        output = outputs[0]
-
-        decoder_hidden_states = outputs.decoder_hidden_states[0]
-        decoder_hidden_states.retain_grad()
-        if self.has_attentions:
-            decoder_attentions = outputs.decoder_attentions[0]
-            decoder_attentions.retain_grad()
-
-        output.flatten()[0].backward(retain_graph=True)
-
-        self.assertIsNotNone(decoder_hidden_states.grad)
-        if self.has_attentions:
-            self.assertIsNotNone(decoder_attentions.grad)
-
     # Tests designed specifically for `DiffusionGemma`, excluding generation tests.
     def test_tied_weights(self):
         """

--- a/tests/models/diffusion_gemma/test_modeling_diffusion_gemma.py
+++ b/tests/models/diffusion_gemma/test_modeling_diffusion_gemma.py
@@ -248,6 +248,35 @@ class DiffusionGemmaVisionText2TextModelTest(ModelTesterMixin, unittest.TestCase
     def test_disk_offload_safetensors(self):
         pass
 
+    def test_retain_grad_hidden_states_attentions(self):
+        # The base test keys the output fields on `config.is_encoder_decoder`. This model returns `Seq2SeqModelOutput`
+        # with `is_encoder_decoder=False`, and only the decoder's hidden states and attentions are populated (the
+        # encoder feeds the decoder through its KV cache).
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        config.output_hidden_states = True
+        config.output_attentions = self.has_attentions
+        config._attn_implementation = "eager"
+
+        model_class = self.all_model_classes[0]
+        model = model_class._from_config(config, attn_implementation="eager")
+        model.to(torch_device)
+
+        inputs = self._prepare_for_class(inputs_dict, model_class)
+        outputs = model(**inputs)
+        output = outputs[0]
+
+        decoder_hidden_states = outputs.decoder_hidden_states[0]
+        decoder_hidden_states.retain_grad()
+        if self.has_attentions:
+            decoder_attentions = outputs.decoder_attentions[0]
+            decoder_attentions.retain_grad()
+
+        output.flatten()[0].backward(retain_graph=True)
+
+        self.assertIsNotNone(decoder_hidden_states.grad)
+        if self.has_attentions:
+            self.assertIsNotNone(decoder_attentions.grad)
+
     # Tests designed specifically for `DiffusionGemma`, excluding generation tests.
     def test_tied_weights(self):
         """


### PR DESCRIPTION
Three small fixes so DiffusionGemma works with Trainer and SFT recipes.

`bos_token_id` was missing from the strict generation config, which crashed `align_special_tokens` and broke checkpoint reload. The forward now also returns the encoder's last hidden state (needed for the encoder AR co-loss used in the reference fine-tuning recipe) and accepts a per-example `self_conditioning_mask`. Gradient checkpointing is declared unsupported since checkpointed layers drop the encoder KV cache writes the decoder reads from, which silently broke training.

Inference is unchanged, all diffusion_gemma tests pass.

cc @gante