### PR TITLE
Fix typo in test_utils.py: 'that that' → 'that'

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -647,7 +647,7 @@ class GenerationConfig(PushToHubMixin):
             )
         # 1.2. Cache attributes
         # "paged" re-routes to continuous batching and so it is a valid cache implementation. But we do not want to test
-        # it with the `generate` as the other would be, so we we cannot add it to ALL_CACHE_IMPLEMENTATIONS
+        # it with the `generate` as the other would be, so we cannot add it to ALL_CACHE_IMPLEMENTATIONS
         valid_cache_implementations = ALL_CACHE_IMPLEMENTATIONS + ("paged",)
         if self.cache_implementation is not None and self.cache_implementation not in valid_cache_implementations:
             raise ValueError(

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1592,7 +1592,7 @@ class GenerationTesterMixin:
 
             # 4. get eager + dynamic cache results for future comparison
             dynamic_outputs = []
-            # Ignores all `torch.compile` usage, useful to test models that that have non-default compilable caches
+            # Ignores all `torch.compile` usage, useful to test models that have non-default compilable caches
             # (who would have used compilation in this section)
             with torch.compiler.set_stance("force_eager"):
                 for model_inputs in model_input_sets:


### PR DESCRIPTION
Fixes a duplicate word typo in `tests/generation/test_utils.py`.