### PR TITLE
Fix: honor cache_config["max_cache_len"] on the static-cache path

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1929,10 +1929,18 @@ class GenerationMixin(ContinuousMixin):
                     f"and will be removed in v5.13. Please only use one of {STATIC_CACHE_IMPLEMENTATIONS}, "
                     "and the layer structure will be inferred automatically."
                 )
+            # A user-supplied `cache_config={"max_cache_len": N}` pins the static cache size, so
+            # repeated `generate()` calls up to that ceiling reuse one cache instead of reallocating
+            # (and, under `torch.compile`, recompiling). This was previously honored only on the
+            # quantized path. `max(...)` guarantees we never under-size the cache for this call.
+            static_max_cache_len = max_cache_length
+            requested_max_cache_len = (generation_config.cache_config or {}).get("max_cache_len")
+            if requested_max_cache_len is not None:
+                static_max_cache_len = max(max_cache_length, requested_max_cache_len)
             model_kwargs[cache_name] = self._prepare_static_cache(
                 cache_implementation=generation_config.cache_implementation,
                 batch_size=max(generation_config.num_beams, generation_config.num_return_sequences) * batch_size,
-                max_cache_len=max_cache_length,
+                max_cache_len=static_max_cache_len,
                 model_kwargs=model_kwargs,
             )
         elif generation_config.cache_implementation == "quantized":

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -108,6 +108,43 @@ class CacheTest(unittest.TestCase):
         self.assertTrue(cached_keys.shape == (1, 1, 10, 128))
         self.assertTrue(cached_values.shape == (1, 1, 10, 128))
 
+    def test_static_cache_honors_cache_config_max_cache_len(self):
+        """
+        Regression test for #46424: on the static-cache path, an explicit
+        `cache_config={"max_cache_len": N}` must size the auto-allocated cache to (at least) N, so
+        repeated `generate()` calls up to that ceiling reuse a single cache instead of reallocating
+        (and, under `torch.compile`, recompiling). Before the fix `cache_config` was read only on the
+        quantized path, so the static cache was always sized to `max_length - 1` and the request was
+        silently ignored.
+        """
+        config = LlamaConfig(
+            vocab_size=256,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=4096,
+        )
+        model = AutoModelForCausalLM.from_config(config).to(torch_device).eval()
+
+        input_ids = torch.randint(0, config.vocab_size, (1, 32), device=torch_device)
+        requested_max_cache_len = 2048
+
+        model.generate(
+            input_ids,
+            max_new_tokens=16,
+            cache_implementation="static",
+            cache_config={"max_cache_len": requested_max_cache_len},
+            do_sample=False,
+            num_beams=1,
+            pad_token_id=0,
+            disable_compile=True,
+        )
+
+        # max_length - 1 here is 32 + 16 - 1 = 47; without the fix the cache is sized 47, not 2048.
+        self.assertEqual(model._cache.max_cache_len, requested_max_cache_len)
+
 
 def _skip_on_failed_cache_prerequisites(test, cache_implementation):
     """Function to skip tests on failed cache prerequisites, given a cache implementation"""


### PR DESCRIPTION
Fixes #46424 x

## What

`GenerationConfig.cache_config` is documented as carrying "arguments used in the key-value cache class", but on the **static**-cache path it is silently ignored. Setting `cache_config={"max_cache_len": N}` together with `cache_implementation="static"` produces a cache sized to `max_length - 1`, not `N`:

```python
gen = GenerationConfig(max_new_tokens=16, cache_implementation="static",
                       cache_config={"max_cache_len": 2048}, do_sample=False)
model.generate(input_ids, generation_config=gen)   # prompt_len = 32
model._cache.max_cache_len      # 47  (== max_length-1), not the requested 2048
```

The practical cost (from the issue): a second `generate()` with a larger `max_new_tokens` pays a full `StaticCache` realloc **+ `torch.compile` recompile**, because the auto-allocated cache was sized for the first call. The documented way to avoid that — pin the size via `cache_config` — is exactly the path that doesn't work today.

## Root cause

In `GenerationMixin._prepare_cache_for_generation` (`src/transformers/generation/utils.py`), `cache_config` is read **only** inside the `elif generation_config.cache_implementation == "quantized"` branch. The static branch sizes the cache straight from the `max_cache_length` argument (`= generation_config.max_length - 1`, computed by the caller) and never consults `cache_config`:

```python
if generation_config.cache_implementation in ALL_STATIC_CACHE_IMPLEMENTATIONS:
    ...
    model_kwargs[cache_name] = self._prepare_static_cache(
        ...
        max_cache_len=max_cache_length,   # <-- cache_config never read here
    )
elif generation_config.cache_implementation == "quantized":
    ...
    cache_config = generation_config.cache_config if ... else {}   # <-- only reader
```

A runtime trace of the repro confirms it: `max_cache_length` arrives as `47`, the static branch is taken, and **neither** the quantized-branch condition **nor** the `cache_config` read ever executes (trace below).

## When it was introduced (not a regression)

`git bisect` has no "good" commit here — the static path has **never** honored `cache_config`. `cache_config` was introduced as a *QuantizedCache* config object, and every refactor since has kept it quantized-only:

```
$ git log -S cache_config -- src/transformers/generation/utils.py   # earliest
d583f1317b  2024-05-23  Quantized KV Cache (#30483)              # cache_config is born, quantized-only
1687954f5a  2026-02-04  🚨 Generation cache preparation (#43679) # current branch structure
```

At both #43679 and its parent commit, `cache_config` is read only on the quantized branch. So this is a long-standing gap dating to the field's origin (#30483), not a regression.

## Fix

Thread `cache_config["max_cache_len"]` into the static path, guarded with `max()` so the cache is never under-sized for the current call:

```python
if generation_config.cache_implementation in ALL_STATIC_CACHE_IMPLEMENTATIONS:
    ...
    static_max_cache_len = max_cache_length
    requested_max_cache_len = (generation_config.cache_config or {}).get("max_cache_len")
    if requested_max_cache_len is not None:
        static_max_cache_len = max(max_cache_length, requested_max_cache_len)
    model_kwargs[cache_name] = self._prepare_static_cache(
        ...
        max_cache_len=static_max_cache_len,
    )
```

When `cache_config` is `None` or carries no `max_cache_len`, the value is unchanged — **no behavior change for the default path**. `max(...)` means an explicit-but-too-small `max_cache_len` can never shrink the cache below what the current call needs.

## Tests

Added `tests/utils/test_cache_utils.py::CacheTest::test_static_cache_honors_cache_config_max_cache_len` (in the existing no-download / no-GPU `CacheTest` class): builds a tiny random Llama, runs `generate()` with `cache_implementation="static"` and `cache_config={"max_cache_len": 2048}`, and asserts the allocated cache is sized to `2048`.

- **With this fix:** passes.
- **Without it:** fails with `AssertionError: 47 != 2048` (the bug).

<details>
<summary>Runtime trace — <b>before</b> the fix (the diagnosis)</summary>

Captured by instrumenting `src/transformers/generation/utils.py` and running the repro. `file:line` are pristine source coordinates.

```
#10  utils.py:2185  → generate(…)  generation_config = { "cache_config": {"max_cache_len": 2048}, "cache_implementation": "static", … }
#190 utils.py:2549  max_cache_length = 47                                                       # = max_length - 1
#192 utils.py:1861  → _prepare_cache_for_generation(… max_cache_length=47)
#207 utils.py:1922  generation_config.cache_implementation == "offloaded" = False
#208 utils.py:1925  generation_config.cache_implementation in ALL_STATIC_CACHE_IMPLEMENTATIONS = True
#209 utils.py:1926  generation_config.cache_implementation in DEPRECATED_STATIC_CACHE_IMPLEMENTATIONS = False
#221 utils.py:1955  self.config.is_encoder_decoder = False
```

The complete set of events between lines 1920–1960 is the four shown above. There is **no event at line 1938** (`elif … == "quantized"`) and **no event at line 1945** (`cache_config = …`): the only code that reads `cache_config` is never reached on the static path, so the requested `2048` is structurally unreachable and `47` sizes the cache.

</details>

<details>
<summary>Runtime trace — <b>after</b> the fix (verification)</summary>

```
#208 utils.py:1925  generation_config.cache_implementation in ALL_STATIC_CACHE_IMPLEMENTATIONS = True
#210 utils.py:1936  static_max_cache_len    = 47       # starts at max_length - 1
#211 utils.py:1937  requested_max_cache_len = 2048     # static path now reads cache_config
#212 utils.py:1938  requested_max_cache_len is not None = True
#213 utils.py:1939  static_max_cache_len    = 2048     # max(47, 2048) → cache sized 2048
```

</details>

## Who can help

@ArthurZucker @Cyrilvallez