### PR TITLE
Fix Wav2Vec2PhonemeCTCTokenizer stale phonemizer_lang state issue

### DIFF
--- a/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
+++ b/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
@@ -223,7 +223,7 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
             self.do_phonemize = do_phonemize
 
         # set the correct phonemizer language
-        if phonemizer_lang is not None:
+        if phonemizer_lang is not None and phonemizer_lang != self.phonemizer_lang:
             self.phonemizer_lang = phonemizer_lang
             self.init_backend(phonemizer_lang)
 
@@ -255,6 +255,7 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
 
         word_delimiter = self.word_delimiter_token + " " if self.word_delimiter_token is not None else ""
         if phonemizer_lang is not None and phonemizer_lang != self.phonemizer_lang:
+            self.phonemizer_lang = phonemizer_lang
             self.init_backend(phonemizer_lang)
         else:
             phonemizer_lang = self.phonemizer_lang


### PR DESCRIPTION
Fixes #46614. Updates the internal phonemizer_lang state when the backend is re-initialized for a different language, preventing subsequent calls from using the incorrect backend cache.