### PR TITLE
fix: position ids does not exist in upstream rotary kernel

### DIFF
--- a/src/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -240,7 +240,7 @@ def _apply_rotary_emb(
 
 
 @use_kernel_func_from_hub("rotary_pos_emb")
-def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
     q_embed = _apply_rotary_emb(q, cos, sin)

--- a/src/transformers/models/gpt_oss/modular_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/modular_gpt_oss.py
@@ -172,7 +172,7 @@ def _apply_rotary_emb(
 
 
 @use_kernel_func_from_hub("rotary_pos_emb")
-def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
     q_embed = _apply_rotary_emb(q, cos, sin)

--- a/src/transformers/models/openai_privacy_filter/modeling_openai_privacy_filter.py
+++ b/src/transformers/models/openai_privacy_filter/modeling_openai_privacy_filter.py
@@ -143,7 +143,7 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
 
 
 @use_kernel_func_from_hub("rotary_pos_emb")
-def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
     q_embed = _apply_rotary_emb(q, cos, sin)

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -71,11 +71,18 @@ class GptOssModelTest(CausalLMModelTest, unittest.TestCase):
 
     @require_kernels
     def test_kernelize_does_not_crash(self):
-        """Regression test #45799: `kernelize` should not crash with `use_kernelized_func` + `use_kernel_func_from_hub`."""
+        """Regression test #45799 and #46619: `kernelize` should not crash with `use_kernelized_func` + `use_kernel_func_from_hub`."""
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         model = GptOssModel(config).to(device=torch_device)
         # This used to raise TypeError because apply_rotary_pos_emb was not wrapped as nn.Module
         model.use_kernels = True
+
+        # Regression test #46619: stale `position_ids` in signature mismatch the hub kernel
+        from transformers.models.gpt_oss.modeling_gpt_oss import apply_rotary_pos_emb
+
+        forward = getattr(type(apply_rotary_pos_emb), "forward", apply_rotary_pos_emb)
+        params = [name for name in inspect.signature(forward).parameters if name != "self"]
+        self.assertEqual(params, ["q", "k", "cos", "sin", "unsqueeze_dim"])
 
     @require_kernels
     @pytest.mark.flash_attn_test

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -76,6 +76,8 @@ class GptOssModelTest(CausalLMModelTest, unittest.TestCase):
         """Regression test #45799 and #46619: `kernelize` should not crash with `use_kernelized_func` + `use_kernel_func_from_hub`."""
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         model = GptOssModel(config).to(device=torch_device)
+        # This used to raise TypeError because apply_rotary_pos_emb was not wrapped as nn.Module
+        # and also because a stale `position_ids` arg made its signature mismatch the hub rotary kernel
         model.set_use_kernels(True)
 
     @require_kernels

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -35,6 +35,7 @@ from transformers.testing_utils import (
     require_deterministic_for_xpu,
     require_kernels,
     require_torch,
+    require_torch_accelerator,
     require_torch_gpu,
     slow,
     torch_device,
@@ -70,19 +71,13 @@ class GptOssModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = GptOssModelTester
 
     @require_kernels
+    @require_torch_accelerator
     def test_kernelize_does_not_crash(self):
         """Regression test #45799 and #46619: `kernelize` should not crash with `use_kernelized_func` + `use_kernel_func_from_hub`."""
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         model = GptOssModel(config).to(device=torch_device)
-        # This used to raise TypeError because apply_rotary_pos_emb was not wrapped as nn.Module
         model.use_kernels = True
-
-        # Regression test #46619: stale `position_ids` in signature mismatch the hub kernel
-        from transformers.models.gpt_oss.modeling_gpt_oss import apply_rotary_pos_emb
-
-        forward = getattr(type(apply_rotary_pos_emb), "forward", apply_rotary_pos_emb)
-        params = [name for name in inspect.signature(forward).parameters if name != "self"]
-        self.assertEqual(params, ["q", "k", "cos", "sin", "unsqueeze_dim"])
+        model.set_use_kernels(True)
 
     @require_kernels
     @pytest.mark.flash_attn_test

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -76,7 +76,6 @@ class GptOssModelTest(CausalLMModelTest, unittest.TestCase):
         """Regression test #45799 and #46619: `kernelize` should not crash with `use_kernelized_func` + `use_kernel_func_from_hub`."""
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         model = GptOssModel(config).to(device=torch_device)
-        model.use_kernels = True
         model.set_use_kernels(True)
 
     @require_kernels


### PR DESCRIPTION
# What does this PR do?

Upstream `https://huggingface.co/kernels-community/rotary` does not have `position_ids` in it. This PR cleans the leftover dead arguments.

When loading the GPT oss model, it would throw an error that position_ids argument does not exist.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@drbh

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
