### PR TITLE
Fix padding mask skipped for batch size 1 in linear-attention models

### DIFF
--- a/src/transformers/models/bamba/modeling_bamba.py
+++ b/src/transformers/models/bamba/modeling_bamba.py
@@ -367,7 +367,11 @@ def apply_mask_to_padding_states(hidden_states, attention_mask):
     Tunes out the hidden states for padding tokens, see https://github.com/state-spaces/mamba/issues/66
     """
     # NOTE: attention mask is a 2D boolean tensor
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if (
+        attention_mask is not None
+        and attention_mask.shape[1] > 1
+        and attention_mask.shape[1] == hidden_states.shape[1]
+    ):
         dtype = hidden_states.dtype
         hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 
@@ -847,7 +851,11 @@ class BambaMixer(nn.Module):
                 "`seq_idx` support requires fast path support. Please install `mamba_ssm` and `causal_conv1d`"
             )
         dtype = hidden_states.dtype
-        if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+        if (
+            attention_mask is not None
+            and attention_mask.shape[1] > 1
+            and attention_mask.shape[1] == hidden_states.shape[1]
+        ):
             # tune out hidden states for pad tokens, see https://github.com/state-spaces/mamba/issues/66
             hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/src/transformers/models/bamba/modular_bamba.py
+++ b/src/transformers/models/bamba/modular_bamba.py
@@ -606,7 +606,11 @@ class BambaMixer(nn.Module):
                 "`seq_idx` support requires fast path support. Please install `mamba_ssm` and `causal_conv1d`"
             )
         dtype = hidden_states.dtype
-        if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+        if (
+            attention_mask is not None
+            and attention_mask.shape[1] > 1
+            and attention_mask.shape[1] == hidden_states.shape[1]
+        ):
             # tune out hidden states for pad tokens, see https://github.com/state-spaces/mamba/issues/66
             hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/src/transformers/models/falcon_h1/modeling_falcon_h1.py
+++ b/src/transformers/models/falcon_h1/modeling_falcon_h1.py
@@ -353,7 +353,11 @@ def apply_mask_to_padding_states(hidden_states, attention_mask):
     Tunes out the hidden states for padding tokens, see https://github.com/state-spaces/mamba/issues/66
     """
     # NOTE: attention mask is a 2D boolean tensor
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if (
+        attention_mask is not None
+        and attention_mask.shape[1] > 1
+        and attention_mask.shape[1] == hidden_states.shape[1]
+    ):
         dtype = hidden_states.dtype
         hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 
@@ -628,7 +632,11 @@ class FalconH1Mixer(nn.Module):
                     dim=-1,
                 )
 
-                if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+                if (
+                    attention_mask is not None
+                    and attention_mask.shape[1] > 1
+                    and attention_mask.shape[1] == hidden_states.shape[1]
+                ):
                     # tune out hidden states for pad tokens, see https://github.com/state-spaces/mamba/issues/66
                     dtype = hidden_states.dtype
                     hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
@@ -867,7 +875,11 @@ class FalconH1Mixer(nn.Module):
         if is_fast_path_available and "cuda" in self.in_proj.weight.device.type and not is_torchdynamo_compiling():
             return self.cuda_kernels_forward(hidden_states, cache_params, attention_mask)
         dtype = hidden_states.dtype
-        if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+        if (
+            attention_mask is not None
+            and attention_mask.shape[1] > 1
+            and attention_mask.shape[1] == hidden_states.shape[1]
+        ):
             # tune out hidden states for pad tokens, see https://github.com/state-spaces/mamba/issues/66
             hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/src/transformers/models/falcon_h1/modular_falcon_h1.py
+++ b/src/transformers/models/falcon_h1/modular_falcon_h1.py
@@ -415,7 +415,11 @@ class FalconH1Mixer(nn.Module):
                     dim=-1,
                 )
 
-                if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+                if (
+                    attention_mask is not None
+                    and attention_mask.shape[1] > 1
+                    and attention_mask.shape[1] == hidden_states.shape[1]
+                ):
                     # tune out hidden states for pad tokens, see https://github.com/state-spaces/mamba/issues/66
                     dtype = hidden_states.dtype
                     hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
@@ -654,7 +658,11 @@ class FalconH1Mixer(nn.Module):
         if is_fast_path_available and "cuda" in self.in_proj.weight.device.type and not is_torchdynamo_compiling():
             return self.cuda_kernels_forward(hidden_states, cache_params, attention_mask)
         dtype = hidden_states.dtype
-        if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+        if (
+            attention_mask is not None
+            and attention_mask.shape[1] > 1
+            and attention_mask.shape[1] == hidden_states.shape[1]
+        ):
             # tune out hidden states for pad tokens, see https://github.com/state-spaces/mamba/issues/66
             hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
@@ -245,7 +245,11 @@ def apply_mask_to_padding_states(hidden_states, attention_mask):
     Tunes out the hidden states for padding tokens, see https://github.com/state-spaces/mamba/issues/66
     """
     # NOTE: attention mask is a 2D boolean tensor
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if (
+        attention_mask is not None
+        and attention_mask.shape[1] > 1
+        and attention_mask.shape[1] == hidden_states.shape[1]
+    ):
         dtype = hidden_states.dtype
         hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 
@@ -725,7 +729,11 @@ class GraniteMoeHybridMambaLayer(nn.Module):
                 "`seq_idx` support requires fast path support. Please install `mamba_ssm` and `causal_conv1d`"
             )
         dtype = hidden_states.dtype
-        if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+        if (
+            attention_mask is not None
+            and attention_mask.shape[1] > 1
+            and attention_mask.shape[1] == hidden_states.shape[1]
+        ):
             # tune out hidden states for pad tokens, see https://github.com/state-spaces/mamba/issues/66
             hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/src/transformers/models/lfm2/modeling_lfm2.py
+++ b/src/transformers/models/lfm2/modeling_lfm2.py
@@ -286,7 +286,11 @@ def apply_mask_to_padding_states(hidden_states, attention_mask):
     Tunes out the hidden states for padding tokens, see https://github.com/state-spaces/mamba/issues/66
     """
     # NOTE: attention mask is a 2D boolean tensor
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if (
+        attention_mask is not None
+        and attention_mask.shape[1] > 1
+        and attention_mask.shape[1] == hidden_states.shape[1]
+    ):
         dtype = hidden_states.dtype
         hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/src/transformers/models/lfm2_moe/modeling_lfm2_moe.py
+++ b/src/transformers/models/lfm2_moe/modeling_lfm2_moe.py
@@ -362,7 +362,11 @@ def apply_mask_to_padding_states(hidden_states, attention_mask):
     Tunes out the hidden states for padding tokens, see https://github.com/state-spaces/mamba/issues/66
     """
     # NOTE: attention mask is a 2D boolean tensor
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if (
+        attention_mask is not None
+        and attention_mask.shape[1] > 1
+        and attention_mask.shape[1] == hidden_states.shape[1]
+    ):
         dtype = hidden_states.dtype
         hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -93,7 +93,11 @@ def apply_mask_to_padding_states(hidden_states, attention_mask):
     Tunes out the hidden states for padding tokens, see https://github.com/state-spaces/mamba/issues/66
     """
     # NOTE: attention mask is a 2D boolean tensor
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if (
+        attention_mask is not None
+        and attention_mask.shape[1] > 1
+        and attention_mask.shape[1] == hidden_states.shape[1]
+    ):
         dtype = hidden_states.dtype
         hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/src/transformers/models/olmo_hybrid/modeling_olmo_hybrid.py
+++ b/src/transformers/models/olmo_hybrid/modeling_olmo_hybrid.py
@@ -487,7 +487,11 @@ def apply_mask_to_padding_states(hidden_states, attention_mask):
     Tunes out the hidden states for padding tokens, see https://github.com/state-spaces/mamba/issues/66
     """
     # NOTE: attention mask is a 2D boolean tensor
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if (
+        attention_mask is not None
+        and attention_mask.shape[1] > 1
+        and attention_mask.shape[1] == hidden_states.shape[1]
+    ):
         dtype = hidden_states.dtype
         hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -207,7 +207,11 @@ def apply_mask_to_padding_states(hidden_states, attention_mask):
     Tunes out the hidden states for padding tokens, see https://github.com/state-spaces/mamba/issues/66
     """
     # NOTE: attention mask is a 2D boolean tensor
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if (
+        attention_mask is not None
+        and attention_mask.shape[1] > 1
+        and attention_mask.shape[1] == hidden_states.shape[1]
+    ):
         dtype = hidden_states.dtype
         hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -205,7 +205,11 @@ def apply_mask_to_padding_states(hidden_states, attention_mask):
     Tunes out the hidden states for padding tokens, see https://github.com/state-spaces/mamba/issues/66
     """
     # NOTE: attention mask is a 2D boolean tensor
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if (
+        attention_mask is not None
+        and attention_mask.shape[1] > 1
+        and attention_mask.shape[1] == hidden_states.shape[1]
+    ):
         dtype = hidden_states.dtype
         hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modeling_qwen3_next.py
@@ -334,7 +334,11 @@ def apply_mask_to_padding_states(hidden_states, attention_mask):
     Tunes out the hidden states for padding tokens, see https://github.com/state-spaces/mamba/issues/66
     """
     # NOTE: attention mask is a 2D boolean tensor
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if (
+        attention_mask is not None
+        and attention_mask.shape[1] > 1
+        and attention_mask.shape[1] == hidden_states.shape[1]
+    ):
         dtype = hidden_states.dtype
         hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/tests/models/qwen3_5/test_modeling_qwen3_5.py
+++ b/tests/models/qwen3_5/test_modeling_qwen3_5.py
@@ -240,6 +240,44 @@ class Qwen3_5TextModelTest(CausalLMModelTest, unittest.TestCase):
 
         torch.testing.assert_close(under_test_first, ref_first, rtol=1e-4, atol=1e-4)
 
+    def test_left_padding_matches_unpadded_batch_size_one(self):
+        """
+        A single left-padded sequence (batch_size == 1) must yield the same hidden states for its
+        real tokens as the unpadded sequence. Qwen3.5's gated-delta-net layers zero padding tokens
+        via apply_mask_to_padding_states, which previously skipped masking when batch_size == 1,
+        letting padding tokens leak into the conv/SSM state and corrupt the real tokens' outputs.
+        Several linear-attention layers are stacked so the leak compounds well above tolerance when
+        the masking is skipped.
+        """
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        config._attn_implementation = "eager"
+        # GatedDeltaNet's fused norm-gate kernel only supports silu/swish/sigmoid.
+        config.hidden_act = "silu"
+        config.num_hidden_layers = 8
+        config.layer_types = ["linear_attention", "linear_attention", "linear_attention", "full_attention"] * 2
+        torch.manual_seed(0)
+        model = Qwen3_5TextModel._from_config(config)
+        model.to(torch_device)
+        model.eval()
+
+        seq = ids_tensor((1, 12), config.vocab_size).to(torch_device)
+        pad_len = 8
+        pad_id = config.pad_token_id if config.pad_token_id is not None else 0
+        padding = torch.full((1, pad_len), pad_id, dtype=seq.dtype, device=torch_device)
+        padded = torch.cat([padding, seq], dim=1)
+        attention_mask = torch.cat(
+            [torch.zeros(1, pad_len, dtype=torch.long, device=torch_device), torch.ones_like(seq)], dim=1
+        )
+        position_ids = (attention_mask.long().cumsum(dim=1) - 1).clamp(min=0)
+
+        with torch.no_grad():
+            unpadded_out = model(input_ids=seq, use_cache=False).last_hidden_state[:, -1, :]
+            padded_out = model(
+                input_ids=padded, attention_mask=attention_mask, position_ids=position_ids, use_cache=False
+            ).last_hidden_state[:, -1, :]
+
+        torch.testing.assert_close(padded_out, unpadded_out, rtol=1e-4, atol=1e-4)
+
 
 class Qwen3_5VisionText2TextModelTester:
     def __init__(


### PR DESCRIPTION

# What does this PR do?

Follow-up to #41790. `apply_mask_to_padding_states` (and the inline mixer copies in Bamba and FalconH1) zeros padding positions before the depthwise conv and the SSM / gated-delta recurrence. It was gated on `attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1`, so a batch-size-1 padded sequence was never masked: its padding flowed through the conv and recurrence into the real tokens and corrupted their logits. Batch size > 1 (the mask ran) and right padding (it follows the real tokens, which a causal model ignores) were unaffected.

The `attention_mask.shape[0] > 1` gate cannot just be dropped. During cached multi-token decode (for example assisted / speculative decoding) `attention_mask` spans the whole sequence while `hidden_states` holds only the new tokens, so the multiply would shape-mismatch and raise; the batch-size gate happened to hide that for batch size 1. This replaces it with an alignment check, `attention_mask.shape[1] == hidden_states.shape[1]`, which is true exactly in the prefill / full forward where the padding needs zeroing and false during cached decode. #41790 already noted the intent was to keep only the prefill guard ("we only make sure it is applied in prefill stage"); this makes that guard robust.

On `Qwen/Qwen3.5-0.8B` in float32, the last-token logits of a left-padded batch-size-1 sequence diverge from the unpadded sequence by ~5.7 on `main` and ~1e-5 with this change. Added `Qwen3_5TextModelTest::test_left_padding_matches_unpadded_batch_size_one` (fails before, passes after); the existing `Lfm2ModelTest::test_assisted_decoding_*` tests crash on a naive removal of the gate and pass with the alignment check.

All ten linear-attention models sharing this code are updated: Bamba, FalconH1, GraniteMoeHybrid, LFM2, LFM2-MoE, Mamba2, Olmo-hybrid, Qwen3.5, Qwen3.5-MoE, Qwen3-Next. The modeling files are regenerated from the modular sources, so `make fix-repo` and `check_modular_conversion` stay clean.

<details>
<summary>Reproduction, evidence, and environment</summary>

Real-last-token logits, unpadded vs the same sequence padded, max abs diff (right padding compares the last real token, which precedes the pad; left padding compares position -1):

```
                       float32         bfloat16
right pad (b=1)        ~1e-5           ~0        # real tokens precede pad, causal -> unaffected
left  pad (b>1)        ~2e-5           ~0.19     # mask already runs; bf16 has a left-pad precision floor
left  pad (b=1) before  5.7            5.7       # mask skipped -> padding leaks into the real tokens
left  pad (b=1) after  ~9e-6           ~0.13     # fixed: back to each dtype's b>1 baseline
```

float32 isolates the bug from precision noise: batch-size-1 left padding jumps from ~1e-5 to 5.7 and the fix restores it. In bfloat16 the corruption is the same magnitude (5.7) and the fix brings batch size 1 back to the ~0.19 floor that batch size > 1 already sits at. Per layer the divergence originates at the first gated-delta-net layer.

```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer

tok = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-0.8B")
m = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3.5-0.8B", dtype=torch.float32).eval()
seq = tok("The capital of France is one of the most", return_tensors="pt").input_ids

ref = m(seq, use_cache=False).logits[0, -1]
pad = torch.full((1, 4), tok.pad_token_id)
ids = torch.cat([pad, seq], 1)
mask = torch.cat([torch.zeros(1, 4, dtype=torch.long), torch.ones_like(seq)], 1)
out = m(ids, attention_mask=mask, use_cache=False).logits[0, -1]
print((ref - out).abs().max())   # ~5.7 before, ~1e-5 after
```

Environment: transformers `main` (5.13.0.dev0), torch 2.8.0+cu128, Python 3.12.3, Linux. The float32 numbers reproduce on CPU (torch fallback); the bfloat16 column was measured on an RTX 4090.
</details>

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Who can review?

@zucchini-nlp
