### PR TITLE
fix: correct 'ouputs' typo in continuous batching docstring

### DIFF
--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -612,7 +612,7 @@ class ContinuousBatchingAsyncIOs:
     between the two batches, which means twice as more VRAM is used for static input tensors and CUDA graph. If your GPU
     is large enough or you want to generate long sequences, this is a good trade-off to make.
 
-    Asynchronous batching works by creating two pairs of host - device inputs and ouputs:
+    Asynchronous batching works by creating two pairs of host - device inputs and outputs:
 
                                     inputs
                       ┌──────────┐ ────────► ┌────────────┐


### PR DESCRIPTION
## What does this PR do?

Fixes a misspelling in the continuous batching docstring: 'ouputs' → 'outputs'.

## Checklist

- [ ] I have read the contributing guidelines.
- [ ] The title of this PR is formatted properly.
- [ ] This PR has a descriptive description.