### PR TITLE
ci: trigger PR CI on ci-* branches

### DIFF
--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - ci-*
 
 concurrency:
   # Group by PR number, commit SHA (main) to avoid cross-branch cancellation, or branch ref for cancellation within each branch


### PR DESCRIPTION
## Summary
- Extend `push` trigger in `pr-ci-caller.yml` to include `ci-*` branch name pattern alongside `main`
