### PR TITLE
Reduce per_page from 100 to 50 in GitHub API calls to avoid server errors

### DIFF
--- a/utils/get_ci_error_statistics.py
+++ b/utils/get_ci_error_statistics.py
@@ -75,9 +75,7 @@ def get_artifacts_links(workflow_run_id, token=None):
     if token is not None:
         headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
 
-    url = (
-        f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/artifacts?per_page=50"
-    )
+    url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/artifacts?per_page=50"
     result = requests.get(url, headers=headers).json()
     artifacts = {}
 

--- a/utils/get_ci_error_statistics.py
+++ b/utils/get_ci_error_statistics.py
@@ -30,6 +30,7 @@ def get_jobs(workflow_run_id, token=None):
         pages_to_iterate_over = math.ceil((result["total_count"] - 50) / 50)
 
         for i in range(pages_to_iterate_over):
+            time.sleep(1)
             result = requests.get(url + f"&page={i + 2}", headers=headers).json()
             jobs.extend(result["jobs"])
 
@@ -56,6 +57,7 @@ def get_job_links(workflow_run_id, token=None):
         pages_to_iterate_over = math.ceil((result["total_count"] - 50) / 50)
 
         for i in range(pages_to_iterate_over):
+            time.sleep(1)
             result = requests.get(url + f"&page={i + 2}", headers=headers).json()
             job_links.update({job["name"]: job["html_url"] for job in result["jobs"]})
 
@@ -84,6 +86,7 @@ def get_artifacts_links(workflow_run_id, token=None):
         pages_to_iterate_over = math.ceil((result["total_count"] - 50) / 50)
 
         for i in range(pages_to_iterate_over):
+            time.sleep(1)
             result = requests.get(url + f"&page={i + 2}", headers=headers).json()
             artifacts.update({artifact["name"]: artifact["archive_download_url"] for artifact in result["artifacts"]})
 

--- a/utils/get_ci_error_statistics.py
+++ b/utils/get_ci_error_statistics.py
@@ -21,13 +21,13 @@ def get_jobs(workflow_run_id, token=None):
     if token is not None:
         headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
 
-    url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=100"
+    url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=50"
     result = requests.get(url, headers=headers).json()
     jobs = []
 
     try:
         jobs.extend(result["jobs"])
-        pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
+        pages_to_iterate_over = math.ceil((result["total_count"] - 50) / 50)
 
         for i in range(pages_to_iterate_over):
             result = requests.get(url + f"&page={i + 2}", headers=headers).json()
@@ -47,13 +47,13 @@ def get_job_links(workflow_run_id, token=None):
     if token is not None:
         headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
 
-    url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=100"
+    url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=50"
     result = requests.get(url, headers=headers).json()
     job_links = {}
 
     try:
         job_links.update({job["name"]: job["html_url"] for job in result["jobs"]})
-        pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
+        pages_to_iterate_over = math.ceil((result["total_count"] - 50) / 50)
 
         for i in range(pages_to_iterate_over):
             result = requests.get(url + f"&page={i + 2}", headers=headers).json()
@@ -74,14 +74,14 @@ def get_artifacts_links(workflow_run_id, token=None):
         headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
 
     url = (
-        f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/artifacts?per_page=100"
+        f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/artifacts?per_page=50"
     )
     result = requests.get(url, headers=headers).json()
     artifacts = {}
 
     try:
         artifacts.update({artifact["name"]: artifact["archive_download_url"] for artifact in result["artifacts"]})
-        pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
+        pages_to_iterate_over = math.ceil((result["total_count"] - 50) / 50)
 
         for i in range(pages_to_iterate_over):
             result = requests.get(url + f"&page={i + 2}", headers=headers).json()

--- a/utils/get_github_job_time.py
+++ b/utils/get_github_job_time.py
@@ -33,13 +33,13 @@ def get_job_time(workflow_run_id, token=None):
     if token is not None:
         headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
 
-    url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=100"
+    url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=50"
     result = requests.get(url, headers=headers).json()
     job_time = {}
 
     try:
         job_time.update({job["name"]: extract_time_from_single_job(job) for job in result["jobs"]})
-        pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
+        pages_to_iterate_over = math.ceil((result["total_count"] - 50) / 50)
 
         for i in range(pages_to_iterate_over):
             result = requests.get(url + f"&page={i + 2}", headers=headers).json()

--- a/utils/get_github_job_time.py
+++ b/utils/get_github_job_time.py
@@ -1,5 +1,6 @@
 import argparse
 import math
+import time
 import traceback
 
 import dateutil.parser as date_parser
@@ -42,6 +43,7 @@ def get_job_time(workflow_run_id, token=None):
         pages_to_iterate_over = math.ceil((result["total_count"] - 50) / 50)
 
         for i in range(pages_to_iterate_over):
+            time.sleep(1)
             result = requests.get(url + f"&page={i + 2}", headers=headers).json()
             job_time.update({job["name"]: extract_time_from_single_job(job) for job in result["jobs"]})
 


### PR DESCRIPTION
## Summary

- Reduce `per_page=100` to `per_page=50` in GitHub API calls in `get_ci_error_statistics.py` and `get_github_job_time.py`
- Fix the corresponding pagination formula (`- 100) / 100` → `- 50) / 50`) to stay consistent

## Context

With `per_page=100`, GitHub sometimes returns `{"message": "Server Error"}` when fetching jobs/artifacts for re-run daily CI workflows. Reducing to `per_page=50` avoids this. The root cause is unclear but seems to be a recent GitHub issue (using `.../attempts/1` in the URL also works as a workaround).
