### PR TITLE
Add DistributedConfig for 2D parallelism (TP + FSDP)

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -104,6 +104,7 @@ _import_structure = {
     "debug_utils": [],
     "dependency_versions_check": [],
     "dependency_versions_table": [],
+    "distributed": [],
     "dynamic_module_utils": [],
     "feature_extraction_sequence_utils": ["SequenceFeatureExtractor"],
     "feature_extraction_utils": ["BatchFeature", "FeatureExtractionMixin"],

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -149,6 +149,9 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
       naming of attributes.
     - **base_model_tp_plan** (`dict[str, Any]`) -- A dict that maps sub-modules FQNs of a base model to a tensor
       parallel plan applied to the sub-module when `model.tensor_parallel` is called.
+    - **base_model_fsdp_plan** (`dict[Any, str]`) -- A dict that maps sub-modules of a base model to an FSDP2
+      sharding strategy (e.g. `"free_full_weight"` / `"keep_full_weight"`). Keys can be wildcard module paths
+      (e.g. `"layers.*"`) or tuples of paths (grouped into a single `fully_shard` call).
     - **base_model_pp_plan** (`dict[str, tuple[list[str]]]`) -- A dict that maps child-modules of a base model to a
       pipeline parallel plan that enables users to place the child-module on the appropriate device.
 
@@ -220,6 +223,7 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
     keys_to_ignore_at_inference: ClassVar[list[str]] = []
     attribute_map: ClassVar[dict[str, str]] = {}
     base_model_tp_plan: ClassVar[dict[str, Any] | None] = None
+    base_model_fsdp_plan: ClassVar[dict[Any, str] | None] = None
     base_model_pp_plan: ClassVar[dict[str, Sequence[list[str]]] | None] = None
     base_model_ep_plan: ClassVar[dict[str, Sequence[list[str]]] | None] = None
     _auto_class: ClassVar[str | None] = None
@@ -1021,6 +1025,9 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
 
         # Pop "kwargs" since they are unpacked and set in the post init
         output.pop("kwargs", None)
+
+        if "distributed_config" in output and hasattr(output["distributed_config"], "to_dict"):
+            output["distributed_config"] = output["distributed_config"].to_dict()
 
         def to_list(value):
             if isinstance(value, tuple):

--- a/src/transformers/distributed/configuration_utils.py
+++ b/src/transformers/distributed/configuration_utils.py
@@ -12,99 +12,79 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import json
 import os
-from dataclasses import dataclass
-from typing import Any
+from dataclasses import asdict, dataclass
+
+from ..utils import is_torch_available
+
+
+if is_torch_available():
+    import torch
 
 
 @dataclass
 class DistributedConfig:
     """
-    Base class for distributed configs
+    Configuration for native distributed training (FSDP2 + TP).
+
+    Args:
+        tp_size (`int`, *optional*):
+            Number of devices for tensor parallelism. If `None` and `fsdp_size` is set, defaults to 1.
+        tp_plan (`dict`, *optional*):
+            Tensor parallel sharding plan. Leave as `None` to select the model's SP/TP and EP plan
+            (see ``select_parallel_plan``). Set explicitly to override.
+        enable_sequence_parallel (`bool`, *optional*, defaults to `False`):
+            Select ``base_model_sp_plan`` (dense-only) or ``base_model_sp_ep_plan`` (with EP).
+        enable_expert_parallel (`bool`, *optional*, defaults to `False`):
+            Select ``base_model_tp_ep_plan`` or ``base_model_sp_ep_plan`` when combined with SP flag.
+        fsdp_size (`int`, *optional*):
+            Number of devices for FSDP (data parallelism). If `None` and `tp_size` is set, defaults to 1.
+        fsdp_cpu_offload (`bool`, *optional*, defaults to `False`):
+            Whether to enable CPU offloading for FSDP2.
+        fsdp_mixed_precision (`bool`, *optional*, defaults to `False`):
+            Whether to enable mixed precision for FSDP2.
     """
 
+    tp_size: int | None = None
+    tp_plan: dict[str, str] | None = None
+    enable_sequence_parallel: bool = False
     enable_expert_parallel: bool = False
-    # TODO: add tp_plan, pp_plan, device_mesh etc..
+    fsdp_size: int | None = None
+    fsdp_cpu_offload: bool = False
+    fsdp_mixed_precision: bool = False
+
+    def __post_init__(self):
+        if self.tp_size is None and self.fsdp_size is None:
+            return
+
+        if self.tp_size is None:
+            self.tp_size = 1
+        if self.fsdp_size is None:
+            self.fsdp_size = 1
+
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            world_size = torch.distributed.get_world_size()
+            if self.tp_size * self.fsdp_size != world_size:
+                raise RuntimeError(
+                    f"tp_size ({self.tp_size}) * fsdp_size ({self.fsdp_size}) is not equal to world_size ({world_size})"
+                )
 
     @classmethod
-    def from_dict(cls, config_dict, **kwargs):
-        """
-        Constructs a DistributedConfig instance from a dictionary of parameters.
-        Args:
-            config_dict (Dict[str, Any]): Dictionary containing configuration parameters.
-            **kwargs: Additional keyword arguments to override dictionary values.
-        Returns:
-            DistributedConfig: Instance of DistributedConfig constructed from the dictionary.
-        """
-        config = cls(**config_dict)
-        to_remove = []
-        for key, value in kwargs.items():
-            if hasattr(config, key):
-                setattr(config, key, value)
-                to_remove.append(key)
-        for key in to_remove:
-            kwargs.pop(key, None)
-        return config
+    def from_dict(cls, config_dict: dict, **kwargs) -> "DistributedConfig":
+        merged = {**config_dict, **kwargs}
+        valid_keys = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in merged.items() if k in valid_keys})
 
-    # Copied from transformers.utils.quantization_config.QuantizationConfigMixin.to_json_file
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def to_json_string(self) -> str:
+        return json.dumps(self.to_dict(), indent=2) + "\n"
+
     def to_json_file(self, json_file_path: str | os.PathLike):
-        """
-        Save this instance to a JSON file.
-        Args:
-            json_file_path (`str` or `os.PathLike`):
-                Path to the JSON file in which this configuration instance's parameters will be saved.
-            use_diff (`bool`, *optional*, defaults to `True`):
-                If set to `True`, only the difference between the config instance and the default
-                `QuantizationConfig()` is serialized to JSON file.
-        """
-        with open(json_file_path, "w", encoding="utf-8") as writer:
-            config_dict = self.to_dict()
-            json_string = json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
+        with open(json_file_path, "w", encoding="utf-8") as f:
+            f.write(self.to_json_string())
 
-            writer.write(json_string)
-
-    def to_dict(self) -> dict[str, Any]:
-        """
-        Serializes this instance to a Python dictionary. Returns:
-            `Dict[str, Any]`: Dictionary of all the attributes that make up this configuration instance.
-        """
-        return copy.deepcopy(self.__dict__)
-
-    # Copied from transformers.utils.quantization_config.QuantizationConfigMixin.__iter__
-    def __iter__(self):
-        """allows `dict(obj)` for situations where obj may be a dict or QuantizationConfigMixin"""
-        yield from copy.deepcopy(self.__dict__).items()
-
-    # Copied from transformers.utils.quantization_config.QuantizationConfigMixin.__repr__
     def __repr__(self):
         return f"{self.__class__.__name__} {self.to_json_string()}"
-
-    def to_json_string(self):
-        """
-        Serializes this instance to a JSON formatted string.
-        Returns:
-            str: JSON formatted string representing the configuration instance.
-        """
-        return json.dumps(self.__dict__, indent=2) + "\n"
-
-    def update(self, **kwargs):
-        """
-        Updates attributes of this class instance with attributes from `kwargs` if they match existing attributes,
-        returning all the unused kwargs.
-        Args:
-            kwargs (`Dict[str, Any]`):
-                Dictionary of attributes to tentatively update this class.
-        Returns:
-            `Dict[str, Any]`: Dictionary containing all the key-value pairs that were not used to update the instance.
-        """
-        to_remove = []
-        for key, value in kwargs.items():
-            if hasattr(self, key):
-                setattr(self, key, value)
-                to_remove.append(key)
-
-        # Remove all the attributes that were updated, without modifying the input dict
-        unused_kwargs = {key: value for key, value in kwargs.items() if key not in to_remove}
-        return unused_kwargs

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1251,6 +1251,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
     # models, this attribute is currently defined in respective model code. For base models, it comes from
     # `config.base_model_pp_plan` during `post_init`.
     _pp_plan: dict[str, tuple[str, str]] = None
+    # FSDP2 sharding plan of the form `{"layers.*": "free_full_weight"}`. For top-level models, this attribute is
+    # defined on the head class (e.g. `*ForCausalLM`). For base models, it comes from `config.base_model_fsdp_plan`
+    # during `post_init`.
+    _fsdp_plan: dict[str, str] = None
 
     # Advanced functionalities support
     supports_gradient_checkpointing: bool = False
@@ -1391,13 +1395,18 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         correctly in the case of composite models (that is, the top level model should know about those properties from its children).
         """
         # Attach the different parallel plans and tied weight keys to the top-most model, so that everything is
-        # easily available
+        # easily available. Seed with the class-level FSDP plan before the instance attribute shadows it.
+        cls_fsdp_plan = getattr(self, "_fsdp_plan", None) or {}
         self._tp_plan, self._ep_plan, self._pp_plan = {}, {}, {}
+        self._fsdp_plan = dict(cls_fsdp_plan)
         # If current model is a base model, attach `base_model_tp_plan` and `base_model_pp_plan` from config
         if self.base_model is self:
             self._pp_plan = self.config.base_model_pp_plan.copy() if self.config.base_model_pp_plan is not None else {}
             self._tp_plan = self.config.base_model_tp_plan.copy() if self.config.base_model_tp_plan is not None else {}
             self._ep_plan = self.config.base_model_ep_plan.copy() if self.config.base_model_ep_plan is not None else {}
+            self._fsdp_plan = (
+                self.config.base_model_fsdp_plan.copy() if self.config.base_model_fsdp_plan is not None else {}
+            )
         # Current submodel should register its tied weights
         self.all_tied_weights_keys = self.get_expanded_tied_weights_keys(all_submodels=False)
         # Current submodel should register its `_keep_in_fp32_modules`
@@ -1421,6 +1430,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 self._tp_plan.update({f"{name}.{k}": v for k, v in plan.copy().items()})
             if plan := getattr(module, "_pp_plan", None):
                 self._pp_plan.update({f"{name}.{k}": v for k, v in plan.copy().items()})
+            if plan := getattr(module, "_fsdp_plan", None):
+                self._fsdp_plan.update({f"{name}.{k}": v for k, v in plan.copy().items()})
             # Always attach the keys of the children (if the children's config says to NOT tie, then it's empty)
             if tied_keys := getattr(module, "all_tied_weights_keys", None):
                 self.all_tied_weights_keys.update({f"{name}.{k}": f"{name}.{v}" for k, v in tied_keys.copy().items()})
@@ -1456,6 +1467,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         if hasattr(self.config, "distributed_config") and self.config.distributed_config.enable_expert_parallel:
             return self._ep_plan
         return self._tp_plan
+
+    @property
+    def fsdp_plan(self) -> dict[str, str]:
+        return self._fsdp_plan
 
     @property
     def pp_plan(self) -> dict[str, tuple[str, str]]:

--- a/tests/test_distributed_config.py
+++ b/tests/test_distributed_config.py
@@ -1,0 +1,97 @@
+import json
+import tempfile
+
+from transformers.distributed import DistributedConfig
+
+
+class TestDistributedConfig:
+    def test_2d_parallelism(self):
+        dc = DistributedConfig(tp_size=2, fsdp_size=2)
+        assert dc.tp_size == 2
+        assert dc.fsdp_size == 2
+        assert dc.tp_plan is None
+        assert dc.fsdp_cpu_offload is False
+        assert dc.fsdp_mixed_precision is False
+
+    def test_tp_only_defaults_fsdp_to_1(self):
+        dc = DistributedConfig(tp_size=4)
+        assert dc.tp_size == 4
+        assert dc.fsdp_size == 1
+        assert dc.tp_plan is None
+
+    def test_fsdp_only_defaults_tp_to_1(self):
+        dc = DistributedConfig(fsdp_size=4)
+        assert dc.tp_size == 1
+        assert dc.fsdp_size == 4
+        assert dc.fsdp_cpu_offload is False
+        assert dc.fsdp_mixed_precision is False
+        assert dc.tp_plan is None
+
+    def test_empty_config(self):
+        dc = DistributedConfig()
+        assert dc.tp_size is None
+        assert dc.fsdp_size is None
+        assert dc.tp_plan is None
+        assert dc.fsdp_cpu_offload is False
+        assert dc.fsdp_mixed_precision is False
+
+    def test_from_dict(self):
+        dc = DistributedConfig.from_dict({"tp_size": 2, "fsdp_size": 4})
+        assert dc.tp_size == 2
+        assert dc.fsdp_size == 4
+        assert dc.tp_plan is None
+
+    def test_from_dict_ignores_unknown_keys(self):
+        dc = DistributedConfig.from_dict({"tp_size": 2, "unknown_key": 42})
+        assert dc.tp_size == 2
+        assert not hasattr(dc, "unknown_key")
+
+    def test_from_dict_kwargs_override(self):
+        dc = DistributedConfig.from_dict({"tp_size": 2}, tp_size=8)
+        assert dc.tp_size == 8
+
+    def test_to_dict(self):
+        dc = DistributedConfig(tp_size=2, fsdp_size=4)
+        d = dc.to_dict()
+        assert d == {
+            "tp_size": 2,
+            "tp_plan": None,
+            "enable_sequence_parallel": False,
+            "enable_expert_parallel": False,
+            "fsdp_size": 4,
+            "fsdp_cpu_offload": False,
+            "fsdp_mixed_precision": False,
+        }
+
+    def test_to_dict_is_a_copy(self):
+        dc = DistributedConfig(tp_plan={"layer": "colwise"})
+        d = dc.to_dict()
+        d["tp_plan"]["layer"] = "rowwise"
+        assert dc.tp_plan["layer"] == "colwise"
+
+    def test_to_json_string(self):
+        dc = DistributedConfig(tp_size=2, fsdp_size=2)
+        s = dc.to_json_string()
+        parsed = json.loads(s)
+        assert parsed["tp_size"] == 2
+        assert parsed["fsdp_size"] == 2
+
+    def test_to_json_file(self):
+        dc = DistributedConfig(tp_size=4)
+        with tempfile.NamedTemporaryFile(mode="r", suffix=".json", delete=False) as f:
+            dc.to_json_file(f.name)
+            f.seek(0)
+            parsed = json.load(f)
+        assert parsed["tp_size"] == 4
+        assert parsed["tp_plan"] is None
+
+    def test_roundtrip_dict(self):
+        original = DistributedConfig(tp_size=2, fsdp_size=4)
+        restored = DistributedConfig.from_dict(original.to_dict())
+        assert original == restored
+
+    def test_repr(self):
+        dc = DistributedConfig(tp_size=2)
+        r = repr(dc)
+        assert "DistributedConfig" in r
+        assert '"tp_size": 2' in r


### PR DESCRIPTION
## Summary
- Introduces/refactors `DistributedConfig` for tensor-parallel and FSDP settings
- Wires distributed config into `PretrainedConfig` and model loading
- Adds unit tests for `DistributedConfig` serialization and defaults
