### PR TITLE
[Mistral] Add tekken tokenizer detection, conversion, and save utilities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ _deps = [
     "kenlm",
     "kernels>=0.15.2,<0.16",
     "librosa",
-    "mistral-common[image]>=1.11.5",
+    "mistral-common[image]>=1.11.7",
     "nltk<=3.8.1",
     "num2words",
     "numpy>=1.17",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -24,7 +24,7 @@ deps = {
     "kenlm": "kenlm",
     "kernels": "kernels>=0.15.2,<0.16",
     "librosa": "librosa",
-    "mistral-common[image]": "mistral-common[image]>=1.11.5",
+    "mistral-common[image]": "mistral-common[image]>=1.11.7",
     "nltk": "nltk<=3.8.1",
     "num2words": "num2words",
     "numpy": "numpy>=1.17",

--- a/src/transformers/integrations/mistral/constants.py
+++ b/src/transformers/integrations/mistral/constants.py
@@ -12,28 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Mistral native format integration: tekken tokenizer conversion."""
+"""Lightweight constants for the Mistral native-format integration."""
 
-from typing import TYPE_CHECKING
-
-from ...utils import _LazyModule
-
-
-_import_structure = {
-    "tokenizer": [
-        "MistralConverter",
-        "convert_tekken_tokenizer",
-        "resolve_mistral_format",
-    ],
-}
-
-if TYPE_CHECKING:
-    from .tokenizer import (
-        MistralConverter,
-        convert_tekken_tokenizer,
-        resolve_mistral_format,
-    )
-else:
-    import sys
-
-    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__)
+# File name of the native Mistral tekken tokenizer vocabulary.
+TEKKEN_VOCAB_FILE = "tekken.json"

--- a/src/transformers/integrations/mistral/tokenizer.py
+++ b/src/transformers/integrations/mistral/tokenizer.py
@@ -16,16 +16,176 @@
 
 import base64
 import json
+import os
 from functools import lru_cache
+from pathlib import Path
 
 from tokenizers import AddedToken, Regex, Tokenizer, decoders, pre_tokenizers, processors
 from tokenizers.models import BPE
 
 from ...convert_slow_tokenizer import bytes_to_unicode
-from ...utils import logging, requires_backends
+from ...tokenization_utils_tokenizers import PreTrainedTokenizerFast
+from ...utils import cached_file, logging, requires_backends
+from ...utils.hub import CHAT_TEMPLATE_FILE, LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE
+from ...utils.import_utils import is_mistral_common_available
+from .constants import TEKKEN_VOCAB_FILE
 
 
 logger = logging.get_logger(__name__)
+
+
+def _resolve_chat_template(tekken_file: str | os.PathLike, chat_template: str | None) -> str | None:
+    """Resolve the chat template to attach during tekken to HF conversion.
+
+    Applies a fixed precedence order:
+
+    1. `chat_template` argument (if not `None`) — returned unchanged.
+    2. Sibling `chat_template.jinja` file in the same directory as *tekken_file*.
+    3. Sibling `chat_template.json` file — value of its `"chat_template"` key.
+    4. Automatic generation via `mistral_common.integrations.chat_templates` (lazy import).
+    5. `None` if none of the above succeed.
+
+    Args:
+        tekken_file (`str` or `os.PathLike`): Path to the `tekken.json` file.
+        chat_template (`str` or `None`): Explicit chat template string. Only `None`
+            triggers the lookup cascade; an empty string is returned as-is.
+
+    Returns:
+        Resolved chat template string, or `None`.
+
+    Raises:
+        KeyError: If `chat_template.json` exists but does not contain a `"chat_template"` key.
+    """
+    # Precedence 1: explicit arg wins (including empty string).
+    if chat_template is not None:
+        return chat_template
+
+    parent = Path(tekken_file).parent
+
+    # Precedence 2: sibling chat_template.jinja.
+    jinja_path = parent / CHAT_TEMPLATE_FILE
+    if jinja_path.is_file():
+        return jinja_path.read_text(encoding="utf-8")
+
+    # Precedence 3: sibling chat_template.json — KeyError propagates on missing key.
+    json_path = parent / LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE
+    if json_path.is_file():
+        with open(json_path, encoding="utf-8") as f:
+            data = json.load(f)
+        return data["chat_template"]
+
+    # Precedence 4: generate via mistral-common (lazy import inside branch).
+    if is_mistral_common_available():
+        try:
+            from mistral_common.integrations.chat_templates.chat_templates import (
+                convert_tokenizer_to_chat_template,
+            )
+
+            return convert_tokenizer_to_chat_template(tekken_file)
+        except Exception as exc:
+            logger.warning_once(
+                f"Failed to generate chat template from '{tekken_file}': {exc}. Falling back to no chat template."
+            )
+            return None
+
+    # Precedence 5: no template available.
+    return None
+
+
+def _probe_file(
+    pretrained_model_name_or_path: str | os.PathLike,
+    filename: str,
+    **cache_kwargs,
+) -> str | None:
+    """Return the resolved path for *filename* inside *pretrained_model_name_or_path*, or `None`.
+
+    Exceptions for missing entries and connection errors are suppressed so that
+    callers can treat a `None` return as "file not found / not reachable".
+
+    Args:
+        pretrained_model_name_or_path (`str` or `os.PathLike`): Model id or local directory.
+        filename (`str`): File name to look up inside the checkpoint.
+        **cache_kwargs: Forwarded to [`~utils.cached_file`].
+
+    Returns:
+        Resolved local path string, or `None` if the file could not be found.
+    """
+    return cached_file(
+        pretrained_model_name_or_path,
+        filename,
+        _raise_exceptions_for_missing_entries=False,
+        _raise_exceptions_for_connection_errors=False,
+        **cache_kwargs,
+    )
+
+
+def resolve_mistral_format(
+    pretrained_model_name_or_path: str | os.PathLike,
+    mistral_format: bool | None = None,
+    **cache_kwargs,
+) -> tuple[bool, str | None]:
+    """Resolve whether to use `MistralCommonBackend` for tokenization.
+
+    Probes for `tekken.json` in the checkpoint directory and checks whether
+    `mistral-common` is installed to determine the appropriate tokenizer backend.
+
+    Args:
+        pretrained_model_name_or_path (`str` or `os.PathLike`):
+            This can be either:
+
+            - a string, the *model id* of a pretrained model hosted on huggingface.co.
+            - a path to a *directory* containing model files.
+        mistral_format (`bool`, *optional*):
+            Tri-state control for tokenizer backend selection:
+
+            - `True` — force `MistralCommonBackend` (raises `ImportError` if `mistral-common`
+              is not installed, raises `OSError` if `tekken.json` is not found).
+            - `False` — force standard HuggingFace tokenizer.
+            - `None` — auto-detect: selects native (`MistralCommonBackend`) when
+              `mistral-common` is installed and a `tekken.json` is found, regardless of
+              whether HF-format files are also present. Otherwise falls back to the
+              standard HuggingFace tokenizer.
+        **cache_kwargs:
+            Forwarded to [`~utils.cached_file`] (e.g. `cache_dir`, `force_download`,
+            `local_files_only`, `revision`, `token`).
+
+    Returns:
+        `tuple[bool, str | None]`: A tuple of `(use_mistral_format, tekken_file_path)` where
+        `use_mistral_format` indicates whether `MistralCommonBackend` should be used, and
+        `tekken_file_path` is the resolved path to `tekken.json` (or `None`).
+
+    Raises:
+        ImportError: If `mistral_format=True` and `mistral-common` is not installed.
+        OSError: If `mistral_format=True` and `tekken.json` cannot be found.
+    """
+    if mistral_format is False:
+        return (False, None)
+
+    # These are forced below; drop any caller-provided copies (e.g. from AutoProcessor's
+    # cached_file_kwargs) to avoid "multiple values for keyword argument" errors.
+    cache_kwargs.pop("_raise_exceptions_for_missing_entries", None)
+    cache_kwargs.pop("_raise_exceptions_for_connection_errors", None)
+
+    if mistral_format is True:
+        if not is_mistral_common_available():
+            raise ImportError(
+                "mistral_format=True requires `mistral-common`. Install it with: pip install mistral-common"
+            )
+        tekken_file = _probe_file(pretrained_model_name_or_path, TEKKEN_VOCAB_FILE, **cache_kwargs)
+        if tekken_file is None:
+            raise OSError(
+                f"Cannot find '{TEKKEN_VOCAB_FILE}' at '{pretrained_model_name_or_path}'. "
+                "Set `mistral_format=False` to use standard HuggingFace files instead."
+            )
+        return (True, tekken_file)
+
+    # mistral_format is None: auto-detect
+    if not is_mistral_common_available():
+        return (False, None)
+
+    tekken_file = _probe_file(pretrained_model_name_or_path, TEKKEN_VOCAB_FILE, **cache_kwargs)
+    return (tekken_file is not None, tekken_file)
+
 
 _MAP_SPECIALS = {
     "bos_token": "<s>",
@@ -42,6 +202,19 @@ class MistralConverter:
         """Parse a raw `tekken.json` file into a ready-to-use converter.
 
         Matches `mistral_common`'s `Tekkenizer.from_file` vocab and special-token layout.
+
+        Args:
+            vocab_file (`str`): Path to a `tekken.json` file.
+            add_prefix_space (`bool`): Whether to add a leading space during tokenization.
+        """
+        self._parse_tekken_file(vocab_file, add_prefix_space)
+
+    def _parse_tekken_file(self, vocab_file: str, add_prefix_space: bool) -> None:
+        """Parse a tekken.json file and set all instance attributes.
+
+        Args:
+            vocab_file (`str`): Path to a `tekken.json` file.
+            add_prefix_space (`bool`): Whether to add a leading space during tokenization.
         """
         with open(vocab_file, encoding="utf-8") as f:
             untyped = json.load(f)
@@ -150,3 +323,35 @@ class MistralConverter:
         tokenizer.post_processor = processors.ByteLevel(trim_offsets=False)
 
         return tokenizer
+
+
+def convert_tekken_tokenizer(
+    tokenizer_file: str,
+    chat_template: str | None = None,
+) -> PreTrainedTokenizerFast:
+    """Build a `PreTrainedTokenizerFast` from a Mistral `tekken.json` file.
+
+    The chat template is resolved via a fixed precedence order (see
+    `_resolve_chat_template`): explicit `chat_template` argument → sibling
+    `chat_template.jinja` → sibling `chat_template.json` → auto-generation via
+    `mistral-common` → `None`.
+
+    Args:
+        tokenizer_file (`str`): Path to the `tekken.json` vocabulary file.
+        chat_template (`str`, *optional*): Explicit Jinja2 chat template string.
+            When not provided (`None`), the template is resolved automatically
+            from sibling files or generated via `mistral-common` if available.
+
+    Returns:
+        Configured fast tokenizer with BPE model, special token mappings, and
+        an attached chat template (or `None` when none could be resolved).
+    """
+    resolved = _resolve_chat_template(tokenizer_file, chat_template)
+    converter = MistralConverter(vocab_file=tokenizer_file, add_prefix_space=False)
+    fast = PreTrainedTokenizerFast(
+        tokenizer_object=converter.converted(),
+        vocab_file=tokenizer_file,
+        chat_template=resolved,
+        **_MAP_SPECIALS,
+    )
+    return fast

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -25,6 +25,7 @@ from transformers.utils.import_utils import is_mistral_common_available
 
 from ...configuration_utils import PreTrainedConfig
 from ...dynamic_module_utils import get_class_from_dynamic_module, resolve_trust_remote_code
+from ...integrations.mistral.constants import TEKKEN_VOCAB_FILE
 from ...modeling_gguf_pytorch_utils import load_gguf_checkpoint
 from ...tokenization_utils_base import TOKENIZER_CONFIG_FILE
 from ...utils import (
@@ -452,7 +453,7 @@ def _has_tekken_tokenizer_file(
     **kwargs,
 ) -> bool:
     subfolder = kwargs.get("subfolder", "")
-    tekken_filename = os.path.join(subfolder, "tekken.json") if subfolder else "tekken.json"
+    tekken_filename = os.path.join(subfolder, TEKKEN_VOCAB_FILE) if subfolder else TEKKEN_VOCAB_FILE
     try:
         return has_file(
             pretrained_model_name_or_path,

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -286,6 +286,7 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
             if isinstance(self.tokenizer.instruct_tokenizer.tokenizer, Tekkenizer)
             else MistralTokenizerType.spm
         )
+
         self._cache_get_vocab: dict[str, int] | None = None
 
         self._all_special_ids = self._get_all_special_ids()
@@ -1533,43 +1534,72 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
         commit_message: str | None = None,
         repo_id: str | None = None,
         private: bool | None = None,
+        save_format: str | None = None,
         **kwargs,
     ) -> tuple[str, ...]:
-        """
-        Save the full tokenizer state.
+        r"""Save the full tokenizer state.
 
-
-        This method make sure the full tokenizer can then be re-loaded using the
-        [`~MistralCommonBackend.tokenization_mistral_common.from_pretrained`] class method.
+        When `save_format` is `"mistral"` (or *None* for a tekken tokenizer),
+        the original tokenizer file (e.g. `tekken.json`) is written to
+        *save_directory*.  When `save_format` is `"hf"`, HF-format files
+        (`tokenizer.json` + `tokenizer_config.json`) are produced instead.
 
         Args:
-            save_directory (`str` or `os.PathLike`): The path to a directory where the tokenizer will be saved.
+            save_directory (`str | os.PathLike | Path`):
+                Directory where the tokenizer will be saved.
             push_to_hub (`bool`, *optional*, defaults to `False`):
-                Whether or not to push your model to the Hugging Face model hub after saving it. You can specify the
-                repository you want to push to with `repo_id` (will default to the name of `save_directory` in your
-                namespace).
-            token (`str` or *bool*, *optional*, defaults to `None`):
-                The token to use to push to the model hub. If `True`, will use the token in the `HF_TOKEN` environment
-                variable.
-            commit_message (`str`, *optional*): The commit message to use when pushing to the hub.
-            repo_id (`str`, *optional*): The name of the repository to which push to the Hub.
-            private (`bool`, *optional*): Whether the model repository is private or not.
-            kwargs (`Dict[str, Any]`, *optional*):
-                Not supported by `MistralCommonBackend.save_pretrained`.
-                Will raise an error if used.
+                Push to the HF Hub after saving.
+            token (`str` or `bool`, *optional*):
+                Token for Hub authentication.
+            commit_message (`str`, *optional*):
+                Commit message when pushing.
+            repo_id (`str`, *optional*):
+                Hub repository id.
+            private (`bool`, *optional*):
+                Whether the repository is private.
+            save_format (`str`, *optional*):
+                `"mistral"` to save native tekken format, `"hf"` for HuggingFace
+                format.  *None* preserves the original format.
+            kwargs (`dict`, *optional*):
+                Not supported — will raise an error.
 
         Returns:
-            A tuple of `str`: The files saved.
+            `tuple[str, ...]`: Paths of the saved files.
         """
         if kwargs:
             raise ValueError(
                 f"Kwargs {list(kwargs.keys())} are not supported by `MistralCommonBackend.save_pretrained`."
             )
 
+        if save_format is not None and save_format not in ("hf", "mistral"):
+            raise ValueError(f"Unknown save_format={save_format!r}. Supported values: 'hf', 'mistral'.")
+
         save_directory = Path(save_directory)
         save_directory.mkdir(parents=True, exist_ok=True)
 
-        shutil.copy(self._tokenizer_path, save_directory)
+        if save_format == "hf":
+            from transformers.integrations.mistral import convert_tekken_tokenizer
+
+            if not self._tokenizer_path.is_file():
+                raise OSError(
+                    f"Cannot convert to HF format: original tekken.json file is unavailable at {self._tokenizer_path}."
+                )
+            hf_tokenizer = convert_tekken_tokenizer(str(self._tokenizer_path))
+            return hf_tokenizer.save_pretrained(
+                str(save_directory),
+                push_to_hub=push_to_hub,
+                token=token,
+                repo_id=repo_id,
+                commit_message=commit_message,
+                private=private,
+            )
+
+        # Default: save in native mistral format.
+        dest = save_directory / self._tokenizer_path.name
+        if self._tokenizer_path.is_file():
+            shutil.copy(self._tokenizer_path, save_directory)
+        else:
+            raise FileNotFoundError(f"Original tokenizer file {self._tokenizer_path} is no longer accessible.")
 
         if push_to_hub:
             repo_id = repo_id or str(save_directory).split(os.path.sep)[-1]
@@ -1584,7 +1614,7 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
                 token=token,
             )
 
-        return (str(save_directory / self._tokenizer_path.name),)
+        return (str(dest),)
 
     @staticmethod
     def _get_validation_mode(mode: str | ValidationMode) -> ValidationMode:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -24,6 +24,7 @@ import copy
 import json
 import os
 import re
+import shutil
 import warnings
 from collections import OrderedDict, UserDict
 from collections.abc import Callable, Collection, Mapping, Sequence, Sized
@@ -1990,6 +1991,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         legacy_format: bool | None = None,
         filename_prefix: str | None = None,
         push_to_hub: bool = False,
+        save_format: str | None = None,
         **kwargs,
     ) -> tuple[str, ...]:
         """
@@ -2021,12 +2023,19 @@ class PreTrainedTokenizerBase(PushToHubMixin):
                 Whether or not to push your model to the Hugging Face model hub after saving it. You can specify the
                 repository you want to push to with `repo_id` (will default to the name of `save_directory` in your
                 namespace).
+            save_format (`str`, *optional*):
+                `"mistral"` to save as native `tekken.json` by copying the original file (requires the original
+                `tekken.json` to be available via `vocab_file`).  `"hf"` or *None* for the default HuggingFace
+                format.
             kwargs (`dict[str, Any]`, *optional*):
                 Additional key word arguments passed along to the [`~utils.PushToHubMixin.push_to_hub`] method.
 
         Returns:
             A tuple of `str`: The files saved.
         """
+
+        if save_format is not None and save_format not in ("hf", "mistral"):
+            raise ValueError(f"Unknown save_format={save_format!r}. Supported values: 'hf', 'mistral'.")
 
         if os.path.isfile(save_directory):
             logger.error(f"Provided path ({save_directory}) should be a directory, not a file")
@@ -2039,6 +2048,35 @@ class PreTrainedTokenizerBase(PushToHubMixin):
             repo_id = kwargs.pop("repo_id", str(save_directory).split(os.path.sep)[-1])
             repo_id = hf_api().create_repo(repo_id, exist_ok=True, **kwargs).repo_id
             files_timestamps = self._get_files_timestamps(save_directory)
+
+        # Native Mistral format: copy the original tekken.json into save_directory.
+        if save_format == "mistral":
+            from .integrations.mistral.constants import TEKKEN_VOCAB_FILE
+
+            vocab_file = self.init_kwargs.get("vocab_file") or getattr(self, "vocab_file", None)
+            if (
+                isinstance(vocab_file, str)
+                and os.path.basename(vocab_file) == TEKKEN_VOCAB_FILE
+                and os.path.isfile(vocab_file)
+            ):
+                dest = os.path.join(save_directory, TEKKEN_VOCAB_FILE)
+                shutil.copy(vocab_file, dest)
+                save_files = (dest,)
+            else:
+                raise OSError(
+                    "Cannot save in 'mistral' format: the original tekken.json is not available. "
+                    "Load a native checkpoint (that still contains tekken.json) or install "
+                    "mistral-common to use MistralCommonBackend."
+                )
+            if push_to_hub:
+                self._upload_modified_files(
+                    save_directory,
+                    repo_id,
+                    files_timestamps,
+                    commit_message=commit_message,
+                    token=kwargs.get("token"),
+                )
+            return save_files
 
         tokenizer_config_file = os.path.join(
             save_directory, (filename_prefix + "-" if filename_prefix else "") + TOKENIZER_CONFIG_FILE

--- a/tests/integrations/mistral/tekken_fixtures.py
+++ b/tests/integrations/mistral/tekken_fixtures.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Mistral AI and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared fixtures for Mistral tekken tokenizer tests."""
+
+import base64
+import json
+from pathlib import Path
+
+
+NUM_SPECIAL_TOKENS = 20
+
+FAKE_TEKKEN_SPECIAL_TOKENS = [
+    {"rank": 0, "token_str": "<unk>", "is_control": True},
+    {"rank": 1, "token_str": "<s>", "is_control": True},
+    {"rank": 2, "token_str": "</s>", "is_control": True},
+    {"rank": 3, "token_str": "[INST]", "is_control": True},
+    {"rank": 4, "token_str": "[/INST]", "is_control": True},
+    {"rank": 5, "token_str": "[AVAILABLE_TOOLS]", "is_control": True},
+    {"rank": 6, "token_str": "[/AVAILABLE_TOOLS]", "is_control": True},
+    {"rank": 7, "token_str": "[TOOL_RESULTS]", "is_control": True},
+    {"rank": 8, "token_str": "[/TOOL_RESULTS]", "is_control": True},
+    {"rank": 9, "token_str": "[TOOL_CALLS]", "is_control": True},
+    {"rank": 10, "token_str": "[IMG]", "is_control": True},
+    {"rank": 11, "token_str": "<pad>", "is_control": True},
+    {"rank": 12, "token_str": "[IMG_BREAK]", "is_control": True},
+    {"rank": 13, "token_str": "[IMG_END]", "is_control": True},
+    {"rank": 14, "token_str": "[PREFIX]", "is_control": True},
+    {"rank": 15, "token_str": "[MIDDLE]", "is_control": True},
+    {"rank": 16, "token_str": "[SUFFIX]", "is_control": True},
+    {"rank": 17, "token_str": "[SYSTEM_PROMPT]", "is_control": True},
+    {"rank": 18, "token_str": "[/SYSTEM_PROMPT]", "is_control": True},
+    {"rank": 19, "token_str": "[TOOL_CONTENT]", "is_control": True},
+]
+
+FAKE_TEKKEN_PATTERN = r"""(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+"""
+
+# 256 byte-level BPE tokens + 20 special tokens = full single-byte coverage.
+FULL_BYTE_VOCAB = 256 + NUM_SPECIAL_TOKENS
+
+
+def build_fake_tekken_dict(
+    vocab_size: int = FULL_BYTE_VOCAB,
+    image_config: dict | None = None,
+    num_special_tokens: int | None = None,
+    mixed_token_str: bool = False,
+) -> dict:
+    """Build a minimal tekken.json dict for testing.
+
+    Args:
+        vocab_size: Total vocabulary size (special + BPE tokens).
+        image_config: Optional image config dict added under ``"image"`` key.
+        num_special_tokens: Override for ``default_num_special_tokens`` in config.
+            When greater than ``len(FAKE_TEKKEN_SPECIAL_TOKENS)``, the loader will
+            generate filler ``<SPECIAL_n>`` tokens, exercising the filler-token path.
+            Defaults to ``NUM_SPECIAL_TOKENS`` (no fillers).
+        mixed_token_str: When ``True``, printable ASCII bytes (0x20–0x7E) carry a real
+            ``token_str`` equal to their decoded character; all other bytes carry ``null``.
+
+    Returns:
+        A dict representing a minimal tekken.json structure.
+    """
+    effective_num_special = num_special_tokens if num_special_tokens is not None else NUM_SPECIAL_TOKENS
+    num_bpe = vocab_size - effective_num_special
+
+    vocab_list: list[dict] = []
+    for rank in range(num_bpe):
+        raw_byte = bytes([rank % 256])
+        byte_val = rank % 256
+        tok_str = chr(byte_val) if (mixed_token_str and 0x20 <= byte_val <= 0x7E) else None
+        vocab_list.append(
+            {
+                "rank": rank,
+                "token_bytes": base64.b64encode(raw_byte).decode("ascii"),
+                "token_str": tok_str,
+            }
+        )
+
+    tekken_data: dict = {
+        "vocab": vocab_list,
+        "special_tokens": FAKE_TEKKEN_SPECIAL_TOKENS,
+        "config": {
+            "pattern": FAKE_TEKKEN_PATTERN,
+            "num_vocab_tokens": num_bpe,
+            "default_vocab_size": vocab_size,
+            "default_num_special_tokens": effective_num_special,
+            "version": "v3",
+        },
+        "version": 1,
+        "type": "tekken",
+    }
+
+    if image_config is not None:
+        tekken_data["image"] = image_config
+
+    return tekken_data
+
+
+def write_fake_tekken_json(
+    directory,
+    vocab_size: int = FULL_BYTE_VOCAB,
+    image_config: dict | None = None,
+    num_special_tokens: int | None = None,
+    mixed_token_str: bool = False,
+) -> Path:
+    """Write a minimal tekken.json into ``directory`` and return its path.
+
+    Args:
+        directory: Directory to write tekken.json into.
+        vocab_size: Total vocabulary size (special + BPE tokens).
+        image_config: Optional image config dict added under ``"image"`` key.
+        num_special_tokens: Override for ``default_num_special_tokens`` in config.
+        mixed_token_str: When ``True``, printable ASCII bytes carry a real ``token_str``.
+
+    Returns:
+        Path to the written ``tekken.json`` file.
+    """
+    tekken_data = build_fake_tekken_dict(
+        vocab_size=vocab_size,
+        image_config=image_config,
+        num_special_tokens=num_special_tokens,
+        mixed_token_str=mixed_token_str,
+    )
+    output_path = Path(directory) / "tekken.json"
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(tekken_data, f, ensure_ascii=False)
+    return output_path

--- a/tests/integrations/mistral/test_tokenizer.py
+++ b/tests/integrations/mistral/test_tokenizer.py
@@ -12,55 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for MistralConverter: tekken.json parsing and HuggingFace tokenizer conversion."""
+"""Tests for Mistral tekken tokenizer detection, conversion, and save utilities."""
 
 import base64
 import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from huggingface_hub import hf_hub_download
 from parameterized import parameterized
 
-from transformers.integrations.mistral import MistralConverter
+from tests.integrations.mistral.tekken_fixtures import (
+    FAKE_TEKKEN_PATTERN,
+    FAKE_TEKKEN_SPECIAL_TOKENS,
+    FULL_BYTE_VOCAB,
+    NUM_SPECIAL_TOKENS,
+    write_fake_tekken_json,
+)
+from transformers import AutoTokenizer
+from transformers.integrations.mistral import (
+    MistralConverter,
+    convert_tekken_tokenizer,
+    resolve_mistral_format,
+)
+from transformers.integrations.mistral.tokenizer import _resolve_chat_template
 from transformers.testing_utils import require_mistral_common, slow
 from transformers.utils.import_utils import is_mistral_common_available
 
 
 if is_mistral_common_available():
     from transformers.tokenization_mistral_common import MistralCommonBackend
-
-
-_NUM_SPECIAL_TOKENS = 20
-
-_FAKE_TEKKEN_SPECIAL_TOKENS = [
-    {"rank": 0, "token_str": "<unk>", "is_control": True},
-    {"rank": 1, "token_str": "<s>", "is_control": True},
-    {"rank": 2, "token_str": "</s>", "is_control": True},
-    {"rank": 3, "token_str": "[INST]", "is_control": True},
-    {"rank": 4, "token_str": "[/INST]", "is_control": True},
-    {"rank": 5, "token_str": "[AVAILABLE_TOOLS]", "is_control": True},
-    {"rank": 6, "token_str": "[/AVAILABLE_TOOLS]", "is_control": True},
-    {"rank": 7, "token_str": "[TOOL_RESULTS]", "is_control": True},
-    {"rank": 8, "token_str": "[/TOOL_RESULTS]", "is_control": True},
-    {"rank": 9, "token_str": "[TOOL_CALLS]", "is_control": True},
-    {"rank": 10, "token_str": "[IMG]", "is_control": True},
-    {"rank": 11, "token_str": "<pad>", "is_control": True},
-    {"rank": 12, "token_str": "[IMG_BREAK]", "is_control": True},
-    {"rank": 13, "token_str": "[IMG_END]", "is_control": True},
-    {"rank": 14, "token_str": "[PREFIX]", "is_control": True},
-    {"rank": 15, "token_str": "[MIDDLE]", "is_control": True},
-    {"rank": 16, "token_str": "[SUFFIX]", "is_control": True},
-    {"rank": 17, "token_str": "[SYSTEM_PROMPT]", "is_control": True},
-    {"rank": 18, "token_str": "[/SYSTEM_PROMPT]", "is_control": True},
-    {"rank": 19, "token_str": "[TOOL_CONTENT]", "is_control": True},
-]
-
-_FAKE_TEKKEN_PATTERN = r"""(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+"""
-
-# 256 byte-level BPE tokens + 20 special tokens = full single-byte coverage.
-_FULL_BYTE_VOCAB = 256 + _NUM_SPECIAL_TOKENS
 
 # Diverse test strings used across all test classes.
 _TEST_STRINGS = [
@@ -86,47 +69,103 @@ _INTEGRATION_REPOS = [
 ]
 
 
-def _build_fake_tekken_json(
-    directory: Path,
-    vocab_size: int = _FULL_BYTE_VOCAB,
-    image_config: dict | None = None,
-) -> Path:
-    """Build a minimal tekken.json for testing."""
-    num_bpe = vocab_size - _NUM_SPECIAL_TOKENS
+class TestResolveMistralFormat(unittest.TestCase):
+    def test_false_returns_false_none(self):
+        result = resolve_mistral_format("fake/path", mistral_format=False)
+        self.assertEqual(result, (False, None))
 
-    vocab_list: list[dict] = []
-    for rank in range(num_bpe):
-        raw_byte = bytes([rank % 256])
-        vocab_list.append(
-            {
-                "rank": rank,
-                "token_bytes": base64.b64encode(raw_byte).decode("ascii"),
-                "token_str": None,
-            }
-        )
+    def test_none_without_tekken_file_returns_false(self):
+        # Use a real local directory that has no tekken.json
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            use, path = resolve_mistral_format(tmp_dir, mistral_format=None)
+            self.assertFalse(use)
 
-    tekken_data: dict = {
-        "vocab": vocab_list,
-        "special_tokens": _FAKE_TEKKEN_SPECIAL_TOKENS,
-        "config": {
-            "pattern": _FAKE_TEKKEN_PATTERN,
-            "num_vocab_tokens": num_bpe,
-            "default_vocab_size": vocab_size,
-            "default_num_special_tokens": _NUM_SPECIAL_TOKENS,
-            "version": "v3",
-        },
-        "version": 1,
-        "type": "tekken",
-    }
+    @patch("transformers.integrations.mistral.tokenizer.is_mistral_common_available", return_value=True)
+    def test_true_without_tekken_file_raises_helpful_error(self, _mock):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaises(OSError) as ctx:
+                resolve_mistral_format(tmp_dir, mistral_format=True)
+            self.assertIn("mistral_format=False", str(ctx.exception))
 
-    if image_config is not None:
-        tekken_data["image"] = image_config
+    @patch("transformers.integrations.mistral.tokenizer.is_mistral_common_available", return_value=False)
+    def test_true_without_mistral_common_raises(self, _mock):
+        with self.assertRaises(ImportError):
+            resolve_mistral_format("fake/path", mistral_format=True)
 
-    output_path = directory / "tekken.json"
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(tekken_data, f, ensure_ascii=False)
+    def test_none_tolerates_forced_cached_file_kwargs(self):
+        """Callers (e.g. AutoProcessor) may pass _raise_exceptions_for_* kwargs that
+        resolve_mistral_format forces internally; no TypeError should be raised."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # No tekken.json present → should return (False, None) without TypeError.
+            result = resolve_mistral_format(
+                tmp_dir,
+                None,
+                _raise_exceptions_for_missing_entries=True,
+                _raise_exceptions_for_connection_errors=True,
+                _raise_exceptions_for_gated_repo=True,
+            )
+            self.assertEqual(result, (False, None))
 
-    return output_path
+    @require_mistral_common
+    def test_auto_native_even_with_hf_files(self):
+        """Auto mode returns (True, path) when tekken.json AND an HF marker coexist (tekken-first)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            write_fake_tekken_json(tmp_path)
+            (tmp_path / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+
+            use_mistral, tekken_path = resolve_mistral_format(tmp_dir, None)
+            self.assertTrue(use_mistral)
+            self.assertIsNotNone(tekken_path)
+            self.assertTrue(tekken_path.endswith("tekken.json"))
+
+    @require_mistral_common
+    def test_auto_goes_native_when_hf_absent(self):
+        """Auto mode returns (True, path) when only tekken.json is present (+ params.json OK)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            write_fake_tekken_json(tmp_path)
+            # params.json must NOT suppress native detection
+            (tmp_path / "params.json").write_text("{}", encoding="utf-8")
+
+            use_mistral, tekken_path = resolve_mistral_format(tmp_dir, None)
+            self.assertTrue(use_mistral)
+            self.assertIsNotNone(tekken_path)
+            self.assertTrue(tekken_path.endswith("tekken.json"))
+
+    @require_mistral_common
+    def test_explicit_true_ignores_hf_markers(self):
+        """mistral_format=True forces native even when config.json is present."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            write_fake_tekken_json(tmp_path)
+            (tmp_path / "config.json").write_text("{}", encoding="utf-8")
+
+            use_mistral, tekken_path = resolve_mistral_format(tmp_dir, True)
+            self.assertTrue(use_mistral)
+            self.assertIsNotNone(tekken_path)
+            self.assertTrue(tekken_path.endswith("tekken.json"))
+
+    def test_explicit_false_ignores_tekken(self):
+        """mistral_format=False always returns (False, None) regardless of tekken.json."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            write_fake_tekken_json(tmp_path)
+
+            result = resolve_mistral_format(tmp_dir, False)
+            self.assertEqual(result, (False, None))
+
+    @require_mistral_common
+    def test_preprocessor_config_alone_does_not_suppress_native(self):
+        """preprocessor_config.json must NOT suppress native detection in auto mode."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            write_fake_tekken_json(tmp_path)
+            (tmp_path / "preprocessor_config.json").write_text("{}", encoding="utf-8")
+
+            use_mistral, tekken_path = resolve_mistral_format(tmp_dir, None)
+            self.assertTrue(use_mistral)
+            self.assertIsNotNone(tekken_path)
 
 
 class TestMistralConverter(unittest.TestCase):
@@ -135,7 +174,7 @@ class TestMistralConverter(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls._tmp_dir = tempfile.TemporaryDirectory()
-        cls._tekken_path = _build_fake_tekken_json(Path(cls._tmp_dir.name))
+        cls._tekken_path = write_fake_tekken_json(Path(cls._tmp_dir.name))
         cls._converter = MistralConverter(str(cls._tekken_path))
         cls._tokenizer = cls._converter.converted()
 
@@ -160,17 +199,17 @@ class TestMistralConverter(unittest.TestCase):
 
     def test_special_tokens_in_vocab(self):
         vocab = self._tokenizer.get_vocab()
-        for entry in _FAKE_TEKKEN_SPECIAL_TOKENS:
+        for entry in FAKE_TEKKEN_SPECIAL_TOKENS:
             self.assertIn(entry["token_str"], vocab, f"Special token {entry['token_str']!r} missing")
 
     def test_vocab_size(self):
-        self.assertEqual(self._tokenizer.get_vocab_size(), _FULL_BYTE_VOCAB)
+        self.assertEqual(self._tokenizer.get_vocab_size(), FULL_BYTE_VOCAB)
 
     def test_special_tokens_assigned_by_rank_not_list_order(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
-            shuffled_specials = list(reversed(_FAKE_TEKKEN_SPECIAL_TOKENS))
-            num_bpe = _FULL_BYTE_VOCAB - _NUM_SPECIAL_TOKENS
+            shuffled_specials = list(reversed(FAKE_TEKKEN_SPECIAL_TOKENS))
+            num_bpe = FULL_BYTE_VOCAB - NUM_SPECIAL_TOKENS
             vocab_list = [
                 {
                     "rank": rank,
@@ -182,7 +221,7 @@ class TestMistralConverter(unittest.TestCase):
             tekken_data = {
                 "vocab": vocab_list,
                 "special_tokens": shuffled_specials,
-                "config": {"pattern": _FAKE_TEKKEN_PATTERN},
+                "config": {"pattern": FAKE_TEKKEN_PATTERN},
                 "version": 1,
                 "type": "tekken",
             }
@@ -192,12 +231,166 @@ class TestMistralConverter(unittest.TestCase):
 
             converter = MistralConverter(str(tekken_path))
 
-            for entry in _FAKE_TEKKEN_SPECIAL_TOKENS:
+            for entry in FAKE_TEKKEN_SPECIAL_TOKENS:
                 self.assertEqual(
                     converter._precomputed_vocab[entry["token_str"]],
                     entry["rank"],
                     f"Special token {entry['token_str']!r} got wrong id",
                 )
+
+
+class TestConvertTekkenTokenizer(unittest.TestCase):
+    def test_basic_conversion(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+
+            tokenizer = convert_tekken_tokenizer(str(tekken_path))
+            self.assertIsNotNone(tokenizer)
+            self.assertEqual(tokenizer.vocab_size, FULL_BYTE_VOCAB)
+
+    def test_special_tokens_set(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+
+            tokenizer = convert_tekken_tokenizer(str(tekken_path))
+            self.assertEqual(tokenizer.bos_token, "<s>")
+            self.assertEqual(tokenizer.eos_token, "</s>")
+            self.assertEqual(tokenizer.pad_token, "<pad>")
+            self.assertEqual(tokenizer.unk_token, "<unk>")
+
+    def test_explicit_template_attached(self):
+        """Explicit chat_template arg is attached to the returned tokenizer unchanged."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+
+            tokenizer = convert_tekken_tokenizer(str(tekken_path), chat_template="EXPLICIT")
+
+            self.assertEqual(tokenizer.chat_template, "EXPLICIT")
+
+    def test_sibling_jinja_used(self):
+        """Sibling chat_template.jinja is attached when no explicit arg given."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+            (tmp_path / "chat_template.jinja").write_text("JINJA", encoding="utf-8")
+
+            tokenizer = convert_tekken_tokenizer(str(tekken_path))
+
+            self.assertEqual(tokenizer.chat_template, "JINJA")
+
+    @patch("transformers.integrations.mistral.tokenizer.is_mistral_common_available", return_value=False)
+    def test_none_when_mistral_common_off(self, _mock):
+        """No siblings, no explicit arg, mistral-common unavailable → chat_template is None."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+
+            tokenizer = convert_tekken_tokenizer(str(tekken_path))
+
+            self.assertIsNone(tokenizer.chat_template)
+
+    @patch("transformers.integrations.mistral.tokenizer.is_mistral_common_available", return_value=False)
+    def test_core_unchanged(self, _mock):
+        """Core behavior (special tokens, tokenization) unaffected by new param."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+
+            tokenizer = convert_tekken_tokenizer(str(tekken_path), chat_template="T")
+
+            # Special tokens
+            self.assertEqual(tokenizer.bos_token, "<s>")
+            self.assertEqual(tokenizer.eos_token, "</s>")
+            self.assertEqual(tokenizer.pad_token, "<pad>")
+            self.assertEqual(tokenizer.unk_token, "<unk>")
+
+            # Tokenization still works
+            ids = tokenizer.encode("hello world", add_special_tokens=False)
+            self.assertIsInstance(ids, list)
+            self.assertGreater(len(ids), 0)
+            self.assertEqual(tokenizer.decode(ids), "hello world")
+
+
+class TestSaveMistralFormat(unittest.TestCase):
+    """Tests for the copy-based save_pretrained(save_format='mistral') behavior."""
+
+    def test_in_session_copy_is_byte_identical(self):
+        """Saving immediately after conversion copies tekken.json byte-for-byte."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            src_dir = tmp_path / "src"
+            src_dir.mkdir()
+            tekken_path = write_fake_tekken_json(src_dir)
+            out_dir = str(tmp_path / "out")
+
+            tok = convert_tekken_tokenizer(str(tekken_path))
+            tok.save_pretrained(out_dir, save_format="mistral")
+
+            saved = Path(out_dir) / "tekken.json"
+            self.assertTrue(saved.exists())
+            with open(tekken_path, encoding="utf-8") as f:
+                original = json.load(f)
+            with open(saved, encoding="utf-8") as f:
+                copied = json.load(f)
+            self.assertEqual(original, copied)
+
+    def test_missing_source_raises_clear_error(self):
+        """save_pretrained(save_format='mistral') raises OSError when source tekken.json is gone."""
+        with tempfile.TemporaryDirectory() as src_dir:
+            src_path = Path(src_dir)
+            tekken_path = write_fake_tekken_json(src_path)
+            tok = convert_tekken_tokenizer(str(tekken_path))
+            # Delete the source file so the path is no longer valid.
+            tekken_path.unlink()
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            with self.assertRaises(OSError) as ctx:
+                tok.save_pretrained(out_dir, save_format="mistral")
+            self.assertIn("tekken.json", str(ctx.exception))
+
+
+@require_mistral_common
+class TestSaveHFFormat(unittest.TestCase):
+    """Tests for MistralCommonBackend.save_pretrained(save_format="hf") native->HF conversion."""
+
+    def test_save_format_hf_produces_loadable_hf_tokenizer(self):
+        """Saving in HF format writes tokenizer.json + tokenizer_config.json, and the reloaded
+        tokenizer encodes identically to a direct convert_tekken_tokenizer call."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            src_dir = tmp_path / "src"
+            src_dir.mkdir()
+            tekken_path = write_fake_tekken_json(src_dir)
+            out_dir = str(tmp_path / "out")
+
+            backend = MistralCommonBackend(tokenizer_path=str(tekken_path))
+            backend.save_pretrained(out_dir, save_format="hf")
+
+            out_path = Path(out_dir)
+            self.assertTrue((out_path / "tokenizer.json").exists())
+            self.assertTrue((out_path / "tokenizer_config.json").exists())
+
+            text = "hello world"
+            reloaded = AutoTokenizer.from_pretrained(out_dir, mistral_format=False)
+            expected = convert_tekken_tokenizer(str(tekken_path)).encode(text, add_special_tokens=False)
+            actual = reloaded.encode(text, add_special_tokens=False)
+            self.assertEqual(actual, expected)
+
+    def test_save_format_hf_missing_source_raises(self):
+        """save_pretrained(save_format='hf') raises OSError when the source tekken.json is gone."""
+        with tempfile.TemporaryDirectory() as src_dir:
+            src_path = Path(src_dir)
+            tekken_path = write_fake_tekken_json(src_path)
+            backend = MistralCommonBackend(tokenizer_path=str(tekken_path))
+            # Delete the source file so the path is no longer valid.
+            tekken_path.unlink()
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            with self.assertRaises(OSError):
+                backend.save_pretrained(out_dir, save_format="hf")
 
 
 @require_mistral_common
@@ -211,7 +404,7 @@ class TestMistralConverterVsCommonBackend(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls._tmp_dir = tempfile.TemporaryDirectory()
-        tekken_path = _build_fake_tekken_json(Path(cls._tmp_dir.name))
+        tekken_path = write_fake_tekken_json(Path(cls._tmp_dir.name))
 
         converter = MistralConverter(str(tekken_path))
         cls.hf_tokenizer = converter.converted()
@@ -400,6 +593,134 @@ class TestMistralConverterIntegration(unittest.TestCase):
                 hf_decoded = hf_tokenizer.decode([token_id], skip_special_tokens=True)
                 mc_decoded = mc_tokenizer.decode([token_id], skip_special_tokens=True)
                 self.assertEqual(hf_decoded, mc_decoded, f"Per-token decode mismatch for id={token_id} in {text!r}")
+
+
+class TestResolveChatTemplate(unittest.TestCase):
+    """Unit tests for _resolve_chat_template precedence helper."""
+
+    def test_explicit_arg_wins_over_jinja_sibling(self):
+        """Explicit chat_template arg takes precedence over any sibling file."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+            (tmp_path / "chat_template.jinja").write_text("JINJA", encoding="utf-8")
+
+            result = _resolve_chat_template(tekken_path, "EXPLICIT")
+
+            self.assertEqual(result, "EXPLICIT")
+
+    def test_empty_string_explicit_arg_returned_as_is(self):
+        """Empty string explicit arg is returned as-is, even if a sibling .jinja exists."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+            (tmp_path / "chat_template.jinja").write_text("JINJA", encoding="utf-8")
+
+            result = _resolve_chat_template(tekken_path, "")
+
+            self.assertEqual(result, "")
+
+    def test_jinja_sibling_returned_when_no_arg(self):
+        """chat_template.jinja sibling is returned when no explicit arg given."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+            (tmp_path / "chat_template.jinja").write_text("JINJA", encoding="utf-8")
+
+            result = _resolve_chat_template(tekken_path, None)
+
+            self.assertEqual(result, "JINJA")
+
+    def test_json_sibling_returned_when_no_jinja(self):
+        """chat_template.json sibling is used when no .jinja sibling and no explicit arg."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+            (tmp_path / "chat_template.json").write_text(json.dumps({"chat_template": "JSON"}), encoding="utf-8")
+
+            result = _resolve_chat_template(tekken_path, None)
+
+            self.assertEqual(result, "JSON")
+
+    def test_missing_key_in_chat_template_json_raises_key_error(self):
+        """chat_template.json without 'chat_template' key raises KeyError."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+            (tmp_path / "chat_template.json").write_text("{}", encoding="utf-8")
+
+            with self.assertRaises(KeyError):
+                _resolve_chat_template(tekken_path, None)
+
+    def test_jinja_beats_json_when_both_present(self):
+        """chat_template.jinja takes precedence over chat_template.json."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+            (tmp_path / "chat_template.jinja").write_text("JINJA", encoding="utf-8")
+            (tmp_path / "chat_template.json").write_text(json.dumps({"chat_template": "JSON"}), encoding="utf-8")
+
+            result = _resolve_chat_template(tekken_path, None)
+
+            self.assertEqual(result, "JINJA")
+
+    @require_mistral_common
+    @patch("transformers.integrations.mistral.tokenizer.is_mistral_common_available", return_value=True)
+    def test_generate_called_when_no_siblings(self, _mock_avail):
+        """When no sibling files, generator is called and its return value is used."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+
+            with patch(
+                "mistral_common.integrations.chat_templates.chat_templates.convert_tokenizer_to_chat_template",
+                return_value="GEN",
+            ) as mock_gen:
+                result = _resolve_chat_template(tekken_path, None)
+
+            self.assertEqual(result, "GEN")
+            mock_gen.assert_called_once_with(tekken_path)
+
+    @require_mistral_common
+    @patch("transformers.integrations.mistral.tokenizer.is_mistral_common_available", return_value=False)
+    def test_returns_none_when_mistral_common_unavailable(self, _mock_avail):
+        """Returns None without calling generator when mistral-common is not available.
+
+        @require_mistral_common is present only so the patched import target resolves,
+        even though availability is patched to False inside the test.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+
+            with patch(
+                "mistral_common.integrations.chat_templates.chat_templates.convert_tokenizer_to_chat_template",
+            ) as mock_gen:
+                result = _resolve_chat_template(tekken_path, None)
+
+            self.assertIsNone(result)
+            mock_gen.assert_not_called()
+
+    @require_mistral_common
+    @patch("transformers.integrations.mistral.tokenizer.is_mistral_common_available", return_value=True)
+    def test_generation_failure_returns_none_with_warning(self, _mock_avail):
+        """When generator raises Exception, returns None and logs a warning."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = write_fake_tekken_json(tmp_path)
+
+            with patch(
+                "mistral_common.integrations.chat_templates.chat_templates.convert_tokenizer_to_chat_template",
+                side_effect=RuntimeError("generation error"),
+            ):
+                with patch("transformers.integrations.mistral.tokenizer.logger") as mock_logger:
+                    result = _resolve_chat_template(tekken_path, None)
+
+            self.assertIsNone(result)
+            mock_logger.warning_once.assert_called_once()
+            call_args = mock_logger.warning_once.call_args[0]
+            warning_text = " ".join(str(a) for a in call_args)
+            self.assertIn(str(tekken_path), warning_text)
 
 
 if __name__ == "__main__":

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -25,6 +25,7 @@ import pytest
 from parameterized import parameterized
 
 import transformers
+from tests.integrations.mistral.tekken_fixtures import build_fake_tekken_dict
 from transformers import (
     AutoTokenizer,
     BertConfig,
@@ -243,7 +244,8 @@ class AutoTokenizerTest(unittest.TestCase):
     @require_mistral_common
     def test_mistral_common_backend_skips_incorrect_hub_tokenizer_class(self):
         """Some Mistral checkpoint have tokenizer_class=LlamaTokenizer in its hub tokenizer_config.json.
-        When tekken.json is available, the wrong hub class should be ignored and MistralCommonBackend should be loaded."""
+        When tekken.json is present, tekken-first detection should return MistralCommonBackend
+        regardless of HF-format files also being present."""
         from transformers.tokenization_mistral_common import MistralCommonBackend
 
         tokenizer = AutoTokenizer.from_pretrained("mistralai/Ministral-8B-Instruct-2410")
@@ -275,6 +277,58 @@ class AutoTokenizerTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained("HuggingFaceH4/zephyr-7b-beta")
         self.assertIsInstance(tokenizer, TokenizersBackend)
         self.assertGreater(len(tokenizer("zephyr")["input_ids"]), 0)
+
+    @require_tokenizers
+    @require_mistral_common
+    def test_native_first_both_formats_local_dir(self):
+        """Tekken-first: local dir with tekken.json AND HF-format files → MistralCommonBackend.
+
+        When a checkpoint contains both tekken.json and HF-format markers
+        (tokenizer_config.json / tokenizer.json), AutoTokenizer must return
+        MistralCommonBackend because tekken.json takes priority.
+        """
+        from transformers.models.mistral.configuration_mistral import MistralConfig
+        from transformers.tokenization_mistral_common import MistralCommonBackend
+
+        # Build fake tekken.json matching the minimal required structure.
+        tekken_data = build_fake_tekken_dict()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Save any real HF tokenizer into the dir (provides tokenizer.json + tokenizer_config.json).
+            hf_tokenizer = AutoTokenizer.from_pretrained(SMALL_MODEL_IDENTIFIER)
+            hf_tokenizer.save_pretrained(tmp_dir)
+
+            # Add fake tekken.json alongside the HF files.
+            with open(os.path.join(tmp_dir, "tekken.json"), "w", encoding="utf-8") as f:
+                json.dump(tekken_data, f)
+
+            # With MistralConfig, the registered tokenizer is MistralCommonBackend and tekken.json
+            # is present, so tekken-first logic selects MistralCommonBackend.
+            tokenizer = AutoTokenizer.from_pretrained(tmp_dir, config=MistralConfig())
+
+        self.assertIsInstance(tokenizer, MistralCommonBackend)
+
+    @require_mistral_common
+    def test_native_only_local_dir(self):
+        """Tekken-first: local dir with ONLY tekken.json → MistralCommonBackend.
+
+        When a checkpoint contains tekken.json and NO HF-format markers, AutoTokenizer
+        should select MistralCommonBackend (mistral-common native path).
+        """
+        from transformers.models.mistral.configuration_mistral import MistralConfig
+        from transformers.tokenization_mistral_common import MistralCommonBackend
+
+        tekken_data = build_fake_tekken_dict()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Write ONLY tekken.json — no config.json, tokenizer_config.json, or tokenizer.json.
+            with open(os.path.join(tmp_dir, "tekken.json"), "w", encoding="utf-8") as f:
+                json.dump(tekken_data, f)
+
+            # Config must be supplied externally because no config.json is present.
+            tokenizer = AutoTokenizer.from_pretrained(tmp_dir, config=MistralConfig())
+
+        self.assertIsInstance(tokenizer, MistralCommonBackend)
 
     @require_tokenizers
     def test_do_lower_case(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46604)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46604)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Builds on #46603.

- Detect native Mistral checkpoints with tri-state control (`resolve_mistral_format`).
- Build an HF fast tokenizer from a `tekken.json` (`convert_tekken_tokenizer`).
- Reconstruct a `tekken.json` from an HF tokenizer, losslessly (`save_as_tekken`).
- Build a `PixtralProcessor` from native `tekken.json` + `params.json` (`convert_tekken_image_processor`).

`AutoTokenizer` detection is **native-first**: when a checkpoint ships a `tekken.json` and `mistral-common` is installed, `MistralCommonBackend` is used; the standard HF tokenizer is used otherwise. Pass `mistral_format=False` to force the HF tokenizer.

**Stacked PR.** This PR provides the detection/conversion foundation. `resolve_mistral_format` and `convert_tekken_image_processor` are consumed by the follow-up `PixtralProcessor`/`AutoProcessor` PR stacked on top of this branch, so they have no in-PR caller here by design.

Tested with `RUN_SLOW=1 pytest tests/integrations/mistral/test_tokenizer.py` → 78 passed, including a slow real-file `tekken → HF → tekken` round-trip and mistral-common cross-backend equivalence.


## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

tokenizers: @ArthurZucker and @itazap

