### PR TITLE
Fix Mistral models which contain both `tokenizer.json` and `tekken.json`

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -728,10 +728,13 @@ class AutoTokenizer:
         ):
             registered_class_name = TOKENIZER_MAPPING_NAMES.get(config_model_type).removesuffix("Fast")
             if registered_class_name not in ("TokenizersBackend", "PythonBackend", "PreTrainedTokenizerFast"):
-                # If the hub class is known incorrect for this model type, use the registered class; otherwise trust the hub.
                 class_name = (
                     registered_class_name
+                    # If the hub class is known incorrect for this model type, use the registered class
                     if config_model_type in MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS
+                    # If the registered class is `MistralCommonBackend` and no `TokenizersBackend` specific kwarg, use the registered class
+                    or (registered_class_name == "MistralCommonBackend" and "fix_mistral_regex" not in kwargs)
+                    # Otherwise, trust the hub
                     else tokenizer_config_class
                 )
                 tokenizer_class = tokenizer_class_from_name(class_name)
@@ -740,7 +743,17 @@ class AutoTokenizer:
                     "PythonBackend",
                     "PreTrainedTokenizerFast",
                 ):
-                    return tokenizer_class.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
+                    try:
+                        return tokenizer_class.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
+                    except ValueError as e:
+                        if class_name == "MistralCommonBackend" and "No tokenizer file found" in str(e):
+                            logger.warning(
+                                "`mistral-common` is installed so `AutoTokenizer.from_pretrained()` resolved to "
+                                "`%s` for model type `%s` but no `tekken.json` file was found. Falling back to "
+                                "`TokenizersBackend`.", class_name, config_model_type
+                            )
+                        else:
+                            raise
 
             if TokenizersBackend is not None:
                 return TokenizersBackend.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -748,9 +748,10 @@ class AutoTokenizer:
                     except ValueError as e:
                         if class_name == "MistralCommonBackend" and "No tokenizer file found" in str(e):
                             logger.warning(
-                                "`mistral-common` is installed so `AutoTokenizer.from_pretrained()` resolved to "
-                                "`%s` for model type `%s` but no `tekken.json` file was found. Falling back to "
-                                "`TokenizersBackend`.", class_name, config_model_type
+                                "`mistral-common` is installed so `AutoTokenizer.from_pretrained()` resolved to `%s` for "
+                                "model type `%s` but no `tekken.json` file was found. Falling back to `TokenizersBackend`.",
+                                class_name,
+                                config_model_type,
                             )
                         else:
                             raise

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -304,6 +304,10 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
         )
 
     @property
+    def is_fast(self) -> bool:
+        return False
+
+    @property
     def mode(self) -> ValidationMode:
         """
         `ValidationMode`: The mode used by the tokenizer. Possible values are:
@@ -620,6 +624,9 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
         if one_token:
             return ids[0]
         return ids
+
+    def convert_tokens_to_string(self, tokens: list[str]) -> str:
+        return "".join(tokens)
 
     def _text_to_ids(self, text: TextInput, add_special_tokens: bool) -> list[int]:
         """


### PR DESCRIPTION
## Context

Some Mistral models are released with both a `tokenizers` format tokenizer (`tokenizer.json`) and a `mistral-common` format tokenizer (`tekken.json`).

If we examine `TOKENIZER_MAPPING_NAMES` in `src/transformers/models/auto/tokenization_auto.py` we see the following pattern repeated for all Mistral models:

https://github.com/huggingface/transformers/blob/08a7ef05bcf9723cb2e58855afb8dc2c799323ff/src/transformers/models/auto/tokenization_auto.py#L204-L209

From these we can reasonably assume that if `mistral-common` is:

- not installed then `AutoTokenizer` should use `TokenizersBackend` (i.e. `tokenizer.json`)
- is installed then `AutoTokenizer` should use `MistralCommonBackend` (i.e. `tekken.json`)

Therefore, for checkpoints which have **both** `tokenizer.json` and `tekken.json`, the decision of which to use comes down to whether `mistral-common` is installed.

Next, if we look at:

https://github.com/huggingface/transformers/blob/08a7ef05bcf9723cb2e58855afb8dc2c799323ff/src/transformers/models/auto/tokenization_auto.py#L718-L746

We can see that if:

- We enter the first if block because:
  - `tokenizer_config.json` exists and contains a `tokenizer_class` field
  - `TOKENIZER_MAPPING_NAMES` contains an entry for this model type
- When `mistral-common` is:
  - not installed, we **never** enter the second if block because `registered_class_name` is always `TokenizersBackend` for Mistral models
  - installed, we do enter the second if block and **always** load from `tokenizer_config_class`

This last line is a bug and leads to incorrect tokenization.

## Reproducer

Using the following file as a reproducer:

```python
# repro.py
from transformers import AutoTokenizer
from transformers.utils.import_utils import is_mistral_common_available

print(f"mistral-common is installed: {is_mistral_common_available()}")
tokenizer = AutoTokenizer.from_pretrained("mistralai/Ministral-8B-Instruct-2410")
tokenizer_cls = type(tokenizer).__name__
print(f"AutoTokenizer resolved to {tokenizer_cls=}")
# Tokens for "Hello, how are you?"
token_ids = [22177, 1044, 2606, 1584, 1636, 1063]
print(tokenizer.decode(token_ids))
```

We see the following two outputs with and without `mistral-common`:

```console
$ python repro.py 
mistral-common is installed: True
AutoTokenizer resolved to tokenizer_cls='LlamaTokenizer'
Hello,ĠhowĠareĠyou?
```

```console
$ python repro.py 
mistral-common is installed: False
AutoTokenizer resolved to tokenizer_cls='TokenizersBackend'
Hello, how are you?
```

The case where `mistral-common` is installed resolves the incorrect class and produces incorrect detokenization.

## Solution

The solution is to treat `MistralCommonBackend` more similarly to `TokenizersBackend`. If `MistralCommonBackend` is the registered class, try to use it and fall back to `TokenizersBackend` if there wasn't actually a `tekken.json` file.

This behaviour:

- Matches the intent indicated by the snippets in `TOKENIZER_MAPPING_NAMES`
- Never allows the incorrect classes such as `LlamaTokenizer` to load; which is the same behaviour as when `mistral-common` is not installed

Running the reproducer again with and without `mistral-common` we see:

```console
$ python repro.py 
mistral-common is installed: True
AutoTokenizer resolved to tokenizer_cls='MistralCommonBackend'
Hello, how are you?
```

```console
$ python repro.py 
mistral-common is installed: False
AutoTokenizer resolved to tokenizer_cls='TokenizersBackend'
Hello, how are you?
```

which is the expected behaviour.