### PR TITLE
fix(t5): use "decoder's " prefix in error messages when called on decoder stack

### DIFF
--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -1251,7 +1251,7 @@ class LongT5Stack(LongT5PreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.return_dict
 
         if input_ids is not None and inputs_embeds is not None:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(
                 f"You cannot specify both {err_msg_prefix}input_ids and {err_msg_prefix}inputs_embeds at the same time"
             )
@@ -1261,7 +1261,7 @@ class LongT5Stack(LongT5PreTrainedModel):
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(f"You have to specify either {err_msg_prefix}input_ids or {err_msg_prefix}inputs_embeds")
 
         if self.gradient_checkpointing and self.training:

--- a/src/transformers/models/mt5/modeling_mt5.py
+++ b/src/transformers/models/mt5/modeling_mt5.py
@@ -654,7 +654,7 @@ class MT5Stack(MT5PreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.return_dict
 
         if input_ids is not None and inputs_embeds is not None:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(
                 f"You cannot specify both {err_msg_prefix}input_ids and {err_msg_prefix}inputs_embeds at the same time"
             )
@@ -664,7 +664,7 @@ class MT5Stack(MT5PreTrainedModel):
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(f"You have to specify either {err_msg_prefix}input_ids or {err_msg_prefix}inputs_embeds")
 
         if self.gradient_checkpointing and self.training:

--- a/src/transformers/models/pop2piano/modeling_pop2piano.py
+++ b/src/transformers/models/pop2piano/modeling_pop2piano.py
@@ -608,7 +608,7 @@ class Pop2PianoStack(Pop2PianoPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.return_dict
 
         if input_ids is not None and inputs_embeds is not None:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(
                 f"You cannot specify both {err_msg_prefix}input_ids and {err_msg_prefix}inputs_embeds at the same time"
             )
@@ -618,7 +618,7 @@ class Pop2PianoStack(Pop2PianoPreTrainedModel):
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(f"You have to specify either {err_msg_prefix}input_ids or {err_msg_prefix}inputs_embeds")
 
         if self.gradient_checkpointing and self.training:

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -643,7 +643,7 @@ class T5Stack(T5PreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.return_dict
 
         if input_ids is not None and inputs_embeds is not None:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(
                 f"You cannot specify both {err_msg_prefix}input_ids and {err_msg_prefix}inputs_embeds at the same time"
             )
@@ -653,7 +653,7 @@ class T5Stack(T5PreTrainedModel):
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(f"You have to specify either {err_msg_prefix}input_ids or {err_msg_prefix}inputs_embeds")
 
         if self.gradient_checkpointing and self.training:

--- a/src/transformers/models/udop/modeling_udop.py
+++ b/src/transformers/models/udop/modeling_udop.py
@@ -1090,7 +1090,7 @@ class UdopStack(UdopPreTrainedModel):
         # input embeddings processing
 
         if input_ids is not None and inputs_embeds is not None:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(
                 f"You cannot specify both {err_msg_prefix}inputs and {err_msg_prefix}inputs_embeds at the same time"
             )
@@ -1107,7 +1107,7 @@ class UdopStack(UdopPreTrainedModel):
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(f"You have to specify either {err_msg_prefix}inputs or {err_msg_prefix}inputs_embeds")
 
         if inputs_embeds is None:

--- a/src/transformers/models/umt5/modeling_umt5.py
+++ b/src/transformers/models/umt5/modeling_umt5.py
@@ -612,7 +612,7 @@ class UMT5Stack(UMT5PreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.return_dict
 
         if input_ids is not None and inputs_embeds is not None:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(
                 f"You cannot specify both {err_msg_prefix}input_ids and {err_msg_prefix}inputs_embeds at the same time"
             )
@@ -622,7 +622,7 @@ class UMT5Stack(UMT5PreTrainedModel):
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:
-            err_msg_prefix = "decoder_" if self.is_decoder else ""
+            err_msg_prefix = "decoder's " if self.is_decoder else ""
             raise ValueError(f"You have to specify either {err_msg_prefix}input_ids or {err_msg_prefix}inputs_embeds")
 
         if self.gradient_checkpointing and self.training:


### PR DESCRIPTION
Fixes #46463.

**Problem**

When `T5Stack` (or any T5-variant stack) is used as a standalone decoder and called with `input_ids`, the error message reads:

```
You cannot specify both decoder_input_ids and decoder_inputs_embeds at the same time
```

The `decoder_` prefix is concatenated directly onto `input_ids`, producing `decoder_input_ids` instead of `decoder's input_ids`. This is confusing because `decoder_input_ids` looks like a valid parameter name and misleads users into thinking they passed a wrong keyword argument.

**Fix**

Change `"decoder_"` → `"decoder's "` in the `err_msg_prefix` assignment inside `T5Stack.forward()`. Applied to all T5-family stacks that share the same pattern: T5, LongT5, mT5, UMT5, Pop2Piano, UDOP.

**Test**

No code logic changed — error messages only. Existing tests unaffected.