### PR TITLE
[`CI`] Fix some failures introduced by myself :grimacing: 

### DIFF
--- a/src/transformers/models/vibevoice_asr/configuration_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/configuration_vibevoice_asr.py
@@ -122,5 +122,13 @@ class VibeVoiceAsrConfig(PreTrainedConfig):
     def max_position_embeddings(self) -> int:
         return math.ceil(self.acoustic_tokenizer_chunk_size / self.acoustic_tokenizer_encoder_config.hop_length)
 
+    @max_position_embeddings.setter
+    def max_position_embeddings(self, value: int):
+        if value <= 0:
+            raise ValueError(f"Attempted to set `max_position_embeddings` to {value}; you need a positive value!")
+
+        hop_length = self.acoustic_tokenizer_encoder_config.hop_length
+        self.acoustic_tokenizer_chunk_size = int(value) * hop_length
+
 
 __all__ = ["VibeVoiceAsrConfig"]

--- a/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
@@ -135,6 +135,14 @@ class VibeVoiceAsrConfig(PreTrainedConfig):
     def max_position_embeddings(self) -> int:
         return math.ceil(self.acoustic_tokenizer_chunk_size / self.acoustic_tokenizer_encoder_config.hop_length)
 
+    @max_position_embeddings.setter
+    def max_position_embeddings(self, value: int):
+        if value <= 0:
+            raise ValueError(f"Attempted to set `max_position_embeddings` to {value}; you need a positive value!")
+
+        hop_length = self.acoustic_tokenizer_encoder_config.hop_length
+        self.acoustic_tokenizer_chunk_size = int(value) * hop_length
+
 
 class VibeVoiceAsrRMSNorm(Qwen2RMSNorm):
     pass

--- a/tests/models/granite4_vision/test_modeling_granite4_vision.py
+++ b/tests/models/granite4_vision/test_modeling_granite4_vision.py
@@ -213,9 +213,13 @@ class Granite4VisionIntegrationTest(unittest.TestCase):
 
     @slow
     def test_small_model_integration_test_batch_matches_single(self):
-        model = Granite4VisionForConditionalGeneration.from_pretrained(self.model_id, torch_dtype=torch.bfloat16).to(
-            torch_device
-        )
+        model = Granite4VisionForConditionalGeneration.from_pretrained(
+            self.model_id,
+            torch_dtype=torch.bfloat16,
+            attn_implementation={
+                "qformer_config": "eager",
+            },
+        ).to(torch_device)
 
         prompt = self.make_prompt("What do you see in this image?")
 

--- a/tests/models/granite_speech/test_modeling_granite_speech.py
+++ b/tests/models/granite_speech/test_modeling_granite_speech.py
@@ -154,10 +154,8 @@ class GraniteSpeechForConditionalGenerationModelTest(ALMModelTest, unittest.Test
             with torch.no_grad():
                 model(**inputs)
 
-    @pytest.mark.generate
-    @slow
-    @unittest.skip(reason="Granite Speech doesn't support SDPA for all backbones")
-    def test_eager_matches_sdpa_generate(self):
+    @unittest.skip(reason="ConformerAttention block forces MATH backend")
+    def test_sdpa_can_dispatch_on_flash(self):
         pass
 
 

--- a/tests/models/instructblip/test_modeling_instructblip.py
+++ b/tests/models/instructblip/test_modeling_instructblip.py
@@ -787,7 +787,9 @@ class InstructBlipModelIntegrationTest(unittest.TestCase):
     def test_inference_vicuna_7b(self):
         processor = InstructBlipProcessor.from_pretrained("Salesforce/instructblip-vicuna-7b")
         model = InstructBlipForConditionalGeneration.from_pretrained(
-            "Salesforce/instructblip-vicuna-7b", quantization_config=BitsAndBytesConfig(load_in_8bit=True)
+            "Salesforce/instructblip-vicuna-7b",
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
+            attn_implementation="eager",
         )
 
         url = "https://raw.githubusercontent.com/salesforce/LAVIS/main/docs/_static/Confusing-Pictures.jpg"


### PR DESCRIPTION
As per title, can be separated into 2 parts
- Qformer based failures
    - SDPA introduces slightly different outputs --> force eager (we could also exchange but yea)
    - Granite speech has a weird SDPA pattern where the MATH backend is forced in a different part of the model; skip FA backend test
- Vibevoice ASR config failure
   - `max_position_embeddings` have been made into an property --> add a best effort setter