### PR TITLE
Sapiens2: Remove modeling imports in image processing

### DIFF
--- a/src/transformers/models/sapiens2/image_processing_sapiens2.py
+++ b/src/transformers/models/sapiens2/image_processing_sapiens2.py
@@ -38,12 +38,6 @@ from ...image_utils import (
 )
 from ...processing_utils import ImagesKwargs, Unpack
 from ...utils import TensorType, auto_docstring, is_torch_available
-from .modeling_sapiens2 import (
-    Sapiens2ImageMattingOutput,
-    Sapiens2NormalEstimatorOutput,
-    Sapiens2PointmapEstimatorOutput,
-    Sapiens2PoseEstimatorOutput,
-)
 
 
 class Sapiens2ImageProcessorKwargs(ImagesKwargs, total=False):
@@ -500,9 +494,9 @@ class Sapiens2ImageProcessor(TorchvisionBackend):
 
     def post_process_pose_estimation(
         self,
-        outputs: Sapiens2PoseEstimatorOutput,
+        outputs,
         boxes: list[list[list[float]]],
-        outputs_flipped: Sapiens2PoseEstimatorOutput | None = None,
+        outputs_flipped=None,
         kernel_size: int = 11,
         threshold: float | None = None,
         source_sizes: TensorType | list[tuple[int, int]] | None = None,
@@ -642,7 +636,7 @@ class Sapiens2ImageProcessor(TorchvisionBackend):
 
     def post_process_normal_estimation(
         self,
-        outputs: Sapiens2NormalEstimatorOutput,
+        outputs,
         source_sizes: TensorType | list[tuple[int, int]] | None = None,
         target_sizes: TensorType | list[tuple[int, int]] | None = None,
         do_remove_padding: bool | None = None,
@@ -678,7 +672,7 @@ class Sapiens2ImageProcessor(TorchvisionBackend):
 
     def post_process_pointmap_estimation(
         self,
-        outputs: Sapiens2PointmapEstimatorOutput,
+        outputs,
         source_sizes: TensorType | list[tuple[int, int]] | None = None,
         target_sizes: TensorType | list[tuple[int, int]] | None = None,
         do_remove_padding: bool | None = None,
@@ -715,7 +709,7 @@ class Sapiens2ImageProcessor(TorchvisionBackend):
 
     def post_process_image_matting(
         self,
-        outputs: Sapiens2ImageMattingOutput,
+        outputs,
         target_sizes: TensorType | list[tuple[int, int]] | None = None,
         backgrounds: ImageInput | None = None,
     ) -> list[dict[str, torch.Tensor]]:

--- a/src/transformers/models/sapiens2/modular_sapiens2.py
+++ b/src/transformers/models/sapiens2/modular_sapiens2.py
@@ -526,9 +526,9 @@ class Sapiens2ImageProcessor(BeitImageProcessor):
 
     def post_process_pose_estimation(
         self,
-        outputs: Sapiens2PoseEstimatorOutput,
+        outputs,
         boxes: list[list[list[float]]],
-        outputs_flipped: Sapiens2PoseEstimatorOutput | None = None,
+        outputs_flipped=None,
         kernel_size: int = 11,
         threshold: float | None = None,
         source_sizes: TensorType | list[tuple[int, int]] | None = None,
@@ -668,7 +668,7 @@ class Sapiens2ImageProcessor(BeitImageProcessor):
 
     def post_process_normal_estimation(
         self,
-        outputs: Sapiens2NormalEstimatorOutput,
+        outputs,
         source_sizes: TensorType | list[tuple[int, int]] | None = None,
         target_sizes: TensorType | list[tuple[int, int]] | None = None,
         do_remove_padding: bool | None = None,
@@ -704,7 +704,7 @@ class Sapiens2ImageProcessor(BeitImageProcessor):
 
     def post_process_pointmap_estimation(
         self,
-        outputs: Sapiens2PointmapEstimatorOutput,
+        outputs,
         source_sizes: TensorType | list[tuple[int, int]] | None = None,
         target_sizes: TensorType | list[tuple[int, int]] | None = None,
         do_remove_padding: bool | None = None,
@@ -741,7 +741,7 @@ class Sapiens2ImageProcessor(BeitImageProcessor):
 
     def post_process_image_matting(
         self,
-        outputs: Sapiens2ImageMattingOutput,
+        outputs,
         target_sizes: TensorType | list[tuple[int, int]] | None = None,
         backgrounds: ImageInput | None = None,
     ) -> list[dict[str, torch.Tensor]]:


### PR DESCRIPTION
# What does this PR do?

* Remove imports from `modeling_sapiens2.py` in `image_processing_sapiens2.py` 
* Remove typings for sapiens2 specific output classes

The purpose of this PR is to remove the unchecked imports from `modeling_sapiens2.py` inside `image_processing_sapiens2.py`. This happened because I typed the post-processing methods with the sapiens2 `ModelOutput` classes which were then automatically added as imports by the modular generator. All other image processors use an `if TYPE_CHECKING` guard for these types of imports (e.g. [here](https://github.com/huggingface/transformers/blob/562021d4ecffcc4d572f9da930ad02d351cb55c8/src/transformers/models/vitpose/image_processing_vitpose.py#L50)). I don't think there is currently any way to instruct the modular generator to guard these imports automatically.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
