### PR TITLE
ci: add merge_group trigger to pr-ci-caller.yml

### DIFF
--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -2,6 +2,7 @@ name: PR CI
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
## What does this PR do?

Adds `merge_group:` as a trigger to `pr-ci-caller.yml` so that the PR CI workflow runs when a PR is added to the merge queue.

Without this, the required status checks never fire for merge queue events, causing GitHub to eject the PR with "no response for status checks".

The companion changes to handle the `merge_group` event correctly inside the called workflows (PR number extraction, `RUN_FLAKY` fix) are in huggingface/transformers-test-ci#51.

- [x] I confirm that this is not a pure code agent PR.