### PR TITLE
Raise early for unsupported QuantizedCache layer types

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1653,10 +1653,18 @@ class QuantizedCache(Cache):
             raise ValueError(f"Unknown quantization backend `{backend}`")
 
         config = config.get_text_config(decoder=True)
-        layers = [
-            layer_class(nbits, axis_key, axis_value, q_group_size, residual_length)
-            for _ in range(config.num_hidden_layers)
-        ]
+        # Like DynamicCache, build the cache from config.layer_types: quantize the attention (key/value) layers
+        # and use the proper linear-attention/hybrid layer for the rest, which are not key/value caches.
+        layer_types = getattr(config, "layer_types", None)
+        if layer_types is None:
+            layer_types = ["full_attention"] * config.num_hidden_layers
+        layers = []
+        for layer_type in layer_types:
+            cache_cls = LAYER_TYPE_CACHE_MAPPING.get(layer_type, DynamicLayer)
+            if cache_cls in (DynamicLayer, DynamicSlidingWindowLayer):
+                layers.append(layer_class(nbits, axis_key, axis_value, q_group_size, residual_length))
+            else:
+                layers.append(cache_cls(config))
         super().__init__(layers=layers)
 
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1653,18 +1653,26 @@ class QuantizedCache(Cache):
             raise ValueError(f"Unknown quantization backend `{backend}`")
 
         config = config.get_text_config(decoder=True)
-        # Like DynamicCache, build the cache from config.layer_types: quantize the attention (key/value) layers
-        # and use the proper linear-attention/hybrid layer for the rest, which are not key/value caches.
         layer_types = getattr(config, "layer_types", None)
-        if layer_types is None:
-            layer_types = ["full_attention"] * config.num_hidden_layers
-        layers = []
-        for layer_type in layer_types:
-            cache_cls = LAYER_TYPE_CACHE_MAPPING.get(layer_type, DynamicLayer)
-            if cache_cls in (DynamicLayer, DynamicSlidingWindowLayer):
-                layers.append(layer_class(nbits, axis_key, axis_value, q_group_size, residual_length))
-            else:
-                layers.append(cache_cls(config))
+        if layer_types is not None:
+            unsupported_layer_types = [
+                layer_type
+                for layer_type in layer_types
+                if LAYER_TYPE_CACHE_MAPPING.get(layer_type, DynamicLayer)
+                not in (DynamicLayer, DynamicSlidingWindowLayer)
+            ]
+            if unsupported_layer_types:
+                unsupported = ", ".join(sorted(set(unsupported_layer_types)))
+                raise ValueError(
+                    "`QuantizedCache` only supports attention key/value cache layers. "
+                    f"Found cache layer types that cannot be quantized: {unsupported}. "
+                    "Please use the default cache implementation instead."
+                )
+
+        layers = [
+            layer_class(nbits, axis_key, axis_value, q_group_size, residual_length)
+            for _ in range(config.num_hidden_layers)
+        ]
         super().__init__(layers=layers)
 
 

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -152,6 +152,31 @@ class CacheTest(unittest.TestCase):
         cache = StaticCache(config=config, max_cache_len=8)
         self.assertEqual(cache.max_cache_len, 8)
 
+    def test_quantized_cache_respects_hybrid_layer_types(self):
+        """
+        Regression test: hybrid (SSM + attention) models must build a QuantizedCache from
+        config.layer_types, like DynamicCache, not a flat list of quantized key/value layers. Otherwise
+        the linear-attention / Mamba layers are treated as key/value caches and generation crashes.
+        """
+        if not is_optimum_quanto_available():
+            self.skipTest("Quanto is not available")
+
+        from transformers.cache_utils import (
+            LinearAttentionAndFullAttentionLayer,
+            LinearAttentionLayer,
+            QuantoQuantizedLayer,
+        )
+
+        config = LlamaConfig(num_hidden_layers=4)
+        config.layer_types = ["full_attention", "mamba", "hybrid", "full_attention"]
+        cache = QuantizedCache(backend="quanto", config=config, nbits=4, q_group_size=16, residual_length=4)
+
+        # Attention layers are quantized; the linear-attention / hybrid layers keep their own class.
+        self.assertIsInstance(cache.layers[0], QuantoQuantizedLayer)
+        self.assertIsInstance(cache.layers[1], LinearAttentionLayer)
+        self.assertIsInstance(cache.layers[2], LinearAttentionAndFullAttentionLayer)
+        self.assertIsInstance(cache.layers[3], QuantoQuantizedLayer)
+
 
 def _skip_on_failed_cache_prerequisites(test, cache_implementation):
     """Function to skip tests on failed cache prerequisites, given a cache implementation"""

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -152,30 +152,23 @@ class CacheTest(unittest.TestCase):
         cache = StaticCache(config=config, max_cache_len=8)
         self.assertEqual(cache.max_cache_len, 8)
 
-    def test_quantized_cache_respects_hybrid_layer_types(self):
-        """
-        Regression test: hybrid (SSM + attention) models must build a QuantizedCache from
-        config.layer_types, like DynamicCache, not a flat list of quantized key/value layers. Otherwise
-        the linear-attention / Mamba layers are treated as key/value caches and generation crashes.
-        """
+    def test_quantized_cache_rejects_non_quantizable_layer_types(self):
         if not is_optimum_quanto_available():
             self.skipTest("Quanto is not available")
 
-        from transformers.cache_utils import (
-            LinearAttentionAndFullAttentionLayer,
-            LinearAttentionLayer,
-            QuantoQuantizedLayer,
-        )
+        from transformers.cache_utils import QuantoQuantizedLayer
 
         config = LlamaConfig(num_hidden_layers=4)
         config.layer_types = ["full_attention", "mamba", "hybrid", "full_attention"]
+        with self.assertRaisesRegex(ValueError, "cannot be quantized"):
+            QuantizedCache(backend="quanto", config=config, nbits=4, q_group_size=16, residual_length=4)
+
+        config.layer_types = ["full_attention"] * config.num_hidden_layers
         cache = QuantizedCache(backend="quanto", config=config, nbits=4, q_group_size=16, residual_length=4)
 
-        # Attention layers are quantized; the linear-attention / hybrid layers keep their own class.
-        self.assertIsInstance(cache.layers[0], QuantoQuantizedLayer)
-        self.assertIsInstance(cache.layers[1], LinearAttentionLayer)
-        self.assertIsInstance(cache.layers[2], LinearAttentionAndFullAttentionLayer)
-        self.assertIsInstance(cache.layers[3], QuantoQuantizedLayer)
+        self.assertEqual(len(cache.layers), config.num_hidden_layers)
+        for layer in cache.layers:
+            self.assertIsInstance(layer, QuantoQuantizedLayer)
 
 
 def _skip_on_failed_cache_prerequisites(test, cache_implementation):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46781)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46781)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`QuantizedCache` currently builds one quantized key/value cache layer per hidden layer, without checking `config.layer_types`:

```python
layers = [
    layer_class(nbits, axis_key, axis_value, q_group_size, residual_length)
    for _ in range(config.num_hidden_layers)
]
```

That works for pure attention models, but hybrid models also contain Mamba, linear-attention, or hybrid state layers that are not plain attention key/value caches. Passing `cache_implementation="quantized"` for those models currently lets the invalid cache get created and then fails later with confusing state-cache errors.

This keeps `QuantizedCache` scoped to attention key/value cache layers. If `config.layer_types` contains a layer type that does not map to a key/value cache layer, `QuantizedCache` now raises during initialization with a clear error asking users to use the default cache implementation instead. Pure attention configs keep the previous behavior: every layer still maps to the selected quantized cache layer.

<details>
<summary>Original crash that motivated the guard</summary>

Built each model from its own `ModelTester.get_config()` (legitimate hybrid configs, no hand-written tiny configs), float16, single RTX 4090. Each model was generated greedily with `cache_implementation="quantized"` using both `quanto` and `hqq`.

Environment: `transformers` 5.13.0.dev0, `torch` 2.8.0+cu128, Python 3.12, Linux, single RTX 4090, `optimum-quanto` and `hqq`.

```python
import importlib, torch
from transformers import AutoModelForCausalLM

class P:
    def __getattr__(self, k): return lambda *a, **kw: None

cfg = getattr(importlib.import_module("tests.models.zamba2.test_modeling_zamba2"),
              "Zamba2ModelTester")(P()).get_config()
cfg.use_cache = True
m = AutoModelForCausalLM.from_config(cfg).to(torch.float16).cuda().eval()
ids = torch.randint(5, 200, (1, 10)).cuda()

with torch.no_grad():
    m.generate(ids, max_new_tokens=12, do_sample=False, cache_implementation="quantized",
               cache_config={"backend": "quanto", "nbits": 4})
```

On main, the same root cause shows up across the tested hybrid families:

| model | result on main |
|---|---|
| Zamba2 | `ValueError: You called has_previous_state on layer index N, but this layer is an Attention layer...` |
| LFM2 | `ValueError: You called has_previous_state on layer index N, but this layer is an Attention layer...` |
| Qwen3-Next | `ValueError: has_previous_state can only be called on LinearAttention layers...` |
| Nemotron-H | `ValueError: has_previous_state can only be called on LinearAttention layers...` |
| Falcon-H1 | `ValueError: has_previous_state can only be called on LinearAttention layers...` |
| Jamba | `ValueError: has_previous_state can only be called on LinearAttention layers...` |

The failure happens because state layers that are not key/value cache layers are represented as quantized attention cache layers. This PR now rejects that unsupported cache layout before generation reaches those state accesses.
</details>

Added `test_quantized_cache_rejects_non_quantizable_layer_types` in `tests/utils/test_cache_utils.py`. It asserts that mixed `full_attention`/`mamba`/`hybrid` layer types raise early, while a pure `full_attention` config still builds quantized cache layers.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@Cyrilvallez