### PR TITLE
Reflect baked post-processor in `add_bos_token`/`add_eos_token`

### DIFF
--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -487,6 +487,9 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         )
         if self._should_update_post_processor:
             self.update_post_processor()
+        else:
+            # Keep the baked post-processor, but make add_bos_token/add_eos_token reflect what it does.
+            self._set_bos_eos_from_post_processor()
 
     @property
     def is_fast(self) -> bool:
@@ -544,6 +547,29 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         self._tokenizer.post_processor = processors.TemplateProcessing(
             single=single, pair=pair, special_tokens=special_tokens
         )
+
+    def _set_bos_eos_from_post_processor(self):
+        """
+        Read the loaded `TemplateProcessing` post-processor and set `add_bos_token` / `add_eos_token`
+        to reflect it, *without* rebuilding the post-processor (we only touch the private flags).
+        Only `TemplateProcessing` models bos/eos; other processors (Bert/Roberta/ByteLevel/Sequence)
+        are left untouched. ponytail: first/last `SpecialToken` only; a richer template isn't decoded.
+        """
+        pp = self._tokenizer.post_processor
+        if pp is None:
+            return
+        state = json.loads(pp.__getstate__())
+        if state.get("type") != "TemplateProcessing":
+            return
+        single = state.get("single") or []
+
+        def _special_id(elem):
+            return elem["SpecialToken"]["id"] if isinstance(elem, dict) and "SpecialToken" in elem else None
+
+        if self.bos_token is not None and single and _special_id(single[0]) == self.bos_token:
+            object.__setattr__(self, "_add_bos_token", True)
+        if self.eos_token is not None and single and _special_id(single[-1]) == self.eos_token:
+            object.__setattr__(self, "_add_eos_token", True)
 
     @property
     def add_eos_token(self):

--- a/tests/test_tokenizers_backend_mixin.py
+++ b/tests/test_tokenizers_backend_mixin.py
@@ -591,3 +591,48 @@ Hey how are you doing"""  # noqa: W293
                     text,
                     f"Roundtrip failed for {model_id} on sample {text!r}",
                 )
+
+
+@require_tokenizers
+class TokenizersBackendBosEosReflectionTest(unittest.TestCase):
+    """
+    `add_bos_token` / `add_eos_token` should reflect a baked `TemplateProcessing` post-processor without
+    rebuilding it. The flags used to stay `False` even when the post-processor was adding bos/eos.
+    """
+
+    @staticmethod
+    def _build(single, pair, special_tokens):
+        from tokenizers import Tokenizer, models, processors
+        from tokenizers.pre_tokenizers import Whitespace
+
+        tokenizer = Tokenizer(
+            models.WordLevel(vocab={"<s>": 0, "</s>": 1, "hello": 2, "world": 3, "[UNK]": 4}, unk_token="[UNK]")
+        )
+        tokenizer.pre_tokenizer = Whitespace()
+        tokenizer.post_processor = processors.TemplateProcessing(
+            single=single, pair=pair, special_tokens=special_tokens
+        )
+        return TokenizersBackend(tokenizer_object=tokenizer, bos_token="<s>", eos_token="</s>", unk_token="[UNK]")
+
+    def test_eos_only_template(self):
+        tok = self._build("$A </s>", "$A </s> $B </s>", [("</s>", 1)])
+        self.assertTrue(tok.add_eos_token)
+        self.assertFalse(tok.add_bos_token)
+        # flags are inferred from the post-processor, not rebuilt from them: tokenization is unchanged
+        self.assertEqual(tok("hello")["input_ids"], [2, 1])
+
+    def test_bos_only_template(self):
+        tok = self._build("<s> $A", "<s> $A $B", [("<s>", 0)])
+        self.assertTrue(tok.add_bos_token)
+        self.assertFalse(tok.add_eos_token)
+        self.assertEqual(tok("hello")["input_ids"], [0, 2])
+
+    def test_bos_and_eos_template(self):
+        tok = self._build("<s> $A </s>", "<s> $A </s> $B </s>", [("<s>", 0), ("</s>", 1)])
+        self.assertTrue(tok.add_bos_token)
+        self.assertTrue(tok.add_eos_token)
+
+    def test_no_special_token_template(self):
+        tok = self._build("$A", "$A $B", [])
+        self.assertFalse(tok.add_bos_token)
+        self.assertFalse(tok.add_eos_token)


### PR DESCRIPTION
Fast tokenizers with a `TemplateProcessing` baked into `tokenizer.json` left `add_bos_token`/`add_eos_token` as `False` despite the post-processor adding bos/eos. Now inferred from the post-processor without rebuilding it. Test added.

cc @itazap