### PR TITLE
Add test for additionalProperties=False in recursive_parse

### DIFF
--- a/tests/utils/test_chat_parsing_utils.py
+++ b/tests/utils/test_chat_parsing_utils.py
@@ -532,6 +532,32 @@ class ChatSchemaParserTest(unittest.TestCase):
             },
         )
 
+    def test_additional_properties_false_filters_extra_keys(self):
+        model_out = {
+            "role": "assistant",
+            "content": "Hello world",
+            "extra_key": "SHOULD_BE_REMOVED",
+        }
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "role": {"const": "assistant"},
+                "content": {"type": "string"},
+            },
+            "additionalProperties": False,
+        }
+
+        parsed = recursive_parse(model_out, schema)
+
+        self.assertEqual(
+            parsed,
+            {
+                "role": "assistant",
+                "content": "Hello world",
+            },
+        )
+
     def test_required_fields_present(self):
         """Test that required fields pass validation when present in the output."""
         schema = {


### PR DESCRIPTION
# What does this PR do?

This PR adds a new unit test for recursive_parse in test_chat_parsing_utils.py. The test verifies that when a schema has additionalProperties: false, any unexpected keys in the input are removed during parsing, making sure the schema rules are properly enforced.

No production code was changed and this PR only improves test coverage for an already existing behavior. This is a test-only change and does not affect runtime behavior.

## Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Did you write any new necessary tests?


## Who can review?
This PR relates to tokenizer parsing and schema-based response handling, so tagging maintainers familiar with tokenization and parsing logic.
@ArthurZucker @Cyrilvallez