### PR TITLE
Raise clear ValueError for empty conversation in apply_chat_template

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3086,6 +3086,11 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
         chat_template = self.get_chat_template(chat_template, tools)
 
+        if isinstance(conversation, (list, tuple)) and len(conversation) == 0:
+            raise ValueError(
+                "apply_chat_template received an empty conversation. Please provide a non-empty list of messages."
+            )
+
         if isinstance(conversation, (list, tuple)) and (
             isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
         ):

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1011,6 +1011,15 @@ Hey how are you doing"""  # noqa: W293
         new_tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
 
     @require_jinja
+    def test_chat_template_empty_conversation_raises(self):
+        # An empty list/tuple used to crash with an unhandled IndexError when probing conversation[0]
+        # to detect batched input. It should raise a clear ValueError instead.
+        tokenizer = self.get_tokenizer()
+        for empty_conversation in ([], ()):
+            with self.assertRaisesRegex(ValueError, "empty conversation"):
+                tokenizer.apply_chat_template(empty_conversation, tokenize=False)
+
+    @require_jinja
     def test_chat_template_save_loading(self):
         tokenizer = self.get_tokenizer()
         signature = inspect.signature(tokenizer.__init__)


### PR DESCRIPTION
Fixes #46752

## What was wrong

Calling `apply_chat_template` with an empty list or tuple crashed with an unhandled `IndexError`:

```python
tokenizer.apply_chat_template([], tokenize=False)
# IndexError: list index out of range
```

This happens in `tokenization_utils_base.py` where `conversation[0]` is read to detect batched input, without first checking that the list is not empty.

## The fix

Add a small guard before that line. If the conversation is empty, we now raise a clear `ValueError` with a helpful message instead of crashing on an index access.

This matches how the rest of the method already reports bad input through `ValueError`.

## Checklist

- small, focused change (a few lines plus a test)
- added a test that checks both empty list and empty tuple raise `ValueError`
- normal single and batched conversations still work as before
