### PR TITLE
fix: define TransformersCompletionCreateParamsStreaming inside conditional to avoid NameError when serve is unavailable (closes #46657)

### DIFF
--- a/src/transformers/cli/serving/chat_completion.py
+++ b/src/transformers/cli/serving/chat_completion.py
@@ -57,6 +57,11 @@ if is_serve_available():
 
         reasoning_content: str | None = None
 
+    class TransformersCompletionCreateParamsStreaming(CompletionCreateParamsStreaming, total=False):
+        generation_config: str
+        seed: int
+        chat_template_kwargs: dict
+
 
 from .utils import (
     BaseGenerateManager,
@@ -75,10 +80,7 @@ if TYPE_CHECKING:
     from transformers import GenerationConfig, PreTrainedModel, PreTrainedTokenizerFast, ProcessorMixin
 
 
-class TransformersCompletionCreateParamsStreaming(CompletionCreateParamsStreaming, total=False):
-    generation_config: str
-    seed: int
-    chat_template_kwargs: dict
+# Note: TransformersCompletionCreateParamsStreaming is defined inside the conditional above to avoid NameError if serve is not available.
 
 
 # Fields accepted by the OpenAI schema but not yet supported.


### PR DESCRIPTION
## What
When `is_serve_available()` returns False (e.g., missing OpenAI package), the class `CompletionCreateParamsStreaming` is never imported, causing a `NameError` at the definition of `TransformersCompletionCreateParamsStreaming`.

## Fix
Move the definition of `TransformersCompletionCreateParamsStreaming` inside the same conditional block where `CompletionCreateParamsStreaming` is imported, so it is only defined when the required dependency is available.

Closes #46657