### PR TITLE
New SP support in Trainer

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2191,9 +2191,14 @@ class Trainer:
                 if self.args.n_gpu > 1 and num_items_in_batch.dim() == 0:
                     # In the DataParallel case, convert the scalar tensor into a 2-dim tensor with the same value repeated
                     num_items_in_batch = num_items_in_batch.unsqueeze(0).expand(self.args.n_gpu, -1)
-                # Divide by number of devices with the same batch
+                # Divide out ranks that replicate the batch (gather over-counts them). The native
+                # "accelerate" SP backend instead shards the sequence, so its ranks hold disjoint tokens
+                # and the gathered count is already global: exclude sp_size from the divisor.
                 if pc := getattr(self.accelerator, "parallelism_config", None):
-                    num_items_in_batch = num_items_in_batch // pc.non_data_parallel_size
+                    divisor = pc.non_data_parallel_size
+                    if pc.sp_enabled and pc.sp_backend == "accelerate":
+                        divisor //= pc.sp_size
+                    num_items_in_batch = num_items_in_batch // divisor
 
         return num_items_in_batch
 
@@ -2343,9 +2348,12 @@ class Trainer:
         len_dataloader = len(dataloader) if has_length(dataloader) else None
         total_train_batch_size = self.get_total_train_batch_size(args)
 
-        # Account for Sequence Parallelism (SP) dataloader adapter's effect
+        # The DeepSpeed (ALST) SP adapter packs sp_size micro-batches into one, shortening the dataloader,
+        # so scale it back up to recover steps-per-epoch. The "accelerate" backend shards in place and
+        # leaves len() unchanged, so it needs no adjustment.
+        pc = getattr(self.accelerator, "parallelism_config", None)
         sp_size = self.get_sp_size()
-        if sp_size > 1 and len_dataloader is not None:
+        if sp_size > 1 and len_dataloader is not None and pc is not None and pc.sp_backend == "deepspeed":
             len_dataloader = len_dataloader * sp_size
 
         # Case 2: We have a dataloader length and can extrapolate

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1639,6 +1639,21 @@ class Trainer:
         pc = getattr(self.accelerator, "parallelism_config", None)
         if pc is not None and pc.sp_backend == "deepspeed" and pc.sp_enabled:
             train_dataloader = self.accelerator.deepspeed_ulysses_dl_adapter(train_dataloader, model)
+        elif pc is not None and pc.sp_backend == "accelerate" and pc.sp_enabled:
+            # Native Ulysses SP: `accelerate.prepare()` already wrapped the DataLoader in a
+            # `SequenceShardingDataLoader`, but it ran before the model was prepared so the Ulysses
+            # attention handler (which pushes the GLOBAL packed/varlen cu_seqlens onto the attention)
+            # was still None. Now that the model is prepared, attach the handler so packed batches take
+            # the flash-varlen path (no-op for non-packed sequences).
+            from accelerate.utils.sequence_parallel import SequenceShardingDataLoader
+
+            if isinstance(train_dataloader, SequenceShardingDataLoader):
+                train_dataloader.attention = getattr(self.accelerator, "_sp_attention", None)
+            else:
+                shard_group = self.accelerator.torch_device_mesh["sp"].get_group()
+                train_dataloader = SequenceShardingDataLoader(
+                    train_dataloader, shard_group, attention=getattr(self.accelerator, "_sp_attention", None)
+                )
 
         # load checkpoint
         if resume_from_checkpoint is not None:

--- a/tests/trainer/distributed/accelerate_configs/ddp_sp.yaml
+++ b/tests/trainer/distributed/accelerate_configs/ddp_sp.yaml
@@ -1,0 +1,6 @@
+distributed_type: MULTI_GPU
+num_machines: 1
+num_processes: 2
+parallelism_config:
+  parallelism_config_sp_size: 2
+  parallelism_config_sp_backend: accelerate

--- a/tests/trainer/distributed/accelerate_configs/deepspeed_zero3_sp_accelerate.yaml
+++ b/tests/trainer/distributed/accelerate_configs/deepspeed_zero3_sp_accelerate.yaml
@@ -1,0 +1,7 @@
+distributed_type: DEEPSPEED
+deepspeed_config:
+  deepspeed_config_file: tests/trainer/distributed/scripts/ds_config_zero3.json
+num_processes: 2
+parallelism_config:
+  parallelism_config_sp_size: 2
+  parallelism_config_sp_backend: accelerate

--- a/tests/trainer/distributed/accelerate_configs/fsdp2_sp.yaml
+++ b/tests/trainer/distributed/accelerate_configs/fsdp2_sp.yaml
@@ -1,0 +1,7 @@
+distributed_type: FSDP
+fsdp_config:
+  fsdp_version: 2
+num_processes: 2
+parallelism_config:
+  parallelism_config_sp_size: 2
+  parallelism_config_sp_backend: accelerate

--- a/tests/trainer/distributed/test_trainer_distributed.py
+++ b/tests/trainer/distributed/test_trainer_distributed.py
@@ -178,3 +178,55 @@ class TrainerDistributedCommon(ABC):
             eval_metrics = json.load(f)
         self.assertIn("eval_loss", eval_metrics)
         self.assertTrue(torch.isfinite(torch.tensor(eval_metrics["eval_loss"])))
+
+    def check_sp_equivalence(self, sp_config_file, no_sp_config_file, launch_args=None, sp_num_processes=2):
+        """Native Ulysses SP (sp_backend="accelerate") must produce the same losses as no SP — it only
+        splits the sequence. Runs the real Trainer with SP enabled vs no SP (1 process) and compares
+        the loss trajectories. Exercises the whole Trainer SP path: the auto-wrapped
+        `SequenceShardingDataLoader`, the attention handler attached after the model is prepared, and
+        the loss / epoch accounting."""
+        common_args = [
+            "--model_name",
+            "hf-internal-testing/tiny-random-LlamaForCausalLM",
+            "--max_steps",
+            "10",
+            "--per_device_train_batch_size",
+            "1",
+            "--seed",
+            "42",
+            "--logging_steps",
+            "1",
+            "--save_strategy",
+            "no",
+            "--model_dtype",
+            "fp32",
+            "--attn_implementation",
+            "sdpa",
+            "--pad_to_multiple_of",
+            "4",
+        ]
+
+        def run(config_file, num_processes):
+            output_dir = self.get_auto_remove_tmp_dir()
+            losses_path = os.path.join(output_dir, "losses.json")
+            cmd = self.get_accelerate_cmd(
+                TRAIN_SCRIPT,
+                config_file=config_file,
+                launch_args=launch_args,
+                script_args=["--output_dir", output_dir, "--loss_output_file", losses_path] + common_args,
+                num_processes=num_processes,
+            )
+            execute_subprocess_async(cmd, env=self.get_env())
+            with open(losses_path) as f:
+                return json.load(f)
+
+        sp_losses = run(sp_config_file, sp_num_processes)
+        no_sp_losses = run(no_sp_config_file, 1)
+        self.assertEqual(len(sp_losses), len(no_sp_losses))
+        torch.testing.assert_close(
+            torch.tensor(sp_losses),
+            torch.tensor(no_sp_losses),
+            rtol=2e-2,
+            atol=2e-2,
+            msg=f"SP losses {sp_losses} do not match non-SP losses {no_sp_losses}",
+        )

--- a/tests/trainer/distributed/test_trainer_distributed_ddp.py
+++ b/tests/trainer/distributed/test_trainer_distributed_ddp.py
@@ -38,6 +38,7 @@ from .test_trainer_distributed import CONFIGS_DIR, SCRIPTS_DIR, TrainerDistribut
 
 
 DDP_CONFIG_FILE = os.path.join(CONFIGS_DIR, "ddp.yaml")
+DDP_SP_CONFIG_FILE = os.path.join(CONFIGS_DIR, "ddp_sp.yaml")
 
 dtypes = []
 if is_torch_bf16_available_on_device(torch_device):
@@ -295,3 +296,7 @@ class TestTrainerDistributedDDPCommon(DDPCommandsMixin, TrainerDistributedCommon
 
     def test_eval(self):
         self.check_eval(config_file=DDP_CONFIG_FILE)
+
+    def test_sp_equivalence(self):
+        """Native Ulysses SP under DDP must produce the same losses as no SP. See `check_sp_equivalence`."""
+        self.check_sp_equivalence(DDP_SP_CONFIG_FILE, DDP_CONFIG_FILE)

--- a/tests/trainer/distributed/test_trainer_distributed_deepspeed.py
+++ b/tests/trainer/distributed/test_trainer_distributed_deepspeed.py
@@ -86,6 +86,7 @@ GPTJ_TINY = "hf-internal-testing/tiny-random-gptj"
 
 # Accelerate config paths
 DS_ZERO2_CONFIG_FILE = os.path.join(CONFIGS_DIR, "deepspeed_zero2.yaml")
+DS_ZERO3_SP_ACCELERATE_CONFIG_FILE = os.path.join(CONFIGS_DIR, "deepspeed_zero3_sp_accelerate.yaml")
 DS_ZERO3_CONFIG_FILE = os.path.join(CONFIGS_DIR, "deepspeed_zero3.yaml")
 
 # DS JSON config paths (used by single-GPU tests via dict and distributed tests via file)
@@ -1115,6 +1116,12 @@ class TestTrainerDistributedDeepSpeedCommon(DeepSpeedCommandsMixin, TrainerDistr
     def test_eval(self):
         # ZeRO inference only works with ZeRO-3
         self.check_eval(config_file=DS_CONFIGS[ZERO3])
+
+    def test_sp_equivalence(self):
+        """Native ("accelerate") Ulysses SP under DeepSpeed ZeRO-3 must produce the same losses as no
+        SP. ZeRO-3 (params sharded too) is the meaningful long-context case. See `check_sp_equivalence`.
+        (The ALST `sp_backend="deepspeed"` path is `test_alst_ulysses_sp`.)"""
+        self.check_sp_equivalence(DS_ZERO3_SP_ACCELERATE_CONFIG_FILE, DS_ZERO3_CONFIG_FILE)
 
     def test_alst_ulysses_sp(self):
         """Test that ALST/Ulysses sequence parallelism produces the same losses as without it."""

--- a/tests/trainer/distributed/test_trainer_distributed_fsdp.py
+++ b/tests/trainer/distributed/test_trainer_distributed_fsdp.py
@@ -60,6 +60,7 @@ if is_torch_available():
 FSDP_CONFIG_FILE = os.path.join(CONFIGS_DIR, "fsdp.yaml")
 FSDP2_CONFIG_FILE = os.path.join(CONFIGS_DIR, "fsdp2.yaml")
 FSDP2_CP_CONFIG_FILE = os.path.join(CONFIGS_DIR, "fsdp2_cp.yaml")
+FSDP2_SP_CONFIG_FILE = os.path.join(CONFIGS_DIR, "fsdp2_sp.yaml")
 FSDP_GENERATE_SCRIPT = os.path.join(SCRIPTS_DIR, "fsdp_generate.py")
 
 FSDP_CONFIGS = {
@@ -641,6 +642,12 @@ class TestTrainerDistributedFSDPCommon(
             atol=2e-2,
             msg=f"CP losses {cp_yes_losses} do not match non-CP losses {cp_no_losses}",
         )
+
+    def test_sp_equivalence(self):
+        """Native Ulysses SP under FSDP2 must produce the same losses as no SP (it only splits the
+        sequence). See `check_sp_equivalence`."""
+        launch_args = list(TRAIN_LAUNCH_ARGS) + ["--fsdp_state_dict_type", "SHARDED_STATE_DICT"]
+        self.check_sp_equivalence(FSDP2_SP_CONFIG_FILE, FSDP2_CONFIG_FILE, launch_args=launch_args)
 
     # -------------------------------------------------------------------
     # FSDP eval tests


### PR DESCRIPTION
# What does this PR do?

This PR adds compatibility with the new native SP support from accelerate. With this, you can perform long context training with FSDPv2, DeepSpeed or even DDP. 

Requires https://github.com/huggingface/accelerate/pull/4084

cc @qgallouedec for viz