### PR TITLE
Add use_temp_cache_if_readonly decorator to testing_utils

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -17,6 +17,7 @@ import collections
 import contextlib
 import copy
 import doctest
+import errno
 import functools
 import gc
 import importlib
@@ -2757,6 +2758,41 @@ def hub_retry(max_attempts: int = 5, wait_before_retry: float | None = 2):
         jitter=wait_before_retry is not None,
         exceptions=(httpx.HTTPError,),
     )
+
+
+def use_temp_cache_if_readonly(test_case):
+    """
+    Decorator for tests that call `from_pretrained` with a model not yet present in a shared,
+    read-only CI cache. On the first attempt the test runs normally; if a read-only filesystem
+    error is raised, the test is transparently retried inside a writable temporary directory.
+
+    The HuggingFace Hub cache constants (`HF_HUB_CACHE`, `HF_XET_CACHE`) are resolved at
+    import time, so they must be patched directly rather than via environment variables.
+
+    Usage::
+
+        @use_temp_cache_if_readonly
+        def test_my_new_model(self):
+            model = AutoModel.from_pretrained("org/new-model")
+    """
+
+    @functools.wraps(test_case)
+    def wrapper(*args, **kwargs):
+        try:
+            return test_case(*args, **kwargs)
+        except OSError as exc:
+            if exc.errno != errno.EROFS:
+                raise
+            import huggingface_hub.constants as hf_constants
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with (
+                    mock.patch.object(hf_constants, "HF_HUB_CACHE", tmpdir),
+                    mock.patch.object(hf_constants, "HF_XET_CACHE", tmpdir),
+                ):
+                    return test_case(*args, **kwargs)
+
+    return wrapper
 
 
 def run_first(test_case):


### PR DESCRIPTION
## Summary

- Adds a `use_temp_cache_if_readonly` decorator to `src/transformers/testing_utils.py` for tests that call `from_pretrained` with a model not yet present in the shared, read-only CI cache.
- On first attempt the test runs normally (hitting the cache if the model is there). If `OSError: [Errno 30] Read-only file system` is raised, the test is transparently retried inside a writable `TemporaryDirectory`.
- Patches `hf_constants.HF_HUB_CACHE` and `hf_constants.HF_XET_CACHE` directly (via `mock.patch.object`) rather than env vars, since both constants are resolved at import time.

## Motivation

Contributors adding new tests with `from_pretrained("org/new-model")` where the model is not yet in the shared CI cache would get an opaque `[Errno 30]` failure. This decorator lets them opt in to a graceful fallback without boilerplate `TemporaryDirectory` + `mock.patch.dict` setup in every test.

## Usage

```python
from transformers.testing_utils import use_temp_cache_if_readonly

@use_temp_cache_if_readonly
def test_my_new_model(self):
    model = AutoModel.from_pretrained("org/new-model")
```