### PR TITLE
Fix dynamic module symlinked cache on trust_remote_code models

### DIFF
--- a/.circleci/parse_test_outputs.py
+++ b/.circleci/parse_test_outputs.py
@@ -5,49 +5,52 @@ import re
 def parse_pytest_output(file_path):
     skipped_tests = {}
     skipped_count = 0
-    with open(file_path, 'r', encoding='utf-8') as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         for line in file:
-            match = re.match(r'^SKIPPED \[(\d+)\] (tests/.*): (.*)$', line)
+            match = re.match(r"^SKIPPED \[(\d+)\] (tests/.*): (.*)$", line)
             if match:
                 skipped_count += 1
                 test_file, test_line, reason = match.groups()
                 skipped_tests[reason] = skipped_tests.get(reason, []) + [(test_file, test_line)]
-    for k,v in sorted(skipped_tests.items(), key=lambda x:len(x[1])):
+    for k, v in sorted(skipped_tests.items(), key=lambda x: len(x[1])):
         print(f"{len(v):4} skipped because: {k}")
     print("Number of skipped tests:", skipped_count)
+
 
 def parse_pytest_failure_output(file_path):
     failed_tests = {}
     failed_count = 0
-    with open(file_path, 'r', encoding='utf-8') as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         for line in file:
-            match = re.match(r'^FAILED (tests/.*) - (.*): (.*)$', line)
+            match = re.match(r"^FAILED (tests/.*) - (.*): (.*)$", line)
             if match:
                 failed_count += 1
                 _, error, reason = match.groups()
                 failed_tests[reason] = failed_tests.get(reason, []) + [error]
-    for k,v in sorted(failed_tests.items(), key=lambda x:len(x[1])):
+    for k, v in sorted(failed_tests.items(), key=lambda x: len(x[1])):
         print(f"{len(v):4} failed because `{v[0]}` -> {k}")
     print("Number of failed tests:", failed_count)
-    if failed_count>0:
+    if failed_count > 0:
         exit(1)
+
 
 def parse_pytest_errors_output(file_path):
     print(file_path)
     error_tests = {}
     error_count = 0
-    with open(file_path, 'r', encoding='utf-8') as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         for line in file:
-            match = re.match(r'^ERROR (tests/.*) - (.*): (.*)$', line)
+            match = re.match(r"^ERROR (tests/.*) - (.*): (.*)$", line)
             if match:
                 error_count += 1
                 _, test_error, reason = match.groups()
                 error_tests[reason] = error_tests.get(reason, []) + [test_error]
-    for k,v in sorted(error_tests.items(), key=lambda x:len(x[1])):
+    for k, v in sorted(error_tests.items(), key=lambda x: len(x[1])):
         print(f"{len(v):4} errored out because of `{v[0]}` -> {k}")
     print("Number of errors:", error_count)
-    if error_count>0:
+    if error_count > 0:
         exit(1)
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/.github/scripts/assign_reviewers.py
+++ b/.github/scripts/assign_reviewers.py
@@ -36,11 +36,12 @@ def pattern_to_regex(pattern):
         pattern = r"^\/?" + pattern  # Allow an optional leading slash after the start of the string
     return pattern
 
+
 def get_file_owners(file_path, codeowners_lines):
     # Process lines in reverse (last matching pattern takes precedence)
     for line in reversed(codeowners_lines):
         # Skip comments and empty lines, strip inline comments
-        line = line.split('#')[0].strip()
+        line = line.split("#")[0].strip()
         if not line:
             continue
 
@@ -56,10 +57,11 @@ def get_file_owners(file_path, codeowners_lines):
             return owners  # Remember, can still be empty!
     return []  # Should never happen, but just in case
 
+
 def pr_author_is_in_hf(pr_author, codeowners_lines):
     # Check if the PR author is in the codeowners file
     for line in codeowners_lines:
-        line = line.split('#')[0].strip()
+        line = line.split("#")[0].strip()
         if not line:
             continue
 
@@ -71,18 +73,19 @@ def pr_author_is_in_hf(pr_author, codeowners_lines):
             return True
     return False
 
+
 def main():
     script_dir = Path(__file__).parent.absolute()
     with open(script_dir / "codeowners_for_review_action") as f:
         codeowners_lines = f.readlines()
 
-    g = Github(os.environ['GITHUB_TOKEN'])
+    g = Github(os.environ["GITHUB_TOKEN"])
     repo = g.get_repo("huggingface/transformers")
-    with open(os.environ['GITHUB_EVENT_PATH']) as f:
+    with open(os.environ["GITHUB_EVENT_PATH"]) as f:
         event = json.load(f)
 
     # The PR number is available in the event payload
-    pr_number = event['pull_request']['number']
+    pr_number = event["pull_request"]["number"]
     pr = repo.get_pull(pr_number)
     pr_author = pr.user.login
     if pr_author_is_in_hf(pr_author, codeowners_lines):
@@ -115,7 +118,6 @@ def main():
         pr.create_review_request(top_owners)
     except github.GithubException as e:
         print(f"Failed to request review for {top_owners}: {e}")
-
 
 
 if __name__ == "__main__":

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -319,20 +319,20 @@ def _compute_local_source_files_hash(
     Computes a stable hash from the bytes of the local source file and its relative-import source files.
     """
     model_path = Path(pretrained_model_name_or_path).resolve()
-    resolved_module_file = Path(resolved_module_file).resolve()
+    resolved_module_file = Path(resolved_module_file)
 
     def _resolve_relative_source_path(source_file_path: Path) -> str:
+        canonical_path = source_file_path.parent.resolve() / source_file_path.name
         try:
-            return source_file_path.relative_to(model_path).as_posix()
+            return canonical_path.relative_to(model_path).as_posix()
         except ValueError:
-            # Fallback for edge cases where the source file is not under the local model directory.
-            return source_file_path.as_posix()
+            return canonical_path.as_posix()
 
     files_to_hash = [
         (_resolve_relative_source_path(resolved_module_file), resolved_module_file),
     ]
     for source_file in get_relative_import_files(resolved_module_file):
-        source_file_path = Path(source_file).resolve()
+        source_file_path = Path(source_file)
         files_to_hash.append((_resolve_relative_source_path(source_file_path), source_file_path))
 
     source_files_hash = hashlib.sha256()

--- a/tests/utils/test_dynamic_module_utils.py
+++ b/tests/utils/test_dynamic_module_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 import os
 from pathlib import Path
 
@@ -220,6 +221,44 @@ def test_get_cached_module_file_local_cache_key_includes_transitive_import_sourc
     # Different content in transitive dep → different hash → different cache dirs
     assert cached_a != cached_b
 
+
+def _build_symlinked_hub_cache(repo_root: Path, files: dict[str, str], revision: str = "abc123") -> Path:
+    blobs = repo_root / "blobs"
+    snapshot = repo_root / "snapshots" / revision
+    blobs.mkdir(parents=True)
+    snapshot.mkdir(parents=True)
+    for name, content in files.items():
+        sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        (blobs / sha).write_text(content, encoding="utf-8")
+        (snapshot / name).symlink_to(Path("..") / ".." / "blobs" / sha)
+
+    return snapshot
+
+
+def test_get_cached_module_file_local_handles_symlinked_hub_cache(monkeypatch, tmp_path):
+    # In a real hub cache the snapshot files are symlinks into a content-addressed ``blobs/`` dir,
+    # so relative-import discovery must follow the named ``*.py`` symlinks in the snapshot dir rather
+    # than their opaque blob targets
+    modules_cache = tmp_path / "hf_modules_cache"
+    monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", str(modules_cache))
+
+    snapshot = _build_symlinked_hub_cache(
+        tmp_path / "models--org--repo",
+        {
+            # A → B → C: only A is the entry point; C is a transitive dep reached via B
+            "custom_model.py": "from .helper import VALUE\n",
+            "helper.py": "from .base import BASE\nVALUE = BASE\n",
+            "base.py": 'BASE = "transitive"\n',
+        },
+    )
+
+    cached_module = get_cached_module_file(str(snapshot), "custom_model.py")
+    cache_dir = modules_cache / Path(cached_module).parent
+
+    assert (cache_dir / "custom_model.py").read_text(encoding="utf-8") == "from .helper import VALUE\n"
+    assert (cache_dir / "helper.py").exists(), "direct import must be copied"
+    assert (cache_dir / "base.py").exists(), "transitive import must be copied"
+    assert (cache_dir / "base.py").read_text(encoding="utf-8") == 'BASE = "transitive"\n'
 
 def test_get_cached_module_file_local_cache_key_keeps_hash_stable_with_different_basenames(monkeypatch, tmp_path):
     modules_cache = tmp_path / "hf_modules_cache"

--- a/tests/utils/test_dynamic_module_utils.py
+++ b/tests/utils/test_dynamic_module_utils.py
@@ -260,6 +260,7 @@ def test_get_cached_module_file_local_handles_symlinked_hub_cache(monkeypatch, t
     assert (cache_dir / "base.py").exists(), "transitive import must be copied"
     assert (cache_dir / "base.py").read_text(encoding="utf-8") == 'BASE = "transitive"\n'
 
+
 def test_get_cached_module_file_local_cache_key_keeps_hash_stable_with_different_basenames(monkeypatch, tmp_path):
     modules_cache = tmp_path / "hf_modules_cache"
     monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", str(modules_cache))


### PR DESCRIPTION
## What this fixes
Loading a `trust_remote_code` model from a **local, symlinked cache** crashes with:

```
FileNotFoundError: [Errno 2] No such file or directory:
'.../blobs/transformers_4_44_2__modeling_rope_utils.py'
```

A standard `huggingface_hub`  cache stores each file twice:

```
models--org--repo/
  blobs/<sha>                  # real content, content-addressed, hash-named, no .py extension
  snapshots/<rev>/modeling.py  # symlink -> ../../blobs/<sha>
```
read: https://huggingface.co/docs/huggingface_hub/en/guides/manage-cache

`_compute_local_source_files_hash` did `Path(resolved_module_file).resolve()` before calling
`get_relative_import_files`. That follows the snapshot symlink into `blobs/`, and
`get_relative_import_files` then derives sibling import paths from `Path(module_file).parent`
(now `blobs/`). The named `.py` siblings only exist in `snapshots/<rev>/`, not in `blobs/`, so the
lookup raises `FileNotFoundError`.

## Fix

- Run relative-import discovery on the **unresolved** snapshot path, so traversal stays inside
  `snapshots/<rev>/` where the named `*.py` symlinks live.
- When building the hash key, canonicalize only the **parent directory** (to normalize symlinked
  path components such as macOS `/var`→`/private/var`) and keep the file's logical name.
  `read_bytes()` still follows the symlink, so content is hashed correctly. For plain
  non-symlinked local dirs the produced hash is unchanged (no cache churn).

## Tests

Added a regression test in `tests/utils/test_dynamic_module_utils.py` that build the real
`blobs/` + `snapshots/` symlink layout:

- `test_get_cached_module_file_local_handles_symlinked_hub_cache` — loads a module with a transitive
  relative-import chain (A→B→C) from a symlinked cache; fails on `main` with the exact
  `FileNotFoundError`, passes with the fix, and asserts the transitive deps are copied with correct
  content.

```
$ python -m pytest tests/utils/test_dynamic_module_utils.py -q
16 passed
```