### PR TITLE
Fix typo in modeling_mobilebert.py: 'embedings' → 'embeddings'

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -994,7 +994,7 @@ class RotaryEmbeddingConfigMixin:
             logger.warning(
                 "`rope_parameters`'s partial_rotary_factor is None. This will default to 1.0 in the computation, "
                 "making this equivalent to the linear_scaling RoPE type. Provide a value in the range [0.0, 1.0) to "
-                "make use of the proportional RoPE funcitonality."
+                "make use of the proportional RoPE functionality."
             )
 
     @staticmethod

--- a/src/transformers/models/mobilebert/modeling_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_mobilebert.py
@@ -682,7 +682,7 @@ class MobileBertForPreTraining(MobileBertPreTrainedModel):
         self.cls.predictions.bias = new_embeddings.bias
 
     def resize_token_embeddings(self, new_num_tokens: int | None = None) -> nn.Embedding:
-        # resize dense output embedings at first
+        # resize dense output embeddings at first
         self.cls.predictions.dense = self._get_resized_lm_head(
             self.cls.predictions.dense, new_num_tokens=new_num_tokens, transposed=True
         )
@@ -782,7 +782,7 @@ class MobileBertForMaskedLM(MobileBertPreTrainedModel):
         self.cls.predictions.bias = new_embeddings.bias
 
     def resize_token_embeddings(self, new_num_tokens: int | None = None) -> nn.Embedding:
-        # resize dense output embedings at first
+        # resize dense output embeddings at first
         self.cls.predictions.dense = self._get_resized_lm_head(
             self.cls.predictions.dense, new_num_tokens=new_num_tokens, transposed=True
         )

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -789,7 +789,7 @@ class ProcessorMixin(PushToHubMixin):
 
         return processed_audio, audio_replacements
 
-    # To be overriden by each model's processor if they need to add placeholder tokens
+    # To be overridden by each model's processor if they need to add placeholder tokens
     def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
         raise NotImplementedError
 


### PR DESCRIPTION
Fixes a misspelling in `src/transformers/models/mobilebert/modeling_mobilebert.py`.