### PR TITLE
Fix Swin2SR padding for aligned images

### DIFF
--- a/src/transformers/models/swin2sr/image_processing_swin2sr.py
+++ b/src/transformers/models/swin2sr/image_processing_swin2sr.py
@@ -100,8 +100,8 @@ class Swin2SRImageProcessor(BaseImageProcessor):
             `np.ndarray`: The padded image.
         """
         old_height, old_width = get_image_size(image, input_data_format)
-        pad_height = (old_height // size + 1) * size - old_height
-        pad_width = (old_width // size + 1) * size - old_width
+        pad_height = (size - old_height % size) % size
+        pad_width = (size - old_width % size) % size
 
         return pad(
             image,

--- a/src/transformers/models/swin2sr/image_processing_swin2sr_fast.py
+++ b/src/transformers/models/swin2sr/image_processing_swin2sr_fast.py
@@ -65,8 +65,8 @@ class Swin2SRImageProcessorFast(BaseImageProcessorFast):
             `torch.Tensor`: The padded images.
         """
         height, width = get_image_size(images, ChannelDimension.FIRST)
-        pad_height = (height // size_divisor + 1) * size_divisor - height
-        pad_width = (width // size_divisor + 1) * size_divisor - width
+        pad_height = (size_divisor - height % size_divisor) % size_divisor
+        pad_width = (size_divisor - width % size_divisor) % size_divisor
 
         return tvF.pad(
             images,

--- a/tests/models/swin2sr/test_image_processing_swin2sr.py
+++ b/tests/models/swin2sr/test_image_processing_swin2sr.py
@@ -79,8 +79,8 @@ class Swin2SRImageProcessingTester:
         else:
             input_height, input_width = img.shape[-2:]
 
-        pad_height = (input_height // self.size_divisor + 1) * self.size_divisor - input_height
-        pad_width = (input_width // self.size_divisor + 1) * self.size_divisor - input_width
+        pad_height = (self.size_divisor - input_height % self.size_divisor) % self.size_divisor
+        pad_width = (self.size_divisor - input_width % self.size_divisor) % self.size_divisor
 
         return self.num_channels, input_height + pad_height, input_width + pad_width
 
@@ -122,8 +122,8 @@ class Swin2SRImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         old_height, old_width = get_image_size(image)
         size = self.image_processor_tester.size_divisor
 
-        pad_height = (old_height // size + 1) * size - old_height
-        pad_width = (old_width // size + 1) * size - old_width
+        pad_height = (size - old_height % size) % size
+        pad_width = (size - old_width % size) % size
         return old_height + pad_height, old_width + pad_width
 
     # Swin2SRImageProcessor does not support batched input
@@ -186,6 +186,15 @@ class Swin2SRImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         encoded_images = image_processing(image_inputs[0], return_tensors="pt").pixel_values
         expected_output_image_shape = self.image_processor_tester.expected_output_image_shape([image_inputs[0]])
         self.assertEqual(tuple(encoded_images.shape), (1, *expected_output_image_shape))
+
+    def test_aligned_image_is_not_padded(self):
+        image = np.zeros((16, 16, 3), dtype=np.uint8)
+
+        for image_processing_class in self.image_processor_list:
+            image_processing = image_processing_class(**self.image_processor_dict)
+            encoded_images = image_processing(image, return_tensors="pt").pixel_values
+
+            self.assertEqual(tuple(encoded_images.shape), (1, 3, 16, 16))
 
     def test_slow_fast_equivalence_batched(self):
         image_inputs = self.image_processor_tester.prepare_image_inputs(equal_resolution=True, torchify=True)


### PR DESCRIPTION
# What does this PR do?

Fixes #46697.

This updates the Swin2SR slow and fast image processors to compute padding with modulo arithmetic, so images whose height/width are already divisible by `size_divisor` are not padded by an extra full divisor. It also updates the test helpers and adds a regression test for an aligned image.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. #46697
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@yonigozlan @molbap
