### PR TITLE
Laguna: support per-element output gating

### DIFF
--- a/src/transformers/models/laguna/configuration_laguna.py
+++ b/src/transformers/models/laguna/configuration_laguna.py
@@ -32,6 +32,10 @@ class LagunaConfig(PreTrainedConfig):
     r"""
     num_attention_heads_per_layer (`list[int]`, *optional*):
         Per-layer override for ``num_attention_heads``. Length must equal ``num_hidden_layers``.
+    gating (`bool` or `str`, *optional*, defaults to `True`):
+        Softplus output-gate granularity. ``True`` or ``"per-head"`` applies one gate per head,
+        broadcast across ``head_dim``; ``"per-element"`` applies one gate per ``(head, head_dim)``
+        channel.
     mlp_layer_types (`list[str]`, *optional*):
         Per-layer MLP type — ``"dense"`` or ``"sparse"``. Length must equal
         ``num_hidden_layers``. Defaults to first layer dense, rest sparse.
@@ -109,6 +113,7 @@ class LagunaConfig(PreTrainedConfig):
     # Laguna-specific attention
     head_dim: int = 128
     attention_bias: bool = False
+    gating: bool | str = True
     num_attention_heads_per_layer: list[int] | None = None
     # Laguna-specific MoE
     mlp_layer_types: list[str] | None = None

--- a/src/transformers/models/laguna/modeling_laguna.py
+++ b/src/transformers/models/laguna/modeling_laguna.py
@@ -367,7 +367,9 @@ class LagunaAttention(nn.Module):
 
         self.q_norm = LagunaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = LagunaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.g_proj = nn.Linear(config.hidden_size, self.num_heads, bias=False)
+        self.gate_per_head = config.gating is True or config.gating == "per-head"
+        g_proj_dim = self.num_heads if self.gate_per_head else self.num_heads * self.head_dim
+        self.g_proj = nn.Linear(config.hidden_size, g_proj_dim, bias=False)
 
     def forward(
         self,
@@ -412,7 +414,12 @@ class LagunaAttention(nn.Module):
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
 
         gate = F.softplus(self.g_proj(hidden_states).float()).to(attn_output.dtype)
-        attn_output = (attn_output.view(*input_shape, -1, self.head_dim) * gate.unsqueeze(-1)).view(*input_shape, -1)
+        if self.gate_per_head:
+            attn_output = (attn_output.view(*input_shape, -1, self.head_dim) * gate.unsqueeze(-1)).view(
+                *input_shape, -1
+            )
+        else:
+            attn_output = attn_output * gate
 
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights

--- a/src/transformers/models/laguna/modular_laguna.py
+++ b/src/transformers/models/laguna/modular_laguna.py
@@ -51,6 +51,10 @@ class LagunaConfig(Qwen2MoeConfig):
     r"""
     num_attention_heads_per_layer (`list[int]`, *optional*):
         Per-layer override for ``num_attention_heads``. Length must equal ``num_hidden_layers``.
+    gating (`bool` or `str`, *optional*, defaults to `True`):
+        Softplus output-gate granularity. ``True`` or ``"per-head"`` applies one gate per head,
+        broadcast across ``head_dim``; ``"per-element"`` applies one gate per ``(head, head_dim)``
+        channel.
     mlp_layer_types (`list[str]`, *optional*):
         Per-layer MLP type — ``"dense"`` or ``"sparse"``. Length must equal
         ``num_hidden_layers``. Defaults to first layer dense, rest sparse.
@@ -108,6 +112,7 @@ class LagunaConfig(Qwen2MoeConfig):
     # Laguna-specific attention
     head_dim: int = 128
     attention_bias: bool = False
+    gating: bool | str = True
     num_attention_heads_per_layer: list[int] | None = None
     # Laguna-specific MoE
     mlp_layer_types: list[str] | None = None
@@ -291,9 +296,10 @@ class LagunaAttention(AfmoeAttention):
         self.q_proj = nn.Linear(config.hidden_size, self.num_heads * self.head_dim, bias=config.attention_bias)
         self.o_proj = nn.Linear(self.num_heads * self.head_dim, config.hidden_size, bias=config.attention_bias)
 
-        # Custom per-head gating
         del self.gate_proj
-        self.g_proj = nn.Linear(config.hidden_size, self.num_heads, bias=False)
+        self.gate_per_head = config.gating is True or config.gating == "per-head"
+        g_proj_dim = self.num_heads if self.gate_per_head else self.num_heads * self.head_dim
+        self.g_proj = nn.Linear(config.hidden_size, g_proj_dim, bias=False)
 
     def forward(
         self,
@@ -338,7 +344,12 @@ class LagunaAttention(AfmoeAttention):
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
 
         gate = F.softplus(self.g_proj(hidden_states).float()).to(attn_output.dtype)
-        attn_output = (attn_output.view(*input_shape, -1, self.head_dim) * gate.unsqueeze(-1)).view(*input_shape, -1)
+        if self.gate_per_head:
+            attn_output = (attn_output.view(*input_shape, -1, self.head_dim) * gate.unsqueeze(-1)).view(
+                *input_shape, -1
+            )
+        else:
+            attn_output = attn_output * gate
 
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights

--- a/tests/models/laguna/test_modeling_laguna.py
+++ b/tests/models/laguna/test_modeling_laguna.py
@@ -18,7 +18,7 @@ import unittest
 from parameterized import parameterized
 
 from transformers import is_torch_available
-from transformers.testing_utils import require_torch, slow, torch_device
+from transformers.testing_utils import Expectations, require_torch, require_torch_accelerator, slow, torch_device
 
 
 if is_torch_available():
@@ -26,6 +26,7 @@ if is_torch_available():
 
     from transformers import (
         LagunaConfig,
+        LagunaForCausalLM,
         LagunaModel,
     )
 
@@ -165,43 +166,80 @@ class LagunaModelTest(CausalLMModelTest, unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             LagunaConfig(**cfg_kwargs)
 
-    def _model_with_gating(self, gating):
+    @parameterized.expand([(True,), ("per-head",), ("per-element",)])
+    def test_gating_variations(self, gating):
+        """Checking whether each flavor option is properly propagated"""
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        cfg_kwargs = config.to_dict()
-        cfg_kwargs["gating"] = gating
-        config = LagunaConfig(**cfg_kwargs)
+        config.gating = gating
+        # We only check the underlying base class for simplicity
         model = self.model_tester.base_model_class(config).to(torch_device).eval()
-        return config, inputs_dict, model
 
-    @parameterized.expand([(True,), ("per-head",)])
-    def test_gating_per_head_shape(self, gating):
-        """`gating=True` / `"per-head"`: one gate per head (g_proj out = num_heads)."""
-        _, _, model = self._model_with_gating(gating)
         for layer in model.layers:
-            self.assertTrue(layer.self_attn.gate_per_head)
-            self.assertEqual(layer.self_attn.g_proj.out_features, layer.self_attn.num_heads)
+            if gating == "per-element":
+                self.assertFalse(layer.self_attn.gate_per_head)
+            else:
+                self.assertTrue(layer.self_attn.gate_per_head)
 
-    def test_gating_per_element_shape_and_forward(self):
-        """`gating="per-element"`: one gate per (head, head_dim) channel."""
-        config, inputs_dict, model = self._model_with_gating("per-element")
-        for layer in model.layers:
-            self.assertFalse(layer.self_attn.gate_per_head)
-            self.assertEqual(
-                layer.self_attn.g_proj.out_features,
-                layer.self_attn.num_heads * config.head_dim,
+            expected_shape = (
+                layer.self_attn.num_heads if gating != "per-element" else layer.self_attn.num_heads * config.head_dim
             )
+            self.assertEqual(layer.self_attn.g_proj.out_features, expected_shape)
+
         with torch.no_grad():
             model(input_ids=inputs_dict["input_ids"].to(torch_device))
 
+    def test_per_element_gating_end_to_end(self):
+        """End-to-end check of the per-element gating path: greedy generation is
+        deterministic, and the gate measurably affects the logits."""
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        config.gating = "per-element"
+        torch.manual_seed(0)
+        model = LagunaForCausalLM(config).to(torch_device).eval()
+        input_ids = inputs_dict["input_ids"].to(torch_device)
 
-@require_torch
+        # Generation runs end-to-end through the per-element path and is deterministic.
+        with torch.no_grad():
+            gen1 = model.generate(input_ids, max_new_tokens=8, min_new_tokens=8, do_sample=False)
+            gen2 = model.generate(input_ids, max_new_tokens=8, min_new_tokens=8, do_sample=False)
+        self.assertEqual(gen1.shape[1], input_ids.shape[1] + 8)
+        self.assertTrue(torch.equal(gen1, gen2))
+
+        # The gate is actually applied: zeroing g_proj collapses softplus(g_proj(x))
+        # to the constant softplus(0)=ln(2), which changes the logits.
+        with torch.no_grad():
+            logits = model(input_ids).logits
+            for layer in model.model.layers:
+                torch.nn.init.zeros_(layer.self_attn.g_proj.weight)
+            logits_gate_collapsed = model(input_ids).logits
+        self.assertFalse(torch.allclose(logits, logits_gate_collapsed))
+
+
+@slow
+@require_torch_accelerator
 class LagunaIntegrationTest(unittest.TestCase):
-    """Slow integration tests — need a public Hub checkpoint.
+    def test_per_element_gating_logits(self):
+        """Logits of a small per-element-gating Laguna checkpoint, batched with padding."""
+        model_id = "poolside/Laguna-tiny-per-element"
+        dummy_input = torch.LongTensor([[0, 0, 0, 0, 0, 0, 1, 2, 3], [1, 1, 2, 3, 4, 5, 6, 7, 8]]).to(torch_device)
+        attention_mask = dummy_input.ne(0).to(torch.long)
 
-    TODO: replace the placeholder id once the Laguna model card is published.
-    """
+        model = LagunaForCausalLM.from_pretrained(model_id, dtype="auto", device_map="auto")
 
-    @slow
-    @unittest.skip("public Laguna checkpoint not yet published")
-    def test_logits_and_generation(self):
-        pass
+        expected_left = Expectations(
+            {
+                ("cuda", 8): [[0.0033, 0.0581, -0.1718], [-0.0559, -0.1834, 0.0085], [-0.0235, -0.0824, -0.0569]],
+            }
+        )  # fmt: skip
+        expected_right = Expectations(
+            {
+                ("cuda", 8): [[0.0132, -0.0518, -0.1204], [-0.0231, -0.0547, 0.0684], [-0.1406, -0.2664, -0.1904]],
+            }
+        )  # fmt: skip
+        expected_left = torch.tensor(expected_left.get_expectation(), device=torch_device)
+        expected_right = torch.tensor(expected_right.get_expectation(), device=torch_device)
+
+        with torch.no_grad():
+            logits = model(dummy_input, attention_mask=attention_mask).logits.float()
+
+        torch.testing.assert_close(logits[0, -3:, -3:], expected_left, atol=1e-3, rtol=1e-3)
+        torch.testing.assert_close(logits[1, -3:, -3:], expected_right, atol=1e-3, rtol=1e-3)

--- a/tests/models/laguna/test_modeling_laguna.py
+++ b/tests/models/laguna/test_modeling_laguna.py
@@ -188,33 +188,9 @@ class LagunaModelTest(CausalLMModelTest, unittest.TestCase):
         with torch.no_grad():
             model(input_ids=inputs_dict["input_ids"].to(torch_device))
 
-    def test_per_element_gating_end_to_end(self):
-        """End-to-end check of the per-element gating path: greedy generation is
-        deterministic, and the gate measurably affects the logits."""
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        config.gating = "per-element"
-        torch.manual_seed(0)
-        model = LagunaForCausalLM(config).to(torch_device).eval()
-        input_ids = inputs_dict["input_ids"].to(torch_device)
-
-        # Generation runs end-to-end through the per-element path and is deterministic.
-        with torch.no_grad():
-            gen1 = model.generate(input_ids, max_new_tokens=8, min_new_tokens=8, do_sample=False)
-            gen2 = model.generate(input_ids, max_new_tokens=8, min_new_tokens=8, do_sample=False)
-        self.assertEqual(gen1.shape[1], input_ids.shape[1] + 8)
-        self.assertTrue(torch.equal(gen1, gen2))
-
-        # The gate is actually applied: zeroing g_proj collapses softplus(g_proj(x))
-        # to the constant softplus(0)=ln(2), which changes the logits.
-        with torch.no_grad():
-            logits = model(input_ids).logits
-            for layer in model.model.layers:
-                torch.nn.init.zeros_(layer.self_attn.g_proj.weight)
-            logits_gate_collapsed = model(input_ids).logits
-        self.assertFalse(torch.allclose(logits, logits_gate_collapsed))
-
 
 @slow
+@require_torch
 @require_torch_accelerator
 class LagunaIntegrationTest(unittest.TestCase):
     def test_per_element_gating_logits(self):

--- a/tests/models/laguna/test_modeling_laguna.py
+++ b/tests/models/laguna/test_modeling_laguna.py
@@ -165,6 +165,34 @@ class LagunaModelTest(CausalLMModelTest, unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             LagunaConfig(**cfg_kwargs)
 
+    def _model_with_gating(self, gating):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        cfg_kwargs = config.to_dict()
+        cfg_kwargs["gating"] = gating
+        config = LagunaConfig(**cfg_kwargs)
+        model = self.model_tester.base_model_class(config).to(torch_device).eval()
+        return config, inputs_dict, model
+
+    @parameterized.expand([(True,), ("per-head",)])
+    def test_gating_per_head_shape(self, gating):
+        """`gating=True` / `"per-head"`: one gate per head (g_proj out = num_heads)."""
+        _, _, model = self._model_with_gating(gating)
+        for layer in model.layers:
+            self.assertTrue(layer.self_attn.gate_per_head)
+            self.assertEqual(layer.self_attn.g_proj.out_features, layer.self_attn.num_heads)
+
+    def test_gating_per_element_shape_and_forward(self):
+        """`gating="per-element"`: one gate per (head, head_dim) channel."""
+        config, inputs_dict, model = self._model_with_gating("per-element")
+        for layer in model.layers:
+            self.assertFalse(layer.self_attn.gate_per_head)
+            self.assertEqual(
+                layer.self_attn.g_proj.out_features,
+                layer.self_attn.num_heads * config.head_dim,
+            )
+        with torch.no_grad():
+            model(input_ids=inputs_dict["input_ids"].to(torch_device))
+
 
 @require_torch
 class LagunaIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

Laguna applies a softplus output gate after attention, whose granularity is set
by `config.gating`. The current implementation hardcodes the per-head case
(`g_proj` sized `num_heads`, gate broadcast over `head_dim`). This PR adds the
configurable per-element setting:

- `True` / `"per-head"`: one gate per head (`g_proj` output = `num_heads`).
- `"per-element"`: one gate per `(head, head_dim)` channel
  (`g_proj` output = `num_heads * head_dim`).

Without it, a config with `gating="per-element"` mismatches the `g_proj` weight
shape at load time.

## Changes

- Add `gating` (`bool | str`, default `True`) to `LagunaConfig`, with docstring.
- Branch `g_proj` allocation and the forward gate application on `config.gating`
  in `modular_laguna.py`; regenerate `modeling_laguna.py` and
  `configuration_laguna.py`.
- Add gating shape tests to `tests/models/laguna/test_modeling_laguna.py`.

The default (`gating=True`) behavior is unchanged, and the dispatch mirrors the
vLLM Laguna implementation. Per-element support is unit-tested at the model
level (g_proj allocation + a per-element forward pass).

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Did you make sure to update the documentation with your changes? (config docstring)
- [x] Did you write any new necessary tests?

## Who can review?

Text-models / `modular` maintainers, I suppose. Laguna was added in #45673.