### PR TITLE
Fix offloaded cache device mismatch on hybrid models

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1006,6 +1006,14 @@ class LinearAttentionAndFullAttentionLayer(LinearAttentionLayer, DynamicLayer):
         if len(args) == 0 and len(kwargs) == 1:
             LinearAttentionLayer.lazy_initialization(self, **kwargs)
 
+    def offload(self):
+        DynamicLayer.offload(self)
+        LinearAttentionLayer.offload(self)
+
+    def prefetch(self):
+        DynamicLayer.prefetch(self)
+        LinearAttentionLayer.prefetch(self)
+
     def reset(self) -> None:
         LinearAttentionLayer.reset(self)
         DynamicLayer.reset(self)

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1399,8 +1399,13 @@ class Cache:
 
     @property
     def is_linear(self) -> list[bool]:
-        """Return whether the layers of the cache are linear attention (Mamba/SSM) layers"""
-        return [isinstance(layer, LinearAttentionCacheLayerMixin) for layer in self.layers]
+        """Return whether the layers of the cache are linear attention (Mamba/SSM) layers. Note that layers containing
+        both linear and full attention states will return False by this function"""
+        return [
+            isinstance(layer, LinearAttentionCacheLayerMixin)
+            and not isinstance(layer, LinearAttentionAndFullAttentionLayer)
+            for layer in self.layers
+        ]
 
     def __len__(self):
         """

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1088,19 +1088,22 @@ class Cache:
 
     def prefetch(self, layer_idx: int, only_non_sliding: bool = True):
         """
-        Prefetch a given layer on its device. If `only_non_sliding` is True, it will try to prefetch only the layers
-        which are non-sliding. If the `layer_idx` is outside the range, this will circle back to the first layers.
-        Note that we use a non-default stream for this, to avoid blocking.
+        Prefetch the next offloaded layer on its device, starting at `layer_idx` and circling back to the beginning
+        if needed. Linear-attention layers are never offloaded and are skipped, as are sliding layers when
+        `only_non_sliding`. Note that we use a non-default stream for this, to avoid blocking.
         """
-        if only_non_sliding:
-            # Try to find next non-sliding, starting at `layer_idx`
-            try:
-                layer_idx = layer_idx + self.is_sliding[layer_idx:].index(False)
-            # In this case, we need to circle back to the beginning
-            except ValueError:
-                layer_idx = self.is_sliding.index(False)
-        else:
-            layer_idx = layer_idx if layer_idx < len(self.layers) else 0
+        # Whether each layer is offloaded, hence worth prefetching: linear-attention layers never go through the
+        # offloading `update` path, and sliding layers are skipped when `only_non_sliding` (kept resident).
+        is_offloaded = [
+            not is_linear and not (only_non_sliding and is_sliding)
+            for is_linear, is_sliding in zip(self.is_linear, self.is_sliding)
+        ]
+        try:
+            # Try to find the next offloaded layer, starting at `layer_idx`
+            layer_idx = layer_idx + is_offloaded[layer_idx:].index(True)
+        # In this case, we need to circle back to the beginning
+        except ValueError:
+            layer_idx = is_offloaded.index(True)
 
         # Prefetch
         with self.prefetch_stream if _is_torch_greater_or_equal_than_2_7 else torch.cuda.stream(self.prefetch_stream):
@@ -1393,6 +1396,11 @@ class Cache:
     def is_sliding(self) -> list[bool]:
         """Return whether the layers of the cache are sliding window"""
         return [getattr(layer, "is_sliding", False) for layer in self.layers]
+
+    @property
+    def is_linear(self) -> list[bool]:
+        """Return whether the layers of the cache are linear attention (Mamba/SSM) layers"""
+        return [isinstance(layer, LinearAttentionCacheLayerMixin) for layer in self.layers]
 
     def __len__(self):
         """

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -56,7 +56,7 @@ if is_torch_available():
         convert_and_export_with_cache,
         pipeline,
     )
-    from transformers.cache_utils import LinearAttentionLayer, StaticLayer
+    from transformers.cache_utils import DynamicLayer, LinearAttentionLayer, StaticLayer
     from transformers.integrations.executorch import export_with_dynamic_cache
 
 
@@ -151,6 +151,34 @@ class CacheTest(unittest.TestCase):
         config.layer_types = ["full_attention", "linear_attention"]
         cache = StaticCache(config=config, max_cache_len=8)
         self.assertEqual(cache.max_cache_len, 8)
+
+    @require_torch_accelerator
+    def test_offloaded_cache_prefetches_across_linear_attention_layers(self):
+        """
+        Regression test for offloaded caches on hybrid (attention + linear-attention) models. Attention layers are
+        offloaded to CPU after their `update` and must be prefetched back before the next decoding step. The prefetch
+        has to skip the interleaved linear-attention layers (which never go through the offloading `update` path) and
+        target the next attention layer; otherwise the offloaded KV stays on CPU and the next `update` fails with a
+        cpu/accelerator device mismatch.
+        """
+        # Hybrid layout: an attention layer every 4 layers, linear-attention layers in between (as in e.g. Qwen3.5).
+        layers = [DynamicLayer() if layer_idx % 4 == 3 else LinearAttentionLayer() for layer_idx in range(8)]
+        attention_indices = [3, 7]
+        cache = Cache(layers=layers, offloading=True, offload_only_non_sliding=False)
+
+        def _kv(seq_len):
+            states = torch.rand(1, 4, seq_len, 16, device=torch_device)
+            return states, states.clone()
+
+        # Prefill: each attention layer is updated once, then offloaded to CPU.
+        for layer_idx in attention_indices:
+            cache.update(*_kv(5), layer_idx)
+
+        # Decode: updating the attention layers again used to raise a device mismatch, as their offloaded KV was
+        # never prefetched back to the accelerator.
+        for layer_idx in attention_indices:
+            keys, _ = cache.update(*_kv(1), layer_idx)
+            self.assertEqual(keys.device.type, torch.device(torch_device).type)
 
 
 def _skip_on_failed_cache_prerequisites(test, cache_implementation):


### PR DESCRIPTION

# What does this PR do?

The offloaded cache (`cache_implementation="offloaded"`) moves each layer's KV to CPU after its `update` and prefetches the next layer back to the accelerator ahead of time. Only attention layers go through this offloading `update` path; linear-attention (Mamba/SSM) layers keep their own small conv/recurrent states and are never offloaded or prefetched.

`Cache.prefetch` picked the prefetch target as the next layer in index order (for `DynamicCache`, `offload_only_non_sliding` defaults to `False`, so it just took `layer_idx + 1`). On a hybrid model that interleaves attention and linear-attention layers, the attention layers are sparse and separated by linear-attention layers, so the prefetch kept landing on the interleaved linear-attention layer (a no-op) and never brought the next attention layer's KV back. After prefill every attention layer's KV is stranded on CPU, and the first decoding `update` then concatenates a CPU cache with a freshly computed accelerator tensor, raising `RuntimeError: Expected all tensors to be on the same device ... cuda:0 ... cpu`. Pure-attention models are unaffected because their layers are contiguous, so the next layer is always the next one that is updated.

The fix makes `prefetch` skip layers that are not offloaded (linear-attention layers, plus sliding layers when `only_non_sliding`) and target the next attention layer that actually goes through the offloading `update` path, wrapping around to the beginning if needed. This is a no-op for non-hybrid caches.

There is no existing issue for this; it was found while running hybrid models (e.g. Qwen3.5) with `cache_implementation="offloaded"`. The parametrized cache tests skip the `offloaded` implementation, so the hybrid path was uncovered; this PR adds a small regression test.

<details>
<summary>Reproduction and before/after</summary>

Environment: `transformers` 5.13.0.dev0 (main), Python 3.12.3, PyTorch 2.8.0+cu128, NVIDIA RTX 4090 (CUDA 12.8).

```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer

mid = "Qwen/Qwen3.5-0.8B"
tok = AutoTokenizer.from_pretrained(mid)
m = AutoModelForCausalLM.from_pretrained(mid, dtype=torch.float32).cuda().eval()
ids = tok("The capital of France is", return_tensors="pt").input_ids.cuda()

dyn = m.generate(ids, max_new_tokens=24, do_sample=False)[0, ids.shape[1]:]
off = m.generate(ids, max_new_tokens=24, do_sample=False, cache_implementation="offloaded")[0, ids.shape[1]:]
print("identical:", torch.equal(dyn.cpu(), off.cpu()))
```

Before this PR the `offloaded` generation raises the `RuntimeError`. After it, generation succeeds and is token-identical to the default `DynamicCache` (`identical: True`). A pure-attention model (`Qwen/Qwen3-0.6B`) is identical before and after.

New regression test (passes after, fails before with the device mismatch):

```
tests/utils/test_cache_utils.py -k test_offloaded_cache_prefetches_across_linear_attention_layers
```
</details>

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

cc @Cyrilvallez
