### PR TITLE
fix: correct 'overriden' typo in multiple files

### DIFF
--- a/src/transformers/image_processing_utils.py
+++ b/src/transformers/image_processing_utils.py
@@ -451,7 +451,7 @@ class BaseImageProcessor(ImageProcessingMixin):
         """
         return rescale(image, scale=scale, data_format=data_format, input_data_format=input_data_format, **kwargs)
 
-    # The next methods are kept for backwards compatibility with remote code, but are overriden by backends.
+    # The next methods are kept for backwards compatibility with remote code, but are overridden by backends.
     def normalize(
         self,
         image: np.ndarray,

--- a/src/transformers/models/ernie4_5_vl_moe/video_processing_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/video_processing_ernie4_5_vl_moe.py
@@ -135,7 +135,7 @@ class Ernie4_5_VLMoeVideoProcessor(BaseVideoProcessor):
     def get_video_processor_dict(
         cls, pretrained_model_name_or_path: str | os.PathLike, **kwargs
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Overriden to additionally load the font for drawing on frames."""
+        """Overridden to additionally load the font for drawing on frames."""
         cache_dir = kwargs.pop("cache_dir", None)
         force_download = kwargs.pop("force_download", False)
         proxies = kwargs.pop("proxies", None)
@@ -273,7 +273,7 @@ class Ernie4_5_VLMoeVideoProcessor(BaseVideoProcessor):
         return video_processor_dict, kwargs
 
     def to_dict(self) -> dict[str, Any]:
-        """Overriden to strip the prefix of the full path for the font, e.g. `tmp/folder/font.tff` -> `font.tff`"""
+        """Overridden to strip the prefix of the full path for the font, e.g. `tmp/folder/font.tff` -> `font.tff`"""
         output = super().to_dict()
 
         if os.path.isfile(output.get("font")):

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -789,7 +789,7 @@ class ProcessorMixin(PushToHubMixin):
 
         return processed_audio, audio_replacements
 
-    # To be overriden by each model's processor if they need to add placeholder tokens
+    # To be overridden by each model's processor if they need to add placeholder tokens
     def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
         raise NotImplementedError
 


### PR DESCRIPTION
## What does this PR do?

Fixes a misspelling 'overriden' → 'overridden' in comments and docstrings across multiple files:
- `processing_utils.py`
- `image_processing_utils.py`
- `video_processing_ernie4_5_vl_moe.py`

## Checklist

- [ ] I have read the contributing guidelines.
- [ ] The title of this PR is formatted properly.
- [ ] This PR has a descriptive description.