### PR TITLE
fix(generation): honor cache_config.max_cache_len for static cache

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1920,10 +1920,15 @@ class GenerationMixin(ContinuousMixin):
                     f"and will be removed in v5.13. Please only use one of {STATIC_CACHE_IMPLEMENTATIONS}, "
                     "and the layer structure will be inferred automatically."
                 )
+            static_max_cache_len = max_cache_length
+            if generation_config.cache_config is not None:
+                user_max_cache_len = generation_config.cache_config.get("max_cache_len")
+                if user_max_cache_len is not None:
+                    static_max_cache_len = max(max_cache_length, user_max_cache_len)
             model_kwargs[cache_name] = self._prepare_static_cache(
                 cache_implementation=generation_config.cache_implementation,
                 batch_size=max(generation_config.num_beams, generation_config.num_return_sequences) * batch_size,
-                max_cache_len=max_cache_length,
+                max_cache_len=static_max_cache_len,
                 model_kwargs=model_kwargs,
             )
         elif generation_config.cache_implementation == "quantized":

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1252,6 +1252,50 @@ class GenerationTesterMixin:
             self._check_past_key_values_for_generate(batch_size, outputs.past_key_values, max_length, text_config)
 
     @pytest.mark.generate
+    def test_prepare_cache_for_generation_static_cache_config_max_cache_len(self):
+        """Regression test for #46424 -- cache_config.max_cache_len should size static caches."""
+        from transformers.generation.configuration_utils import GenerationMode
+
+        for model_class in self.all_generative_model_classes:
+            if not model_class._can_compile_fullgraph:
+                continue
+
+            config, inputs_dict = self.prepare_config_and_inputs_for_generate()
+            if config.is_encoder_decoder:
+                continue
+
+            model = model_class(config).to(torch_device).eval()
+            user_max_cache_len = 128
+            model.generation_config = GenerationConfig(
+                use_cache=True,
+                cache_implementation="static",
+                max_new_tokens=4,
+                num_beams=1,
+                num_return_sequences=1,
+                cache_config={"max_cache_len": user_max_cache_len},
+            )
+
+            input_ids = inputs_dict["input_ids"]
+            batch_size = input_ids.shape[0]
+            auto_max_cache_length = input_ids.shape[1] + 4 - 1
+            self.assertLess(auto_max_cache_length, user_max_cache_len)
+
+            model._prepare_cache_for_generation(
+                model.generation_config,
+                dict(inputs_dict),
+                GenerationMode.GREEDY_SEARCH,
+                batch_size,
+                auto_max_cache_length,
+            )
+
+            cache = model._cache
+            if isinstance(cache, EncoderDecoderCache):
+                cache = cache.self_attention_cache
+            self.assertIsInstance(cache, StaticCache)
+            self.assertEqual(cache.max_cache_len, user_max_cache_len)
+            break
+
+    @pytest.mark.generate
     def test_generate_continue_from_past_key_values(self):
         # Tests that we can continue generating from past key values, returned from a previous `generate` call
         for model_class in self.all_generative_model_classes:


### PR DESCRIPTION
## Summary
- Apply `generation_config.cache_config["max_cache_len"]` when allocating `StaticCache`, not only on the quantized cache path
- Use `max(auto_max_cache_length, user_max_cache_len)` so the cache is always large enough for the current call while allowing callers to pin a larger ceiling for subsequent `generate()` calls (avoids realloc + torch.compile recompile)

Fixes #46424

## Test plan
- [x] Manual repro with `hf-internal-testing/tiny-random-LlamaForCausalLM`: `cache_config={"max_cache_len": 2048}` now yields `StaticCache.max_cache_len == 2048` (was 47)
- [x] Added `test_prepare_cache_for_generation_static_cache_config_max_cache_len` in `tests/generation/test_utils.py`

/cc @ArthurZucker @Cyrilvallez