### PR TITLE
Update GLM-5.2 docs

### DIFF
--- a/docs/source/en/model_doc/glm_moe_dsa.md
+++ b/docs/source/en/model_doc/glm_moe_dsa.md
@@ -16,7 +16,7 @@ limitations under the License.
 ⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be rendered properly in your Markdown viewer.
 
 -->
-*This model was published in HF papers on 2026-02-17 and contributed to Hugging Face Transformers on 2026-06-17.*
+*This model was published in HF papers on 2026-02-17 and contributed to Hugging Face Transformers on 2026-02-09.*
 
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
@@ -34,7 +34,7 @@ GLM-5.2, our latest flagship model for long-horizon tasks. It marks a substantia
 GLM-5.2's new capabilities include:
 - **Solid 1M Context:** A solid 1M-token context that stably sustains long-horizon work
 - **Advanced Coding with Flexible Effort**: Stronger coding capabilities with multiple thinking effort levels to balance performance and latency
-- **Improved Architecture**: We propose [IndexShare](https://arxiv.org/abs/2603.12201), which reuses the same indexer across every four sparse attention layers, reducing per-token FLOPs by 2.9× at a 1M context length. We also improve GLM-5.2’s MTP layer for speculative decoding, increasing the acceptance length by up to 20%
+- **Improved Architecture**: We propose [IndexShare](https://huggingface.co/papers/2603.12201), which reuses the same indexer across every four sparse attention layers, reducing per-token FLOPs by 2.9× at a 1M context length. We also improve GLM-5.2’s MTP layer for speculative decoding, increasing the acceptance length by up to 20%
 
 ![bench_52](https://raw.githubusercontent.com/zai-org/GLM-5/refs/heads/main/resources/bench_52.png)
 

--- a/docs/source/en/model_doc/glm_moe_dsa.md
+++ b/docs/source/en/model_doc/glm_moe_dsa.md
@@ -27,6 +27,10 @@ limitations under the License.
 
 # GLM-5, GLM-5.1, GLM-5.2
 
+## Overview
+
+**GLM-5**, **GLM-5.1** and **GLM-5.2** language model use this class. The implementation in transformers does not include an MTP layer.
+
 ### GLM-5.2
 
 GLM-5.2, our latest flagship model for long-horizon tasks. It marks a substantial leap in long-horizon task capability over its predecessor GLM-5.1 and, for the first time, delivers that capability on a **solid 1M-token context**. 

--- a/docs/source/en/model_doc/glm_moe_dsa.md
+++ b/docs/source/en/model_doc/glm_moe_dsa.md
@@ -16,7 +16,7 @@ limitations under the License.
 ⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be rendered properly in your Markdown viewer.
 
 -->
-*This model was published in HF papers on 2026-02-17 and contributed to Hugging Face Transformers on 2026-02-09.*
+*This model was published in HF papers on 2026-02-17 and contributed to Hugging Face Transformers on 2026-06-17.*
 
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
@@ -25,49 +25,43 @@ limitations under the License.
     </div>
 </div>
 
-# GlmMoeDsa
+# GLM-5, GLM-5.1, GLM-5.2
 
-[GlmMoeDsa](https://huggingface.co/papers/2602.15763) (GLM-5) is a 744B-parameter mixture-of-experts model with 40B active parameters per token, using DeepSeek Sparse Attention (DSA) for efficient 200K-token context handling. It was trained entirely on Huawei Ascend chips and matches frontier-level performance on reasoning and long-context benchmarks.
+### GLM-5.2
 
-The example below demonstrates how to generate text with [`Pipeline`] or the [`AutoModelForCausalLM`] class.
+GLM-5.2, our latest flagship model for long-horizon tasks. It marks a substantial leap in long-horizon task capability over its predecessor GLM-5.1 and, for the first time, delivers that capability on a **solid 1M-token context**. 
 
-<hfoptions id="usage">
-<hfoption id="Pipeline">
+GLM-5.2's new capabilities include:
+- **Solid 1M Context:** A solid 1M-token context that stably sustains long-horizon work
+- **Advanced Coding with Flexible Effort**: Stronger coding capabilities with multiple thinking effort levels to balance performance and latency
+- **Improved Architecture**: We propose [IndexShare](https://arxiv.org/abs/2603.12201), which reuses the same indexer across every four sparse attention layers, reducing per-token FLOPs by 2.9× at a 1M context length. We also improve GLM-5.2’s MTP layer for speculative decoding, increasing the acceptance length by up to 20%
 
-```python
-from transformers import pipeline
+![bench_52](https://raw.githubusercontent.com/zai-org/GLM-5/refs/heads/main/resources/bench_52.png)
+
+On standard coding benchmarks, GLM-5.2 is the strongest open-source model, improving on GLM-5.1 by a wide margin: 81.0 vs. 62.0 on Terminal-Bench 2.1 and 62.1 vs. 58.4 on SWE-bench Pro. It also closes much of the gap to the closed-source frontier — on Terminal-Bench 2.1 (81.0) it lands within a few points of Claude Opus 4.8 (85.0) — while staying ahead of Gemini 3.1 Pro.
+
+For more detail, check our [blog](https://z.ai/blog/glm-5.2).
+
+### GLM-5.1
+
+GLM-5.1 is our next-generation flagship model for agentic engineering, with significantly stronger coding capabilities than its predecessor. It achieves state-of-the-art performance on SWE-Bench Pro and leads GLM-5 by a wide margin on NL2Repo (repo generation) and Terminal-Bench 2.0 (real-world terminal tasks).
+
+![bench_51](https://raw.githubusercontent.com/zai-org/GLM-5/refs/heads/main/resources/bench_51.png)
+
+But the most meaningful leap goes beyond first-pass performance. Previous models—including GLM-5—tend to exhaust their repertoire early: they apply familiar techniques for quick initial gains, then plateau. Giving them more time doesn't help.
+
+GLM-5.1, by contrast, is built to stay effective on agentic tasks over much longer horizons. We've found that the model handles ambiguous problems with better judgment and stays productive over longer sessions. It breaks complex problems down, runs experiments, reads results, and identifies blockers with real precision. By revisiting its reasoning and revising its strategy through repeated iteration, GLM-5.1 sustains optimization over hundreds of rounds and thousands of tool calls. The longer it runs, the better the result.
 
 
-pipe = pipeline(
-    task="text-generation",
-    model="zai-org/GLM-5",
-)
-pipe("The theory of relativity states that")
-```
+### GLM-5
 
-</hfoption>
-<hfoption id="AutoModelForCausalLM">
-
-```python
-from transformers import AutoModelForCausalLM, AutoTokenizer
+GLM-5 ([GlmMoeDsa](https://huggingface.co/papers/2602.15763)) is a 744B-parameter mixture-of-experts model with 40B active parameters per token, using DeepSeek Sparse Attention (DSA) for efficient 200K-token context handling. It was trained entirely on Huawei Ascend chips and matches frontier-level performance on reasoning and long-context benchmarks.
 
 
-tokenizer = AutoTokenizer.from_pretrained("zai-org/GLM-5")
-model = AutoModelForCausalLM.from_pretrained(
-    "zai-org/GLM-5",
-    device_map="auto",
-)
-input_ids = tokenizer("The theory of relativity states that", return_tensors="pt").to(model.device)
+With advances in both pre-training and post-training, GLM-5 delivers significant improvement compared to GLM-4.7 across a wide range of academic benchmarks and achieves best-in-class performance among all open-source models in the world on reasoning, coding, and agentic tasks, closing the gap with frontier models.
 
-output = model.generate(**input_ids, max_new_tokens=50)
-print(tokenizer.decode(output[0], skip_special_tokens=True))
-```
+![bench](https://raw.githubusercontent.com/zai-org/GLM-5/refs/heads/main/resources/bench.png)
 
-</hfoption>
-</hfoptions>
-
-> [!NOTE]
-> **The MLA query LoRA path (`q_lora_rank`) is required.** Like DeepSeek-V3.2, the DSA indexer scores queries from the low-rank query latent `q_a_layernorm(q_a_proj(x))` (its `wq_b` projection is sized by `q_lora_rank`), so the model always uses the LoRA query path and `q_lora_rank` must be set — the released checkpoint uses `2048`. The optional non-LoRA `q_proj` path that [DeepSeek-V3](./deepseek_v3) exposes for `q_lora_rank=None` is **not supported** here: without the query latent there is nothing for the indexer to consume.
 
 ## GlmMoeDsaConfig
 


### PR DESCRIPTION
### Docs Update
Update the official docs for a comprehensive overview of the GLM-5 series, including GLM-5, GLM-5.1, and the new GLM-5.2. 