### PR TITLE
Fix dynamic module loading from symlinked Hub cache (snapshots -> blobs)

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -319,20 +319,29 @@ def _compute_local_source_files_hash(
     Computes a stable hash from the bytes of the local source file and its relative-import source files.
     """
     model_path = Path(pretrained_model_name_or_path).resolve()
-    resolved_module_file = Path(resolved_module_file).resolve()
+    # Do *not* resolve the module file itself before discovering its relative imports. In a Hub cache the
+    # snapshot directory holds the named `*.py` files as symlinks pointing into the content-addressed
+    # `blobs/` directory. Resolving here would move relative-import discovery into `blobs/`, where only
+    # opaque hash-named files exist and the sibling `.py` imports cannot be found (raising
+    # `FileNotFoundError`). Symlinks are still transparently followed when we read the bytes below.
+    resolved_module_file = Path(resolved_module_file)
 
     def _resolve_relative_source_path(source_file_path: Path) -> str:
+        # Resolve the parent directory (canonicalizing any symlinked path components) but keep the file
+        # name, so a snapshot symlink is reported by its logical name under the model directory rather
+        # than its opaque `blobs/` target.
+        canonical_path = source_file_path.parent.resolve() / source_file_path.name
         try:
-            return source_file_path.relative_to(model_path).as_posix()
+            return canonical_path.relative_to(model_path).as_posix()
         except ValueError:
             # Fallback for edge cases where the source file is not under the local model directory.
-            return source_file_path.as_posix()
+            return canonical_path.as_posix()
 
     files_to_hash = [
         (_resolve_relative_source_path(resolved_module_file), resolved_module_file),
     ]
     for source_file in get_relative_import_files(resolved_module_file):
-        source_file_path = Path(source_file).resolve()
+        source_file_path = Path(source_file)
         files_to_hash.append((_resolve_relative_source_path(source_file_path), source_file_path))
 
     source_files_hash = hashlib.sha256()

--- a/tests/utils/test_dynamic_module_utils.py
+++ b/tests/utils/test_dynamic_module_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 import os
 from pathlib import Path
 
@@ -219,6 +220,81 @@ def test_get_cached_module_file_local_cache_key_includes_transitive_import_sourc
 
     # Different content in transitive dep → different hash → different cache dirs
     assert cached_a != cached_b
+
+
+def _build_symlinked_hub_cache(repo_root: Path, files: dict[str, str], revision: str = "abc123") -> Path:
+    """
+    Builds the standard HuggingFace/NGC hub cache layout for ``files`` and returns the snapshot dir:
+
+        models--org--repo/
+            blobs/<sha>                  <- real, content-addressed, hash-named (no `.py` extension)
+            snapshots/<revision>/x.py    <- symlink -> ../../blobs/<sha>
+    """
+    blobs = repo_root / "blobs"
+    snapshot = repo_root / "snapshots" / revision
+    blobs.mkdir(parents=True)
+    snapshot.mkdir(parents=True)
+    for name, content in files.items():
+        sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        (blobs / sha).write_text(content, encoding="utf-8")
+        (snapshot / name).symlink_to(Path("..") / ".." / "blobs" / sha)
+    return snapshot
+
+
+def test_get_cached_module_file_local_handles_symlinked_hub_cache(monkeypatch, tmp_path):
+    # In a real Hub/NGC cache the snapshot files are symlinks into a content-addressed ``blobs/`` dir,
+    # so relative-import discovery must follow the named ``*.py`` symlinks in the snapshot dir rather
+    # than their opaque blob targets. Regression test for the FileNotFoundError raised when loading a
+    # trust_remote_code model with transitive relative imports from such a cache (see PR #46022).
+    modules_cache = tmp_path / "hf_modules_cache"
+    monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", str(modules_cache))
+
+    snapshot = _build_symlinked_hub_cache(
+        tmp_path / "models--org--repo",
+        {
+            # A → B → C: only A is the entry point; C is a transitive dep reached via B
+            "custom_model.py": "from .helper import VALUE\n",
+            "helper.py": "from .base import BASE\nVALUE = BASE\n",
+            "base.py": 'BASE = "transitive"\n',
+        },
+    )
+
+    cached_module = get_cached_module_file(str(snapshot), "custom_model.py")
+    cache_dir = modules_cache / Path(cached_module).parent
+
+    assert (cache_dir / "custom_model.py").read_text(encoding="utf-8") == "from .helper import VALUE\n"
+    assert (cache_dir / "helper.py").exists(), "direct import must be copied"
+    assert (cache_dir / "base.py").exists(), "transitive import must be copied"
+    assert (cache_dir / "base.py").read_text(encoding="utf-8") == 'BASE = "transitive"\n'
+
+
+def test_get_cached_module_file_symlinked_hub_cache_hash_tracks_blob_content(monkeypatch, tmp_path):
+    # Two snapshots whose transitive dep symlinks to blobs with *different* content must hash to
+    # different cache dirs: bytes are read by following the symlink, not from the snapshot-relative name.
+    modules_cache = tmp_path / "hf_modules_cache"
+    monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", str(modules_cache))
+
+    snapshot_a = _build_symlinked_hub_cache(
+        tmp_path / "models--org--repo_a",
+        {
+            "custom_model.py": "from .helper import VALUE\n",
+            "helper.py": "from .base import BASE\nVALUE = BASE\n",
+            "base.py": 'BASE = "X"\n',
+        },
+    )
+    snapshot_b = _build_symlinked_hub_cache(
+        tmp_path / "models--org--repo_b",
+        {
+            "custom_model.py": "from .helper import VALUE\n",
+            "helper.py": "from .base import BASE\nVALUE = BASE\n",
+            "base.py": 'BASE = "Y"\n',
+        },
+    )
+
+    cached_a = get_cached_module_file(str(snapshot_a), "custom_model.py")
+    cached_b = get_cached_module_file(str(snapshot_b), "custom_model.py")
+
+    assert Path(cached_a).parent.name != Path(cached_b).parent.name
 
 
 def test_get_cached_module_file_local_cache_key_keeps_hash_stable_with_different_basenames(monkeypatch, tmp_path):


### PR DESCRIPTION
## What this fixes

Loading a `trust_remote_code` model from a **local, symlinked Hub/NGC cache** crashes with:

```
FileNotFoundError: [Errno 2] No such file or directory:
'.../blobs/transformers_4_44_2__modeling_rope_utils.py'
```

A standard `huggingface_hub` / NGC cache stores each file twice:

```
models--org--repo/
  blobs/<sha>                  # real content, content-addressed, hash-named, no .py extension
  snapshots/<rev>/modeling.py  # symlink -> ../../blobs/<sha>
```

`_compute_local_source_files_hash` did `Path(resolved_module_file).resolve()` before calling
`get_relative_import_files`. That follows the snapshot symlink into `blobs/`, and
`get_relative_import_files` then derives sibling import paths from `Path(module_file).parent`
(now `blobs/`). The named `.py` siblings only exist in `snapshots/<rev>/`, not in `blobs/`, so the
lookup raises `FileNotFoundError`.

## Fix

- Run relative-import discovery on the **unresolved** snapshot path, so traversal stays inside
  `snapshots/<rev>/` where the named `*.py` symlinks live.
- When building the hash key, canonicalize only the **parent directory** (to normalize symlinked
  path components such as macOS `/var`→`/private/var`) and keep the file's logical name.
  `read_bytes()` still follows the symlink, so content is hashed correctly. For plain
  non-symlinked local dirs the produced hash is unchanged (no cache churn).

## Regression range

- Good: `5.8.1` / `5.9.0` / `5.10.0`
- Broken: `5.10.1` / `5.10.2` … current `main`
- Introduced by #46022 ("include transitive relative imports when loading from local directory"),
  which switched the local hash path to `get_relative_import_files(resolved_module_file)` on the
  resolved path.

Real-world impact: NIM/vLLM serving custom-code models (e.g.
`nvidia/llama-3.3-nemotron-super-49b-v1.5`) from the NGC cache fails to start.

## Tests

Added two regression tests in `tests/utils/test_dynamic_module_utils.py` that build the real
`blobs/` + `snapshots/` symlink layout:

- `test_get_cached_module_file_local_handles_symlinked_hub_cache` — loads a module with a transitive
  relative-import chain (A→B→C) from a symlinked cache; fails on `main` with the exact
  `FileNotFoundError`, passes with the fix, and asserts the transitive deps are copied with correct
  content.
- `test_get_cached_module_file_symlinked_hub_cache_hash_tracks_blob_content` — ensures the cache key
  still tracks blob content (read via the symlink), not the snapshot-relative name.

```
$ python -m pytest tests/utils/test_dynamic_module_utils.py -q
17 passed
```

Both new tests were confirmed to fail on unpatched `main` with the production `FileNotFoundError`.
Also verified clean: `ruff check`, `ruff format`, `check_copies`, `check_modular_conversion`.

## Duplicate-work / coordination

- No existing open issue or PR addresses this (searched `gh issue/pr list` for
  `_compute_local_source_files_hash`, dynamic-module `symlink`/`blobs`, and
  `trust_remote_code FileNotFoundError snapshots`). The only related PR, #42891, is an unrelated,
  closed change.
- This is a net-new regression report + fix with a self-contained reproducer; it does not duplicate
  existing work.

## Disclosure

AI assistance (Claude Code) was used to root-cause and draft this change. The human submitter has
reviewed every changed line and is responsible for its contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
