### PR TITLE
Lfm2: thread `seq_idx` through ShortConv for packed/varlen inputs

### DIFF
--- a/src/transformers/models/lfm2/modeling_lfm2.py
+++ b/src/transformers/models/lfm2/modeling_lfm2.py
@@ -325,6 +325,7 @@ class Lfm2ShortConv(nn.Module):
         x: torch.Tensor,
         past_key_values: Cache | None = None,
         attention_mask: torch.Tensor | None = None,
+        seq_idx: torch.IntTensor | None = None,
     ):
         x = apply_mask_to_padding_states(x, attention_mask)
         BCx = self.in_proj(x).transpose(-1, -2)
@@ -347,7 +348,8 @@ class Lfm2ShortConv(nn.Module):
                 conv_state = nn.functional.pad(Bx, (self.L_cache - Bx.shape[-1], 0))
                 conv_state = past_key_values.update_conv_state(conv_state, self.layer_idx)
 
-            conv_out = causal_conv1d_fn(Bx, conv_weights, self.conv.bias, activation=None)
+            # `seq_idx` resets conv state at packed-sample boundaries; None = previous behaviour.
+            conv_out = causal_conv1d_fn(Bx, conv_weights, self.conv.bias, activation=None, seq_idx=seq_idx)
 
         y = C * conv_out
         y = self.out_proj(y.transpose(-1, -2).contiguous())
@@ -391,9 +393,10 @@ class Lfm2ShortConv(nn.Module):
         hidden_states: torch.Tensor,
         past_key_values: Cache | None = None,
         attention_mask: torch.Tensor | None = None,
+        seq_idx: torch.IntTensor | None = None,
     ):
         if is_fast_path_available and "cuda" in hidden_states.device.type and not is_torchdynamo_compiling():
-            return self.cuda_kernels_forward(hidden_states, past_key_values, attention_mask)
+            return self.cuda_kernels_forward(hidden_states, past_key_values, attention_mask, seq_idx=seq_idx)
         return self.slow_forward(hidden_states, past_key_values, attention_mask)
 
 
@@ -434,6 +437,7 @@ class Lfm2DecoderLayer(GradientCheckpointingLayer):
                 hidden_states=self.operator_norm(hidden_states),
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
+                seq_idx=kwargs.get("seq_idx"),
             )
         hidden_states = hidden_states + residual
         hidden_states = hidden_states + self.feed_forward(self.ffn_norm(hidden_states))

--- a/src/transformers/models/lfm2/modular_lfm2.py
+++ b/src/transformers/models/lfm2/modular_lfm2.py
@@ -160,6 +160,7 @@ class Lfm2ShortConv(nn.Module):
         x: torch.Tensor,
         past_key_values: Cache | None = None,
         attention_mask: torch.Tensor | None = None,
+        seq_idx: torch.IntTensor | None = None,
     ):
         x = apply_mask_to_padding_states(x, attention_mask)
         BCx = self.in_proj(x).transpose(-1, -2)
@@ -182,7 +183,8 @@ class Lfm2ShortConv(nn.Module):
                 conv_state = nn.functional.pad(Bx, (self.L_cache - Bx.shape[-1], 0))
                 conv_state = past_key_values.update_conv_state(conv_state, self.layer_idx)
 
-            conv_out = causal_conv1d_fn(Bx, conv_weights, self.conv.bias, activation=None)
+            # `seq_idx` resets conv state at packed-sample boundaries; None = previous behaviour.
+            conv_out = causal_conv1d_fn(Bx, conv_weights, self.conv.bias, activation=None, seq_idx=seq_idx)
 
         y = C * conv_out
         y = self.out_proj(y.transpose(-1, -2).contiguous())
@@ -226,9 +228,10 @@ class Lfm2ShortConv(nn.Module):
         hidden_states: torch.Tensor,
         past_key_values: Cache | None = None,
         attention_mask: torch.Tensor | None = None,
+        seq_idx: torch.IntTensor | None = None,
     ):
         if is_fast_path_available and "cuda" in hidden_states.device.type and not is_torchdynamo_compiling():
-            return self.cuda_kernels_forward(hidden_states, past_key_values, attention_mask)
+            return self.cuda_kernels_forward(hidden_states, past_key_values, attention_mask, seq_idx=seq_idx)
         return self.slow_forward(hidden_states, past_key_values, attention_mask)
 
 
@@ -269,6 +272,7 @@ class Lfm2DecoderLayer(GradientCheckpointingLayer):
                 hidden_states=self.operator_norm(hidden_states),
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
+                seq_idx=kwargs.get("seq_idx"),
             )
         hidden_states = hidden_states + residual
         hidden_states = hidden_states + self.feed_forward(self.ffn_norm(hidden_states))

--- a/src/transformers/models/lfm2_moe/modeling_lfm2_moe.py
+++ b/src/transformers/models/lfm2_moe/modeling_lfm2_moe.py
@@ -401,6 +401,7 @@ class Lfm2MoeShortConv(nn.Module):
         x: torch.Tensor,
         past_key_values: Cache | None = None,
         attention_mask: torch.Tensor | None = None,
+        seq_idx: torch.IntTensor | None = None,
     ):
         x = apply_mask_to_padding_states(x, attention_mask)
         BCx = self.in_proj(x).transpose(-1, -2)
@@ -423,7 +424,8 @@ class Lfm2MoeShortConv(nn.Module):
                 conv_state = nn.functional.pad(Bx, (self.L_cache - Bx.shape[-1], 0))
                 conv_state = past_key_values.update_conv_state(conv_state, self.layer_idx)
 
-            conv_out = causal_conv1d_fn(Bx, conv_weights, self.conv.bias, activation=None)
+            # `seq_idx` resets conv state at packed-sample boundaries; None = previous behaviour.
+            conv_out = causal_conv1d_fn(Bx, conv_weights, self.conv.bias, activation=None, seq_idx=seq_idx)
 
         y = C * conv_out
         y = self.out_proj(y.transpose(-1, -2).contiguous())
@@ -467,9 +469,10 @@ class Lfm2MoeShortConv(nn.Module):
         hidden_states: torch.Tensor,
         past_key_values: Cache | None = None,
         attention_mask: torch.Tensor | None = None,
+        seq_idx: torch.IntTensor | None = None,
     ):
         if is_fast_path_available and "cuda" in hidden_states.device.type and not is_torchdynamo_compiling():
-            return self.cuda_kernels_forward(hidden_states, past_key_values, attention_mask)
+            return self.cuda_kernels_forward(hidden_states, past_key_values, attention_mask, seq_idx=seq_idx)
         return self.slow_forward(hidden_states, past_key_values, attention_mask)
 
 
@@ -514,6 +517,7 @@ class Lfm2MoeDecoderLayer(GradientCheckpointingLayer):
                 hidden_states=self.operator_norm(hidden_states),
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
+                seq_idx=kwargs.get("seq_idx"),
             )
         hidden_states = hidden_states + residual
         hidden_states = hidden_states + self.feed_forward(self.ffn_norm(hidden_states))


### PR DESCRIPTION
## What this PR fixes

`Lfm2ShortConv.cuda_kernels_forward` calls `causal_conv1d_fn` without
`seq_idx`. When the model is run on packed/varlen inputs — e.g. multiple
samples flattened into a single sequence with boundaries marked via
`cu_seqlens` (derived from `position_ids`), as in any sequence-packed
training pipeline — the 1-D conv slides across sample boundaries and the
conv state of one sample leaks into the next.

Attention is already isolated per-sample (FlashAttention / `cu_seqlens`),
but conv state is not. This causes a per-token logprob divergence
between packed-and-unpacked forwards of the same sample, observable as
a higher k3_kl when comparing the actor's packed forward against an
inference engine's per-sample forward.

This is the standard pattern already used by `bamba`, `mamba2`,
`qwen3_next`, `qwen3_5(_moe)`, `falcon_h1`, `zamba2`, `nemotron_h`,
`granitemoehybrid`, …: pass a per-token int tensor `seq_idx` (segment
`i` labels its own tokens with `i`) to `causal_conv1d_fn`; the CUDA
kernel resets conv state at every boundary.

## Changes

- `Lfm2ShortConv.cuda_kernels_forward` and `Lfm2ShortConv.forward` accept
  a new `seq_idx: torch.IntTensor | None = None` kwarg and forward it to
  `causal_conv1d_fn`.
- `Lfm2DecoderLayer.forward` passes `seq_idx=kwargs.get("seq_idx")` to
  `self.conv(...)` so callers can supply it through the model `forward`
  kwargs (same convention as `qwen3_next`).
- Backward-compatible: `seq_idx=None` (the default) preserves the prior
  behaviour exactly; the `causal_conv1d_fn` kernel treats `None` as "no
  boundaries". No change for unpacked / single-sequence inference.
- LFM2-MoE inherits via `class Lfm2MoeShortConv(Lfm2ShortConv): pass`,
  so the change benefits LFM2-MoE too.

## Note on modular conversion

The change to the parent class body in `modular_lfm2.py` did not
propagate into the generated `modeling_lfm2_moe.py` when running
`utils/modular_model_converter.py` locally (the subclass body in
`modular_lfm2_moe.py` is `pass`). I applied the same change manually in
`modeling_lfm2_moe.py` to keep modeling and modular intent in sync.
Happy to instead extend `modular_lfm2_moe.py` with explicit method
overrides if reviewers prefer that, or to dig into the converter.

## Caller usage (example)

```python
# Build seq_idx for a flattened batch with cu_seqlens (LongTensor[N+1]):
seq_idx = torch.zeros(total_tokens, dtype=torch.int32, device=device)
for i in range(len(cu_seqlens) - 1):
    seq_idx[cu_seqlens[i]:cu_seqlens[i+1]] = i
outputs = model(input_ids=flat, position_ids=pos_ids, seq_idx=seq_idx)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
