### PR TITLE
Fix: reject Hub kernel repo patterns in attn_implementation loaded from config

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -296,7 +296,15 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
 
         # Attention/Experts implementation to use, if relevant (it sets it recursively on sub-configs)
         self._output_attentions: bool | None = kwargs.pop("output_attentions", False)
-        self._attn_implementation: str | None = kwargs.pop("attn_implementation", None)
+        _attn_from_config = kwargs.pop("attn_implementation", None)
+        if _attn_from_config is not None and "/" in str(_attn_from_config):
+            logger.warning_once(
+                f"Ignoring `attn_implementation='{_attn_from_config}'` from config as it looks like a Hub repo. "
+                "Kernel-style attention implementations must be set explicitly via "
+                "`from_pretrained(attn_implementation=...)`."
+            )
+            _attn_from_config = None
+        self._attn_implementation: str | None = _attn_from_config
         self._experts_implementation: str | None = kwargs.pop("experts_implementation", None)
 
         # Additional attributes without default values


### PR DESCRIPTION
## Summary

Reject Hub kernel repository patterns (containing `/`) in the `attn_implementation` field when loaded from `config.json`. This prevents a malicious model config from silently triggering remote kernel code download and execution during `from_pretrained()` without `trust_remote_code=True`.

## Problem

When a model's `config.json` contains `"attn_implementation": "some-org/some-repo"`, the value is processed by `kwargs.pop()` at line 299 of `configuration_utils.py` and passed through the `_attn_implementation` property setter, which writes it to `_attn_implementation_internal`. During model initialization, `is_kernel()` matches the Hub repo pattern, and `get_kernel()` is called to download and execute kernel code — all without requiring `trust_remote_code=True`.

An attacker can exploit this by publishing a model with a crafted `config.json` to achieve remote code execution on any user who loads the model.

## Fix

Validate that `attn_implementation` values loaded from config do not contain `/` (the Hub repo pattern). This blocks kernel-style repo IDs from being injected via config while preserving all standard values (`eager`, `sdpa`, `flash_attention_2`, `flash_attention_3`).

Users can still set kernel implementations explicitly via `from_pretrained(attn_implementation=...)` as that code path in `modeling_utils.py` runs after config loading and is a deliberate user choice.

## Test plan

- [ ] Existing tests pass (standard `attn_implementation` values unaffected)
- [ ] `config.json` with `"attn_implementation": "some-org/some-kernel"` is rejected with warning
- [ ] `from_pretrained(attn_implementation="kernels-community/flash-attn")` still works (user-explicit)
