### PR TITLE
fix(serve): don't classify Gemma 4 closed prefilled thinking block as reasoning

### DIFF
--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -263,7 +263,7 @@ def get_reasoning_config(processor, model: "PreTrainedModel", input_ids=None) ->
         schema = _DEFAULT_THINKING_TOKENS["schema"]
     config: dict = {"start_ids": start_ids, "end_id": end_id, "schema": schema}
     if input_ids is not None:
-        config["start_in_thinking"] = _starts_in_thinking(input_ids, start_ids)
+        config["start_in_thinking"] = _starts_in_thinking(input_ids, start_ids, end_id)
     return config
 
 
@@ -287,7 +287,7 @@ def parse_reasoning(processor, generated_ids, content: str, reasoning_config: di
     return content, None
 
 
-def _starts_in_thinking(input_ids, start_ids: list[int]) -> bool:
+def _starts_in_thinking(input_ids, start_ids: list[int], end_id: int | None = None) -> bool:
     """True if the rendered prompt ends with an unclosed thinking block.
 
     Some reasoning-model chat templates prefill the thinking opener as the final
@@ -298,6 +298,10 @@ def _starts_in_thinking(input_ids, start_ids: list[int]) -> bool:
 
     The prefill always lands at the tail of the prompt (optionally followed by a
     single whitespace token like ``\\n``), so we only inspect the last few tokens.
+    When the single trailing token is the thinking *end* token, the block was
+    prefilled already-closed (e.g. Gemma 4 with thinking disabled emits an empty
+    ``<|channel>thought\\n<channel|>``), so the prompt is *not* left inside a
+    thinking block and we must not match.
     """
     if hasattr(input_ids, "tolist"):
         input_ids = input_ids.tolist()
@@ -311,6 +315,8 @@ def _starts_in_thinking(input_ids, start_ids: list[int]) -> bool:
         if len(input_ids) >= n + trailing:
             end = len(input_ids) - trailing
             if input_ids[end - n : end] == start_ids:
+                if trailing == 1 and end_id is not None and input_ids[end] == end_id:
+                    return False
                 return True
     return False
 

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -37,6 +37,7 @@ from transformers.cli.serving.utils import (
     BaseHandler,
     GenerationState,
     Modality,
+    _starts_in_thinking,
     get_tool_call_config,
     parse_tool_calls,
 )
@@ -538,6 +539,34 @@ class TestChunkSSE(unittest.TestCase):
     def test_chunk_to_sse_wraps_plain_string(self):
         result = BaseHandler.chunk_to_sse("hello")
         self.assertEqual(result, "data: hello\n\n")
+
+
+@require_serve
+class TestStartsInThinking(unittest.TestCase):
+    def test_prompt_ends_exactly_with_opener(self):
+        # DeepSeek-R1 / QwQ style: prompt ends with the thinking opener.
+        self.assertTrue(_starts_in_thinking([1, 2, 3, 100], [100]))
+
+    def test_opener_with_single_trailing_whitespace(self):
+        # Tolerate one trailing token (e.g. "\n") after the opener.
+        self.assertTrue(_starts_in_thinking([1, 2, 100, 7], [100]))
+
+    def test_closed_block_trailing_end_token_is_not_in_thinking(self):
+        # Gemma 4 with thinking disabled prefills an empty, already-closed block:
+        # ``<|channel>thought\n<channel|>``. The single trailing token is the end
+        # token, so the prompt is NOT left inside a thinking block.
+        self.assertFalse(_starts_in_thinking([1, 2, 100, 45518, 107, 101], [100, 45518, 107], end_id=101))
+
+    def test_closed_block_without_end_id_still_matches(self):
+        # Without ``end_id`` the closing-tag guard cannot fire (back-compat).
+        self.assertTrue(_starts_in_thinking([1, 2, 100, 45518, 107, 101], [100, 45518, 107]))
+
+    def test_no_thinking_tail(self):
+        self.assertFalse(_starts_in_thinking([1, 2, 3, 4], [100], end_id=101))
+
+    def test_batched_input_ids(self):
+        self.assertTrue(_starts_in_thinking([[1, 2, 100]], [100]))
+        self.assertFalse(_starts_in_thinking([[1, 2, 100], [3, 4, 100]], [100]))
 
 
 @require_serve


### PR DESCRIPTION
## What

Fixes #46561. With `transformers serve` and a Gemma 4 model, a normal (thinking-disabled) chat completion comes back with empty `content` — the whole answer is misclassified as `reasoning_content`.

## Root cause

Gemma 4's chat template prefills an **empty, already-closed** thinking block at the end of the prompt when thinking is disabled, so the prompt tail is `<|channel>thought\n<channel|>` → `[..., 100, 45518, 107, 101]` where `start_ids = [100, 45518, 107]` and the trailing token `101` is the thinking **end** token (`<channel|>`).

`_starts_in_thinking()` matches `start_ids` at the tail while tolerating one trailing token (so genuine prefilled openers like DeepSeek-R1 / QwQ that emit `<think>\n` still match). The closing tag was accepted as that tolerated trailing token, so the heuristic wrongly reported `start_in_thinking=True`. Because the output contains no thinking markers, `parse_reasoning()` then takes the "prefilled opener truncated before close" branch and returns `content=""` with everything in reasoning.

## Fix

Thread the already-computed `end_id` into `_starts_in_thinking()` and reject the one-trailing-token match when that trailing token is the thinking end token — a closed prefilled block means the prompt is *not* left inside a thinking block. The `trailing == 0` (ends exactly on opener) and `trailing == 1` with a non-end token (DeepSeek-R1 / QwQ `\n`) cases are unchanged.

## Tests

Added `TestStartsInThinking` (CPU-only, no model download) covering: ends-exactly-on-opener, opener + whitespace trailing, the Gemma 4 closed-block case (returns `False`), the closed block without `end_id` (back-compat still matches), no-thinking tail, and batched `input_ids`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
