### PR TITLE
[CI] Fix artifact download path in self-comment-ci workflow

### DIFF
--- a/.github/workflows/self-comment-ci.yml
+++ b/.github/workflows/self-comment-ci.yml
@@ -215,11 +215,19 @@ jobs:
     if: ${{ always() && needs.create_run.result == 'success' }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download model CI new failures artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: new_failures_with_bad_commit_{run_models_gpu,run_quantization_torch_gpu}
-          path: ./new_failures
-          merge-multiple: false
+          name: new_failures_with_bad_commit_run_models_gpu
+          path: ./new_failures/new_failures_with_bad_commit_run_models_gpu
+        continue-on-error: true
+
+      - name: Download quantization CI new failures artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: new_failures_with_bad_commit_run_quantization_torch_gpu
+          path: ./new_failures/new_failures_with_bad_commit_run_quantization_torch_gpu
+        continue-on-error: true
 
       - name: List downloaded artifacts
         run: |


### PR DESCRIPTION
## What does this PR do?

Fixes the artifact download step in `self-comment-ci.yml` where files were landing in the wrong directory, causing the model/quantization CI report steps to always print \"No report found\".

### Root cause

The original step used a glob pattern with `merge-multiple: false`:
```yaml
pattern: new_failures_with_bad_commit_{run_models_gpu,run_quantization_torch_gpu}
path: ./new_failures
```

When only **one** of the two artifacts exists (e.g. the quantization artifact is absent), `actions/download-artifact` downloads the files directly into `./new_failures/` instead of into a named subdirectory. So instead of:
```
./new_failures/new_failures_with_bad_commit_run_models_gpu/new_failures_with_bad_commit.json
```
the files ended up at:
```
./new_failures/new_failures_with_bad_commit.json
```

### Fix

Split into two separate download steps, each using `name:` (not `pattern:`) with an explicit subdirectory as `path:`, and `continue-on-error: true` so the workflow doesn't fail when an artifact doesn't exist (e.g. quantization tests were skipped):

```yaml
- name: Download model CI new failures artifact
  uses: actions/download-artifact@...
  with:
    name: new_failures_with_bad_commit_run_models_gpu
    path: ./new_failures/new_failures_with_bad_commit_run_models_gpu
  continue-on-error: true

- name: Download quantization CI new failures artifact
  uses: actions/download-artifact@...
  with:
    name: new_failures_with_bad_commit_run_quantization_torch_gpu
    path: ./new_failures/new_failures_with_bad_commit_run_quantization_torch_gpu
  continue-on-error: true
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?

## Who can review?

@ydshieh (CIs)