### PR TITLE
ci: add NO_COLOR=1 to suppress ANSI color codes in CI output

### DIFF
--- a/.github/workflows/model_jobs.yml
+++ b/.github/workflows/model_jobs.yml
@@ -169,7 +169,7 @@ jobs:
           elif [ "$model" = "trainer" ] && [ "$report_name_prefix" = "run_trainer_and_fsdp_gpu" ]; then
             test_path="tests/trainer --ignore=tests/trainer/distributed"
           fi
-          script -q -c "PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS=yes _PATCHED_TESTING_METHODS_OUTPUT_DIR=/transformers/reports/${machine_type}_${report_name_prefix}_${matrix_folders}_test_reports python3 -m pytest -rsfE -v -m '${pytest_marker}' --make-reports=${machine_type}_${report_name_prefix}_${matrix_folders}_test_reports tests/models/phimoe/test_modeling_phimoe.py::PhimoeIntegrationTest" test_outputs.txt
+          script -q -c "PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS=yes _PATCHED_TESTING_METHODS_OUTPUT_DIR=/transformers/reports/${machine_type}_${report_name_prefix}_${matrix_folders}_test_reports python3 -m pytest -rsfE -v -m '${pytest_marker}' --make-reports=${machine_type}_${report_name_prefix}_${matrix_folders}_test_reports ${test_path}" test_outputs.txt
           ls -la
           # Extract the exit code from the output file
           EXIT_CODE=$(tail -1 test_outputs.txt | grep -o 'COMMAND_EXIT_CODE="[0-9]*"' | cut -d'"' -f2)

--- a/.github/workflows/model_jobs.yml
+++ b/.github/workflows/model_jobs.yml
@@ -43,6 +43,7 @@ env:
   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   TF_FORCE_GPU_ALLOW_GROWTH: true
   CUDA_VISIBLE_DEVICES: 0,1
+  NO_COLOR: 1
 
 permissions:
   contents: read
@@ -168,7 +169,7 @@ jobs:
           elif [ "$model" = "trainer" ] && [ "$report_name_prefix" = "run_trainer_and_fsdp_gpu" ]; then
             test_path="tests/trainer --ignore=tests/trainer/distributed"
           fi
-          script -q -c "PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS=yes _PATCHED_TESTING_METHODS_OUTPUT_DIR=/transformers/reports/${machine_type}_${report_name_prefix}_${matrix_folders}_test_reports python3 -m pytest -rsfE -v -m '${pytest_marker}' --make-reports=${machine_type}_${report_name_prefix}_${matrix_folders}_test_reports ${test_path}" test_outputs.txt
+          script -q -c "PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS=yes _PATCHED_TESTING_METHODS_OUTPUT_DIR=/transformers/reports/${machine_type}_${report_name_prefix}_${matrix_folders}_test_reports python3 -m pytest -rsfE -v -m '${pytest_marker}' --make-reports=${machine_type}_${report_name_prefix}_${matrix_folders}_test_reports tests/models/phimoe/test_modeling_phimoe.py::PhimoeIntegrationTest" test_outputs.txt
           ls -la
           # Extract the exit code from the output file
           EXIT_CODE=$(tail -1 test_outputs.txt | grep -o 'COMMAND_EXIT_CODE="[0-9]*"' | cut -d'"' -f2)


### PR DESCRIPTION
## What does this PR do?

Sets `NO_COLOR=1` in the `model_jobs.yml` workflow environment to suppress ANSI color escape codes in test output, making logs cleaner and easier to parse.

- [x] I confirm that this is not a pure code agent PR.

Without this PR, the raw logs looks

```bash
2026-06-12T13:17:47.9759715Z [33mWARNING [0m transformers.core_model_loading:core_model_loading.py:1484 Offloading parameter to disk — target_name='model.norm.weight', param_device='disk', in_model_buffers=False, offload_buffers=False, param shape=(4096,), dtype=torch.bfloat16, device=cpu, numel=4096, disk_offload_folder='/tmp/tmp02u8krsi', mapping=WeightRenaming(source_patterns=['model.norm.weight'], target_patterns=['model.norm.weight'])
2026-06-12T13:17:48.3755050Z [33mWARNING [0m accelerate.big_modeling:big_modeling.py:448 Some parameters are on the meta device because they were offloaded to the cpu and disk.
2026-06-12T13:18:01.1559419Z [32mPASSED[0m[33m                                                                   [ 33%][0mtests/models/phimoe/test_modeling_phimoe.py::PhimoeIntegrationTest::test_model_phimoe_instruct_logits [PASSED] 229.05s
2026-06-12T13:18:01.1561332Z 
2026-06-12T13:18:01.4551981Z tests/models/phimoe/test_modeling_phimoe.py::PhimoeIntegrationTest::test_phimoe_instruct_generation 
2026-06-12T13:18:01.4553024Z [1m-------------------------------- live log call ---------------------------------[0m
2026-06-12T13:18:01.4554680Z [33mWARNING [0m transformers.modeling_rope_utils:modeling_rope_utils.py:1028 Unrecognized keys in `rope_parameters` for 'rope_type'='longrope': {'short_mscale', 'long_mscale'}
2026-06-12T13:20:51.3094758Z [32mPASSED[0m[33m                                                                   [ 66%][0mtests/models/phimoe/test_modeling_phimoe.py::PhimoeIntegrationTest::test_phimoe_instruct_generation [PASSED] 170.15s
2026-06-12T13:20:51.3099246Z 
2026-06-12T13:20:51.5951284Z tests/models/phimoe/test_modeling_phimoe.py::PhimoeIntegrationTest::test_phimoe_instruct_with_static_cache 
2026-06-12T13:20:51.5952175Z [1m-------------------------------- live log call ---------------------------------[0m
2026-06-12T13:20:51.5953317Z [33mWARNING [0m transformers.modeling_rope_utils:modeling_rope_utils.py:1028 Unrecognized keys in `rope_parameters` for 'rope_type'='longrope': {'short_mscale', 'long_mscale'}
2026-06-12T13:24:43.8435241Z [32mPASSED[0m[33m    
```
