### PR TITLE
Fix non-idempotent revert_weight_conversion corrupting trust_remote_code saves

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1508,6 +1508,38 @@ def convert_and_load_state_dict_in_model(
     return loading_info, disk_offload_index
 
 
+def _forward_renaming_changes_any_key(
+    forward_conversions: list[WeightTransform], state_dict: dict[str, torch.Tensor]
+) -> bool:
+    """Whether the forward (disk -> in-memory) renamings would rename any key in `state_dict`.
+
+    `revert_weight_conversion` fabricates a mapping from the hardcoded table only when the model was not loaded
+    through the conversion engine (`_weight_conversions is None`). Reverting that mapping is correct only when
+    the in-memory keys are already in the canonical (post-load) layout. When the keys are still in their original
+    on-disk layout - e.g. a `trust_remote_code` model whose remote `from_pretrained` builds the state dict
+    directly - the forward renamings still match them, and reverting is a no-op-that-corrupts: the reverse of an
+    unanchored rename is not idempotent on already-original keys (it doubles the prefix, e.g. `encoder.layers` ->
+    `encoder.encoder.layers`). A `True` result means the keys are still in disk layout and must not be reverted.
+
+    Args:
+        forward_conversions (`list[WeightTransform]`):
+            The forward (disk -> in-memory) conversions fabricated from the hardcoded mapping.
+        state_dict (`dict[str, torch.Tensor]`):
+            The state dict being saved.
+
+    Returns:
+        `bool`: `True` if any key would be renamed by the forward renamings (keys still in disk layout).
+    """
+    forward_renamings = [transform for transform in forward_conversions if isinstance(transform, WeightRenaming)]
+    if not forward_renamings:
+        return False
+    for source_key in state_dict:
+        renamed_key, _ = rename_source_key(source_key, forward_renamings, [])
+        if renamed_key != source_key:
+            return True
+    return False
+
+
 def revert_weight_conversion(model: PreTrainedModel, state_dict: dict[str, torch.Tensor]):
     """
     Revert the conversion mapping that was used to load the model with `from_pretrained`, or the default one
@@ -1527,6 +1559,15 @@ def revert_weight_conversion(model: PreTrainedModel, state_dict: dict[str, torch
         # was there or not during load)
         weight_conversions = [x for x in weight_conversions if not isinstance(x, PrefixChange)]
         weight_conversions = weight_conversions if len(weight_conversions) > 0 else None
+
+        # The fabricated mapping describes disk(source) -> in-memory(target). Reverting it is only correct when
+        # the in-memory keys are already in the canonical (post-load) layout. If applying the forward renamings
+        # would still rename a key, the keys are in their original on-disk layout (e.g. a `trust_remote_code`
+        # model whose remote `from_pretrained` builds the state dict directly), and reverting a never-applied,
+        # non-idempotent rename would double the affected prefix (`encoder.layers` -> `encoder.encoder.layers`)
+        # and silently corrupt the checkpoint, so there is nothing to revert.
+        if weight_conversions is not None and _forward_renaming_changes_any_key(weight_conversions, state_dict):
+            return state_dict
 
     # We did not find any operations to perform -> quick escape
     if weight_conversions is None:

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1524,7 +1524,7 @@ def revert_weight_conversion(model: PreTrainedModel, state_dict: dict[str, torch
         # unanchored rename doubles the prefix on already-original keys, e.g. `encoder.layers` ->
         # `encoder.encoder.layers`), so there is nothing to revert. Native models built with `from_config`
         # carry canonical keys and are reverted normally below.
-        if type(model).__module__.startswith(TRANSFORMERS_DYNAMIC_MODULE_NAME):
+        if type(model).__module__.startswith(TRANSFORMERS_DYNAMIC_MODULE_NAME + "."):
             return state_dict
 
         from .conversion_mapping import get_model_conversion_mapping

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -32,7 +32,7 @@ import torch
 
 from .integrations.accelerate import get_device, offload_weight
 from .integrations.tensor_parallel import ALL_PARALLEL_STYLES
-from .utils import is_env_variable_true
+from .utils import TRANSFORMERS_DYNAMIC_MODULE_NAME, is_env_variable_true
 from .utils.loading_report import LoadStateDictInfo
 from .utils.logging import get_logger, tqdm
 
@@ -1508,38 +1508,6 @@ def convert_and_load_state_dict_in_model(
     return loading_info, disk_offload_index
 
 
-def _forward_renaming_changes_any_key(
-    forward_conversions: list[WeightTransform], state_dict: dict[str, torch.Tensor]
-) -> bool:
-    """Whether the forward (disk -> in-memory) renamings would rename any key in `state_dict`.
-
-    `revert_weight_conversion` fabricates a mapping from the hardcoded table only when the model was not loaded
-    through the conversion engine (`_weight_conversions is None`). Reverting that mapping is correct only when
-    the in-memory keys are already in the canonical (post-load) layout. When the keys are still in their original
-    on-disk layout - e.g. a `trust_remote_code` model whose remote `from_pretrained` builds the state dict
-    directly - the forward renamings still match them, and reverting is a no-op-that-corrupts: the reverse of an
-    unanchored rename is not idempotent on already-original keys (it doubles the prefix, e.g. `encoder.layers` ->
-    `encoder.encoder.layers`). A `True` result means the keys are still in disk layout and must not be reverted.
-
-    Args:
-        forward_conversions (`list[WeightTransform]`):
-            The forward (disk -> in-memory) conversions fabricated from the hardcoded mapping.
-        state_dict (`dict[str, torch.Tensor]`):
-            The state dict being saved.
-
-    Returns:
-        `bool`: `True` if any key would be renamed by the forward renamings (keys still in disk layout).
-    """
-    forward_renamings = [transform for transform in forward_conversions if isinstance(transform, WeightRenaming)]
-    if not forward_renamings:
-        return False
-    for source_key in state_dict:
-        renamed_key, _ = rename_source_key(source_key, forward_renamings, [])
-        if renamed_key != source_key:
-            return True
-    return False
-
-
 def revert_weight_conversion(model: PreTrainedModel, state_dict: dict[str, torch.Tensor]):
     """
     Revert the conversion mapping that was used to load the model with `from_pretrained`, or the default one
@@ -1549,6 +1517,16 @@ def revert_weight_conversion(model: PreTrainedModel, state_dict: dict[str, torch
     # In this case, the model was not created with `from_pretrained` -> let's check if it's in the hardcoded
     # mappings, and recreate the mapping from there if it is
     if weight_conversions is None:
+        # A `trust_remote_code` model keeps its weights in their original on-disk layout: its remote modeling
+        # code builds the state dict directly and never goes through the conversion engine, so the hardcoded
+        # mapping (which describes disk -> canonical for the *native* architecture) was never applied on load.
+        # Reverting it here would re-apply a never-applied, non-idempotent rename and corrupt the keys (an
+        # unanchored rename doubles the prefix on already-original keys, e.g. `encoder.layers` ->
+        # `encoder.encoder.layers`), so there is nothing to revert. Native models built with `from_config`
+        # carry canonical keys and are reverted normally below.
+        if type(model).__module__.startswith(TRANSFORMERS_DYNAMIC_MODULE_NAME):
+            return state_dict
+
         from .conversion_mapping import get_model_conversion_mapping
 
         # Do not resave with the legacy renaming, if present
@@ -1559,15 +1537,6 @@ def revert_weight_conversion(model: PreTrainedModel, state_dict: dict[str, torch
         # was there or not during load)
         weight_conversions = [x for x in weight_conversions if not isinstance(x, PrefixChange)]
         weight_conversions = weight_conversions if len(weight_conversions) > 0 else None
-
-        # The fabricated mapping describes disk(source) -> in-memory(target). Reverting it is only correct when
-        # the in-memory keys are already in the canonical (post-load) layout. If applying the forward renamings
-        # would still rename a key, the keys are in their original on-disk layout (e.g. a `trust_remote_code`
-        # model whose remote `from_pretrained` builds the state dict directly), and reverting a never-applied,
-        # non-idempotent rename would double the affected prefix (`encoder.layers` -> `encoder.encoder.layers`)
-        # and silently corrupt the checkpoint, so there is nothing to revert.
-        if weight_conversions is not None and _forward_renaming_changes_any_key(weight_conversions, state_dict):
-            return state_dict
 
     # We did not find any operations to perform -> quick escape
     if weight_conversions is None:

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -35,7 +35,6 @@ from transformers.core_model_loading import (
     PrefixChange,
     WeightConverter,
     WeightRenaming,
-    _forward_renaming_changes_any_key,
     build_glob_alternation,
     convert_and_load_state_dict_in_model,
     rename_source_key,
@@ -990,19 +989,17 @@ class TestConvertAndLoadStateDict(unittest.TestCase):
         self.assertTrue(compare_state_dicts(reversed_state_dict, state_dict))
 
 
-class TestRevertWeightConversionIdempotency(unittest.TestCase):
-    """`revert_weight_conversion` must not corrupt checkpoints saved without going through the conversion
-    engine (`_weight_conversions is None`), e.g. a `trust_remote_code` model whose remote `from_pretrained`
-    builds the state dict directly.
+class TestRevertWeightConversionRemoteCode(unittest.TestCase):
+    """`revert_weight_conversion` must not corrupt a `trust_remote_code` checkpoint on save.
 
-    The hardcoded conversion mappings describe disk(source) -> in-memory(target) renames; many are unanchored
-    substring renames whose reverse is not idempotent. Reverting one against keys that are *already* in the
-    on-disk layout doubles the affected prefix (`encoder.layers` -> `encoder.encoder.layers`) and silently
-    drops every affected weight on reload. The save path must skip reverting a never-applied conversion while
-    still reverting genuinely canonical (in-memory) keys.
+    A remote model keeps its weights in their original on-disk layout: its remote modeling code builds the
+    state dict directly, so `_weight_conversions is None` and the hardcoded native conversion mapping was
+    never applied. Reverting that mapping would re-apply a never-applied, non-idempotent rename and double the
+    affected prefix (`encoder.layers` -> `encoder.encoder.layers`), silently dropping every affected weight on
+    reload. Native models built with `from_config` carry canonical keys and must still be reverted.
     """
 
-    def _build_model(self, model_type):
+    def _build_model(self, model_type, module_name):
         config = PreTrainedConfig()
         config.model_type = model_type
 
@@ -1011,32 +1008,28 @@ class TestRevertWeightConversionIdempotency(unittest.TestCase):
                 super().__init__(config)
                 self.post_init()
 
-        return _Model(config)
+        model = _Model(config)
+        # Fake the namespace the discriminator keys off (set after construction so `post_init` still finds the
+        # real class source). Remote classes live under `transformers_modules`; native ones do not.
+        type(model).__module__ = module_name
+        return model
 
-    def test_forward_renaming_changes_any_key_detects_disk_layout(self):
-        forward = [WeightRenaming("encoder.layers", "layers")]
-        # Keys still in on-disk layout match the forward source pattern -> must not be reverted.
-        self.assertTrue(_forward_renaming_changes_any_key(forward, {"encoder.layers.0.weight": torch.zeros(1)}))
-        # Canonical (in-memory) keys do not match the forward source -> safe to revert.
-        self.assertFalse(_forward_renaming_changes_any_key(forward, {"layers.0.weight": torch.zeros(1)}))
-        # No renamings -> nothing to detect.
-        self.assertFalse(_forward_renaming_changes_any_key([], {"encoder.layers.0.weight": torch.zeros(1)}))
-
-    def test_revert_skips_non_idempotent_rename_on_disk_layout_keys(self):
-        register_checkpoint_conversion_mapping("test_nonidempotent_disk", [WeightRenaming("encoder.layers", "layers")])
-        model = self._build_model("test_nonidempotent_disk")
-        # `_weight_conversions is None` -> revert falls back to the hardcoded mapping. The keys are already in
-        # on-disk layout, so reverting would double the prefix; the guard must return them unchanged.
+    def test_revert_skips_trust_remote_code_model(self):
+        register_checkpoint_conversion_mapping(
+            "test_remote_nonidempotent", [WeightRenaming("encoder.layers", "layers")]
+        )
+        model = self._build_model("test_remote_nonidempotent", "transformers_modules.acme.modeling_acme")
+        # Remote model: keys already in on-disk layout, so reverting would double the prefix -> must be skipped.
         saved = revert_weight_conversion(model, {"encoder.layers.0.attn.weight": torch.zeros(1)})
         self.assertEqual(set(saved), {"encoder.layers.0.attn.weight"})
         self.assertNotIn("encoder.encoder.layers.0.attn.weight", saved)
 
-    def test_revert_still_reverts_canonical_layout_keys(self):
+    def test_revert_still_reverts_native_model(self):
         register_checkpoint_conversion_mapping(
-            "test_nonidempotent_canonical", [WeightRenaming("encoder.layers", "layers")]
+            "test_native_nonidempotent", [WeightRenaming("encoder.layers", "layers")]
         )
-        model = self._build_model("test_nonidempotent_canonical")
-        # Canonical in-memory keys (e.g. a model built with `from_config`) must still round-trip to disk layout.
+        model = self._build_model("test_native_nonidempotent", "transformers.models.fake.modeling_fake")
+        # Native model (not in `transformers_modules`): canonical keys must still round-trip to disk layout.
         saved = revert_weight_conversion(model, {"layers.0.attn.weight": torch.zeros(1)})
         self.assertEqual(set(saved), {"encoder.layers.0.attn.weight"})
 

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -35,6 +35,7 @@ from transformers.core_model_loading import (
     PrefixChange,
     WeightConverter,
     WeightRenaming,
+    _forward_renaming_changes_any_key,
     build_glob_alternation,
     convert_and_load_state_dict_in_model,
     rename_source_key,
@@ -987,6 +988,57 @@ class TestConvertAndLoadStateDict(unittest.TestCase):
 
         # Make sure both saved state_dict are identical
         self.assertTrue(compare_state_dicts(reversed_state_dict, state_dict))
+
+
+class TestRevertWeightConversionIdempotency(unittest.TestCase):
+    """`revert_weight_conversion` must not corrupt checkpoints saved without going through the conversion
+    engine (`_weight_conversions is None`), e.g. a `trust_remote_code` model whose remote `from_pretrained`
+    builds the state dict directly.
+
+    The hardcoded conversion mappings describe disk(source) -> in-memory(target) renames; many are unanchored
+    substring renames whose reverse is not idempotent. Reverting one against keys that are *already* in the
+    on-disk layout doubles the affected prefix (`encoder.layers` -> `encoder.encoder.layers`) and silently
+    drops every affected weight on reload. The save path must skip reverting a never-applied conversion while
+    still reverting genuinely canonical (in-memory) keys.
+    """
+
+    def _build_model(self, model_type):
+        config = PreTrainedConfig()
+        config.model_type = model_type
+
+        class _Model(PreTrainedModel):
+            def __init__(self, config):
+                super().__init__(config)
+                self.post_init()
+
+        return _Model(config)
+
+    def test_forward_renaming_changes_any_key_detects_disk_layout(self):
+        forward = [WeightRenaming("encoder.layers", "layers")]
+        # Keys still in on-disk layout match the forward source pattern -> must not be reverted.
+        self.assertTrue(_forward_renaming_changes_any_key(forward, {"encoder.layers.0.weight": torch.zeros(1)}))
+        # Canonical (in-memory) keys do not match the forward source -> safe to revert.
+        self.assertFalse(_forward_renaming_changes_any_key(forward, {"layers.0.weight": torch.zeros(1)}))
+        # No renamings -> nothing to detect.
+        self.assertFalse(_forward_renaming_changes_any_key([], {"encoder.layers.0.weight": torch.zeros(1)}))
+
+    def test_revert_skips_non_idempotent_rename_on_disk_layout_keys(self):
+        register_checkpoint_conversion_mapping("test_nonidempotent_disk", [WeightRenaming("encoder.layers", "layers")])
+        model = self._build_model("test_nonidempotent_disk")
+        # `_weight_conversions is None` -> revert falls back to the hardcoded mapping. The keys are already in
+        # on-disk layout, so reverting would double the prefix; the guard must return them unchanged.
+        saved = revert_weight_conversion(model, {"encoder.layers.0.attn.weight": torch.zeros(1)})
+        self.assertEqual(set(saved), {"encoder.layers.0.attn.weight"})
+        self.assertNotIn("encoder.encoder.layers.0.attn.weight", saved)
+
+    def test_revert_still_reverts_canonical_layout_keys(self):
+        register_checkpoint_conversion_mapping(
+            "test_nonidempotent_canonical", [WeightRenaming("encoder.layers", "layers")]
+        )
+        model = self._build_model("test_nonidempotent_canonical")
+        # Canonical in-memory keys (e.g. a model built with `from_config`) must still round-trip to disk layout.
+        saved = revert_weight_conversion(model, {"layers.0.attn.weight": torch.zeros(1)})
+        self.assertEqual(set(saved), {"encoder.layers.0.attn.weight"})
 
 
 class TestConversionMapping(unittest.TestCase):

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -1016,7 +1016,7 @@ class TestRevertWeightConversionRemoteCode(unittest.TestCase):
 
     def test_revert_skips_trust_remote_code_model(self):
         register_checkpoint_conversion_mapping(
-            "test_remote_nonidempotent", [WeightRenaming("encoder.layers", "layers")]
+            "test_remote_nonidempotent", [WeightRenaming("encoder.layers", "layers")], overwrite=True
         )
         model = self._build_model("test_remote_nonidempotent", "transformers_modules.acme.modeling_acme")
         # Remote model: keys already in on-disk layout, so reverting would double the prefix -> must be skipped.
@@ -1026,7 +1026,7 @@ class TestRevertWeightConversionRemoteCode(unittest.TestCase):
 
     def test_revert_still_reverts_native_model(self):
         register_checkpoint_conversion_mapping(
-            "test_native_nonidempotent", [WeightRenaming("encoder.layers", "layers")]
+            "test_native_nonidempotent", [WeightRenaming("encoder.layers", "layers")], overwrite=True
         )
         model = self._build_model("test_native_nonidempotent", "transformers.models.fake.modeling_fake")
         # Native model (not in `transformers_modules`): canonical keys must still round-trip to disk layout.


### PR DESCRIPTION
# What does this PR do?

Fixes #46650

`save_pretrained` silently corrupts the checkpoint of a `trust_remote_code` model whose `model_type` has a
hardcoded conversion mapping in `conversion_mapping.py` (currently `nomic_bert` and `jina_embeddings_v3`).

A remote model is loaded by its own remote modeling code, which builds the state dict directly and never
runs the core conversion engine, so `model._weight_conversions is None` and its in-memory keys are already
in the **original on-disk layout**. On save, `revert_weight_conversion` (`core_model_loading.py`) fabricates
the mapping from the hardcoded table and applies its **reverse** anyway. For an unanchored `WeightRenaming`
whose target is a substring of its source — e.g. `nomic_bert` / `jina_embeddings_v3`
`WeightRenaming("encoder.layers", "layers")` — reverting keys that already carry the prefix double-prepends
it:

```python
from transformers.core_model_loading import WeightRenaming

rev = WeightRenaming(r"encoder.layers", r"layers").reverse_transform()
print(rev.rename_source_key("encoder.layers.0.attn.out_proj.weight")[0])
# -> 'encoder.encoder.layers.0.attn.out_proj.weight'   (expected: unchanged)
```

End-to-end, `AutoModel.from_pretrained("nomic-ai/nomic-embed-text-v1", trust_remote_code=True)`
→ `save_pretrained(d)` → `from_pretrained(d, trust_remote_code=True)` reports every `encoder.layers.*` weight
as missing and silently keeps the randomly-initialised weights — accuracy collapses, with no error raised.

## Fix

The fabricated mapping only ever applies to a model whose in-memory keys are in the **canonical (native)**
layout. That is never the case for a `trust_remote_code` model — its keys are already on-disk. So skip the
fabricated revert when the model class lives in the dynamic `transformers_modules` namespace, and revert
native models (built via `from_config`, whose keys are canonical) exactly as before.

Alternatives considered and ruled out:
- **Detecting "keys already on disk" per-key** (does the forward mapping still rename a key?): false-positives
  on native models whose canonical keys still match an unanchored forward rename — it wrongly skipped their
  legitimate revert and broke `test_reverse_loading_mapping` for ~10 models. The canonical-vs-disk question
  is undecidable per-key for the `X.model -> X` mapping family.
- **Anchoring each affected mapping** (`^encoder\.layers`): only patches one model and breaks the `nomic_bert`
  wrapper classes (`base_model_prefix` nesting under `nomic_bert.`) on both load and save.
- **Migrating these mappings to `PrefixChange`** (à la #45567): does not address the unanchored reverse rename
  and still requires per-model migration.

## Tests

`tests/utils/test_core_model_loading.py::TestRevertWeightConversionRemoteCode`:
- a `trust_remote_code` model (class in `transformers_modules`) with on-disk-layout keys is saved unchanged
  (no `encoder.encoder.*`),
- a native model (built via `from_config`) with canonical keys still round-trips to the on-disk layout.

The full `test_reverse_loading_mapping` suite (which builds native models) is unchanged by this fix. `ruff
check` + `ruff format` clean.

## Code Agent Policy

- [ ] I confirm that this is not a pure code agent PR.

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [ ] Was this discussed/approved via a Github issue? — #46650
- [ ] Did you write any new necessary tests? — `TestRevertWeightConversionRemoteCode`

## Who can review?

@Cyrilvallez — this directly extends your #45567 (`PrefixChange` filter in `revert_weight_conversion`).
