### PR TITLE
Fix beam cache reordering for non-default cache keys

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2909,6 +2909,18 @@ class GenerationMixin(ContinuousMixin):
         shape = list(tensor.shape)
         return torch.reshape(tensor, [batch_size, num_beams] + shape[1:])
 
+    def _reorder_cache_for_beam_search(self, model_kwargs: dict[str, Any], beam_idx: torch.Tensor) -> None:
+        cache_key = next((key for key in ALL_CACHE_NAMES if model_kwargs.get(key) is not None), None)
+        if cache_key is None:
+            return
+        if hasattr(self, "_reorder_cache"):
+            model_kwargs[cache_key] = self._reorder_cache(model_kwargs[cache_key], beam_idx)
+        elif hasattr(model_kwargs[cache_key], "reorder_cache"):
+            model_kwargs[cache_key].reorder_cache(beam_idx)
+        elif cache_key == "past_key_values":
+            # Preserve the legacy default-cache failure mode, but allow linear-state caches under custom names.
+            model_kwargs[cache_key].reorder_cache(beam_idx)
+
     @staticmethod
     def _gather_beams(tensor: torch.Tensor, beam_indices: torch.Tensor) -> torch.Tensor:
         """
@@ -3401,12 +3413,8 @@ class GenerationMixin(ContinuousMixin):
 
             # pluck the cache from the beam indices that will be used in the next iteration
             # NOTE: we need to check if `self._reorder_cache` exists for special models like RAG, RecurrentGemma etc.
-            if model_kwargs.get("past_key_values") is not None:
-                beam_idx = self._flatten_beam_dim(running_beam_indices[..., cur_len - decoder_prompt_len])
-                if hasattr(self, "_reorder_cache"):
-                    model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                else:
-                    model_kwargs["past_key_values"].reorder_cache(beam_idx)
+            beam_idx = self._flatten_beam_dim(running_beam_indices[..., cur_len - decoder_prompt_len])
+            self._reorder_cache_for_beam_search(model_kwargs, beam_idx)
 
             cur_len = cur_len + 1
             is_early_stop_heuristic_unsatisfied = self._check_early_stop_heuristic(

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -93,6 +93,7 @@ if is_torch_available():
         GenerateDecoderOnlyOutput,
         GenerateEncoderDecoderOutput,
         GenerationConfig,
+        GenerationMixin,
         LogitsProcessorList,
         MaxLengthCriteria,
         MinLengthLogitsProcessor,
@@ -2825,6 +2826,45 @@ def floats_tensor(shape, scale=1.0, rng=None, name=None):
 @pytest.mark.generate
 @require_torch
 class GenerationIntegrationTests(unittest.TestCase):
+    def test_beam_search_reorders_non_default_cache_key(self):
+        class DummyCache:
+            beam_idx = None
+
+            def reorder_cache(self, beam_idx):
+                self.beam_idx = beam_idx
+
+        cache = DummyCache()
+        beam_idx = torch.tensor([2, 0, 1])
+        model_kwargs = {"past_key_values": None, "cache_params": cache}
+
+        GenerationMixin()._reorder_cache_for_beam_search(model_kwargs, beam_idx)
+
+        self.assertIs(cache.beam_idx, beam_idx)
+        self.assertIs(model_kwargs["cache_params"], cache)
+
+    def test_beam_search_uses_model_reorder_for_non_default_cache_key(self):
+        class DummyModel(GenerationMixin):
+            def _reorder_cache(self, cache, beam_idx):
+                return {"cache": cache, "beam_idx": beam_idx}
+
+        cache = object()
+        beam_idx = torch.tensor([1, 0])
+        model_kwargs = {"mems": cache}
+
+        DummyModel()._reorder_cache_for_beam_search(model_kwargs, beam_idx)
+
+        self.assertIs(model_kwargs["mems"]["cache"], cache)
+        self.assertIs(model_kwargs["mems"]["beam_idx"], beam_idx)
+
+    def test_beam_search_skips_non_default_cache_without_reorder(self):
+        cache = object()
+        beam_idx = torch.tensor([1, 0])
+        model_kwargs = {"past_key_values": None, "cache_params": cache}
+
+        GenerationMixin()._reorder_cache_for_beam_search(model_kwargs, beam_idx)
+
+        self.assertIs(model_kwargs["cache_params"], cache)
+
     def test_generation_config_defaults(self):
         "Tests that we can set config value to a global default. See https://github.com/huggingface/transformers/issues/42762"
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)


### PR DESCRIPTION
## Summary

Beam search only reordered `past_key_values`, so models that keep generation state under another supported cache key could skip cache reordering during beam updates.

This patch resolves the active cache through `ALL_CACHE_NAMES` and reorders whichever cache key is actually populated. It keeps the model-specific `_reorder_cache` path for models such as XLNet/RAG, and otherwise calls `reorder_cache()` on cache objects.

Fixes #46612.

## Validation

- `python3 -m py_compile src/transformers/generation/utils.py tests/generation/test_utils.py`
- `PYTHONPATH=src /Users/yinxiaogou/Documents/resume/.venvs/transformers-test/bin/python -m pytest -q tests/generation/test_utils.py -k "beam_search_reorders_non_default_cache_key or beam_search_uses_model_reorder_for_non_default_cache_key"`

The test venv only added the missing main-branch test dependencies needed locally (`huggingface-hub>=1.5`, `safetensors>=0.8`, `pytest-xdist`, `parameterized`).