### PR TITLE
[`Kernels`] Trigger proper kernelization on `use_kernels=True`

### DIFF
--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -524,7 +524,9 @@ def kernelize(model: "PreTrainedModel", mode: "Mode | None" = None):
     """Temporarily register hidden kernel wrappers so `kernelize` can discover and replace them."""
     if not is_kernels_available():
         raise ValueError(
-            "Kernels are not available. To use kernels, please install kernels using `pip install -U kernels`"
+            "Kernels are not available. "
+            f"Please install a compatible version ({KERNELS_MIN_VERSION} <= version < {KERNELS_MAX_VERSION}), "
+            f"e.g. `pip install kernels=={KERNELS_MIN_VERSION}`"
         )
 
     def attach_hidden_kernels(module):

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -523,11 +523,7 @@ def lazy_load_kernel(kernel_name: str, mapping: dict[str, ModuleType | None] = _
 def kernelize(model: "PreTrainedModel", mode: "Mode | None" = None):
     """Temporarily register hidden kernel wrappers so `kernelize` can discover and replace them."""
     if not is_kernels_available():
-        raise ValueError(
-            "Kernels are not available. "
-            f"Please install a compatible version ({KERNELS_MIN_VERSION} <= version < {KERNELS_MAX_VERSION}), "
-            f"e.g. `pip install kernels=={KERNELS_MIN_VERSION}`"
-        )
+        raise ImportError(_MISSING_KERNELS_MESSAGE)
 
     def attach_hidden_kernels(module):
         for name, fn in getattr(module, "_hidden_kernels", {}).items():

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4676,7 +4676,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             return
 
         if value:
-            kernelize(self)
+            self.set_use_kernels(True)
         else:
             if getattr(self, "_use_kernels", False):
                 logger.warning_once(

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -591,17 +591,21 @@ class TestUseKernelsLifecycle(TestCasePlus):
         cleanup(torch_device, gc_collect=True)
 
     def test_setting_use_kernels_twice_does_not_rekernelize(self):
-        call_count = {"n": 0}
-
-        def spy_kernelize(*args, **kwargs):
-            call_count["n"] += 1
-
-        with patch.object(hub_kernels_pkg, "_kernels_kernelize", side_effect=spy_kernelize):
+        with (
+            patch.object(hub_kernels_pkg, "register_kernel_mapping_transformers") as mock_register,
+            patch.object(hub_kernels_pkg, "_kernels_kernelize") as mock_kernelize,
+        ):
             self.model.use_kernels = True
+
             self.assertTrue(self.model.use_kernels)
-            self.assertEqual(call_count["n"], 1)
+            # Check that both registraton and the underlying kernelize call happened
+            mock_register.assert_called_once_with()
+            self.assertEqual(mock_kernelize.call_count, 1)
+
             self.model.use_kernels = True
-            self.assertEqual(call_count["n"], 1)
+
+            mock_register.assert_called_once_with()
+            self.assertEqual(mock_kernelize.call_count, 1)
 
     def test_train_eval_calls_kernelize_with_correct_mode(self):
         last_modes = []


### PR DESCRIPTION
As per title, regression in #46520. Partially on me, should've extended the test from the get go

When we set `use_kernels=True`, we call `kernelize` but ignore any underlying registration of our kernel mappings leading to an empty kernelization (i.e. no op). Imo, this is not intended as we would expect the default mapping to work on `use_kernels`, otherwise we wouldn't even call kernelize. 

Expanded the existing test to also check for the call of the registration fn.