### PR TITLE
[`Blip2`] Fix cross attention reshape

### DIFF
--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -602,7 +602,8 @@ class Blip2QFormerMultiHeadAttention(nn.Module):
             **kwargs,
         )
 
-        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        # NOTE: KV has a different bsz than Q so we take the broadcasted shapes instead of the input shape
+        attn_output = attn_output.reshape(*attn_output.shape[:2], -1).contiguous()
         return attn_output, attn_weights
 
 

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -510,7 +510,8 @@ class InstructBlipQFormerMultiHeadAttention(nn.Module):
             **kwargs,
         )
 
-        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        # NOTE: KV has a different bsz than Q so we take the broadcasted shapes instead of the input shape
+        attn_output = attn_output.reshape(*attn_output.shape[:2], -1).contiguous()
         return attn_output, attn_weights
 
 

--- a/src/transformers/models/instructblipvideo/modeling_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/modeling_instructblipvideo.py
@@ -514,7 +514,8 @@ class InstructBlipVideoQFormerMultiHeadAttention(nn.Module):
             **kwargs,
         )
 
-        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        # NOTE: KV has a different bsz than Q so we take the broadcasted shapes instead of the input shape
+        attn_output = attn_output.reshape(*attn_output.shape[:2], -1).contiguous()
         return attn_output, attn_weights
 
 


### PR DESCRIPTION
As per title. It's a regression caused by #46401 (discovered it during #46039) where the cross attn final shape is not done properly (the root cause is that there oftentimes is some broadcasting going on between q and kv so the final shape is not "static").

Tbh, I'm not sure why this was even mergable with the merge queue as it is already indicated with fast test using granite speech plus.