### PR TITLE
[docs] compile level and batch/scheduling limits

### DIFF
--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -205,6 +205,7 @@ By default, `num_blocks` and `max_batch_tokens` are inferred automatically from 
 | `scheduler` | | ✓ scheduling policy | ✓ TTFT |
 | CUDA graphs | ↑ graph storage | ✓ less dispatch overhead | ✓ |
 | Async batching | ↑ ~2× I/O buffers | ✓ overlaps CPU/GPU | |
+| Compilation | ↑ warmup-time only | ✓ faster forward passes | ✓ |
 | Decode fast path | ↑ block table per request | ✓ faster decode-only steps | ✓ |
 | CPU offloading | ↑ pinned CPU memory | ✓ skips some re-prefills | |
 | Prefix caching | ↓ shared KV blocks | ✓ skips redundant prefill | ✓ TTFT |
@@ -272,6 +273,25 @@ cb_config = ContinuousBatchingConfig(
     use_async_batching=True,
 )
 ```
+
+### Compilation
+
+`default_compile_level` applies `torch.compile` to the model's forward passes. Compilation trades a one-time warmup cost for faster forward passes during generation. Higher levels run more aggressive optimization, which improves throughput but lengthens warmup. Keep the level low for tests and benchmark iteration, and raise it for long-running serving workloads where the warmup cost is paid back over many requests.
+
+The level ranges from `0` to `3`. Level `0` is the default and skips compilation entirely.
+
+| Level | `mode` | `dynamic` | Trade-off |
+|---|---|---|---|
+| 0 | — | — | No compilation (default), fastest startup |
+| 1 | `default` | `True` | Modest speedup, short warmup |
+| 2 | `max-autotune-no-cudagraphs` | `True` | More speedup, longer warmup |
+| 3 | `max-autotune-no-cudagraphs` | `False` | Best throughput, longest warmup |
+
+```py
+cb_config = ContinuousBatchingConfig(default_compile_level=1)
+```
+
+The level supplies a default [`CompileConfig`] to the varlen and decode execution paths. It only applies to a path that has no explicit config, so `varlen_compile_config` and `decode_compile_config` take precedence when set. Under FlashAttention, the varlen path skips compilation because `max_seqlen_k` triggers frequent recompilation, so the level affects only the decode path in that case.
 
 ### Decode fast path
 

--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -212,6 +212,8 @@ By default, `num_blocks` and `max_batch_tokens` are inferred automatically from 
 | Paged attention | ↓ no fragmentation | ✓ dynamic batch membership | |
 | Sliding window | ↓ bounded KV per layer | | |
 | Per-request processors | | ✓ mixed sampling params per batch | |
+| `max_requests_per_batch` | ↓ caps logits buffer | ✓ bounds batch size | |
+| `safety_margin` | | | ✓ protects decode latency |
 
 ```py
 from transformers.generation import ContinuousBatchingConfig
@@ -228,6 +230,22 @@ outputs = model.generate_batch(
     continuous_batching_config=cb_config,
 )
 ```
+
+### Batch and scheduling limits
+
+`max_requests_per_batch` caps how many requests run in a single forward pass. The model produces a logits tensor sized by the number of batch tokens and the vocabulary size, and it's cast to `fp32` for sampling, which doubles the footprint. Each request only needs one next-token prediction, so a smaller cap keeps this tensor smaller and avoids out-of-memory errors on prefill-heavy batches with large vocabularies. By default it's set to the number of prompts submitted, with a fallback of 1024, then capped to fit `max_batch_tokens` and `num_blocks`.
+
+```py
+cb_config = ContinuousBatchingConfig(max_requests_per_batch=256)
+```
+
+`safety_margin` reserves a fraction of the KV cache for active requests. When free blocks fall below `safety_margin * num_blocks`, the scheduler stops admitting new prefills and only continues decoding the requests already in progress. This prioritizes finishing active work over starting new requests, which protects decode latency and delays [offloading](./continuous_batching_architecture#offloading). The value must fall between `0` and `1`, where `0` disables the margin.
+
+```py
+cb_config = ContinuousBatchingConfig(safety_margin=0.15)
+```
+
+The default depends on the scheduler. For the FIFO scheduler, it's `0.15` and for `prefill_first`, it's `0.0`. See [Admission](./continuous_batching_architecture#admission) for how the margin interacts with scheduling.
 
 ### Log probabilities
 

--- a/docs/source/en/continuous_batching_architecture.md
+++ b/docs/source/en/continuous_batching_architecture.md
@@ -62,10 +62,11 @@ When a new request's prompt exceeds the available token budget (set by `max_batc
 
 ## Scheduler
 
-The scheduler decides which requests join each forward pass based on two budgets.
+The scheduler decides which requests join each forward pass based on two budgets and a request cap.
 
 - Token budget — the maximum number of query tokens processed in a single forward pass, set by `max_batch_tokens` in [`ContinuousBatchingConfig`].
 - Cache budget — the total number of KV pages that can be read in a single pass, which is bounded by the total cache size.
+- Request cap — the maximum number of requests in a single forward pass, set by `max_requests_per_batch`. The logits tensor scales with the vocabulary size, so this cap bounds peak memory for large-vocabulary models.
 
 ### FIFO
 
@@ -116,7 +117,7 @@ cb_config = ContinuousBatchingConfig(
 
 Before a request joins the batch, the scheduler checks that enough free blocks exist for every layer group. If any group would fall short, the request is rejected and nothing is allocated.
 
-To avoid filling the cache until [offloading](#offloading) is the only option, the default FIFO scheduler enforces a safety margin. Once free blocks fall below 20% of the total, new prefills are held back and only active decodes continue.
+To avoid filling the cache until [offloading](#offloading) is the only option, the scheduler enforces a `safety_margin`. Once free blocks fall below `safety_margin * num_blocks`, new prefills are held back and only active decodes continue. The FIFO scheduler defaults to `0.15` (15% of blocks held in reserve), while `prefill_first` defaults to `0.0`. Set `safety_margin` in [`ContinuousBatchingConfig`] to tune it, where `0` disables the margin.
 
 ### Prefix caching
 


### PR DESCRIPTION
adds docs for #46533 and #46434:

- setting levels for `default_compile_level` and the tradeoffs
- setting `max_requests_per_batch` and `safety_margin`