### PR TITLE
skip decorators must appear after @parameterized.expand in pytest

### DIFF
--- a/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
@@ -345,7 +345,7 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         result = processor.apply_chat_template(messages, tokenize=True)
         self.assertIsInstance(result, torch.Tensor)
 
-    @unittest.skip("MiniCPM can't sample already decoded videos, have to turn off sampling!")
     @parameterized.expand([(1, "pt")])
+    @unittest.skip("MiniCPM can't sample already decoded videos, have to turn off sampling!")
     def test_apply_chat_template_decoded_video(self, batch_size: int, return_tensors: str):
         pass


### PR DESCRIPTION
# What does this PR do?

In pytest v8.4+, skip decorators must be applied to the function being tested, which isn't the case if unittest.skip wraps `parameterized.expand`.

## Code Agent Policy

- [X] I confirm that this is not a pure code agent PR.

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

@zucchini-nlp FYI!
