### PR TITLE
fix: correct 'depreciated' typo in BART deprecation warning

### DIFF
--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -447,7 +447,7 @@ class BartPreTrainedModel(PreTrainedModel):
 class PretrainedBartModel(BartPreTrainedModel):
     def __init_subclass__(self):
         warnings.warn(
-            "The class `PretrainedBartModel` has been depreciated, please use `BartPreTrainedModel` instead.",
+            "The class `PretrainedBartModel` has been deprecated, please use `BartPreTrainedModel` instead.",
             FutureWarning,
         )
 
@@ -455,7 +455,7 @@ class PretrainedBartModel(BartPreTrainedModel):
 class BartPretrainedModel(BartPreTrainedModel):
     def __init_subclass__(self):
         warnings.warn(
-            "The class `PretrainedBartModel` has been depreciated, please use `BartPreTrainedModel` instead.",
+            "The class `PretrainedBartModel` has been deprecated, please use `BartPreTrainedModel` instead.",
             FutureWarning,
         )
 


### PR DESCRIPTION
## What does this PR do?

Fixes a misspelling in the BART deprecation warning: 'depreciated' → 'deprecated'.

## Before/After

- Before: `The class 'PretrainedBartModel' has been depreciated`
- After: `The class 'PretrainedBartModel' has been deprecated`

## Checklist

- [ ] I have read the contributing guidelines.
- [ ] The title of this PR is formatted properly.
- [ ] This PR has a descriptive description.