### PR TITLE
[CB] Slice logits inside the model

### DIFF
--- a/src/transformers/generation/continuous_batching/model_runner.py
+++ b/src/transformers/generation/continuous_batching/model_runner.py
@@ -48,6 +48,7 @@ class ModelRunner:
         self.return_logprobs = return_logprobs
         self.use_cuda_graph_varlen, self.use_cuda_graph_decode = self.cb_config.cuda_graph_booleans
         self.cache = cache
+        self.__cached_supports_logits_to_keep = None  # boolean variable that we cache in the first forward
 
         # Padding only happen when CUDA graphs or compile is used
         cuda_graph = self.use_cuda_graph_varlen or self.use_cuda_graph_decode
@@ -89,6 +90,12 @@ class ModelRunner:
             max_kv_read = 0
         return num_q_tokens, max_kv_read
 
+    def supports_logits_to_keep(self, model: nn.Module) -> bool:
+        """Returns True if the model supports the logits_to_keep kwarg."""
+        if self.__cached_supports_logits_to_keep is None:
+            self.__cached_supports_logits_to_keep = hasattr(model, "_supports_logits_to_keep") and model._supports_logits_to_keep()
+        return self.__cached_supports_logits_to_keep
+
     def compute_batch(self, model: nn.Module, batch_data: dict) -> None:
         """Runs the forward pass, processes the logits and samples the next tokens. It also handles which version of
         the forward pass to use (varlen or decode), whether to use CUDA graphs (with the eventual capture of the graph)
@@ -98,6 +105,13 @@ class ModelRunner:
         # This is the stream on which the compute happens
         compute_stream = self.inputs_and_outputs.compute_stream
 
+        # If the model supports logits to keep, we use that instead of manual slicing
+        if self.supports_logits_to_keep(model):
+            batch_data["logits_to_keep"] = batch_data["logits_indices"]
+            slice_logits = False
+        else:
+            slice_logits = True
+
         # Get the appropriate forward function (compiled or not, based on current path)
         forward_fn, use_cuda_graph = self._get_forward_fn(use_block_table=self.inputs_and_outputs.use_block_table)
 
@@ -105,7 +119,7 @@ class ModelRunner:
         if not use_cuda_graph:
             maybe_stream = torch.cuda.stream(compute_stream) if compute_stream is not None else nullcontext()
             with maybe_stream:
-                forward_fn(model, batch_data, carry_over_ids, prev_output_ids, output_ids)
+                forward_fn(model, batch_data, carry_over_ids, prev_output_ids, output_ids, slice_logits)
 
         # Otherwise, we either create or replay the graph (CUDA is available in this path)
         else:
@@ -116,7 +130,7 @@ class ModelRunner:
                     graph.replay()
             # Otherwise, the graph does not exist, so we create it
             else:
-                args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids)
+                args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids, slice_logits)
                 self._capture_graph(forward_fn, compute_stream, *args)
 
     def _get_forward_fn(self, use_block_table: bool) -> tuple[Callable, bool]:
@@ -150,6 +164,7 @@ class ModelRunner:
         carry_over_ids: torch.Tensor,
         prev_output_ids: torch.Tensor,
         output_ids: torch.Tensor,
+        slice_logits: bool,
     ) -> None:
         """This function performs the forward pass, logits processing, and sampling. This is what is either captured
         and/or compiled."""
@@ -157,12 +172,12 @@ class ModelRunner:
         self.inputs_and_outputs.carry_over_tokens(batch_data["input_ids"], carry_over_ids, prev_output_ids)
 
         # Run model forward pass
-        logits = model(**batch_data).logits  # shape [1, seq_len, vocab_size]
+        logits = model(**batch_data).logits  # shape [1, seq_len OR num_logits, vocab_size]
 
-        # Extract prediction + some padding: this reduces the size of the logits from the nb of query tokens (capped at
-        # max_batch_tokens) to the nb of requests in the batch (capped at max_requests_per_batch <= max_batch_tokens)
+        # If it has not been done already, extract only the logits that are used to predict new tokens
         logits_indices = batch_data["logits_indices"]  # shape [num_logits]
-        logits = logits[:, logits_indices, :]  # shape [1, num_logits, vocab_size]
+        if slice_logits:
+            logits = logits[:, logits_indices, :]  # shape [1, num_logits, vocab_size]
         # Convert to fp32 to match generate
         logits = logits.float()  # shape [1, num_logits, vocab_size]
 
@@ -284,14 +299,7 @@ class ModelRunner:
                 future_states, self.logit_processor, use_decode_fast_path, padded_q, padded_kv, use_padding=True
             )
             batch_data = self.inputs_and_outputs.get_model_kwargs(use_padding=True)
-            carry_over_ids, prev_output_ids, output_ids = self.inputs_and_outputs.get_cb_kwargs()
-            forward_fn, use_cuda_graph = self._get_forward_fn(use_block_table=self.inputs_and_outputs.use_block_table)
-            forward_fn_args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids)
-            if use_cuda_graph:
-                self._capture_graph(forward_fn, self.inputs_and_outputs.compute_stream, *forward_fn_args)
-            else:
-                with torch.cuda.stream(self.inputs_and_outputs.compute_stream):
-                    forward_fn(*forward_fn_args)
+            self.compute_batch(model, batch_data)
             duration = time.perf_counter() - start
             logger.debug(f"Warmup completed in {duration:.2f}s")
 

--- a/src/transformers/generation/continuous_batching/model_runner.py
+++ b/src/transformers/generation/continuous_batching/model_runner.py
@@ -48,7 +48,7 @@ class ModelRunner:
         self.return_logprobs = return_logprobs
         self.use_cuda_graph_varlen, self.use_cuda_graph_decode = self.cb_config.cuda_graph_booleans
         self.cache = cache
-        self.__cached_supports_logits_to_keep = None  # boolean variable that we cache in the first forward
+        self._model_supports_logits_to_keep: bool | None = None  # resolved on first forward
 
         # Padding only happen when CUDA graphs or compile is used
         cuda_graph = self.use_cuda_graph_varlen or self.use_cuda_graph_decode
@@ -91,10 +91,12 @@ class ModelRunner:
         return num_q_tokens, max_kv_read
 
     def supports_logits_to_keep(self, model: nn.Module) -> bool:
-        """Returns True if the model supports the logits_to_keep kwarg."""
-        if self.__cached_supports_logits_to_keep is None:
-            self.__cached_supports_logits_to_keep = hasattr(model, "_supports_logits_to_keep") and model._supports_logits_to_keep()
-        return self.__cached_supports_logits_to_keep
+        """Returns True if the model accepts the logits_to_keep kwarg in its forward."""
+        if self._model_supports_logits_to_keep is None:
+            self._model_supports_logits_to_keep = (
+                hasattr(model, "_supports_logits_to_keep") and model._supports_logits_to_keep()
+            )
+        return self._model_supports_logits_to_keep
 
     def compute_batch(self, model: nn.Module, batch_data: dict) -> None:
         """Runs the forward pass, processes the logits and samples the next tokens. It also handles which version of
@@ -105,12 +107,9 @@ class ModelRunner:
         # This is the stream on which the compute happens
         compute_stream = self.inputs_and_outputs.compute_stream
 
-        # If the model supports logits to keep, we use that instead of manual slicing
+        # If supported, the model slices hidden states at logits_indices before lm_head, instead of us slicing logits
         if self.supports_logits_to_keep(model):
             batch_data["logits_to_keep"] = batch_data["logits_indices"]
-            slice_logits = False
-        else:
-            slice_logits = True
 
         # Get the appropriate forward function (compiled or not, based on current path)
         forward_fn, use_cuda_graph = self._get_forward_fn(use_block_table=self.inputs_and_outputs.use_block_table)
@@ -119,7 +118,7 @@ class ModelRunner:
         if not use_cuda_graph:
             maybe_stream = torch.cuda.stream(compute_stream) if compute_stream is not None else nullcontext()
             with maybe_stream:
-                forward_fn(model, batch_data, carry_over_ids, prev_output_ids, output_ids, slice_logits)
+                forward_fn(model, batch_data, carry_over_ids, prev_output_ids, output_ids)
 
         # Otherwise, we either create or replay the graph (CUDA is available in this path)
         else:
@@ -130,7 +129,7 @@ class ModelRunner:
                     graph.replay()
             # Otherwise, the graph does not exist, so we create it
             else:
-                args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids, slice_logits)
+                args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids)
                 self._capture_graph(forward_fn, compute_stream, *args)
 
     def _get_forward_fn(self, use_block_table: bool) -> tuple[Callable, bool]:
@@ -164,7 +163,6 @@ class ModelRunner:
         carry_over_ids: torch.Tensor,
         prev_output_ids: torch.Tensor,
         output_ids: torch.Tensor,
-        slice_logits: bool,
     ) -> None:
         """This function performs the forward pass, logits processing, and sampling. This is what is either captured
         and/or compiled."""
@@ -174,9 +172,9 @@ class ModelRunner:
         # Run model forward pass
         logits = model(**batch_data).logits  # shape [1, seq_len OR num_logits, vocab_size]
 
-        # If it has not been done already, extract only the logits that are used to predict new tokens
+        # If it has not been done by the model, extract only the logits that are used to predict new tokens
         logits_indices = batch_data["logits_indices"]  # shape [num_logits]
-        if slice_logits:
+        if "logits_to_keep" not in batch_data:
             logits = logits[:, logits_indices, :]  # shape [1, num_logits, vocab_size]
         # Convert to fp32 to match generate
         logits = logits.float()  # shape [1, num_logits, vocab_size]


### PR DESCRIPTION
# Summary

This PR leverages an **awesome** kwarg in transformers: `logits_to_keep`. Simply, this drop the tokens for which we won't use the next token predictions before we enter the `lm_head`. Reduces the memory footprints of large prefill batches, increase their throughput, makes everyone happy.

## Performance ✅ 

label | main acc | new PR acc | main (tok/s) | new PR (tok/s) | diff
-- | -- | -- | -- | -- | --
gsm8k_default | 0.822 | 0.822 | 2460.91 | 2477.15 | +0.66%
gsm8k_sampling | 0.787 | 0.784 | 1952.33 | 1958.65 | +0.32%
gsm8k_compile | 0.821 | 0.821 | 2461.93 | 2473.02 | +0.45%
gsm8k_no_fast_decode | 0.822 | 0.822 | 2350.41 | 2355.21 | +0.20%
gsm8k_bare_bones | 0.821 | 0.821 | 1845.35 | 1845.52 | +0.01%
ifeval_default | 0.445 | 0.447 | 9007.60 | 9015.87 | +0.09%
few_blocks | - | - | 666.92 | 664.97 | -0.29%
multi_return_seq | - | - | 1610.03 | 1627.67 | +1.10%
rollouts_1024 | - | - | 3546.62 | 3550.29 | +0.10%
rollouts_2048 | - | - | 3371.13 | 3373.68 | +0.08%
rollouts_4096 | - | - | 2973.00 | 2974.99 | +0.07%
rollouts_8192 | - | - | 2361.10 | 2362.95 | +0.08%
rollouts_16384 | - | - | 1549.11 | 1549.40 | +0.02%

No performance degradation.

## Tests ✅ 

All tests pass

## AI Reviewed ✅ 

Done and addressed