### PR TITLE
[Whisper] Add Unpack[TransformersKwargs] to forward() and set use_cache=False when labels provided

### DIFF
--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1003,7 +1003,7 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
         decoder_position_ids: tuple[torch.LongTensor] | None = None,
         labels: torch.LongTensor | None = None,
         use_cache: bool | None = None,
-        **kwargs,
+        **kwargs: Unpack[TransformersKwargs],
     ) -> tuple[torch.Tensor] | Seq2SeqLMOutput:
         r"""
         decoder_input_ids (`torch.LongTensor` of shape `(batch_size, target_sequence_length)`, *optional*):
@@ -1056,6 +1056,9 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
         ' Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel.'
         ```"""
         if labels is not None:
+            if use_cache:
+                logger.warning("The `use_cache` argument is changed to `False` since `labels` is provided.")
+            use_cache = False
             if labels.shape[1] > self.max_target_positions:
                 raise ValueError(
                     f"Labels' sequence length {labels.shape[1]} cannot exceed the maximum allowed length of {self.max_target_positions} tokens."
@@ -1163,7 +1166,7 @@ class WhisperForCausalLM(WhisperPreTrainedModel, GenerationMixin):
         inputs_embeds: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
         use_cache: bool | None = None,
-        **kwargs,
+        **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | CausalLMOutputWithCrossAttentions:
         r"""
         encoder_outputs (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):


### PR DESCRIPTION
Fixes #36119

### What's changed and why?

I noticed two inconsistencies between `WhisperForConditionalGeneration` and `BartForConditionalGeneration` (which Whisper is based on):

1. **Missing `Unpack[TransformersKwargs]` typing**
   Whisper's `forward()` had bare `**kwargs` instead of `**kwargs: Unpack[TransformersKwargs]`. Adding the type annotation fixes IDE autocompletion and aligns it with Bart and the other encoder-decoder models.

2. **`use_cache` was not disabled during training**
   When `labels` are passed, Whisper did not set `use_cache = False`. Without this, key/value caching remains active during training. If gradient accumulation is used, cached states from previous accumulation steps can bleed into subsequent steps, leading to incorrect loss. Added the same warning/guard that Bart has to disable the cache when labels are present.

### Testing
Ran the Whisper model tests locally:
```bash
pytest tests/models/whisper/test_modeling_whisper.py -x -q -k "not slow"
