### PR TITLE
docs: move SmolLM3 to Text models category in _toctree.yml

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -853,6 +853,8 @@
         title: RWKV
       - local: model_doc/seed_oss
         title: Seed-Oss
+      - local: model_doc/smollm3
+        title: SmolLM3
       - local: model_doc/solar_open
         title: SolarOpen
       - local: model_doc/splinter
@@ -1437,8 +1439,6 @@
         title: SLANet
       - local: model_doc/slanext
         title: SLANeXt
-      - local: model_doc/smollm3
-        title: SmolLM3
       - local: model_doc/smolvlm
         title: SmolVLM
       - local: model_doc/speech-encoder-decoder


### PR DESCRIPTION
# What does this PR do?

This PR moves the `SmolLM3` documentation entry from the `Multimodal` section to its correct alphabetical position under the `Text models` section in `_toctree.yml`. 

Fixes huggingface/hub-docs#2031 (moved from hub-docs repository).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the forum? Please add a link to it if that's the case. (Approved in huggingface/hub-docs#2031)
- [x] Did you make sure to update the documentation with your changes according to the guidelines?

## Who can review?

Tagging @stevhliu for documentation review.