### PR TITLE
Fix gradient inflation when combining label smoothing with gradient accumulation

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2007,9 +2007,9 @@ class Trainer:
                 else unwrapped_model._get_name()
             )
             if model_name in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES.values():
-                loss = self.label_smoother(outputs, labels, shift_labels=True)
+                loss = self.label_smoother(outputs, labels, shift_labels=True, num_items_in_batch=num_items_in_batch)
             else:
-                loss = self.label_smoother(outputs, labels)
+                loss = self.label_smoother(outputs, labels, num_items_in_batch=num_items_in_batch)
         else:
             if isinstance(outputs, dict) and "loss" not in outputs:
                 raise ValueError(

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -448,7 +448,7 @@ class LabelSmoother:
     epsilon: float = 0.1
     ignore_index: int = -100
 
-    def __call__(self, model_output, labels, shift_labels=False):
+    def __call__(self, model_output, labels, shift_labels=False, num_items_in_batch=None):
         logits = model_output["logits"] if isinstance(model_output, dict) else model_output[0]
         if shift_labels:
             logits = logits[..., :-1, :].contiguous()
@@ -469,10 +469,15 @@ class LabelSmoother:
         nll_loss.masked_fill_(padding_mask, 0.0)
         smoothed_loss.masked_fill_(padding_mask, 0.0)
 
-        # Take the mean over the label dimensions, then divide by the number of active elements (i.e. not-padded):
-        num_active_elements = padding_mask.numel() - padding_mask.long().sum()
-        nll_loss = nll_loss.sum() / num_active_elements
-        smoothed_loss = smoothed_loss.sum() / (num_active_elements * log_probs.shape[-1])
+        # Under gradient accumulation the Trainer passes num_items_in_batch; otherwise reduce over this
+        # micro-batch's active (non-padded) tokens.
+        if num_items_in_batch is None:
+            num_items_in_batch = padding_mask.numel() - padding_mask.long().sum()
+        elif torch.is_tensor(num_items_in_batch):
+            # The count may be on another device.
+            num_items_in_batch = num_items_in_batch.to(nll_loss.device)
+        nll_loss = nll_loss.sum() / num_items_in_batch
+        smoothed_loss = smoothed_loss.sum() / (num_items_in_batch * log_probs.shape[-1])
         return (1 - self.epsilon) * nll_loss + self.epsilon * smoothed_loss
 
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -223,6 +223,7 @@ class TrainerGradientAccumulationTest(TestCasePlus, TrainerIntegrationCommon):
         loss_tolerance,
         model_accepts_loss_kwargs=True,
         compute_loss_func=None,
+        label_smoothing_factor=0.0,
     ):
         """
         Train twice with the same effective batch (base_batch_size vs gas_batch_size * gas_steps)
@@ -230,6 +231,8 @@ class TrainerGradientAccumulationTest(TestCasePlus, TrainerIntegrationCommon):
         """
         model_name = self._ga_model_name
         args_kwargs = {"logging_steps": 1, "max_steps": 3, "learning_rate": 1e-4, "max_grad_norm": 0.0}
+        if label_smoothing_factor:
+            args_kwargs["label_smoothing_factor"] = label_smoothing_factor
         trainer_kwargs = {"train_dataset": self._ga_dataset, "data_collator": self._ga_data_collator}
         if compute_loss_func is not None:
             trainer_kwargs["compute_loss_func"] = compute_loss_func
@@ -311,6 +314,22 @@ class TrainerGradientAccumulationTest(TestCasePlus, TrainerIntegrationCommon):
             gas_steps=8,
             loss_tolerance=0.001,
             compute_loss_func=partial(compute_loss, vocab_size=vocab_size),
+        )
+
+    def test_gradient_accumulation_grad_norm_with_label_smoothing(self):
+        """
+        With label_smoothing_factor > 0 the Trainer computes the loss through LabelSmoother
+        instead of the model. LabelSmoother must reduce over num_items_in_batch so grad norms
+        and losses match between a large-batch baseline and an equivalent GAS run. Before the
+        fix LabelSmoother mean-reduced over the current micro-batch only, so the GAS grad norm
+        was inflated by roughly gas_steps.
+        """
+        # Tight tolerance: num_items_in_batch properly averages the smoothed loss across micro-batches
+        self._check_gradient_accumulation(
+            base_batch_size=8, gas_batch_size=1, gas_steps=8, loss_tolerance=0.001, label_smoothing_factor=0.1
+        )
+        self._check_gradient_accumulation(
+            base_batch_size=8, gas_batch_size=4, gas_steps=2, loss_tolerance=0.001, label_smoothing_factor=0.1
         )
 
     @require_torch_non_multi_accelerator


### PR DESCRIPTION
## What this fixes

`label_smoothing_factor > 0` with `gradient_accumulation_steps > 1` inflates gradients by ~`gradient_accumulation_steps` for any model whose forward accepts loss kwargs. Repro and write-up in #46731.

## Root cause

#34198 wired `num_items_in_batch` into `trainer.py` but not into `LabelSmoother` (`trainer_pt_utils.py`). When `model_accepts_loss_kwargs` is True, `training_step` skips the `1/gradient_accumulation_steps` normalization on the assumption the loss already divided by the effective batch — but `LabelSmoother` mean-reduces over the micro-batch instead. The same `num_items_in_batch` is already threaded into the adjacent `compute_loss_func` branch.

## Fix

- `LabelSmoother.__call__` takes `num_items_in_batch` and uses it as the denominator, falling back to the active-token count when it's `None` (so standalone calls are unchanged).
- `compute_loss` passes `num_items_in_batch` into both `label_smoother` calls.

## Test

`test_gradient_accumulation_grad_norm_with_label_smoothing`: the grad-norm ratio between a large-batch baseline and an equivalent accumulation run goes from ~9x at `gradient_accumulation_steps=8` to ~1.0. Existing `TrainerGradientAccumulationTest` / `TrainerLabelSmoothingTest` still pass.

## Backward compatibility

Changes loss/gradient magnitude by ~`gradient_accumulation_steps` for existing label-smoothing + accumulation runs (previously over-scaled). LRs tuned against the old magnitude may need re-checking.

## Scope

Single-device and default DDP token averaging become exact. Legacy DataParallel (`n_gpu > 1`) keeps the same `n_gpu` approximation the `compute_loss_func` path already has, so this doesn't add DP-specific behavior.

Closes #46731
