### PR TITLE
ci: grant pull-requests:write to the security gate caller

### DIFF
--- a/.github/workflows/pr-ci-security-gate.yml
+++ b/.github/workflows/pr-ci-security-gate.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: write
   contents: read
+  pull-requests: write
 
 jobs:
   security-gate:


### PR DESCRIPTION
## What does this PR do?

The PR CI security gate reusable workflow (`transformers-test-ci`) was recently updated to post a PR comment when it blocks automatic CI approval (allowlist violation or new Bandit high-severity finding). That comment step requires `pull-requests: write`.

The reusable workflow already declares the permission, but a reusable workflow can only use permissions that the **caller** explicitly grants. The caller here (`pr-ci-security-gate.yml`) only declared `actions: write` and `contents: read`, causing a workflow validation failure:

> The workflow is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.

This PR adds `pull-requests: write` to the caller's `permissions` block. Since the caller uses `pull_request_target` (runs in the base repo context, not the fork), this permission is fully available and safe to grant.