### PR TITLE
Reject path traversal in sharded checkpoint index files

### DIFF
--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -464,8 +464,18 @@ def accelerate_disk_offload(
         if sharded_metadata is None:
             weight_map = dict.fromkeys(safe_open(checkpoint_files[0], framework="pt").keys(), checkpoint_files[0])
         else:
-            folder = os.path.sep.join(checkpoint_files[0].split(os.path.sep)[:-1])
-            weight_map = {k: os.path.join(folder, v) for k, v in sharded_metadata["weight_map"].items()}
+            folder = os.path.dirname(checkpoint_files[0])
+            from ..utils.hub import _join_checkpoint_shard_path
+
+            resolved_by_name = {os.path.basename(path): path for path in checkpoint_files}
+            weight_map = {}
+            for key, shard_filename in sharded_metadata["weight_map"].items():
+                if shard_filename in resolved_by_name:
+                    weight_map[key] = resolved_by_name[shard_filename]
+                else:
+                    weight_map[key] = _join_checkpoint_shard_path(
+                        folder, "", shard_filename, "model.safetensors.index.json"
+                    )
 
         # Update the weight names according to the `weight_mapping`
         weight_renaming_map = {

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -1095,6 +1095,11 @@ def load_sharded_checkpoint(model, folder, strict=True, prefer_safe=True):
         index = json.load(f)
 
     shard_files = list(set(index["weight_map"].values()))
+    load_index_name = os.path.basename(load_index)
+    from .utils.hub import _join_checkpoint_shard_path, _validate_checkpoint_shard_filename
+
+    for shard_file in shard_files:
+        _validate_checkpoint_shard_filename(shard_file, load_index_name)
 
     # If strict=True, error before loading any of the state dicts.
     # TODO: Here, update the weight map with the config.dynamic_weight_conversion
@@ -1119,7 +1124,8 @@ def load_sharded_checkpoint(model, folder, strict=True, prefer_safe=True):
         loader = partial(torch.load, map_location="cpu", weights_only=True)
 
     for shard_file in shard_files:
-        state_dict = loader(os.path.join(folder, shard_file))
+        shard_path = _join_checkpoint_shard_path(folder, "", shard_file, load_index_name)
+        state_dict = loader(shard_path)
         model.load_state_dict(state_dict, strict=False)
 
         # Make sure memory is freed before we load the next state dict.

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -401,7 +401,7 @@ def cached_files(
             existing_files.append(resolved_file)
 
     if os.path.isdir(path_or_repo_id):
-        return existing_files if existing_files else None
+        return existing_files or None
 
     if cache_dir is None:
         cache_dir = constants.HF_HUB_CACHE
@@ -848,6 +848,42 @@ def convert_file_size_to_int(size: int | str):
     raise ValueError("`size` is not in a valid format. Use an integer followed by the unit, e.g., '5GB'.")
 
 
+def _validate_checkpoint_shard_filename(shard_filename: str, index_filename: str) -> None:
+    """
+    Reject shard filenames that could escape the checkpoint directory (CWE-22).
+
+    Uses a lexical check only (abspath + commonpath, not realpath/resolve) so legitimate
+    Hugging Face cache symlinks are not broken.
+    """
+    if os.path.isabs(shard_filename) or shard_filename.startswith(("/", "\\")):
+        raise ValueError(
+            f"Invalid shard filename {shard_filename!r} in index file {index_filename!r}. "
+            "Shard filenames must be relative paths."
+        )
+    if ".." in Path(shard_filename).parts:
+        raise ValueError(
+            f"Invalid shard filename {shard_filename!r} in index file {index_filename!r}. "
+            "Shard filenames must not contain '..' path components."
+        )
+
+
+def _join_checkpoint_shard_path(base_dir: str, subfolder: str, shard_filename: str, index_filename: str) -> str:
+    _validate_checkpoint_shard_filename(shard_filename, index_filename)
+    base = os.path.abspath(os.path.join(base_dir, subfolder))
+    shard_path = os.path.join(base_dir, subfolder, shard_filename)
+    resolved = os.path.abspath(shard_path)
+    try:
+        contained = os.path.commonpath([base, resolved]) == base
+    except ValueError:
+        contained = False
+    if not contained:
+        raise ValueError(
+            f"Invalid shard filename {shard_filename!r} in index file {index_filename!r}. "
+            "Resolved shard path must stay within the model directory."
+        )
+    return shard_path
+
+
 def get_checkpoint_shard_files(
     pretrained_model_name_or_path,
     index_filename,
@@ -880,13 +916,18 @@ def get_checkpoint_shard_files(
         index = json.loads(f.read())
 
     shard_filenames = sorted(set(index["weight_map"].values()))
+    for shard_filename in shard_filenames:
+        _validate_checkpoint_shard_filename(shard_filename, index_filename)
     sharded_metadata = index["metadata"]
     sharded_metadata["all_checkpoint_keys"] = list(index["weight_map"].keys())
     sharded_metadata["weight_map"] = index["weight_map"].copy()
 
     # First, let's deal with local folder.
     if os.path.isdir(pretrained_model_name_or_path):
-        shard_filenames = [os.path.join(pretrained_model_name_or_path, subfolder, f) for f in shard_filenames]
+        shard_filenames = [
+            _join_checkpoint_shard_path(pretrained_model_name_or_path, subfolder, f, index_filename)
+            for f in shard_filenames
+        ]
         return shard_filenames, sharded_metadata
 
     # At this stage pretrained_model_name_or_path is a model identifier on the Hub. Try to get everything from cache,

--- a/tests/utils/test_checkpoint_shard_path_traversal.py
+++ b/tests/utils/test_checkpoint_shard_path_traversal.py
@@ -1,0 +1,77 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+
+SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+hub = importlib.import_module("transformers.utils.hub")
+utils_init = importlib.import_module("transformers.utils")
+
+SAFE_WEIGHTS_INDEX_NAME = utils_init.SAFE_WEIGHTS_INDEX_NAME
+_join_checkpoint_shard_path = hub._join_checkpoint_shard_path
+get_checkpoint_shard_files = hub.get_checkpoint_shard_files
+
+
+class CheckpointShardPathTraversalTests(unittest.TestCase):
+    def _write_malicious_index(self, directory: str, weight_map: dict[str, str]) -> str:
+        index_path = os.path.join(directory, SAFE_WEIGHTS_INDEX_NAME)
+        with open(index_path, "w", encoding="utf-8") as f:
+            json.dump({"metadata": {"total_size": 1}, "weight_map": weight_map}, f)
+        return index_path
+
+    def test_rejects_parent_directory_escape_in_weight_map(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            index_path = self._write_malicious_index(
+                tmp_dir,
+                {
+                    "model.layer.weight": "../../etc/passwd",
+                    "model.embed.weight": "model-00001-of-00001.safetensors",
+                },
+            )
+            with self.assertRaises(ValueError):
+                get_checkpoint_shard_files(tmp_dir, index_path)
+
+    def test_rejects_absolute_shard_paths(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            index_path = self._write_malicious_index(tmp_dir, {"model.layer.weight": "/etc/passwd"})
+            with self.assertRaises(ValueError):
+                get_checkpoint_shard_files(tmp_dir, index_path)
+
+    def test_allows_nested_shard_paths(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            nested_dir = os.path.join(tmp_dir, "shards")
+            os.makedirs(nested_dir)
+            shard_name = os.path.join("shards", "model-00001-of-00001.safetensors")
+            open(os.path.join(tmp_dir, shard_name), "wb").close()
+            index_path = self._write_malicious_index(tmp_dir, {"model.layer.weight": shard_name})
+            shard_files, _ = get_checkpoint_shard_files(tmp_dir, index_path)
+            self.assertEqual(len(shard_files), 1)
+            self.assertTrue(shard_files[0].endswith(shard_name.replace("/", os.sep)))
+
+    def test_join_helper_rejects_traversal(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaises(ValueError):
+                _join_checkpoint_shard_path(tmp_dir, "", "../../etc/passwd", "model.safetensors.index.json")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Loading a model from a local directory with a crafted `model.safetensors.index.json` lets `weight_map` values escape the model folder via `../` or absolute paths. `get_checkpoint_shard_files` joined those strings directly, so `from_pretrained("/tmp/malicious_model")` could attempt to read arbitrary files the process can access.

## Root cause

Shard filenames from the index JSON were never validated before `os.path.join`. The same pattern existed in Trainer resume loading and Accelerate disk offload re-join logic.

## Fix

- Validate shard filenames reject `..`, absolute paths, and resolved paths outside the model directory (lexical `abspath` + `commonpath`, matching the existing Bark preset guard).
- Apply the same validation in `load_sharded_checkpoint` and when rebuilding offload weight maps.

## Testing

Added `tests/utils/test_checkpoint_shard_path_traversal.py` covering traversal rejection, absolute paths, and valid nested shard paths.

Fixes #46097