### PR TITLE
[Offloading] Support full disk offloading

### DIFF
--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -486,6 +486,13 @@ def accelerate_disk_offload(
             # Need to check if it's in the mapping in case of unexpected keys that would result in KeyError (we skip them)
             if target_name in param_device_map and param_device_map[target_name] == "disk"
         }
+
+        # Tie weights which are both disk offloaded
+        all_tied_weights_keys = getattr(model, "all_tied_weights_keys", {})
+        for target_param_name, source_param_name in all_tied_weights_keys.items():
+            if source_param_name in disk_offload_index and target_param_name not in disk_offload_index:
+                disk_offload_index[target_param_name] = disk_offload_index[source_param_name]
+
     # In this case we will resave every offloaded weight
     else:
         disk_offload_index = {}

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2693,7 +2693,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                     source_param = self.get_parameter(source_param_name)
                     target_param = self.get_parameter(target_param_name)
 
-                    # Skip check if both are disk offloaded
+                    # Skip check if both are disk offloaded. Tied tensors always
+                    # share the same offload device as per `infer_auto_device_map`
                     if source_param.device.type == "meta" and target_param.device.type == "meta":
                         continue
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4363,7 +4363,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 **kwargs,
             )
 
-        # If the device_map has more than 1 device: dispatch model with hooks on all devices
+        # If the device_map has more than 1 device or disk offloading: dispatch model with hooks
         if device_map is not None and (len(set(device_map.values())) > 1 or "disk" in set(device_map.values())):
             accelerate_dispatch(model, hf_quantizer, device_map, offload_folder, disk_offload_index, offload_buffers)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2690,9 +2690,16 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 # Both are already present -> it means the config is wrong and do not reflect the actual
                 # checkpoint -> let's raise a warning and NOT tie them
                 if source_is_there and target_is_there:
+                    source_param = self.get_parameter(source_param_name)
+                    target_param = self.get_parameter(target_param_name)
+
+                    # Skip check if both are disk offloaded
+                    if source_param.device.type == "meta" and target_param.device.type == "meta":
+                        continue
+
                     # If both are present, check if the weights are exactly similar, and only tie in this case
                     # This check is important, as torch `.bin` checkpoints always contain both keys, referencing the same storage
-                    if not torch.equal(self.get_parameter(source_param_name), self.get_parameter(target_param_name)):
+                    if not torch.equal(source_param, target_param):
                         logger.warning(
                             f"The tied weights mapping and config for this model specifies to tie {source_param_name} to "
                             f"{target_param_name}, but both are present in the checkpoints with different values, so we will NOT "
@@ -4358,7 +4365,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             )
 
         # If the device_map has more than 1 device: dispatch model with hooks on all devices
-        if device_map is not None and len(set(device_map.values())) > 1:
+        if device_map is not None and (len(set(device_map.values())) > 1 or "disk" in set(device_map.values())):
             accelerate_dispatch(model, hf_quantizer, device_map, offload_folder, disk_offload_index, offload_buffers)
 
         if hf_quantizer is not None:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4326,8 +4326,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         # Prepare the full device map
         if device_map is not None:
             device_map = _get_device_map(model, device_map, max_memory, hf_quantizer)
-            if len(devices := list(device_map.values())) == 1 and devices[0] == "disk":
-                raise ValueError("Trying to load everything on `disk` which means the model doesn't fit in memory.")
 
         # Finalize model weight initialization
         load_config = LoadStateDictConfig(


### PR DESCRIPTION
## Purpose ##
* Support full disk offloading of an entire model
  * This is useful for testing and cases like [vllm-project/llm-compressor](https://github.com/vllm-project/llm-compressor) which heavily utilizes disk offloading to compress large models
* Add missing handling for when tied weights are disk offloaded
* This PR can be merged independently from https://github.com/huggingface/accelerate/pull/4083

## Changes ##
* Add tied tensor targets to the disk index when they do not appear in checkpoint files
  * This handles the case where lm_head does not appear the checkpoint
* Skip `torch.equal` check, which is not supported for meta tensors
  * This handles the case where embeddings are tied, but both appear in the checkpoint and both are disk offloaded
* Force `accelerate_dispatch` to be called if the model is full disk offloaded
  * This causes hooks to be added to the model, which are required for disk offloading

## Testing ##
* Tested changes with `test_disk_offloading.py` in conjunction with https://github.com/huggingface/accelerate/pull/4083
  * This test should not be merged into main because it requires changes from accelerate

<details open><summary>test_disk_offloading.py</summary>

```python
import torch
import pytest

from transformers import AutoModelForCausalLM


# Qwen3-0.6B has tied weights, two copies in checkpoint
# Llama-3.2-1B-Instruct has tied weights, only one copy in checkpoint
# tinysmokeqwen3 has untied weights
@torch.no_grad()
@pytest.mark.parametrize("model_id,cpu_mem", [
    ("Qwen/Qwen3-0.6B", 0),
    ("Qwen/Qwen3-0.6B", 6e8),
    ("meta-llama/Llama-3.2-1B-Instruct", 0),
    ("meta-llama/Llama-3.2-1B-Instruct", 1e9),
    ("nm-testing/tinysmokeqwen3", 0),
    ("nm-testing/tinysmokeqwen3", 1.5e6),
])
def test_tied_in_checkpoint(model_id, cpu_mem):
    true_model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto")
    model = AutoModelForCausalLM.from_pretrained(
        model_id,
        device_map="auto",
        max_memory={"cpu": cpu_mem},
        offload_folder="./offload_folder",
    )

    inputs = {key: value.to(true_model.device) for key, value in model.dummy_inputs.items()}

    true_outputs = true_model(**model.dummy_inputs)
    outputs = model(**model.dummy_inputs)
    assert torch.nn.functional.mse_loss(true_outputs.logits, outputs.logits) < 1e-2
```

</details>