### PR TITLE
Fix beam search cache reorder for non-standard caches

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -964,8 +964,25 @@ class GenerationMixin(ContinuousMixin):
 
         if hasattr(self, "_reorder_cache"):
             model_kwargs[cache_name] = self._reorder_cache(model_kwargs[cache_name], beam_idx)
-        else:
+        elif hasattr(model_kwargs[cache_name], "reorder_cache"):
             model_kwargs[cache_name].reorder_cache(beam_idx)
+        else:
+            model_kwargs[cache_name] = self._reorder_tensor_cache(model_kwargs[cache_name], beam_idx)
+
+    @staticmethod
+    def _reorder_tensor_cache(cache: Any, beam_idx: torch.Tensor) -> Any:
+        if isinstance(cache, torch.Tensor):
+            return cache.index_select(0, beam_idx.to(cache.device))
+        if isinstance(cache, list):
+            return [GenerationMixin._reorder_tensor_cache(item, beam_idx) for item in cache]
+        if isinstance(cache, tuple):
+            return tuple(GenerationMixin._reorder_tensor_cache(item, beam_idx) for item in cache)
+        if isinstance(cache, dict):
+            return {key: GenerationMixin._reorder_tensor_cache(value, beam_idx) for key, value in cache.items()}
+        if hasattr(cache, "rnn_state"):
+            cache.rnn_state = GenerationMixin._reorder_tensor_cache(cache.rnn_state, beam_idx)
+            return cache
+        raise AttributeError(f"{type(cache).__name__} does not support beam cache reordering")
 
     def _get_candidate_generator(
         self: "GenerativePreTrainedModel",

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -955,6 +955,18 @@ class GenerationMixin(ContinuousMixin):
 
         return model_kwargs
 
+    def _reorder_cache_for_beam_search(self, model_kwargs: dict[str, Any], beam_idx: torch.Tensor) -> None:
+        cache_name = next(
+            (cache_name for cache_name in ALL_CACHE_NAMES if model_kwargs.get(cache_name) is not None), None
+        )
+        if cache_name is None:
+            return
+
+        if hasattr(self, "_reorder_cache"):
+            model_kwargs[cache_name] = self._reorder_cache(model_kwargs[cache_name], beam_idx)
+        else:
+            model_kwargs[cache_name].reorder_cache(beam_idx)
+
     def _get_candidate_generator(
         self: "GenerativePreTrainedModel",
         generation_config: GenerationConfig,
@@ -3392,12 +3404,9 @@ class GenerationMixin(ContinuousMixin):
 
             # pluck the cache from the beam indices that will be used in the next iteration
             # NOTE: we need to check if `self._reorder_cache` exists for special models like RAG, RecurrentGemma etc.
-            if model_kwargs.get("past_key_values") is not None:
+            if any(model_kwargs.get(cache_name) is not None for cache_name in ALL_CACHE_NAMES):
                 beam_idx = self._flatten_beam_dim(running_beam_indices[..., cur_len - decoder_prompt_len])
-                if hasattr(self, "_reorder_cache"):
-                    model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                else:
-                    model_kwargs["past_key_values"].reorder_cache(beam_idx)
+                self._reorder_cache_for_beam_search(model_kwargs, beam_idx)
 
             cur_len = cur_len + 1
             is_early_stop_heuristic_unsatisfied = self._check_early_stop_heuristic(

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2729,6 +2729,36 @@ class UtilsFunctionsTest(unittest.TestCase):
         self.assertIs(model_kwargs["state"]["cache"], cache)
         self.assertIs(model_kwargs["state"]["beam_idx"], beam_idx)
 
+    def test_beam_search_reorders_tensor_state_cache(self):
+        state = [torch.tensor([[0, 1], [2, 3], [4, 5]]), torch.tensor([[6], [7], [8]])]
+        beam_idx = torch.tensor([2, 0])
+        model_kwargs = {"state": state}
+
+        GenerationMixin()._reorder_cache_for_beam_search(model_kwargs, beam_idx)
+
+        self.assertEqual(model_kwargs["state"][0].tolist(), [[4, 5], [0, 1]])
+        self.assertEqual(model_kwargs["state"][1].tolist(), [[8], [6]])
+
+    def test_beam_search_reorders_cache_with_rnn_state(self):
+        class DummyRnnCache:
+            def __init__(self):
+                self.rnn_state = {
+                    0: (
+                        torch.tensor([[0, 1], [2, 3], [4, 5]]),
+                        torch.tensor([[6], [7], [8]]),
+                    )
+                }
+
+        cache = DummyRnnCache()
+        beam_idx = torch.tensor([2, 0])
+        model_kwargs = {"cache_params": cache}
+
+        GenerationMixin()._reorder_cache_for_beam_search(model_kwargs, beam_idx)
+
+        self.assertIs(model_kwargs["cache_params"], cache)
+        self.assertEqual(cache.rnn_state[0][0].tolist(), [[4, 5], [0, 1]])
+        self.assertEqual(cache.rnn_state[0][1].tolist(), [[8], [6]])
+
     def test_speculative_sampling(self):
         # assume vocab size 10, input length 5 + 3 generated candidates
         candidate_input_ids = torch.tensor([[8, 0, 3, 9, 8, 1, 4, 5]])  # input tokens

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -93,6 +93,7 @@ if is_torch_available():
         GenerateDecoderOnlyOutput,
         GenerateEncoderDecoderOutput,
         GenerationConfig,
+        GenerationMixin,
         LogitsProcessorList,
         MaxLengthCriteria,
         MinLengthLogitsProcessor,
@@ -2697,6 +2698,37 @@ class GenerationTesterMixin:
 
 @require_torch
 class UtilsFunctionsTest(unittest.TestCase):
+    def test_beam_search_reorders_non_standard_cache_name(self):
+        class DummyCache:
+            def __init__(self):
+                self.beam_idx = None
+
+            def reorder_cache(self, beam_idx):
+                self.beam_idx = beam_idx
+
+        cache = DummyCache()
+        beam_idx = torch.tensor([1, 0])
+        model_kwargs = {"past_key_values": None, "cache_params": cache}
+
+        GenerationMixin()._reorder_cache_for_beam_search(model_kwargs, beam_idx)
+
+        self.assertIs(cache.beam_idx, beam_idx)
+        self.assertIs(model_kwargs["cache_params"], cache)
+
+    def test_beam_search_reorders_non_standard_cache_name_with_legacy_hook(self):
+        class DummyModel(GenerationMixin):
+            def _reorder_cache(self, cache, beam_idx):
+                return {"cache": cache, "beam_idx": beam_idx}
+
+        cache = object()
+        beam_idx = torch.tensor([1, 0])
+        model_kwargs = {"state": cache}
+
+        DummyModel()._reorder_cache_for_beam_search(model_kwargs, beam_idx)
+
+        self.assertIs(model_kwargs["state"]["cache"], cache)
+        self.assertIs(model_kwargs["state"]["beam_idx"], beam_idx)
+
     def test_speculative_sampling(self):
         # assume vocab size 10, input length 5 + 3 generated candidates
         candidate_input_ids = torch.tensor([[8, 0, 3, 9, 8, 1, 4, 5]])  # input tokens


### PR DESCRIPTION
Fixes #46612

## What changed

Beam search now reorders the active generation cache by scanning the supported cache names in `ALL_CACHE_NAMES` instead of only checking `past_key_values`.

The reorder path still preserves the legacy `_reorder_cache` hook for models that define it, and otherwise calls `reorder_cache` on the active cache object.

## Why

Models that store generation cache under names such as `cache_params` or `state` could otherwise keep stale beam ordering between decoding steps.

## Validation

- `PYTHONPATH=src python -m pytest tests/generation/test_utils.py::UtilsFunctionsTest -q`
- `PYTHONPATH=src python -m pytest tests/models/rwkv/test_modeling_rwkv.py::RwkvModelTest::test_beam_search_generate tests/models/rwkv/test_modeling_rwkv.py::RwkvModelTest::test_beam_sample_generate tests/models/rwkv/test_modeling_rwkv.py::RwkvModelTest::test_generate_from_inputs_embeds_1_beam_search tests/models/xlstm/test_modeling_xlstm.py::xLSTMModelTest::test_beam_search_generate tests/models/xlstm/test_modeling_xlstm.py::xLSTMModelTest::test_beam_sample_generate -q`
- `PYTHONPATH=src python -m compileall -q src/transformers/generation/utils.py tests/generation/test_utils.py`
- `python -m ruff check --select I src/transformers/generation/utils.py tests/generation/test_utils.py`
- `git diff --check`
