### PR TITLE
[CI] Enable PR CI for all fork PRs via security gate

### DIFF
--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -15,29 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  debug-conditions:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Print if-condition values
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-          PR_USER_LOGIN: ${{ github.event.pull_request.user.login }}
-          IS_PUSH: ${{ github.event_name == 'push' }}
-          IS_MEMBER: ${{ contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) }}
-          IS_YDSHIEH2: ${{ github.event.pull_request.user.login == 'ydshieh2' }}
-        run: |
-          echo "event_name:             $EVENT_NAME"
-          echo "author_association:     $AUTHOR_ASSOCIATION"
-          echo "pr_user_login:          $PR_USER_LOGIN"
-          echo "--- condition result ---"
-          echo "is push:                $IS_PUSH"
-          echo "is member/owner/collab: $IS_MEMBER"
-          echo "is ydshieh2:            $IS_YDSHIEH2"
-
   pr-ci:
-    # Allow `ydshieh2` for testing during development
-    if: github.event_name == 'push' || contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) || github.event.pull_request.user.login == 'ydshieh2'
     # DON'T use commit sha here before the CI migration is finished
     uses: huggingface/transformers-test-ci/.github/workflows/pr-ci_dynamic_caller_example.yml@main # main
 


### PR DESCRIPTION
## Summary

- Remove the `if:` condition on `pr-ci` that previously restricted runs to members/collaborators/owners
- Remove the `debug-conditions` job (no longer needed)

Fork PRs from external contributors now hit GitHub's "Approve and run" gate, which is automatically handled by `pr-ci-security-gate.yml` → `huggingface/transformers-test-ci` security gate workflow. The security gate checks for shell/process execution issues and high severity findings introduced by the PR before approving the run.