### PR TITLE
fix(masking): cast tensor q_offset/kv_offset to int in flex_attention_mask

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -721,6 +721,16 @@ def flex_attention_mask(
         padding_mask = prepare_padding_mask(attention_mask, kv_length, kv_offset)
         mask_function = and_masks(mask_function, padding_mask_function(padding_mask))
 
+    # flex's mask_mod is vmapped over scalar `q_idx`/`kv_idx`, so the offsets must be Python ints.
+    # A cache may hand them back as 0-d tensors to avoid graph breaks on the eager/sdpa path (see
+    # `_preprocess_mask_arguments`), where they are only added to a 1-D `arange` and stay harmless.
+    # Here, adding a tensor to the scalar indices injects an extra dimension, making the resulting
+    # mask >4D and raising a `ValueError` inside `create_block_mask`.
+    if isinstance(q_offset, torch.Tensor):
+        q_offset = q_offset.item()
+    if isinstance(kv_offset, torch.Tensor):
+        kv_offset = kv_offset.item()
+
     # Add the offsets on top (because flex interface only allows length, not start and end indices)
     mask_function = add_offsets_to_mask_function(mask_function, q_offset, kv_offset)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #46682.

When flex attention is used together with a cache, `flex_attention_mask` can crash with a `ValueError` about the mask having more than 4 dimensions:

```python
tok = ...  # Qwen3-4B, attn_implementation="flex_attention", use_cache=True
model.generate(...)  # ValueError inside create_block_mask
```

### Root cause

`_preprocess_mask_arguments` obtains the offset from the cache:

```python
q_offset = past_key_values.get_seq_length()
# To avoid graph breaks, StaticLayer returns a tensor instead of int -> this has no impact on the ops, but we
# need the correct device
q_offset = q_offset.to(inputs_embeds.device) if isinstance(q_offset, torch.Tensor) else q_offset
```

So `q_offset` (and similarly `kv_offset` from `get_mask_sizes`) can be a 0-d tensor. This is intentional and harmless on the eager/sdpa path, where the offset is only ever added to a 1-D `arange`:

```python
q_arange = torch.arange(q_length, device=device) + q_offset
```

But `flex_attention_mask` routes the offsets through `add_offsets_to_mask_function`, whose `mask_mod` is vmapped over **scalar** `q_idx`/`kv_idx`:

```python
def inner_mask(batch_idx, head_idx, q_idx, kv_idx):
    return mask_function(batch_idx, head_idx, q_idx + q_offset, kv_idx + kv_offset)
```

Adding a tensor to the scalar indices injects an extra dimension, so the resulting block mask ends up with more than 4 dimensions and `create_block_mask` raises. The original reporter confirmed that converting the offset to a Python `int` via `.item()` before building the mask resolves it (verified under `torch.compile` / inductor).

### Fix

Cast `q_offset`/`kv_offset` to Python ints **inside `flex_attention_mask` only**, right before they are baked into the `mask_mod`. The eager/sdpa path keeps the 0-d tensor (and its graph-break-avoidance benefit) untouched; flex genuinely needs scalar offsets for its vmapped `mask_mod`.

The conversion is guarded by `isinstance(..., torch.Tensor)`, so the common `int` (default `0`) case is unaffected.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a GitHub issue? Fixes #46682.
- [ ] Did you make sure to update the documentation with your changes? (no docs change needed)
- [ ] Did you write any new necessary tests?

## Who can review?

@ArthurZucker @CyrilVallez (flex attention masking)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
