### PR TITLE
feat(examples): add minimal Tensor Parallelism training example with …

### DIFF
--- a/examples/pytorch/tensor_parallelism/tp_training.py
+++ b/examples/pytorch/tensor_parallelism/tp_training.py
@@ -1,0 +1,171 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Minimal Tensor Parallelism (TP) training example using Trainer.
+
+Tensor Parallelism shards individual weight matrices across GPUs, so every
+GPU participates in every forward pass.  This is distinct from Data
+Parallelism (each GPU holds a full model replica) or FSDP (each GPU holds
+a shard of the full model).  TP is useful when a single model layer is too
+large to fit on one GPU, or to reduce per-GPU memory at the cost of
+all-reduce communication within each layer.
+
+Requirements
+------------
+    pip install transformers accelerate>=1.12.0 datasets
+
+Usage
+-----
+    # 2-GPU Tensor Parallelism with torchrun
+    torchrun --nproc_per_node=2 tp_training.py
+
+    # Or with accelerate (equivalent)
+    accelerate launch --num_processes=2 tp_training.py
+
+Common pitfalls
+---------------
+* Do NOT pass ``device_map="auto"`` when using TP with Trainer — that flag
+  is for inference-time device placement and will conflict with Trainer's
+  distributed setup.
+* Do NOT use ``init_empty_weights()`` here — it is for inference, not
+  training.
+* The number of processes (``--nproc_per_node``) must divide the model's
+  hidden dimensions evenly.  Most standard models (Llama, Mistral,
+  SmolLM2, …) already satisfy this for TP sizes 2, 4, or 8.
+"""
+
+import os
+import torch
+from datasets import load_dataset
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    DataCollatorForLanguageModeling,
+    Trainer,
+    TrainingArguments,
+)
+
+
+def main():
+    # ------------------------------------------------------------------ #
+    #  Configuration                                                       #
+    # ------------------------------------------------------------------ #
+    # SmolLM2-1.7B is small enough to run quickly and is publicly
+    # available.  Swap in any causal LM whose architecture supports
+    # tp_plan (Llama, Mistral, Gemma, Qwen, …).
+    model_id = "HuggingFaceTB/SmolLM2-1.7B"
+    output_dir = "./tp_training_output"
+    max_seq_length = 512
+    per_device_batch_size = 2
+    num_train_epochs = 1
+
+    # ------------------------------------------------------------------ #
+    #  Tokenizer                                                           #
+    # ------------------------------------------------------------------ #
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    # Many causal LMs do not define a pad token; reuse eos instead.
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    # ------------------------------------------------------------------ #
+    #  Model — loaded with tp_plan="auto"                                 #
+    # ------------------------------------------------------------------ #
+    # ``tp_plan="auto"`` is the single switch that enables Tensor
+    # Parallelism.  It:
+    #   1. Reads WORLD_SIZE from the environment (set by torchrun /
+    #      accelerate launch) to determine the TP degree.
+    #   2. Shards eligible weight matrices (attention projections, MLP
+    #      weights, …) across all available GPUs via DTensor.
+    #   3. Sets ``model.tp_size`` so that Trainer can auto-configure the
+    #      accelerate ``ParallelismConfig``.
+    model = AutoModelForCausalLM.from_pretrained(
+        model_id,
+        tp_plan="auto",
+        torch_dtype=torch.bfloat16,  # recommended for modern GPUs
+    )
+
+    # ------------------------------------------------------------------ #
+    #  Dataset                                                             #
+    # ------------------------------------------------------------------ #
+    # TinyStories is a small, freely available text corpus — good for
+    # quick iteration.  Replace with your own dataset as needed.
+    raw_dataset = load_dataset("roneneldan/TinyStories", split="train[:1%]")
+
+    def tokenize(examples):
+        out = tokenizer(
+            examples["text"],
+            truncation=True,
+            max_length=max_seq_length,
+            padding=False,
+        )
+        # For causal LM the labels are the same as input_ids (shifted
+        # internally by the model).
+        out["labels"] = out["input_ids"].copy()
+        return out
+
+    dataset = raw_dataset.map(
+        tokenize,
+        batched=True,
+        remove_columns=raw_dataset.column_names,
+    )
+
+    # ------------------------------------------------------------------ #
+    #  Training arguments                                                  #
+    # ------------------------------------------------------------------ #
+    # No special TP flags are needed here.  Trainer detects
+    # ``model.tp_size > 1`` and automatically creates the required
+    # accelerate ``ParallelismConfig``.
+    #
+    # If you need explicit control (e.g. combining TP with CP or DP), you
+    # can pass a ``parallelism_config`` directly:
+    #
+    #   from accelerate import ParallelismConfig
+    #   pc = ParallelismConfig(tp_size=2, dp_replicate_size=2)
+    #   args = TrainingArguments(..., parallelism_config=pc)
+    #
+    args = TrainingArguments(
+        output_dir=output_dir,
+        per_device_train_batch_size=per_device_batch_size,
+        num_train_epochs=num_train_epochs,
+        bf16=True,
+        logging_steps=10,
+        # ``remove_unused_columns=False`` keeps the dataset columns in the
+        # format expected by the data collator.
+        remove_unused_columns=False,
+        # Disable DDP's unused-parameter check — with TP some parameters
+        # are intentionally not used on every rank.
+        ddp_find_unused_parameters=False,
+        # Disable saving to keep this example self-contained.
+        save_strategy="no",
+        report_to=[],
+    )
+
+    # ------------------------------------------------------------------ #
+    #  Trainer                                                             #
+    # ------------------------------------------------------------------ #
+    trainer = Trainer(
+        model=model,
+        args=args,
+        train_dataset=dataset,
+        # DataCollatorForLanguageModeling handles padding and creates the
+        # causal-LM labels automatically.
+        data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False),
+    )
+
+    print(f"Starting TP training | tp_size={model.tp_size} | model={model_id}")
+    trainer.train()
+    print("Training complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…Trainer (#41141)

Adds examples/pytorch/tensor_parallelism/tp_training.py, a focused, runnable example of TP-only training using Trainer.

Key points:
- Load model with tp_plan='auto' (the only TP-specific flag needed)
- Trainer auto-detects model.tp_size and creates ParallelismConfig
- Uses SmolLM2-1.7B + TinyStories for low-resource reproducibility
- Explains common pitfalls: device_map='auto', init_empty_weights()
- Shows explicit ParallelismConfig usage as a comment for 3D parallelism

Fixes #41141

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
