### PR TITLE
[`CB`] Add FA2 to the fast path

### DIFF
--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -333,7 +333,7 @@ The fast path relies on the `flash_attn_with_kvcache` kernel, which is available
 
 | Device | `attn_implementation` |
 |---|---|
-| CUDA | `flash_attention_3` |
+| CUDA | `flash_attention_2` or `flash_attention_3` |
 | XPU | [flash_attention_2](https://huggingface.co/kernels-community/flash-attn2) |
 
 For any other combination, or when the kernel can't be imported, the manager falls back to the varlen path. It logs a warning only when you set `max_blocks_per_request` explicitly.

--- a/src/transformers/generation/continuous_batching/initialization.py
+++ b/src/transformers/generation/continuous_batching/initialization.py
@@ -123,9 +123,8 @@ def ensure_decode_fast_path_is_available(
     available, and no user-provided max blocks per request, set it to the fallback default."""
     # Then, if the decode fast path is not turned off, check if it is available
     if cb_config.max_blocks_per_request != 0:
-        # NOTE: For CUDA, block table should be available with FA2 and FA3, but there seems to be an issue with FA2 atm
         cuda_available = torch.cuda.is_available()
-        fa_cuda = is_flash_attention_requested(config, version=3) and cuda_available
+        fa_cuda = is_flash_attention_requested(config, version=[2, 3]) and cuda_available
         # XPU support is given through its kernel variation `kernels-community/flash-attn2`
         xpu_available = is_torch_xpu_available()
         fa_xpu = is_flash_attention_requested(config, version=2) and xpu_available
@@ -145,7 +144,7 @@ def ensure_decode_fast_path_is_available(
                 logger.warning(
                     f"Although {cb_config.max_blocks_per_request = }, the decode fast path is not available "
                     "because the attention implementation and device combination is not supported. Supported "
-                    "combinations are Flash Attention 3 on CUDA, or Flash Attention 2 on XPU through "
+                    "combinations are Flash Attention 2/3 on CUDA, or Flash Attention 2 on XPU through "
                     "`kernels-community/flash-attn2`. "
                     f"Got {config._attn_implementation = }, {cuda_available = }, {xpu_available = }."
                 )

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -263,10 +263,10 @@ def is_mlx_array(x) -> bool:
 
 
 def is_flash_attention_requested(
-    config=None, requested_attention_implementation: str | None = None, version: int | None = None
+    config=None, requested_attention_implementation: str | None = None, version: int | list[int] | None = None
 ) -> bool:
     """
-    Checks whether some flavor of flash attention is requested or not. Optionally, checks for a specific version of
+    Checks whether some flavor of flash attention is requested or not. Optionally, checks for specific versions of
     flash attention.
 
     This is checked against one of the two arguments, i.e. either the `config` or the directly passed value
@@ -293,7 +293,10 @@ def is_flash_attention_requested(
 
     # If a specific version is requested, look for a pattern of type "flash...{version}"
     if version is not None:
-        return re.match(r".*flash.*" + str(version), checked_attention_implementation) is not None
+        if isinstance(version, int):
+            version = [version]
+        return any(re.match(r".*flash.*" + str(v), checked_attention_implementation) is not None for v in version)
+
     # Otherwise, just check "flash" is in the attention implementation
     return "flash" in checked_attention_implementation
 


### PR DESCRIPTION
Should be resolved now on upstream kernels so no longer any need to exclude FA2