### PR TITLE
Fix silent weight re-initialization for custom PreTrainedModel subclasses

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2496,18 +2496,16 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         if getattr(module, "_is_hf_initialized", False):
             return
 
-        # This check is for remote code that does NOT use either `torch.init` or `transformers.initialization` in `_init_weights`
-        # which allow to check the flag directly on param. As they don't and write the params in-place, params would be reinitialized
-        # otherwise
-        if (
-            is_remote_code
-            and all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
-            and all(
-                getattr(buffer, "_is_hf_initialized", False)
-                for buffer in module.buffers(recurse=False)
-                if buffer is not None
-            )
-        ):
+        # Backstop for any `_init_weights` (custom/out-of-tree models as well as remote code) that does not go through
+        # `torch.init` or `transformers.initialization`, which check the `_is_hf_initialized` flag directly on the
+        # param/buffer. Such implementations write the params in-place (e.g. `module.weight.data.normal_(...)`), so
+        # already-loaded params would be silently reinitialized otherwise. If this module directly owns params/buffers
+        # and all of them are already initialized, skip re-initialization entirely.
+        # Only modules that directly own params/buffers are eligible: a module owning none (its params live in child
+        # modules) may still initialize those children via parent dispatch in `_init_weights`, so it must not be
+        # skipped here (otherwise e.g. the projections of a `T5`-style attention block would never be initialized).
+        own_tensors = [*module.parameters(recurse=False), *(b for b in module.buffers(recurse=False) if b is not None)]
+        if own_tensors and all(getattr(tensor, "_is_hf_initialized", False) for tensor in own_tensors):
             module._is_hf_initialized = True
             return
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1356,6 +1356,50 @@ class ModelUtilsTest(TestCasePlus):
             for p1, p2 in zip(model.parameters(), new_model.parameters()):
                 torch.testing.assert_close(p1, p2)
 
+    def test_from_pretrained_does_not_reinit_custom_model_weights(self):
+        # Regression test for #46620: a custom (out-of-tree) `PreTrainedModel` whose `_init_weights` writes
+        # parameters in-place (e.g. `module.weight.data.normal_(...)`, the common downstream pattern) used to have
+        # its loaded weights silently overwritten by `_init_weights` during `from_pretrained`, returning a
+        # randomly-initialized model while `loading_info` still reported a clean load (no missing/unexpected/
+        # mismatched keys, no warning).
+        class CustomModel(PreTrainedModel):
+            base_model_prefix = "custom"
+            config_class = PreTrainedConfig
+
+            def __init__(self, config):
+                super().__init__(config)
+                self.linear = nn.Linear(5, 5)
+                self.post_init()
+
+            def _init_weights(self, module):
+                if isinstance(module, nn.Linear):
+                    module.weight.data.normal_(mean=0.0, std=0.02)
+                    if module.bias is not None:
+                        module.bias.data.zero_()
+
+            def forward(self, x):
+                return self.linear(x)
+
+        model = CustomModel(PreTrainedConfig())
+        with torch.no_grad():
+            for param in model.parameters():
+                param.fill_(0.5)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model.save_pretrained(tmp_dir)
+            reloaded, loading_info = CustomModel.from_pretrained(tmp_dir, output_loading_info=True)
+
+        # The saved weights must survive loading (they used to be overwritten by `_init_weights`).
+        for name, param in reloaded.named_parameters():
+            self.assertTrue(
+                torch.allclose(param, torch.full_like(param, 0.5)),
+                f"`{name}` was re-initialized after loading instead of keeping the saved weights",
+            )
+        # The load was (and stays) clean - this is what made the bug silent.
+        self.assertEqual(len(loading_info["missing_keys"]), 0)
+        self.assertEqual(len(loading_info["unexpected_keys"]), 0)
+        self.assertEqual(len(loading_info["mismatched_keys"]), 0)
+
     def test_safetensors_load_from_hub(self):
         safetensors_model = BertModel.from_pretrained("hf-internal-testing/tiny-random-bert-safetensors")
         pytorch_model = BertModel.from_pretrained("hf-internal-testing/tiny-random-bert")


### PR DESCRIPTION
## What does this PR do?

Fixes #46620.

`from_pretrained` silently returned a **randomly-initialized** model — with a clean `loading_info` (`missing_keys`/`unexpected_keys`/`mismatched_keys` empty, no warning) — for custom out-of-tree `PreTrainedModel` subclasses whose `_init_weights` writes parameters in-place (e.g. `module.weight.data.normal_(...)`). The weights were loaded correctly from the checkpoint and then overwritten by `_init_weights` *after* loading.

### Root cause

During loading, `set_param_for_module` materializes each param from the checkpoint and flags it `_is_hf_initialized = True`. `_initialize_missing_keys` → `initialize_weights()` → `_initialize_weights(module)` then runs.

`_initialize_weights` has a param-level backstop: skip a module when its directly-owned params/buffers are already `_is_hf_initialized`. But that backstop was gated behind `is_remote_code`. A custom subclass loaded directly (not via `trust_remote_code`) has `is_remote_code() == False`, so the backstop was skipped and `self._init_weights(module)` ran, overwriting the freshly-loaded weights in place.

In-tree models are unaffected by the *bug* because their `_init_weights` go through the guarded `torch.init` / `transformers.initialization` helpers, which check `_is_hf_initialized` per tensor. A user writing `weight.data.normal_(...)` operates on `.data` (a distinct tensor without the flag), so it isn't protected — exactly the scenario this backstop was added for, but it was limited to remote code.

### Fix

Apply the backstop to **all** models, but only skip a module that **directly owns** params/buffers (with all of them already initialized). A module that owns none — its params live in child modules — may still initialize those children via *parent dispatch* in `_init_weights` (e.g. a `T5`-style attention block initializes its `q`/`k`/`v`/`o` projections), so it must keep running `_init_weights`. Dropping the `is_remote_code` gate *without* this guard would skip such parent modules and leave their children uninitialized (an empty `all(...)` over no owned tensors is `True`).

The `is_remote_code` parameter is kept on the signature because `_initialize_weights` is used as a callback (`fn(module, is_remote_code)`) by both `smart_apply` and the DeepSpeed ZeRO-3 path (`initialize_weights_zero3`); it is simply no longer consulted by the gate.

In-tree models are otherwise unaffected: their `_init_weights` go through the guarded helpers, so skipping a fully-loaded module is equivalent to running them.

### Tests

Added `test_from_pretrained_does_not_reinit_custom_model_weights`: a save→load round-trip on a minimal custom `PreTrainedModel` with an in-place `_init_weights`, asserting the loaded weights survive and `loading_info` is clean. The test **fails on `main` and passes with this change**.

Verified locally (transformers `5.13.0.dev0`, torch `2.12.0+cpu`):
- the issue's exact repro now reports the saved weight mean (`0.5`) instead of `~0.0007`;
- the new regression test passes (and fails without the fix);
- the parent-dispatch path is covered: `test_can_init_all_missing_weights` passes for a `T5`-family model (UDOP), along with its `test_save_load`;
- related load / init / tied-weight tests in `tests/utils/test_modeling_utils.py`, plus Llama/T5 `test_save_load`, still pass.

## Before submitting
- [x] This PR fixes a bug (link to issue: #46620).
- [x] Did you write any new necessary tests?

## Who can review?

Anyone, but the modeling/loading area is owned by @Cyrilvallez and @SunMarc.
