### PR TITLE
Fix Wav2Vec2 word delimiter special token handling

### DIFF
--- a/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
@@ -281,9 +281,10 @@ class Wav2Vec2CTCTokenizer(PreTrainedTokenizer):
             return self._added_tokens_decoder[ids].content if ids in self._added_tokens_decoder else self.unk_token
 
         tokens = []
+        word_delimiter_id = self.word_delimiter_token_id
         for index in ids:
             index = int(index)
-            if skip_special_tokens and index in self.all_special_ids:
+            if skip_special_tokens and index in self.all_special_ids and index != word_delimiter_id:
                 continue
             if index in self.decoder:
                 tokens.append(self.decoder[index])
@@ -292,6 +293,22 @@ class Wav2Vec2CTCTokenizer(PreTrainedTokenizer):
             else:
                 tokens.append(self.unk_token)
         return tokens
+
+    def get_special_tokens_mask(
+        self, token_ids_0: list[int], token_ids_1: list[int] | None = None, already_has_special_tokens: bool = False
+    ) -> list[int]:
+        if already_has_special_tokens:
+            mask = super().get_special_tokens_mask(token_ids_0, token_ids_1, already_has_special_tokens=True)
+            word_delimiter_id = self.word_delimiter_token_id
+            if word_delimiter_id is not None:
+                mask = [
+                    0 if int(token_id) == word_delimiter_id else value for token_id, value in zip(token_ids_0, mask)
+                ]
+            return mask
+
+        if token_ids_1 is None:
+            return [0] * len(token_ids_0)
+        return [0] * (len(token_ids_0) + len(token_ids_1))
 
     def convert_tokens_to_string(
         self,

--- a/tests/models/wav2vec2/test_tokenization_wav2vec2.py
+++ b/tests/models/wav2vec2/test_tokenization_wav2vec2.py
@@ -158,6 +158,16 @@ class Wav2Vec2CTCTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertEqual(batch_tokens, batch_tokens_2)
         self.assertEqual(batch_tokens, ["HELLO<unk>", "BYE BYE<unk>"])
 
+    def test_word_delimiter_is_not_skipped_as_special_token(self):
+        tokenizer = self.get_tokenizer()
+        token_ids = tokenizer("HELLO WORLD").input_ids
+
+        special_tokens_mask = tokenizer.get_special_tokens_mask(token_ids, already_has_special_tokens=True)
+        self.assertEqual(special_tokens_mask, [0] * len(token_ids))
+        self.assertIn(
+            tokenizer.word_delimiter_token, tokenizer.convert_ids_to_tokens(token_ids, skip_special_tokens=True)
+        )
+
     def test_tokenizer_decode_added_tokens(self):
         tokenizer = self.tokenizer_class.from_pretrained("facebook/wav2vec2-base-960h")
         tokenizer.add_tokens(["!", "?", "<new_tokens>"])


### PR DESCRIPTION
Fixes #46552.\n\nThis keeps the Wav2Vec2 CTC word delimiter from being treated as removable special token by special-token-aware APIs, matching the decode path behavior.\n\nChanges:\n- Preserve the word delimiter in convert_ids_to_tokens(..., skip_special_tokens=True).\n- Exclude the word delimiter from get_special_tokens_mask(..., already_has_special_tokens=True).\n- Add a regression test for delimiter masking/skipping.\n\nTests:\n- python -m pytest tests/models/wav2vec2/test_tokenization_wav2vec2.py -q