### PR TITLE
Fix typo in modeling_mask2former.py: 'from from' → 'from'

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -647,7 +647,7 @@ class GenerationConfig(PushToHubMixin):
             )
         # 1.2. Cache attributes
         # "paged" re-routes to continuous batching and so it is a valid cache implementation. But we do not want to test
-        # it with the `generate` as the other would be, so we we cannot add it to ALL_CACHE_IMPLEMENTATIONS
+        # it with the `generate` as the other would be, so we cannot add it to ALL_CACHE_IMPLEMENTATIONS
         valid_cache_implementations = ALL_CACHE_IMPLEMENTATIONS + ("paged",)
         if self.cache_implementation is not None and self.cache_implementation not in valid_cache_implementations:
             raise ValueError(

--- a/src/transformers/models/mask2former/modeling_mask2former.py
+++ b/src/transformers/models/mask2former/modeling_mask2former.py
@@ -1090,7 +1090,7 @@ class Mask2FormerPixelDecoderEncoderLayer(nn.Module):
         return outputs
 
 
-# Modified from from transformers.models.detr.modeling_deformable_detr.DeformableDetrEncoder with DeformableDetrEncoder->Mask2FormerPixelDecoderEncoderOnly
+# Modified from transformers.models.detr.modeling_deformable_detr.DeformableDetrEncoder with DeformableDetrEncoder->Mask2FormerPixelDecoderEncoderOnly
 class Mask2FormerPixelDecoderEncoderOnly(nn.Module):
     """
     Transformer encoder consisting of *config.encoder_layers* deformable attention layers. Each layer is a
@@ -1219,7 +1219,7 @@ class Mask2FormerPixelDecoderEncoderOnly(nn.Module):
         )
 
 
-# Modified from from transformers.models.detr.modeling_deformable_detr.DeformableDetrModel with DeformableDetrModel->Mask2FormerPixelDecoder
+# Modified from transformers.models.detr.modeling_deformable_detr.DeformableDetrModel with DeformableDetrModel->Mask2FormerPixelDecoder
 class Mask2FormerPixelDecoder(nn.Module):
     def __init__(self, config: Mask2FormerConfig, feature_channels):
         super().__init__()

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1592,7 +1592,7 @@ class GenerationTesterMixin:
 
             # 4. get eager + dynamic cache results for future comparison
             dynamic_outputs = []
-            # Ignores all `torch.compile` usage, useful to test models that that have non-default compilable caches
+            # Ignores all `torch.compile` usage, useful to test models that have non-default compilable caches
             # (who would have used compilation in this section)
             with torch.compiler.set_stance("force_eager"):
                 for model_inputs in model_input_sets:


### PR DESCRIPTION
Fixes a duplicate word typo in `src/transformers/models/mask2former/modeling_mask2former.py`.