### PR TITLE
Add Gefen optimizer support to Trainer

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -102,6 +102,7 @@ from .utils import (
     is_fsdp_available,
     is_g2p_en_available,
     is_galore_torch_available,
+    is_gefen_available,
     is_gguf_available,
     is_gptqmodel_available,
     is_grokadamw_available,
@@ -496,6 +497,13 @@ def require_grokadamw(test_case):
     Decorator marking a test that requires GrokAdamW. These tests are skipped when GrokAdamW isn't installed.
     """
     return unittest.skipUnless(is_grokadamw_available(), "test requires GrokAdamW")(test_case)
+
+
+def require_gefen(test_case):
+    """
+    Decorator marking a test that requires Gefen. These tests are skipped when Gefen isn't installed.
+    """
+    return unittest.skipUnless(is_gefen_available(), "test requires Gefen")(test_case)
 
 
 def require_schedulefree(test_case):

--- a/src/transformers/trainer_optimizer.py
+++ b/src/transformers/trainer_optimizer.py
@@ -35,6 +35,7 @@ from .utils import (
     is_apollo_torch_available,
     is_bitsandbytes_available,
     is_galore_torch_available,
+    is_gefen_available,
     is_grokadamw_available,
     is_lomo_available,
     is_schedulefree_available,
@@ -542,6 +543,26 @@ def _get_stable_adamw(ctx: OptimizerContext) -> tuple[Any, dict[str, Any]]:
     return StableAdamW, ctx.optimizer_kwargs
 
 
+def _get_gefen(ctx: OptimizerContext) -> tuple[Any, dict[str, Any]]:
+    """Get Gefen optimizer."""
+    if not is_gefen_available():
+        raise ImportError(
+            "You need to install `gefen` in order to use the Gefen optimizer. Install it with `pip install gefen`."
+        )
+
+    from gefen import Gefen
+
+    ctx.adam_kwargs["weight_decay"] = ctx.args.weight_decay
+    gefen_kwargs = {
+        "fused": strtobool(ctx.optim_args.get("fused", "True")),
+        "verbose": strtobool(ctx.optim_args.get("verbose", "False")),
+    }
+
+    ctx.optimizer_kwargs.update(ctx.adam_kwargs)
+    ctx.optimizer_kwargs.update(gefen_kwargs)
+    return Gefen, ctx.optimizer_kwargs
+
+
 # =============================================================================
 # Dispatch table
 # =============================================================================
@@ -605,6 +626,7 @@ _OPTIMIZER_HANDLERS: dict[str, OptimizerHandler] = {
     OptimizerNames.RMSPROP: _get_rmsprop,
     OptimizerNames.GROKADAMW: _get_grokadamw,
     OptimizerNames.STABLE_ADAMW: _get_stable_adamw,
+    OptimizerNames.GEFEN: _get_gefen,
     OptimizerNames.LOMO: _get_lomo_optimizer,
     OptimizerNames.ADALOMO: _get_lomo_optimizer,
     **dict.fromkeys(_BITSANDBYTES_OPTIMIZERS, _get_bitsandbytes_optimizer),

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -155,6 +155,7 @@ class OptimizerNames(ExplicitEnum):
     APOLLO_ADAMW = "apollo_adamw"
     APOLLO_ADAMW_LAYERWISE = "apollo_adamw_layerwise"
     STABLE_ADAMW = "stable_adamw"
+    GEFEN = "gefen"
 
 
 def _convert_str_dict(passed_value: dict):

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -145,6 +145,7 @@ from .import_utils import (
     is_fsdp_available,
     is_g2p_en_available,
     is_galore_torch_available,
+    is_gefen_available,
     is_gguf_available,
     is_gptqmodel_available,
     is_grokadamw_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -755,6 +755,11 @@ def is_galore_torch_available() -> bool:
 
 
 @lru_cache
+def is_gefen_available() -> bool:
+    return _is_package_available("gefen")[0]
+
+
+@lru_cache
 def is_apollo_torch_available() -> bool:
     return _is_package_available("apollo_torch")[0]
 

--- a/tests/trainer/test_trainer_optimizers.py
+++ b/tests/trainer/test_trainer_optimizers.py
@@ -15,7 +15,7 @@
 """
 Trainer optimizer and LR scheduler tests: custom optimizers, LR scheduler kwargs, cosine-with-min-lr,
 reduce-on-plateau, Adafactor, bitsandbytes (RMSProp, AdEMAMix), LOMO, GrokAdamW, schedule-free,
-GaLore, Apollo, Stable AdamW, Liger kernel, optimizer choice resolution, factory pattern detection,
+GaLore, Apollo, Stable AdamW, Gefen, Liger kernel, optimizer choice resolution, factory pattern detection,
 and model parameter inspection.
 """
 
@@ -38,6 +38,7 @@ from transformers.testing_utils import (
     require_apollo_torch,
     require_bitsandbytes,
     require_galore_torch,
+    require_gefen,
     require_grokadamw,
     require_lomo,
     require_schedulefree,
@@ -249,6 +250,38 @@ class TrainerOptimizerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
     @require_torch_accelerator
     def test_grokadamw(self):
         self._train_with_llama("grokadamw", learning_rate=2e-5, max_steps=20)
+
+    # ---------------------------------------------------------------------------
+    # Gefen test
+    # ---------------------------------------------------------------------------
+
+    @require_gefen
+    def test_gefen_trainer_adamw_args(self):
+        from gefen import Gefen
+
+        tiny_llama, train_dataset = self._get_llama_and_dataset()
+        args = TrainingArguments(
+            self.get_auto_remove_tmp_dir(),
+            learning_rate=1e-9,
+            logging_steps=5,
+            weight_decay=0.001,
+            adam_beta1=0.89,
+            adam_beta2=0.98,
+            adam_epsilon=1e-8,
+            optim="gefen",
+            optim_args="fused=False,verbose=True",
+        )
+        trainer = Trainer(tiny_llama, args, train_dataset=train_dataset)
+        trainer.create_optimizer_and_scheduler(num_training_steps=10)
+
+        self.assertIsInstance(trainer.optimizer, Gefen)
+        self.assertFalse(trainer.optimizer.fused)
+        self.assertTrue(trainer.optimizer.verbose)
+        self.assertEqual(trainer.optimizer.defaults["lr"], args.learning_rate)
+        self.assertEqual(trainer.optimizer.defaults["beta1"], args.adam_beta1)
+        self.assertEqual(trainer.optimizer.defaults["beta2"], args.adam_beta2)
+        self.assertEqual(trainer.optimizer.defaults["eps"], args.adam_epsilon)
+        self.assertIn(args.weight_decay, {group["weight_decay"] for group in trainer.optimizer.param_groups})
 
     # ---------------------------------------------------------------------------
     # Schedule-free tests


### PR DESCRIPTION
# What does this PR do?

Adds `optim="gefen"` support to `TrainingArguments` / `Trainer`.

Gefen is an AdamW-style memory-efficient optimizer. Gefen is a drop-in replacement for the AdamW optimizer for memory-efficient training. It keeps the familiar AdamW training recipe while dramatically reducing optimizer-state memory: an 8x reduction in AdamW memory footprint, or about 6.5 GiB saved per billion parameters, while maintaining AdamW-level performance. The reduced memory footprint lets you train larger models or use larger batch sizes and, as a result, achieve higher training throughput.

Users can now write:

```python
training_args = TrainingArguments(
    ...,
    optim="gefen",
)
```

Gefen-specific options can be passed via optim_args:

```
training_args = TrainingArguments(
    ...,
    optim="gefen",
    optim_args="fused=False,verbose=False",
)
```

Tests:

python -m pytest tests/trainer/test_trainer_optimizers.py::TrainerOptimizerIntegrationTest::test_gefen_trainer_adamw_args -q


