### PR TITLE
Restore RNG state before fetching resumed training batches

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1684,7 +1684,6 @@ class Trainer:
         num_update_steps_trained = 0
         if epoch == epochs_trained and resume_from_checkpoint is not None:
             if steps_trained_in_current_epoch > 0 and not self.args.ignore_data_skip:
-                train_dataloader = skip_first_batches(train_dataloader, steps_trained_in_current_epoch)
                 step = steps_trained_in_current_epoch - 1
                 num_update_steps_trained = steps_trained_in_current_epoch // self.args.gradient_accumulation_steps
                 rng_to_sync = True
@@ -1694,6 +1693,16 @@ class Trainer:
         if hasattr(train_dataloader, "set_epoch"):
             train_dataloader.set_epoch(epoch)
         epoch_iterator = iter(train_dataloader)
+
+        # Mid-epoch resume: materialize skipped micro-batches, then restore the checkpoint
+        # RNG stream before the first real training fetch. `skip_first_batches` cannot be used
+        # here because it still runs `__getitem__` for discarded batches inside the first
+        # `next(epoch_iterator)`, which advances the global RNG between restore and fetch.
+        if rng_to_sync:
+            for _ in range(steps_trained_in_current_epoch):
+                next(epoch_iterator)
+            self._load_rng_state(resume_from_checkpoint)
+            rng_to_sync = False
 
         # We chunkify the epoch iterator into gradient accumulation steps `n` batches
         remainder = steps_in_epoch % self.args.gradient_accumulation_steps
@@ -1707,10 +1716,6 @@ class Trainer:
             num_batches = (
                 self.args.gradient_accumulation_steps if update_step != (num_update_steps_per_epoch - 1) else remainder
             )
-            if rng_to_sync:
-                self._load_rng_state(resume_from_checkpoint)
-                rng_to_sync = False
-
             batch_samples, num_items_in_batch = self.get_batch_samples(epoch_iterator, num_batches, self.args.device)
 
             # This is used to correctly scale the loss when the last accumulation step has fewer batches.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -213,7 +213,7 @@ if is_peft_available():
     from peft import PeftModel
 
 if is_accelerate_available():
-    from accelerate import Accelerator, skip_first_batches
+    from accelerate import Accelerator
     from accelerate.state import AcceleratorState
     from accelerate.utils import (
         DataLoaderConfiguration,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1707,16 +1707,15 @@ class Trainer:
             num_batches = (
                 self.args.gradient_accumulation_steps if update_step != (num_update_steps_per_epoch - 1) else remainder
             )
+            if rng_to_sync:
+                self._load_rng_state(resume_from_checkpoint)
+                rng_to_sync = False
+
             batch_samples, num_items_in_batch = self.get_batch_samples(epoch_iterator, num_batches, self.args.device)
 
             # This is used to correctly scale the loss when the last accumulation step has fewer batches.
             # Not used if `num_items_in_batch` is not None.
             self.current_gradient_accumulation_steps = len(batch_samples)
-
-            # need to sync after if we skipped the batches in `get_batch_samples` for shuffle order reason
-            if rng_to_sync:
-                self._load_rng_state(resume_from_checkpoint)
-                rng_to_sync = False
 
             # Inner loop: forward + backward for each micro-batch. Gradients are
             # accumulated without syncing until the last micro-batch, then we clip,

--- a/tests/trainer/test_trainer_checkpointing.py
+++ b/tests/trainer/test_trainer_checkpointing.py
@@ -611,6 +611,62 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
         self.assertEqual(parameters, parameters1)
         self.check_trainer_state_are_the_same(state, state1)
 
+    def test_mid_epoch_resume_restores_rng_before_first_fetch(self):
+        """Regression for #39215: stochastic __getitem__ must match after mid-epoch resume."""
+        batch_size = 2
+        dataset_size = 64
+
+        class StochasticDataset(torch.utils.data.Dataset):
+            def __init__(self):
+                self.draws = []
+
+            def __len__(self):
+                return dataset_size
+
+            def __getitem__(self, idx):
+                draw = torch.rand(4)
+                self.draws.append(draw)
+                return {"x": torch.full((4,), float(idx)) + draw}
+
+        class TinyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = nn.Parameter(torch.ones(4))
+
+            def forward(self, x, **kwargs):
+                return {"loss": (x * self.w).sum() ** 2 * 1e-4}
+
+        def run_training(output_dir, max_steps, resume_from=None):
+            set_seed(7)
+            dataset = StochasticDataset()
+            args = TrainingArguments(
+                output_dir=output_dir,
+                max_steps=max_steps,
+                per_device_train_batch_size=batch_size,
+                save_strategy="steps",
+                save_steps=4,
+                seed=7,
+                report_to=[],
+                use_cpu=True,
+                logging_strategy="no",
+                disable_tqdm=True,
+                dataloader_num_workers=0,
+            )
+            trainer = Trainer(model=TinyModel(), args=args, train_dataset=dataset)
+            trainer.train(resume_from_checkpoint=resume_from)
+            return dataset.draws
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            full_draws = run_training(os.path.join(tmp_dir, "full"), max_steps=8)
+            resumed_draws = run_training(
+                os.path.join(tmp_dir, "resume"),
+                max_steps=8,
+                resume_from=os.path.join(tmp_dir, "full", "checkpoint-4"),
+            )
+
+        for full_draw, resumed_draw in zip(full_draws[8:], resumed_draws[8:]):
+            self.assertTrue(torch.equal(full_draw, resumed_draw))
+
 
 # ---------------------------------------------------------------------------
 # Auto batch size finder tests


### PR DESCRIPTION
## Problem

On checkpoint resume inside an epoch, `Trainer` fetched the next micro-batches with `get_batch_samples()` before calling `_load_rng_state()`. Any randomness in the dataloader (random augmentations, noisy datasets, etc.) therefore ran on the live RNG stream instead of the restored checkpoint state.

## Root cause (updated after @chikoneuru's verification)

Moving `_load_rng_state()` before `get_batch_samples()` is not enough. `skip_first_batches` still materializes discarded batches inside the first `next(epoch_iterator)` (via `SkipBatchSampler`), which advances the global RNG **between** restore and the first real training fetch.

## Fix

For mid-epoch resume (`rng_to_sync`):
1. Stop using `skip_first_batches` (it couples skip + fetch in one iterator step).
2. Fast-forward `epoch_iterator` through `steps_trained_in_current_epoch` discarded micro-batches.
3. Call `_load_rng_state(resume_from_checkpoint)` **after** the skip, **before** the first `get_batch_samples()` fetch.

This mirrors what the epoch-boundary path already does (restore before any real fetch), without the hidden RNG advance inside `skip_first_batches`.

## Testing

- `repro_39215.py` from #39215 — mid-epoch resume now bit-reproducible (`first divergent item = None`)
- `tests/trainer/test_trainer_checkpointing.py::test_mid_epoch_resume_restores_rng_before_first_fetch`

Fixes #39215