### PR TITLE
[CB] Changes to increase max_batch_tokens

### DIFF
--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -277,7 +277,6 @@ cb_config = ContinuousBatchingConfig(
     use_cuda_graph=True,
     q_padding_interval_size=64,
     kv_padding_interval_size=16384,
-    max_cached_graphs=32,
 )
 ```
 

--- a/docs/source/en/continuous_batching_architecture.md
+++ b/docs/source/en/continuous_batching_architecture.md
@@ -143,7 +143,7 @@ Because the batch shapes change every step, the continuous batching system handl
 
 1. Query lengths are padded to the nearest multiple of `q_padding_interval_size`.
 2. KV lengths are padded to the nearest multiple of `kv_padding_interval_size`.
-3. Recorded graphs are stored in an LRU cache of up to `max_cached_graphs` entries.
+3. Recorded graphs are stored in a cache.
 
 When a batch's padded shape matches a cached graph, the graph replays without any CPU dispatch. New shapes trigger a new graph capture.
 

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1661,8 +1661,6 @@ class ContinuousBatchingConfig:
         kv_padding_interval_size (`int`, *optional*, defaults to 0):
             KV padding granularity in tokens for CUDA graphs. Uses a preset from `continuous_api.py` when
             set to 0.
-        max_cached_graphs (`int`, *optional*, defaults to 0):
-            Maximum number of cached CUDA graphs. Uses a preset from `continuous_api.py` when set to 0.
         varlen_compile_config (`CompileConfig`, *optional*):
             CompileConfig for varlen (prefill) path. Default is None (uses generation_config fallback)
             The varlen path handles batches with varying query and KV lengths, often benefiting from dynamic=True.
@@ -1700,6 +1698,8 @@ class ContinuousBatchingConfig:
             for no timeout. Default is 300 seconds.
         use_default_compile_configs (`bool | None`, *optional*):
             Deprecated in 5.11: please use default_compile_level instead.
+        max_cached_graphs (`int`, *optional*):
+            Deprecated in 5.13: maximum number of graph is no longer an issue.
     """
 
     # Size of each KV cache block. Must be at least 4 (and for an efficient cache, it should be well above that).
@@ -1740,7 +1740,6 @@ class ContinuousBatchingConfig:
     # top of the continuous_batching/continuous_api.py file.
     q_padding_interval_size: int = 0
     kv_padding_interval_size: int = 0
-    max_cached_graphs: int = 0
 
     # Compile configs for the two execution paths. If None, uses the compile_config from generation_config as fallback.
     varlen_compile_config: CompileConfig | None = None
@@ -1796,6 +1795,7 @@ class ContinuousBatchingConfig:
 
     # Deprecated arguments
     use_default_compile_configs: bool | None = None
+    max_cached_graphs: int | None = None
 
     def __post_init__(self):
         # Only turn off graph mixing support if TP is on
@@ -1817,6 +1817,10 @@ class ContinuousBatchingConfig:
             logger.warning(
                 "use_default_compile_configs is deprecated: please use default_compile_level instead. For backwards "
                 f"compatibility, {level_msg}"
+            )
+        if self.max_cached_graphs is not None:  # Deprecated in 5.13
+            logger.warning(
+                "max_cached_graphs is deprecated: maximum number of graph is no longer an issue. Deprecated in 5.13."
             )
 
     @property

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -206,6 +206,10 @@ class PagedAttentionCache:
             config.hidden_size + q_bytes_per_token + 2 * page_size,  # hidden state + Q + new K and V
         )
 
+        # If somehow the max memory percent is not yet resolved, resolve it conservatively
+        if continuous_batching_config.max_memory_percent is None:
+            resolve_max_memory_percent(cb_config=continuous_batching_config, has_logit_processors=True)
+
         memory_handler = PagedAttentionMemoryHandler(
             continuous_batching_config=continuous_batching_config,
             page_size=page_size,
@@ -215,14 +219,9 @@ class PagedAttentionCache:
             num_attention_masks=num_attention_masks,
         )
 
-        # If somehow the max memory percent is not yet resolved, resolve it conservatively
-        if continuous_batching_config.max_memory_percent is None:
-            resolve_max_memory_percent(cb_config=continuous_batching_config, has_logit_processors=True)
-
         num_blocks, max_batch_tokens = memory_handler.infer_num_blocks_and_max_batch_tokens(
             num_blocks=continuous_batching_config.num_blocks,
             max_batch_tokens=continuous_batching_config.max_batch_tokens,
-            max_memory_percent=continuous_batching_config.max_memory_percent,
             cache_dtype=self.dtype,
         )
 
@@ -579,8 +578,10 @@ class PagedAttentionMemoryHandler:
 
     _activation_dtype = torch.bfloat16
     _input_dtype = torch.int32
-    _upper_bound_max_batch_tokens = 1024
     _upper_bound_num_blocks = 4096
+
+    _min_max_batch_tokens = 256
+    _default_max_batch_tokens = 8192
 
     def __init__(
         self,
@@ -594,6 +595,7 @@ class PagedAttentionMemoryHandler:
         """Initialize the memory handler. `activation_peaks` is a list of `(Δcn, Δcm)` pairs giving the activation memory
         contributions proportional to N (pages) and M (batch tokens) for each peak. Memory must satisfy the constraint
         at every peak, so we solve each polynomial independently and take the most restrictive result."""
+        self.cb_config = continuous_batching_config
         self.block_size = continuous_batching_config.block_size
         self.page_size = page_size
         self.num_groups = num_groups
@@ -608,20 +610,133 @@ class PagedAttentionMemoryHandler:
         # This account for the set of 2 IOs if async batching is used
         self.io_multiplier = 2 if continuous_batching_config.use_async_batching else 1
 
-    @staticmethod
-    def get_available_memory(max_memory_percent: float = 1.0) -> int:
-        """Calculate available GPU memory for cache allocation, accounting for already allocated tensors."""
+    def get_available_memory(self) -> int:
+        """Calculate available GPU memory for cache allocation in bytes, accouting for the maximum memory percent limit
+        fixed by the continuous batching config."""
         _, total, reserved, allocated = get_device_and_memory_breakdown()
         available_memory = total - max(allocated, reserved)
-        available_memory = int(available_memory * max_memory_percent)
+        available_memory = int(available_memory * self.cb_config.max_memory_percent)
+        logger.info(f"Memory available for cache allocation: {available_memory // 1024**2} MB")
         return available_memory
+
+    def infer_num_blocks_and_max_batch_tokens(
+        self,
+        max_batch_tokens: int | None = None,
+        num_blocks: int | None = None,
+        cache_dtype: torch.dtype = torch.float16,
+    ) -> tuple[int, int]:
+        """Infers max_batch_tokens and num_blocks based on the available memory and the size of the activation peaks.
+        If neither value is provided, we use a default value of 8192 for max_batch_tokens, apply bounds depending on the
+        available VRAM, and solve for num_blocks. If one value is provided, the other is found using a linear solve."""
+        available = self.get_available_memory()
+
+        # If both values are provided, just make sure they make sense
+        if num_blocks is not None and max_batch_tokens is not None:
+            return self._check_footprint(max_batch_tokens, num_blocks, available, cache_dtype)
+
+        # If one or more value is provided, solve for the other
+        if num_blocks is not None or max_batch_tokens is not None:
+            max_batch_tokens, num_blocks = self._solve_for_peaks(
+                max_batch_tokens, num_blocks, available, cache_dtype, cache_fill_per_batch=None)
+            return self._check_footprint(max_batch_tokens, num_blocks, available, cache_dtype)
+
+        # If no value is provided, use the default value for max_batch_tokens w/ VRAM-based upper bound
+        upper_bound_vram, _ = self._solve_for_peaks(
+            max_batch_tokens=None,
+            num_blocks=None,
+            available=available,
+            cache_dtype=cache_dtype,
+            cache_fill_per_batch=0.1,  # each cache must fill 10% of the cache at most
+        )
+        max_batch_tokens = min(self._default_max_batch_tokens, upper_bound_vram)
+        max_batch_tokens = max(max_batch_tokens, self._min_max_batch_tokens)
+        # Then solve with that value
+        max_batch_tokens, num_blocks = self._solve_for_peaks(
+            max_batch_tokens, num_blocks, available, cache_dtype, cache_fill_per_batch=None
+        )
+        return self._check_footprint(max_batch_tokens, num_blocks, available, cache_dtype)
+
+    def _solve_for_peaks(
+        self,
+        max_batch_tokens: int | None,
+        num_blocks: int | None,
+        available: int,
+        cache_dtype: torch.dtype,
+        cache_fill_per_batch: float | None,
+    ) -> tuple[int, int]:
+        """Returns max_batch_tokens and num_blocks so that their memory footprint is within the available memory for all
+        activation peaks. If neither value is given, a value must be provided for cache_fill_per_batch: this means we
+        solve for both varibles by saying each batch fill a certain percentage of the cache (eg, if cache_fill_per_batch
+        is 0.01, each batch will fill 1% of the cache)."""
+        solutions = []
+        for peak in self.activation_peaks:
+            m_batch_tokens, n_blocks = self._solve_for_peak(
+                peak, max_batch_tokens, num_blocks, available, cache_dtype, cache_fill_per_batch
+            )
+            solutions.append((m_batch_tokens, n_blocks))
+        return max(solutions, key=lambda m, n: n)  # returns the solution with the highest num_blocks
+
+    def _solve_for_peak(
+        self,
+        peak: tuple[int, int],
+        max_batch_tokens: int | None,
+        num_blocks: int | None,
+        available: int,
+        cache_dtype: torch.dtype,
+        m: float | None,
+    ) -> tuple[int, int]:
+        """Returns a couple of `(max_batch_tokens, num_blocks)` that satisfy the memory constraint for the given
+        activation peak."""
+        cm, cn, cmn, cmm = self._equation_coefficients(peak, cache_dtype)
+
+        # If neither variable is defined, use a quadratic solver
+        if num_blocks is None and max_batch_tokens is None:
+            # Substitute M = m·N → (coeff_nm·m + coeff_mm·m²)·N² + (coeff_n + coeff_m·m)·N − avail = 0
+            if m is None:
+                raise ValueError("m must be provided if num_blocks and max_batch_tokens are None")
+            num_pages = self._solve_quadratic(cmn * m + cmm * m**2, cn + cm * m, -available)
+            max_batch_tokens = int(num_pages * m)
+
+        # Otherwise, use a linear solver
+        elif num_blocks is None:
+            # M given → linear in N: (coeff_n + coeff_nm·M)·N = avail − coeff_m·M − coeff_mm·M²
+            M = max_batch_tokens
+            num_pages = floor((available - cm * M - cmm * M**2) / (cn + cmn * M))
+
+        elif max_batch_tokens is None:
+            # N given → quadratic in M: coeff_mm·M² + (coeff_m + coeff_nm·N)·M + (coeff_n·N − avail) = 0
+            N = num_blocks * self.block_size
+            M = self._solve_quadratic(cmm, cm + cmn * N, cn * N - available)
+
+        return max_batch_tokens, num_blocks
+
+    def _check_footprint(
+        self, max_batch_tokens: int, num_blocks: int, available: int, cache_dtype: torch.dtype
+    ) -> tuple[int, int]:
+        """Checks if the footprint of the cache is within the available memory."""
+        memory_footprint = self.compute_memory_footprint(max_batch_tokens, num_blocks, cache_dtype)
+        if memory_footprint > available:
+            raise MemoryError(f"Memory footprint {memory_footprint} is more than available memory {available}")
+        return max_batch_tokens, num_blocks
+
+    def _solve_quadratic(self, a: float, b: float, c: float) -> int:
+        """Largest positive root of a·x² + b·x + c = 0. Falls back to linear when a == 0. Rounded down."""
+        if a == 0:
+            return -c / b
+        discriminant = b**2 - 4 * a * c
+        if discriminant < 0:
+            raise ValueError(f"No real solution (discriminant = {discriminant})")
+        root = (-b + sqrt(discriminant)) / (2 * a)
+        if root < 0:
+            raise ValueError(f"No positive solution (root = {root})")
+        return int(floor(root))
 
     # Formatting is disabled because of comment indentation, which improves readability.
     # fmt: off
     def _equation_coefficients(
         self, peak: tuple[int, int], cache_dtype: torch.dtype
     ) -> tuple[int, int, int, int]:
-        """Returns `(coeff_n, coeff_m, coeff_nm, coeff_mm)` for the memory polynomial of a single activation peak.
+        """Returns `(coeff_m, coeff_n, coeff_mn, coeff_mm)` for the memory polynomial of a single activation peak.
         `peak = (Δcn, Δcm)` is the peak-specific activation contribution; the rest of the coefficients are shared
         across peaks. Each addend is annotated with the tensor it corresponds to in
         `ContinuousBatchingIOs._setup_static_tensors` (or the forward pass, for activation terms).
@@ -650,101 +765,22 @@ class PagedAttentionMemoryHandler:
         )
         # TODO: the above could be refined by introducing the max_requests_per_batch, but then there is a min() and this
         # is no longer a simple polynomial. Could be worth checking into.
-        # -- N·M terms: cost per (page × batch token) --------------------------------------
-        coeff_nm = k * self.num_attention_masks * a    # attention_mask: [1, 1, M, N + M] (N·M part only)
+        # -- M·N terms: cost per (page × batch token) --------------------------------------
+        coeff_mn = k * self.num_attention_masks * a    # attention_mask: [1, 1, M, N + M] (N·M part only)
         # -- M² terms: cost per (batch token squared) --------------------------------------
         coeff_mm = k * self.num_attention_masks * a    # attention_mask: [1, 1, M, N + M] (M² part only)
 
-        return coeff_n, coeff_m, coeff_nm, coeff_mm
+        return coeff_m, coeff_n, coeff_mn, coeff_mm
     # fmt: on
 
-    @staticmethod
-    def _solve_quadratic(a: float, b: float, c: float) -> float:
-        """Largest positive root of a·x² + b·x + c = 0. Falls back to linear when a == 0."""
-        if a == 0:
-            return -c / b
-        discriminant = b**2 - 4 * a * c
-        if discriminant < 0:
-            raise ValueError(f"No real solution (discriminant = {discriminant})")
-        root = (-b + sqrt(discriminant)) / (2 * a)
-        if root < 0:
-            raise ValueError(f"No positive solution (root = {root})")
-        return root
-
-    def _solve_for_peak(
-        self,
-        peak: tuple[int, int],
-        available: int,
-        num_blocks: int | None,
-        max_batch_tokens: int | None,
-        cache_dtype: torch.dtype,
-    ) -> tuple[int, int]:
-        """Solve for `(num_blocks, max_batch_tokens)` against one activation peak's memory polynomial. Clamps to upper
-        bounds. Either input may be None; whichever is None is solved for."""
-        cn, cm, cnm, cmm = self._equation_coefficients(peak, cache_dtype)
-
-        if num_blocks is None and max_batch_tokens is None:
-            # Substitute M = m·N → (coeff_nm·m + coeff_mm·m²)·N² + (coeff_n + coeff_m·m)·N − avail = 0
-            m = 0.01
-            num_pages = self._solve_quadratic(cnm * m + cmm * m**2, cn + cm * m, -available)
-            max_batch_tokens = int(num_pages * m)
-            if max_batch_tokens > self._upper_bound_max_batch_tokens:
-                max_batch_tokens = self._upper_bound_max_batch_tokens
-                # If max_batch_tokens is clamped, we recompute num_blocks below to get a higher value
-                num_blocks = None
-            else:
-                num_blocks = min(floor(num_pages) // self.block_size, self._upper_bound_num_blocks)
-
-        if num_blocks is None:
-            # M given → linear in N: (coeff_n + coeff_nm·M)·N = avail − coeff_m·M − coeff_mm·M²
-            M = max_batch_tokens
-            num_pages = floor((available - cm * M - cmm * M**2) / (cn + cnm * M))
-            num_blocks = min(num_pages // self.block_size, self._upper_bound_num_blocks)
-        elif max_batch_tokens is None:
-            # N given → quadratic in M: coeff_mm·M² + (coeff_m + coeff_nm·N)·M + (coeff_n·N − avail) = 0
-            N = num_blocks * self.block_size
-            M = self._solve_quadratic(cmm, cm + cnm * N, cn * N - available)
-            max_batch_tokens = min(floor(M), self._upper_bound_max_batch_tokens)
-
-        return num_blocks, max_batch_tokens
-
-    def infer_num_blocks_and_max_batch_tokens(
-        self,
-        num_blocks: int | None = None,
-        max_batch_tokens: int | None = None,
-        max_memory_percent: float = 0.9,
-        cache_dtype: torch.dtype = torch.float16,
-    ) -> tuple[int, int]:
-        """Solve for the missing variable(s) in the memory polynomial (see ``_equation_coefficients``). There is one
-        polynomial per activation peak; we solve each independently and take the most restrictive (smallest) result.
-        When both `N` and `M` are unknown, assumes `M = m·N` (m = 0.01, i.e. one batch fills ~1 % of the cache) and
-        solves the resulting quadratic in N.
-        """
-        available = self.get_available_memory(max_memory_percent)
-        logger.info(f"Cache memory: {available}")
-        # Solve each peak independently, then take the element-wise min (tightest constraint wins)
-        acc_num_blocks = float("inf")
-        acc_max_batch_tokens = float("inf")
-        for peak in self.activation_peaks:
-            n_blocks, m_batch_tokens = self._solve_for_peak(peak, available, num_blocks, max_batch_tokens, cache_dtype)
-            acc_num_blocks = min(acc_num_blocks, n_blocks)
-            acc_max_batch_tokens = min(acc_max_batch_tokens, m_batch_tokens)
-        # Now update the value (cannot update in loop, it would overwrite the user-passed values)
-        num_blocks, max_batch_tokens = acc_num_blocks, acc_max_batch_tokens
-        # Validate
-        memory_footprint = self.compute_memory_footprint(num_blocks, max_batch_tokens, cache_dtype)
-        if memory_footprint > available:
-            raise MemoryError(f"Memory footprint {memory_footprint} is more than available memory {available}")
-        return num_blocks, max_batch_tokens
-
-    def compute_memory_footprint(self, num_blocks: int, max_batch_tokens: int, cache_dtype: torch.dtype) -> int:
+    def compute_memory_footprint(self, max_batch_tokens: int, num_blocks: int, cache_dtype: torch.dtype) -> int:
         """Evaluate the memory polynomial at concrete (N, M) values, taking the max across activation peaks."""
-        N = num_blocks * self.block_size
         M = max_batch_tokens
+        N = num_blocks * self.block_size
 
         max_memory_footprint = 0
         for peak in self.activation_peaks:
-            cn, cm, cnm, cmm = self._equation_coefficients(peak, cache_dtype)
-            memory_footprint = cn * N + cm * M + cnm * N * M + cmm * M * M
+            cm, cn, cmn, cmm = self._equation_coefficients(peak, cache_dtype)
+            memory_footprint = cn * N + cm * M + cmn * N * M + cmm * M * M
             max_memory_footprint = max(max_memory_footprint, memory_footprint)
         return max_memory_footprint

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -26,6 +26,23 @@ from .initialization import resolve_max_memory_percent
 from .requests import RequestState, RequestStatus, get_device_and_memory_breakdown, logger
 
 
+def find_num_kv_heads(config: PreTrainedConfig) -> int:
+    """Finds the number of key-value heads for the given config."""
+    for attr in ["num_key_value_heads", "num_attention_heads"]:
+        if hasattr(config, attr):
+            return getattr(config, attr)
+    raise ValueError(f"num_key_value_heads or num_attention_heads could not be found in the config:\n{config}")
+
+
+def find_head_dim(config: PreTrainedConfig) -> int:
+    """Finds the head dimension for the given config."""
+    if hasattr(config, "head_dim"):
+        return config.head_dim
+    if hasattr(config, "hidden_size") and hasattr(config, "num_attention_heads"):
+        return config.hidden_size // config.num_attention_heads
+    raise ValueError(f"head_dim or (hidden_size and num_attention_heads) could not be found in the config:\n{config}")
+
+
 def group_layers_by_attn_type(config: PreTrainedConfig) -> tuple[list[list[int]], list[str]]:
     """
     Group layers depending on the attention mix, according to VLLM's hybrid allocator rules:
@@ -136,17 +153,15 @@ class PagedAttentionCache:
             device: Device for the cache tensors
             distributed_helper: TP-aware helper. Used to dispatch attention heads and ensure coherent cache size
             tp_plan: Tensor parallelism plan
-            dtype: Data type of the cache
+            dtype: Data type of the activation and the cache (for now, these are the same)
         """
         self.config = config
         self.dtype = dtype
         self.device = device
 
         # Extract model dimensions
-        kv_heads = getattr(config, "num_key_value_heads", None)
-        self.num_key_value_heads: int = kv_heads if kv_heads is not None else config.num_attention_heads
-        head_dim = getattr(config, "head_dim", None)
-        self.head_dim: int = head_dim if head_dim is not None else config.hidden_size // config.num_attention_heads
+        self.num_key_value_heads: int = find_num_kv_heads(config)
+        self.head_dim: int = find_head_dim(config)
 
         # Extract cache dimensions. Default used to be 32, now it's 256 to be compatible with flash_with_kvcache.
         self.block_size = continuous_batching_config.block_size
@@ -184,61 +199,29 @@ class PagedAttentionCache:
                 )
             self.num_key_value_heads //= tp_size
 
-        # Infer number of blocks and max batch tokens
-        page_size = self.head_dim * self.num_key_value_heads
-
-        if is_flash_attention_requested(self.config):
-            num_attention_masks = 0  # only used to compute the default memory footprint args
-        elif "sliding_attention" in group_types:
-            # TODO: when we generalize to allow for block-attn, we can use `num_attention_masks=sum(set(group_types))`
-            num_attention_masks = 2
-        else:
-            num_attention_masks = 1
-
-        # Peak activations coefficients (for number of blocks and number of batch tokens)
-        q_bytes_per_token = config.num_attention_heads * self.head_dim
-        lm_head_peak = (
-            0,  # number of blocks does not affect the LM head peak activation
-            config.hidden_size + 2 * config.vocab_size,  # hidden states + logits
-        )
-        attention_peak = (
-            2 * page_size,  # old K and V, read from cache (in the worst case scenario: whole cache is read)
-            config.hidden_size + q_bytes_per_token + 2 * page_size,  # hidden state + Q + new K and V
-        )
-
         # If somehow the max memory percent is not yet resolved, resolve it conservatively
         if continuous_batching_config.max_memory_percent is None:
             resolve_max_memory_percent(cb_config=continuous_batching_config, has_logit_processors=True)
 
-        memory_handler = PagedAttentionMemoryHandler(
+        max_batch_tokens, num_blocks = PagedAttentionMemoryHandler(
+            config=config,
             continuous_batching_config=continuous_batching_config,
-            page_size=page_size,
-            num_groups=self.num_groups,
+            dtype=self.dtype,
+            group_types=group_types,
             group_size=group_size,
-            activation_peaks=[lm_head_peak, attention_peak],
-            num_attention_masks=num_attention_masks,
-        )
+        ).infer_max_batch_tokens_and_num_blocks()
 
-        num_blocks, max_batch_tokens = memory_handler.infer_num_blocks_and_max_batch_tokens(
-            num_blocks=continuous_batching_config.num_blocks,
-            max_batch_tokens=continuous_batching_config.max_batch_tokens,
-            cache_dtype=self.dtype,
-        )
-
-        # For TP, align num_blocks and max_batch_tokens to the minimal value across the TP group
+        # For TP, align max_batch_tokens and num_blocks to the minimal value across the TP group
         if tp_size > 1:
-            sync = torch.tensor([num_blocks, max_batch_tokens], device=self.device, dtype=torch.int64)
+            sync = torch.tensor([max_batch_tokens, num_blocks], device=self.device, dtype=torch.int64)
             distributed_helper.tp_all_reduce_min(sync)
-            num_blocks, max_batch_tokens = int(sync[0].item()), int(sync[1].item())
+            max_batch_tokens, num_blocks = int(sync[0].item()), int(sync[1].item())
 
         # Add the inferred attributes to the class
-        self.num_blocks = num_blocks
         self.max_batch_tokens = max_batch_tokens
+        self.num_blocks = num_blocks
         self.num_pages = self.num_blocks * self.block_size
-        logger.info(
-            f"PagedAttentionCache initialized with {self.num_blocks = }, {self.block_size = }, {page_size = }, "
-            f"{self.max_batch_tokens = } {num_attention_masks = }"
-        )
+        logger.info(f"Paged cache initialized: {self.max_batch_tokens = }, {self.num_blocks = }, {self.block_size = }")
 
         # If max_blocks_per_request is not set, initialize it to the non-zero fallback value
         max_blocks_per_request = continuous_batching_config.max_blocks_per_request
@@ -562,46 +545,52 @@ class PagedAttentionCache:
             self.free_blocks(request_id)
 
 
-# TODO: rework computation with the groups and their sizes
 class PagedAttentionMemoryHandler:
-    """Determines the optimal number of pages (N) and max batch tokens (M) for the paged attention cache, given
+    """Determines the optimal max batch tokens (M) and number of blocks (N) for the paged attention cache, given
     available GPU memory. The relation between N and number of blocks is: num_blocks = N // block_size.
 
-    The memory footprint is a polynomial in N and M, where each term maps to a tensor allocated in
+    The memory footprint is a polynomial in M and N, where each term maps to a tensor allocated in
     ``ContinuousBatchingIOs._setup_static_tensors`` or ``PagedAttentionCache.__init__``:
 
-        memory(N, M)  =  coeff_n · N  +  coeff_m · M  +  coeff_nm · N·M  +  coeff_mm · M²
+        memory(M, N)  =  coeff_m · M  +  coeff_n · N  +  coeff_mn · M·N  +  coeff_mm · M²
 
     See ``_equation_coefficients`` for the breakdown.  All three solving modes (auto, fixed-N, fixed-M) reduce to
     solving this equation, which is at most quadratic in one variable.
     """
-
-    _activation_dtype = torch.bfloat16
-    _input_dtype = torch.int32
-    _upper_bound_num_blocks = 4096
 
     _min_max_batch_tokens = 256
     _default_max_batch_tokens = 8192
 
     def __init__(
         self,
+        config: PreTrainedConfig,
         continuous_batching_config: ContinuousBatchingConfig,
-        page_size: int,
-        num_groups: int,
+        dtype: torch.dtype,
+        group_types: list[str],
         group_size: int,
-        activation_peaks: list[tuple[int, int]],
-        num_attention_masks: int,
     ) -> None:
-        """Initialize the memory handler. `activation_peaks` is a list of `(Δcn, Δcm)` pairs giving the activation memory
-        contributions proportional to N (pages) and M (batch tokens) for each peak. Memory must satisfy the constraint
-        at every peak, so we solve each polynomial independently and take the most restrictive result."""
+        """Initialize the memory handler. Args:
+        - config: the model configuration
+        - continuous_batching_config: the continuous batching configuration
+        - dtype: the data type of the activation and the cache
+        - group_types: the list of all attention group types, formatted as strings
+        - group_size: the size (in layers) of an attention group
+        """
+        self.config = config
         self.cb_config = continuous_batching_config
+        self.cache_dtype = dtype
+        self.activation_dtype = dtype
         self.block_size = continuous_batching_config.block_size
-        self.page_size = page_size
-        self.num_groups = num_groups
+        self.page_size = find_head_dim(config) * find_num_kv_heads(config)
+        self.num_groups = len(group_types)
         self.group_size = group_size
-        self.activation_peaks = activation_peaks
-        self.num_attention_masks = num_attention_masks
+
+        # TODO: when we generalize to allow for block-attn, we can use `num_attention_masks=sum(set(group_types))`
+        if is_flash_attention_requested(self.config):
+            self.num_attention_masks = 0
+        else:
+            self.num_attention_masks = 2 if "sliding_attention" in group_types else 1
+
         self.max_blocks_per_request = continuous_batching_config.max_blocks_per_request
         if self.max_blocks_per_request is None:
             self.max_blocks_per_request = continuous_batching_config.fallback_max_blocks_per_request
@@ -609,6 +598,30 @@ class PagedAttentionMemoryHandler:
         self.num_output_rows = 2 if continuous_batching_config.return_logprobs else 1
         # This account for the set of 2 IOs if async batching is used
         self.io_multiplier = 2 if continuous_batching_config.use_async_batching else 1
+        self.available_memory = self.get_available_memory()
+
+    @property
+    def activation_peak(self) -> dict[str, tuple[int, ...]]:
+        mem_per_q_token = self.config.num_attention_heads * find_head_dim(self.config)
+        mem_per_k_or_v_token = self.page_size
+        peaks = {}
+
+        # LM head peak: this is when we turn the hidden states into logits
+        delta_m = self.config.hidden_size * self.activation_dtype.itemsize  # hidden_shape, shape [M, hidden_size]
+        delta_m += self.config.vocab_size * torch.float32.itemsize  # logits, shape [M, V], always in fp32
+        peaks["lm_head"] = (delta_m, 0, 0, 0)
+
+        # Attention peak: this is when we read the key and value states from the cache
+        delta_m = self.activation_dtype.itemsize * (
+            self.config.hidden_size  # hidden state, shape [M, hidden_size]
+            + mem_per_q_token  # q_projection, shape [M, mem_per_q_token]
+            + 2 * mem_per_k_or_v_token  # new K and V, shape [M, page_size]
+        )
+        # old K and V, read from cache (worst case scenario: whole cache is read)
+        delta_n = 2 * mem_per_k_or_v_token * self.activation_dtype.itemsize
+        peaks["attention"] = (delta_m, delta_n, 0, 0)
+
+        return peaks
 
     def get_available_memory(self) -> int:
         """Calculate available GPU memory for cache allocation in bytes, accouting for the maximum memory percent limit
@@ -619,49 +632,40 @@ class PagedAttentionMemoryHandler:
         logger.info(f"Memory available for cache allocation: {available_memory // 1024**2} MB")
         return available_memory
 
-    def infer_num_blocks_and_max_batch_tokens(
-        self,
-        max_batch_tokens: int | None = None,
-        num_blocks: int | None = None,
-        cache_dtype: torch.dtype = torch.float16,
-    ) -> tuple[int, int]:
+    def infer_max_batch_tokens_and_num_blocks(self) -> tuple[int, int]:
         """Infers max_batch_tokens and num_blocks based on the available memory and the size of the activation peaks.
         If neither value is provided, we use a default value of 8192 for max_batch_tokens, apply bounds depending on the
         available VRAM, and solve for num_blocks. If one value is provided, the other is found using a linear solve."""
-        available = self.get_available_memory()
+        max_batch_tokens = self.cb_config.max_batch_tokens
+        num_blocks = self.cb_config.num_blocks
 
         # If both values are provided, just make sure they make sense
-        if num_blocks is not None and max_batch_tokens is not None:
-            return self._check_footprint(max_batch_tokens, num_blocks, available, cache_dtype)
+        if max_batch_tokens is not None and num_blocks is not None:
+            return self._check_footprint(max_batch_tokens, num_blocks)
 
         # If one or more value is provided, solve for the other
-        if num_blocks is not None or max_batch_tokens is not None:
+        if max_batch_tokens is not None or num_blocks is not None:
             max_batch_tokens, num_blocks = self._solve_for_peaks(
-                max_batch_tokens, num_blocks, available, cache_dtype, cache_fill_per_batch=None)
-            return self._check_footprint(max_batch_tokens, num_blocks, available, cache_dtype)
+                max_batch_tokens, num_blocks, cache_fill_per_batch=None
+            )
+            return self._check_footprint(max_batch_tokens, num_blocks)
 
         # If no value is provided, use the default value for max_batch_tokens w/ VRAM-based upper bound
         upper_bound_vram, _ = self._solve_for_peaks(
             max_batch_tokens=None,
             num_blocks=None,
-            available=available,
-            cache_dtype=cache_dtype,
             cache_fill_per_batch=0.1,  # each cache must fill 10% of the cache at most
         )
         max_batch_tokens = min(self._default_max_batch_tokens, upper_bound_vram)
         max_batch_tokens = max(max_batch_tokens, self._min_max_batch_tokens)
         # Then solve with that value
-        max_batch_tokens, num_blocks = self._solve_for_peaks(
-            max_batch_tokens, num_blocks, available, cache_dtype, cache_fill_per_batch=None
-        )
-        return self._check_footprint(max_batch_tokens, num_blocks, available, cache_dtype)
+        max_batch_tokens, num_blocks = self._solve_for_peaks(max_batch_tokens, num_blocks, cache_fill_per_batch=None)
+        return self._check_footprint(max_batch_tokens, num_blocks)
 
     def _solve_for_peaks(
         self,
         max_batch_tokens: int | None,
         num_blocks: int | None,
-        available: int,
-        cache_dtype: torch.dtype,
         cache_fill_per_batch: float | None,
     ) -> tuple[int, int]:
         """Returns max_batch_tokens and num_blocks so that their memory footprint is within the available memory for all
@@ -669,60 +673,65 @@ class PagedAttentionMemoryHandler:
         solve for both varibles by saying each batch fill a certain percentage of the cache (eg, if cache_fill_per_batch
         is 0.01, each batch will fill 1% of the cache)."""
         solutions = []
-        for peak in self.activation_peaks:
-            m_batch_tokens, n_blocks = self._solve_for_peak(
-                peak, max_batch_tokens, num_blocks, available, cache_dtype, cache_fill_per_batch
-            )
-            solutions.append((m_batch_tokens, n_blocks))
-        return max(solutions, key=lambda m, n: n)  # returns the solution with the highest num_blocks
+
+        for peak_deltas in self.activation_peak.values():
+            m, n = self._solve_for_peak(peak_deltas, max_batch_tokens, num_blocks, cache_fill_per_batch)
+            solutions.append((m, n))
+
+        final_m = min([solution[0] for solution in solutions])
+        final_n = min([solution[1] for solution in solutions])
+        return final_m, final_n
 
     def _solve_for_peak(
         self,
-        peak: tuple[int, int],
+        peak: tuple[int, ...],
         max_batch_tokens: int | None,
         num_blocks: int | None,
-        available: int,
-        cache_dtype: torch.dtype,
-        m: float | None,
+        cache_fill_per_batch: float | None,
     ) -> tuple[int, int]:
         """Returns a couple of `(max_batch_tokens, num_blocks)` that satisfy the memory constraint for the given
         activation peak."""
-        cm, cn, cmn, cmm = self._equation_coefficients(peak, cache_dtype)
+        cm, cn, cmn, cmm = self._equation_coefficients(peak)
 
         # If neither variable is defined, use a quadratic solver
-        if num_blocks is None and max_batch_tokens is None:
+        if max_batch_tokens is None and num_blocks is None:
             # Substitute M = m·N → (coeff_nm·m + coeff_mm·m²)·N² + (coeff_n + coeff_m·m)·N − avail = 0
-            if m is None:
-                raise ValueError("m must be provided if num_blocks and max_batch_tokens are None")
-            num_pages = self._solve_quadratic(cmn * m + cmm * m**2, cn + cm * m, -available)
+            if cache_fill_per_batch is None:
+                raise ValueError("m must be provided if max_batch_tokens and num_blocks are None")
+            m = cache_fill_per_batch  # as in, m is a substitute for big M, which is max_batch_tokens
+            num_pages = self._solve_quadratic(cmn * m + cmm * m**2, cn + cm * m, -self.available_memory)
             max_batch_tokens = int(num_pages * m)
+            num_blocks = int(num_pages) // self.block_size
 
         # Otherwise, use a linear solver
         elif num_blocks is None:
             # M given → linear in N: (coeff_n + coeff_nm·M)·N = avail − coeff_m·M − coeff_mm·M²
             M = max_batch_tokens
-            num_pages = floor((available - cm * M - cmm * M**2) / (cn + cmn * M))
+            num_pages = floor((self.available_memory - cm * M - cmm * M**2) / (cn + cmn * M))
+            num_blocks = num_pages // self.block_size
 
         elif max_batch_tokens is None:
             # N given → quadratic in M: coeff_mm·M² + (coeff_m + coeff_nm·N)·M + (coeff_n·N − avail) = 0
             N = num_blocks * self.block_size
-            M = self._solve_quadratic(cmm, cm + cmn * N, cn * N - available)
+            max_batch_tokens = int(self._solve_quadratic(cmm, cm + cmn * N, cn * N - self.available_memory))
 
         return max_batch_tokens, num_blocks
 
-    def _check_footprint(
-        self, max_batch_tokens: int, num_blocks: int, available: int, cache_dtype: torch.dtype
-    ) -> tuple[int, int]:
+    def _check_footprint(self, max_batch_tokens: int, num_blocks: int) -> tuple[int, int]:
         """Checks if the footprint of the cache is within the available memory."""
-        memory_footprint = self.compute_memory_footprint(max_batch_tokens, num_blocks, cache_dtype)
-        if memory_footprint > available:
-            raise MemoryError(f"Memory footprint {memory_footprint} is more than available memory {available}")
+        memory_footprint = self.compute_memory_footprint(max_batch_tokens, num_blocks)
+        if memory_footprint > self.available_memory:
+            raise MemoryError(
+                f"Memory footprint {memory_footprint} is more than available memory {self.available_memory}"
+            )
+        if max_batch_tokens <= 0 or num_blocks <= 0:
+            raise ValueError(f"Invalid values: max_batch_tokens = {max_batch_tokens}, num_blocks = {num_blocks}")
         return max_batch_tokens, num_blocks
 
     def _solve_quadratic(self, a: float, b: float, c: float) -> int:
         """Largest positive root of a·x² + b·x + c = 0. Falls back to linear when a == 0. Rounded down."""
         if a == 0:
-            return -c / b
+            return int(-c / b)
         discriminant = b**2 - 4 * a * c
         if discriminant < 0:
             raise ValueError(f"No real solution (discriminant = {discriminant})")
@@ -733,29 +742,25 @@ class PagedAttentionMemoryHandler:
 
     # Formatting is disabled because of comment indentation, which improves readability.
     # fmt: off
-    def _equation_coefficients(
-        self, peak: tuple[int, int], cache_dtype: torch.dtype
-    ) -> tuple[int, int, int, int]:
-        """Returns `(coeff_m, coeff_n, coeff_mn, coeff_mm)` for the memory polynomial of a single activation peak.
-        `peak = (Δcn, Δcm)` is the peak-specific activation contribution; the rest of the coefficients are shared
-        across peaks. Each addend is annotated with the tensor it corresponds to in
-        `ContinuousBatchingIOs._setup_static_tensors` (or the forward pass, for activation terms).
-        """
-        i = self._input_dtype.itemsize       # int32
-        a = self._activation_dtype.itemsize  # bfloat16
-        c = cache_dtype.itemsize
+    def _equation_coefficients(self, peak_deltas: tuple[int, ...]) -> tuple[int, ...]:
+        """Given some deltas corresponding to an activation peak, returns the coefficients for the memory polynomial of
+        that peak. The memory polynomial is described in that class docstring."""
+        delta_m, delta_n, delta_mm, delta_mn = peak_deltas
+
+        i = torch.int32.itemsize             # size of int32 in bytes, used for index, input_ids, ...
+        a = self.activation_dtype.itemsize             # for now, the cache and the activation have the same dtype
+        c = self.cache_dtype.itemsize
         k = self.io_multiplier               # 1 sync, 2 async (IO tensors only)
-        delta_n, delta_m = peak
 
         # -- N terms: cost per cache page --------------------------------------------------
         coeff_n = (
-            2 * self.group_size * self.page_size * c   # kv_cache: 2 * group_size * [N, page_size] * cache_dtype
-            + k * self.num_groups * 8                  # read_index: [num_groups, N + M]  (N part only, int64)
-            + delta_n * a                              # activation peak: N-proportional part
+            delta_n                                      # activation peak: N-proportional part
+            + 2 * self.group_size * self.page_size * c   # kv_cache: 2 * group_size * [N, page_size] * cache_dtype
+            + k * self.num_groups * 8                    # read_index: [num_groups, N + M]  (N part only, int64)
         )
         # -- M terms: cost per batch token -------------------------------------------------
         coeff_m = (
-            delta_m * a                                # activation peak: M-proportional part
+            delta_m                                    # activation peak: M-proportional part
             + k * 7 * i                                # bulk_input: [7, M] int32, packed as 7 rows
             + k * self.num_output_rows * i             # output_ids: [num_output_rows, M] int32
             + k * self.num_groups                      # block_table: [bt_groups, M, max_blocks_per_req] int32
@@ -766,21 +771,27 @@ class PagedAttentionMemoryHandler:
         # TODO: the above could be refined by introducing the max_requests_per_batch, but then there is a min() and this
         # is no longer a simple polynomial. Could be worth checking into.
         # -- M·N terms: cost per (page × batch token) --------------------------------------
-        coeff_mn = k * self.num_attention_masks * a    # attention_mask: [1, 1, M, N + M] (N·M part only)
+        coeff_mn = (
+            delta_mn                             # activation peak: M·N-proportional part
+            + k * self.num_attention_masks * a   # attention_mask: [1, 1, M, N + M] (N·M part only)
+        )
         # -- M² terms: cost per (batch token squared) --------------------------------------
-        coeff_mm = k * self.num_attention_masks * a    # attention_mask: [1, 1, M, N + M] (M² part only)
+        coeff_mm = (
+            delta_mm                            # activation peak: M²-proportional part
+            + k * self.num_attention_masks * a  # attention_mask: [1, 1, M, N + M] (M² part only)
+        )
 
         return coeff_m, coeff_n, coeff_mn, coeff_mm
     # fmt: on
 
-    def compute_memory_footprint(self, max_batch_tokens: int, num_blocks: int, cache_dtype: torch.dtype) -> int:
+    def compute_memory_footprint(self, max_batch_tokens: int, num_blocks: int) -> int:
         """Evaluate the memory polynomial at concrete (N, M) values, taking the max across activation peaks."""
         M = max_batch_tokens
         N = num_blocks * self.block_size
 
         max_memory_footprint = 0
-        for peak in self.activation_peaks:
-            cm, cn, cmn, cmm = self._equation_coefficients(peak, cache_dtype)
+        for peak in self.activation_peak.values():
+            cm, cn, cmn, cmm = self._equation_coefficients(peak)
             memory_footprint = cn * N + cm * M + cmn * N * M + cmm * M * M
             max_memory_footprint = max(max_memory_footprint, memory_footprint)
         return max_memory_footprint

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -28,18 +28,28 @@ from .requests import RequestState, RequestStatus, get_device_and_memory_breakdo
 
 def find_num_kv_heads(config: PreTrainedConfig) -> int:
     """Finds the number of key-value heads for the given config."""
-    for attr in ["num_key_value_heads", "num_attention_heads"]:
-        if hasattr(config, attr):
-            return getattr(config, attr)
+    # If the model supports GQA, we leverage it by using the num_key_value_heads attribute
+    kv_heads = getattr(config, "num_key_value_heads", None)
+    if kv_heads is not None:
+        return kv_heads
+    # Otherwise, the number of KV heads is the same as the number of attention heads
+    kv_heads = getattr(config, "num_attention_heads", None)
+    if kv_heads is not None:
+        return kv_heads
     raise ValueError(f"num_key_value_heads or num_attention_heads could not be found in the config:\n{config}")
 
 
 def find_head_dim(config: PreTrainedConfig) -> int:
     """Finds the head dimension for the given config."""
-    if hasattr(config, "head_dim"):
-        return config.head_dim
-    if hasattr(config, "hidden_size") and hasattr(config, "num_attention_heads"):
-        return config.hidden_size // config.num_attention_heads
+    # If the model has the head_dim attribute, there is nothing to do but return it
+    head_dim = getattr(config, "head_dim", None)
+    if head_dim is not None:
+        return head_dim
+    # If it is missing, we may reconstruct it from the hidden size and the number of attention heads
+    hidden_size = getattr(config, "hidden_size", None)
+    num_attention_heads = getattr(config, "num_attention_heads", None)
+    if hidden_size is not None and num_attention_heads is not None:
+        return hidden_size // num_attention_heads
     raise ValueError(f"head_dim or (hidden_size and num_attention_heads) could not be found in the config:\n{config}")
 
 

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -60,7 +60,6 @@ memory and time to create, we use an LRU cache with a fixed size to limit memory
 - Q: 64 tokens gives ~4 graphs for max_batch_tokens=256, which is a good balance
 - KV: 8192 tokens (256 blocks at block_size=32) gives reasonable granularity for large caches
 
-The maximum number of cached graphs is controlled by max_cached_graphs (default 32), which uses LRU eviction.
 All defaults are stored in ContinuousBatchingConfig.resolve_sentinel_values().
 """
 

--- a/src/transformers/generation/continuous_batching/initialization.py
+++ b/src/transformers/generation/continuous_batching/initialization.py
@@ -33,7 +33,6 @@ FALLBACK_DEFAULTS = {
     "max_blocks_per_request": 32,
     "q_padding_interval_size": 64,
     "kv_padding_interval_size": 64 * 256,  # 64 blocks of 256 tokens ie. 16384 tokens
-    "max_cached_graphs": 32,
 }
 
 
@@ -49,9 +48,7 @@ def resolve_continuous_batching_config(
     # Look at whether the user explicitly asked for the decode fast path before we assign a default value
     user_requested_decode_path = cb_config.max_blocks_per_request is not None
     # Same for cuda graphs, if the user signals they want CUDA graphs via any padding/cached-graph parameter
-    cuda_graph_requested = any(
-        [cb_config.q_padding_interval_size, cb_config.kv_padding_interval_size, cb_config.max_cached_graphs]
-    )
+    cuda_graph_requested = any([cb_config.q_padding_interval_size, cb_config.kv_padding_interval_size])
 
     # Resolve missing attributes for which we have hints. Must happen before no-hints resolve.
     resolve_using_hints(cb_config, workload_hints)
@@ -112,8 +109,6 @@ def resolve_without_hints(cb_config: ContinuousBatchingConfig) -> None:
         cb_config.q_padding_interval_size = FALLBACK_DEFAULTS["q_padding_interval_size"]
     if cb_config.kv_padding_interval_size == 0:
         cb_config.kv_padding_interval_size = FALLBACK_DEFAULTS["kv_padding_interval_size"]
-    if cb_config.max_cached_graphs == 0:
-        cb_config.max_cached_graphs = FALLBACK_DEFAULTS["max_cached_graphs"]
 
 
 def ensure_decode_fast_path_is_available(

--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -111,7 +111,7 @@ class ContinuousBatchingIOs:
         # Setup other accumulators
         self.requests_in_batch: list[FutureRequestState] = []
         self.req_id_to_new_token_position: dict[str, int] = {}  # only used for async API
-        self.graphs: CudaGraphBuffer = CudaGraphBuffer(continuous_batching_config.max_cached_graphs)
+        self.graphs: CudaGraphBuffer = CudaGraphBuffer()
         self._read_trash_index = cache.read_trash_index
         self._write_trash_index = cache.write_trash_index
         # Setup static tensors and compute stream
@@ -546,13 +546,12 @@ class ContinuousBatchingIOs:
         # Keys for varlen path
         return (self.num_q_tokens, self.max_kv_read, *self.max_seqlen_k.values())
 
-    def get_graph(self) -> torch.cuda.CUDAGraph | None:
+    def get_graph(self, prefix: str = "") -> torch.cuda.CUDAGraph | None:
         key = self._get_graph_key()
         graph = self.graphs.get_graph(key)
         # If this point is reached, it means the next step will be a new graph capture
         if graph is None:
-            self.graphs.plan_for_new_graph()
-            logger.info(f"Creating graph for {key = }")
+            logger.info(f"{prefix}Creating graph for {key = }")
         return graph
 
     def set_graph(self, graph: torch.cuda.CUDAGraph) -> None:
@@ -781,7 +780,8 @@ class ContinuousBatchingAsyncIOs:
         return self.io_pairs[self.current_pair].device_io.output_ids
 
     def get_graph(self) -> torch.cuda.CUDAGraph | None:
-        return self.io_pairs[self.current_pair].device_io.get_graph()
+        prefix = f"(IO {self.current_pair})"
+        return self.io_pairs[self.current_pair].device_io.get_graph(prefix=prefix)
 
     def set_graph(self, graph: torch.cuda.CUDAGraph) -> None:
         self.io_pairs[self.current_pair].device_io.set_graph(graph)

--- a/src/transformers/generation/continuous_batching/requests.py
+++ b/src/transformers/generation/continuous_batching/requests.py
@@ -208,7 +208,8 @@ class RequestState:
             self.lifespan = (time.perf_counter(), -1)
         elif value == RequestStatus.FINISHED:
             self.lifespan = (self.lifespan[0], time.perf_counter())
-            self.log_end_of_request()
+            if logger.isEnabledFor(logging.DEBUG):
+                self.log_end_of_request()
         self._status = value
 
     @property
@@ -220,7 +221,7 @@ class RequestState:
         decode_len = self.generated_len()
         start_time = self.lifespan[0] - self.created_time
         end_time = self.lifespan[1] - self.created_time
-        logger.info(
+        logger.debug(
             f"Request {self.request_id} finished: {prefill_len = } {decode_len = } {start_time = } {end_time = }"
         )
 

--- a/src/transformers/generation/continuous_batching/utils.py
+++ b/src/transformers/generation/continuous_batching/utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import queue
-from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from math import ceil, log2
@@ -23,40 +22,24 @@ import torch
 from transformers.configuration_utils import PretrainedConfig
 from transformers.utils import is_torch_greater_or_equal
 
-from .requests import FutureRequestState, RequestState, RequestStatus, logger
+from .requests import FutureRequestState, RequestState, RequestStatus
 
 
 class CudaGraphBuffer:
-    """A fixed-size dict for CUDA graphs with LRU eviction when full."""
+    """A dict for CUDA graphs with a special __del__ method to make sure the graphs are properly reset."""
 
-    def __init__(self, max_size: int) -> None:
-        if max_size <= 0:
-            raise ValueError(f"max_size must be positive, but got {max_size}")
-        self.max_size = max_size
-        self._storage: OrderedDict[tuple[int, ...], torch.cuda.CUDAGraph] = OrderedDict()
+    def __init__(self) -> None:
+        self._storage: dict[tuple[int, ...], torch.cuda.CUDAGraph] = {}
 
     def __del__(self) -> None:
-        original_max_size = self.max_size
-        self.max_size = 1  # 0 would cause an infinite loop, 1 is enough to clear all graphs
-        self.plan_for_new_graph(silent=True)
-        self.max_size = original_max_size
+        while self._storage:
+            _, graph = self._storage.popitem()
+            graph.reset()
 
     def get_graph(self, key: tuple[int, ...]) -> torch.cuda.CUDAGraph | None:
-        graph = self._storage.get(key)
-        if graph is not None:
-            self._storage.move_to_end(key)
-        return graph
-
-    def plan_for_new_graph(self, silent: bool = False) -> None:
-        while len(self._storage) >= self.max_size:
-            evicted_key, evicted_graph = self._storage.popitem(last=False)
-            if not silent:
-                logger.info(f"Evicting graph for {evicted_key = }")
-            evicted_graph.reset()
+        return self._storage.get(key)
 
     def set_graph(self, key: tuple[int, ...], graph: torch.cuda.CUDAGraph) -> None:
-        # In our use case, this should not have any effect because we plan for a new graph before it is captured
-        self.plan_for_new_graph()
         self._storage[key] = graph
 
 

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -17,6 +17,7 @@ import gc
 import itertools
 import os
 import unittest
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -44,7 +45,12 @@ from transformers.generation.continuous_batching.continuous_api import OutputRou
 from transformers.generation.continuous_batching.distributed import DistributedHelper
 from transformers.generation.continuous_batching.input_outputs import build_attention_mask
 from transformers.generation.continuous_batching.offloading_manager import OffloadingManager
-from transformers.generation.continuous_batching.requests import GenerationOutput, RequestState, RequestStatus
+from transformers.generation.continuous_batching.requests import (
+    GenerationOutput,
+    RequestState,
+    RequestStatus,
+    get_device_and_memory_breakdown,
+)
 from transformers.testing_utils import (
     require_deterministic_for_xpu,
     require_flash_attn,
@@ -908,6 +914,48 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             attn_implementation="sdpa",
         )
 
+    @with_flush_memory
+    def test_memory_footprint_respects_max_memory_percent(self) -> None:
+        """Runs a short batched generation with an auto-inferred cache size and checks that the real peak memory the
+        cache, IOs and activations add on top of the model stays within the configured max_memory_percent of the free
+        device memory (within a tolerance, to account for allocator rounding and the spare cache blocks)."""
+        if not (torch.cuda.is_available() or is_torch_xpu_available()):
+            self.skipTest("Peak memory tracking requires CUDA or XPU")
+        accelerator = torch.cuda if torch.cuda.is_available() else torch.xpu
+
+        model_id = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+        max_memory_percent = 0.5
+        tolerance = 0.05
+
+        tokenizer, model = get_tokenizer_and_model(model_id, "sdpa", torch_device, torch.float16)
+        input_ids = get_generation_inputs(_DEFAULT_USER_MESSAGES, tokenizer, for_continuous_batching=True)
+        model.generation_config.max_new_tokens = 20
+        model.generation_config.do_sample = False
+        cb_config = ContinuousBatchingConfig(
+            max_memory_percent=max_memory_percent, use_cuda_graph=False, use_async_batching=False
+        )
+
+        # Budget = max_memory_percent of the free device memory, computed exactly as the memory handler does
+        _, total, reserved, allocated = get_device_and_memory_breakdown()
+        budget = max_memory_percent * (total - max(allocated, reserved))
+
+        # Everything continuous batching allocates (cache + IOs + activations) lives on top of the already-loaded model
+        accelerator.reset_peak_memory_stats()
+        model_footprint = accelerator.memory_allocated()
+        model.generate_batch(
+            inputs=input_ids,
+            generation_config=model.generation_config,
+            continuous_batching_config=cb_config,
+        )
+        cb_footprint = accelerator.max_memory_allocated() - model_footprint
+
+        self.assertLessEqual(
+            cb_footprint,
+            budget * (1 + tolerance),
+            f"Continuous batching peak footprint {cb_footprint / 1024**2:.0f} MB exceeds the {max_memory_percent:.0%} "
+            f"budget of {budget / 1024**2:.0f} MB (+{tolerance:.0%} tolerance)",
+        )
+
     def test_continuous_batching_long_generate(self) -> None:
         model_id = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
         continuous_batching_config = ContinuousBatchingConfig(
@@ -1538,93 +1586,127 @@ class TestMemoryHandlerPrediction(unittest.TestCase):
     """Verifies that ``PagedAttentionMemoryHandler.compute_memory_footprint`` matches real GPU memory usage.
 
     For each configuration we allocate tensors at the *idealized* sizes modeled by the handler (same shapes, same
-    dtypes, no alignment padding or extra blocks) and compare the CUDA memory delta to the handler's prediction.
+    dtypes, no alignment padding or extra blocks) and compare the CUDA memory delta to the handler's prediction. The
+    handler derives the page size and the two activation peaks (LM head and attention) from the model config, so we
+    allocate the tensors of whichever peak dominates -- that is the one ``compute_memory_footprint`` reports.
     """
-
-    # (block_size, page_size, num_groups, group_size, peak_act, num_attn_masks, max_bpr, logprobs, cache_dtype, use_async_batching)
-    CONFIGS = [
-        (32, 256, 1, 22, 34048, 1, 0, False, torch.float16, False),  # sdpa-like, 1 attn mask
-        (256, 256, 1, 22, 34048, 0, 0, False, torch.float16, False),  # flash-like, no attn mask
-        (32, 256, 2, 14, 34048, 2, 0, False, torch.bfloat16, False),  # hybrid model, 2 groups + 2 masks
-        (32, 128, 1, 16, 8192, 1, 8, True, torch.float16, False),  # with block_table + logprobs
-        (32, 128, 1, 16, 8192, 1, 8, True, torch.float16, True),  # with block_table + logprobs + async batching
-    ]
 
     NUM_BLOCKS = 4
     MAX_BATCH_TOKENS = 64
+
+    # Each tuple fully specifies a synthetic model config plus the CB knobs; page_size = head_dim * num_kv_heads.
+    # fmt: off
+    # (block_size, head_dim, num_kv_heads, num_attention_heads, hidden_size, vocab_size, group_types, group_size, attn_impl, max_bpr, logprobs, dtype, use_async)
+    CONFIGS = [
+        (32, 64, 4, 8, 512, 32000, ["full_attention"], 22, "sdpa", 0, False, torch.float16, False),  # sdpa-like, 1 mask
+        (256, 64, 4, 8, 512, 32000, ["full_attention"], 22, "flash_attention_2", 0, False, torch.float16, False),  # flash-like, no mask
+        (32, 64, 4, 8, 512, 32000, ["full_attention", "sliding_attention"], 14, "sdpa", 0, False, torch.bfloat16, False),  # hybrid, 2 groups + 2 masks
+        (32, 64, 2, 8, 512, 32000, ["full_attention"], 16, "sdpa", 8, True, torch.float16, False),  # block_table + logprobs
+        (32, 64, 2, 8, 512, 32000, ["full_attention"], 16, "sdpa", 8, True, torch.float16, True),  # block_table + logprobs + async
+    ]
+    # fmt: on
 
     @parameterized.expand(CONFIGS)
     def test_memory_prediction(
         self,
         block_size: int,
-        page_size: int,
-        num_groups: int,
+        head_dim: int,
+        num_kv_heads: int,
+        num_attention_heads: int,
+        hidden_size: int,
+        vocab_size: int,
+        group_types: list[str],
         group_size: int,
-        peak_act: int,
-        num_attn_masks: int,
+        attn_impl: str,
         max_bpr: int,
         logprobs: bool,
-        cache_dtype: torch.dtype,
-        use_async_batching: bool,
+        dtype: torch.dtype,
+        use_async: bool,
     ) -> None:
+        config = SimpleNamespace(  # rather than creating a full config that we would only use for the namespace
+            head_dim=head_dim,
+            num_key_value_heads=num_kv_heads,
+            num_attention_heads=num_attention_heads,
+            hidden_size=hidden_size,
+            vocab_size=vocab_size,
+            _attn_implementation=attn_impl,
+        )
         cb_config = ContinuousBatchingConfig(
+            block_size=block_size,
             max_blocks_per_request=max_bpr,
             return_logprobs=logprobs,
-            use_async_batching=use_async_batching,
-            block_size=block_size,
+            use_async_batching=use_async,
+            max_memory_percent=0.9,
+        )
+        handler = PagedAttentionMemoryHandler(
+            config=config,
+            continuous_batching_config=cb_config,
+            dtype=dtype,
+            group_types=group_types,
+            group_size=group_size,
         )
 
-        handler = PagedAttentionMemoryHandler(
-            continuous_batching_config=cb_config,
-            page_size=page_size,
-            num_groups=num_groups,
-            group_size=group_size,
-            activation_peaks=[(0, peak_act)],
-            num_attention_masks=num_attn_masks,
-        )
+        num_groups = len(group_types)
+        num_attn_masks = handler.num_attention_masks
+        num_output_rows = 2 if logprobs else 1
+        page_size = head_dim * num_kv_heads
+        q_dim = num_attention_heads * head_dim
 
         N = self.NUM_BLOCKS * block_size  # num_pages
         M = self.MAX_BATCH_TOKENS
-        predicted = handler.compute_memory_footprint(self.NUM_BLOCKS, M, cache_dtype)
-        num_output_rows = 2 if logprobs else 1
-        act_dtype = handler._activation_dtype
-        i32 = handler._input_dtype
+        k = handler.io_multiplier  # 1 sync, 2 async -- scales IO tensors only
+        predicted = handler.compute_memory_footprint(M, self.NUM_BLOCKS)
 
         # -- Allocate tensors at the exact idealized sizes the handler models --
         device = "cuda"
         torch.cuda.empty_cache()
         baseline = torch.cuda.memory_allocated(device)
 
-        k = handler.io_multiplier  # 1 sync, 2 async -- scales IO tensors only
-        tensors = []
+        # Tensors present regardless of which activation peak is live
+        fixed = []
         # kv_cache: 2 * group_size tensors of [N, page_size] (not scaled by k)
         for _ in range(group_size):
-            tensors.append(torch.empty((N, page_size), dtype=cache_dtype, device=device))
-            tensors.append(torch.empty((N, page_size), dtype=cache_dtype, device=device))
-        # activation peak: flat tensor of peak_act * M elements (not scaled by k)
-        tensors.append(torch.empty(peak_act * M, dtype=act_dtype, device=device))
+            fixed.append(torch.empty((N, page_size), dtype=dtype, device=device))
+            fixed.append(torch.empty((N, page_size), dtype=dtype, device=device))
         # IO tensors below are allocated k times (once per IO instance)
         for _ in range(k):
-            # bulk_input: [7, M]
-            tensors.append(torch.empty((7, M), dtype=i32, device=device))
-            # output_ids: [num_output_rows, M]
-            tensors.append(torch.empty((num_output_rows, M), dtype=i32, device=device))
-            # attention_mask: [1, 1, M, N + M] per mask type
-            for _ in range(num_attn_masks):
-                tensors.append(torch.empty((1, 1, M, N + M), dtype=act_dtype, device=device))
-            # block_table: [num_groups, M, max_bpr] (empty when max_bpr == 0)
-            if max_bpr > 0:
-                tensors.append(torch.empty((num_groups, M, max_bpr), dtype=i32, device=device))
-            # write_index: [num_groups, M]
-            tensors.append(torch.empty((num_groups, M), dtype=torch.int64, device=device))
-            # read_index: [num_groups, N + M]
-            tensors.append(torch.empty((num_groups, N + M), dtype=torch.int64, device=device))
+            fixed.append(torch.empty((7, M), dtype=torch.int32, device=device))  # bulk_input
+            fixed.append(torch.empty((num_output_rows, M), dtype=torch.int32, device=device))  # output_ids
+            for _ in range(num_attn_masks):  # attention_mask: [1, 1, M, N + M] per mask type
+                fixed.append(torch.empty((1, 1, M, N + M), dtype=dtype, device=device))
+            if max_bpr > 0:  # block_table: [num_groups, M, max_bpr] (skipped when max_bpr == 0)
+                fixed.append(torch.empty((num_groups, M, max_bpr), dtype=torch.int32, device=device))
+            fixed.append(torch.empty((num_groups, M), dtype=torch.int64, device=device))  # write_index
+            fixed.append(torch.empty((num_groups, N + M), dtype=torch.int64, device=device))  # read_index
+
+        # Activation peaks: only one is live at a time, so the footprint uses whichever is larger
+        peaks = {
+            # LM head: hidden states [M, hidden] turned into logits [M, vocab] (always fp32)
+            "lm_head": [
+                torch.empty((M, hidden_size), dtype=dtype, device=device),
+                torch.empty((M, vocab_size), dtype=torch.float32, device=device),
+            ],
+            # Attention: hidden + Q + new K/V over M, plus old K/V read from the whole cache over N
+            "attention": [
+                torch.empty((M, hidden_size), dtype=dtype, device=device),
+                torch.empty((M, q_dim), dtype=dtype, device=device),
+                torch.empty((M, page_size), dtype=dtype, device=device),
+                torch.empty((M, page_size), dtype=dtype, device=device),
+                torch.empty((N, page_size), dtype=dtype, device=device),
+                torch.empty((N, page_size), dtype=dtype, device=device),
+            ],
+        }
+        peak_nbytes = {name: sum(t.nbytes for t in ts) for name, ts in peaks.items()}
+        dominant = max(peak_nbytes, key=peak_nbytes.get)
+        # Free the non-dominant peak so the CUDA delta reflects only the live one
+        for name in [n for n in peaks if n != dominant]:
+            del peaks[name]
 
         actual_cuda = torch.cuda.memory_allocated(device) - baseline
-        expected_nbytes = sum(t.nbytes for t in tensors)
-        num_allocations = len(tensors)
+        expected_nbytes = sum(t.nbytes for t in fixed) + peak_nbytes[dominant]
+        num_allocations = len(fixed) + len(peaks[dominant])
 
-        del tensors
+        del fixed, peaks
         torch.cuda.empty_cache()
 
         # 1) Exact check: prediction must equal the sum of tensor nbytes. This validates the polynomial


### PR DESCRIPTION
# Summary

This PR aims at increasing the performances of continuous batching, especially for prefill batches. To that order, it changes the following things:
- rework the cache size estimator by adding a default `max_batch_tokens` of 8192 and applying a VRAM-based bound. In effect, this means that the prefill batches can now be much bigger
- along with this behavioral change, the cache size estimator has been reworked to be more readable and self contained
- deprecate the `max_cached_graph` attributes, because it was made useless by the graph pool: since all graphs share the same pool, the memory footprint of new graphs is negligible. Actually, this parameter was hurting performance because discarding and recording new graphs led to fragmentation and more memory being used in the end

## Performance ✅ 

label | main acc | new PR acc | main (tok/s) | new PR (tok/s) | diff
-- | -- | -- | -- | -- | --
gsm8k_default | 0.825 | 0.822 | 2477.36 | 3301.09 | +33.25%
gsm8k_sampling | 0.790 | 0.788 | 1952.49 | 2936.00 | +50.37%
gsm8k_compile | 0.825 | 0.823 | 2477.76 | 3444.92 | +39.03%
gsm8k_no_fast_decode | 0.825 | 0.822 | 2364.45 | 2348.65 | -0.67%
gsm8k_bare_bones | 0.825 | 0.816 | 1886.61 | 1911.51 | +1.32%
ifeval_default | 0.457 | 0.445 | 8958.99 | 10163.10 | +13.44%
few_blocks | - | - | 666.69 | 674.44 | +1.16%
multi_return_seq | - | - | 1626.68 | 1764.44 | +8.47%
rollouts_1024 | - | - | 3545.67 | 3609.38 | +1.80%
rollouts_2048 | - | - | 3363.86 | 3394.07 | +0.90%
rollouts_4096 | - | - | 2958.96 | 2984.04 | +0.85%
rollouts_8192 | - | - | 2360.50 | 2362.29 | +0.08%
rollouts_16384 | - | - | 1549.78 | 1537.00 | -0.83%

Big performance improvements for prefill-bound workloads. Small accuracy regression on "bare-bones", because the size of the batch affects the generated tokens.

## Tests ✅ 

This PR adds a new test to verify the actual memory footprint is aligned with the expected one.
All tests pass

## AI Review ✅ 

Reviewed and addressed. 