### PR TITLE
Fix `peft` lower bound

### DIFF
--- a/docs/source/en/peft.md
+++ b/docs/source/en/peft.md
@@ -15,7 +15,7 @@ rendered properly in your Markdown viewer.
 
 Transformers integrates directly with the PEFT library through [`~integrations.PeftAdapterMixin`], added to all [`PreTrainedModel`] classes. You can load, add, train, switch, and delete adapters without wrapping your model in a separate [`~peft.PeftModel`]. All non-prompt-learning PEFT methods are supported (LoRA, IA3, AdaLoRA). Prompt-based methods like prompt tuning and prefix tuning require using the [PEFT library](https://huggingface.co/docs/peft/index) directly.
 
-Install PEFT to get started. The integration requires `peft >= 0.18.0`.
+Install PEFT to get started. The integration requires `peft >= 0.19.0`.
 
 ```shell
 pip install -U peft

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ _deps = [
     "pandas<2.3.0",  # `datasets` requires `pandas` while `pandas==2.3.0` has issues with CircleCI on 2025/06/05
     "packaging>=20.0",
     "parameterized>=0.9",  # older version of parameterized cause pytest collection to fail on .expand
-    "peft>=0.18.0",
+    "peft>=0.19.0",
     "phonemizer",
     "protobuf",
     "psutil",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -36,7 +36,7 @@ deps = {
     "pandas": "pandas<2.3.0",
     "packaging": "packaging>=20.0",
     "parameterized": "parameterized>=0.9",
-    "peft": "peft>=0.18.0",
+    "peft": "peft>=0.19.0",
     "phonemizer": "phonemizer",
     "protobuf": "protobuf",
     "psutil": "psutil",

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -58,7 +58,7 @@ if is_accelerate_available():
     from accelerate.utils import get_balanced_memory, infer_auto_device_map
 
 # Minimum PEFT version supported for the integration
-MIN_PEFT_VERSION = "0.18.2"
+MIN_PEFT_VERSION = "0.19.0"
 
 
 logger = logging.get_logger(__name__)
@@ -415,7 +415,7 @@ class PeftAdapterMixin:
     prompt tuning, prompt learning are out of scope as these adapters are not "injectable" into a torch module. For
     using these methods, please refer to the usage guide of PEFT library.
 
-    With this mixin, if the correct PEFT version is installed (>= 0.18.0), it is possible to:
+    With this mixin, if the correct PEFT version is installed (>= 0.19.0), it is possible to:
 
     - Load an adapter stored on a local path or in a remote Hub repository, and inject it in the model
     - Attach new adapters in the model and train them with Trainer or by your own.


### PR DESCRIPTION
As of https://github.com/huggingface/transformers/pull/45155, Transformers started importing `from peft.utils.save_and_load import _maybe_shard_state_dict_for_tp` in the peft integration. This import did not exist until https://github.com/huggingface/peft/pull/3096, which was first released in `peft==0.19.0`.

This PR corrects the `peft` lower bound.