### PR TITLE
[RT-DETRv2] Fix MPS crash in build_2d_sinusoidal_position_embedding (float64 → dtype)

### DIFF
--- a/src/transformers/models/aimv2/modeling_aimv2.py
+++ b/src/transformers/models/aimv2/modeling_aimv2.py
@@ -134,7 +134,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Dtype used for all internal tensor arithmetic and the output.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -143,11 +143,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=dtype, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=dtype, device=device)
+    grid_w = torch.arange(width, dtype=dtype, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -156,7 +156,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=dtype, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/d_fine/modeling_d_fine.py
+++ b/src/transformers/models/d_fine/modeling_d_fine.py
@@ -631,7 +631,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Dtype used for all internal tensor arithmetic and the output.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -640,11 +640,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=dtype, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=dtype, device=device)
+    grid_w = torch.arange(width, dtype=dtype, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -653,7 +653,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=dtype, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/deimv2/modeling_deimv2.py
+++ b/src/transformers/models/deimv2/modeling_deimv2.py
@@ -703,7 +703,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Dtype used for all internal tensor arithmetic and the output.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -712,11 +712,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=dtype, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=dtype, device=device)
+    grid_w = torch.arange(width, dtype=dtype, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -725,7 +725,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=dtype, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/pp_doclayout_v2/modeling_pp_doclayout_v2.py
+++ b/src/transformers/models/pp_doclayout_v2/modeling_pp_doclayout_v2.py
@@ -1551,7 +1551,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Dtype used for all internal tensor arithmetic and the output.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -1560,11 +1560,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=dtype, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=dtype, device=device)
+    grid_w = torch.arange(width, dtype=dtype, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -1573,7 +1573,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=dtype, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/pp_doclayout_v3/modeling_pp_doclayout_v3.py
+++ b/src/transformers/models/pp_doclayout_v3/modeling_pp_doclayout_v3.py
@@ -804,7 +804,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Dtype used for all internal tensor arithmetic and the output.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -813,11 +813,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=dtype, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=dtype, device=device)
+    grid_w = torch.arange(width, dtype=dtype, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -826,7 +826,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=dtype, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -847,7 +847,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Dtype used for all internal tensor arithmetic and the output.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -856,11 +856,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=dtype, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=dtype, device=device)
+    grid_w = torch.arange(width, dtype=dtype, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -869,7 +869,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=dtype, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -976,7 +976,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Dtype used for all internal tensor arithmetic and the output.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -985,11 +985,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=dtype, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=dtype, device=device)
+    grid_w = torch.arange(width, dtype=dtype, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -998,7 +998,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=dtype, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/vit_mae/modeling_vit_mae.py
+++ b/src/transformers/models/vit_mae/modeling_vit_mae.py
@@ -152,7 +152,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Dtype used for all internal tensor arithmetic and the output.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -161,11 +161,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=dtype, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=dtype, device=device)
+    grid_w = torch.arange(width, dtype=dtype, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -174,7 +174,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=dtype, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/vit_mae/modular_vit_mae.py
+++ b/src/transformers/models/vit_mae/modular_vit_mae.py
@@ -62,7 +62,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Dtype used for all internal tensor arithmetic and the output.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -71,11 +71,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=dtype, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=dtype, device=device)
+    grid_w = torch.arange(width, dtype=dtype, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -84,7 +84,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=dtype, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 


### PR DESCRIPTION
**Fixes #46159**

While tracing the MPS crash in **RT-DETRv2**, I noticed the same **build_2d_sinusoidal_position_embedding** function with the same **torch.float64** issue exists across several other models too **— rt_detr, d_fine, deimv2,** **pp_doclayout_v2, pp_doclayout_v3, aimv2, and vit_mae**. They all share essentially the same copy of this function, and they all crash on MPS for the same reason.

The function already accepts a dtype parameter (defaults to float32), but the body completely ignores it, every tensor is created with **dtype=torch.float64** hardcoded. On CUDA this is fine, just slightly wasteful. On MPS it crashes immediately because Apple's Metal framework doesn't support float64 at all. The **.to(dtype)** at the end never runs because the crash happens earlier, at tensor creation.

Also updated the docstring which said "frequency arithmetic uses float64 internally", that was the original intention but clearly wasn't what the dtype param was supposed to communicate.

Applied the fix at the root in **vit_mae/modular_vit_mae.py** and across all downstream copies, then re-ran the modular converter so rt_detr_v2 regenerates cleanly and the consistency check passes.

**_pytest tests/models/rt_detr_v2/ tests/models/rt_detr/ tests/models/vit_mae/ tests/models/aimv2/ -x -q -k "not slow"_**

****Also confirmed MPS inference works locally on M-series after the change.**