### PR TITLE
Fix left-padding token selection in `BioGptForSequenceClassification`

### DIFF
--- a/src/transformers/models/biogpt/modeling_biogpt.py
+++ b/src/transformers/models/biogpt/modeling_biogpt.py
@@ -616,19 +616,23 @@ class BioGptForSequenceClassification(BioGptPreTrainedModel):
         else:
             batch_size, sequence_length = inputs_embeds.shape[:2]
 
+        if self.config.pad_token_id is None and batch_size != 1:
+            raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_length = -1
+            last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device, dtype=torch.int32)
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
-            if input_ids is not None:
-                sequence_length = (torch.ne(input_ids, self.config.pad_token_id).sum(-1) - 1).to(logits.device)
-            else:
-                sequence_length = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_length]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/biogpt/modular_biogpt.py
+++ b/src/transformers/models/biogpt/modular_biogpt.py
@@ -448,19 +448,23 @@ class BioGptForSequenceClassification(BioGptPreTrainedModel):
         else:
             batch_size, sequence_length = inputs_embeds.shape[:2]
 
+        if self.config.pad_token_id is None and batch_size != 1:
+            raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_length = -1
+            last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device, dtype=torch.int32)
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
-            if input_ids is not None:
-                sequence_length = (torch.ne(input_ids, self.config.pad_token_id).sum(-1) - 1).to(logits.device)
-            else:
-                sequence_length = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_length]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/tests/models/biogpt/test_modeling_biogpt.py
+++ b/tests/models/biogpt/test_modeling_biogpt.py
@@ -384,6 +384,25 @@ class BioGptModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         result = model(input_ids, attention_mask=attention_mask, labels=sequence_labels)
         self.assertEqual(result.logits.shape, (self.model_tester.batch_size, self.model_tester.num_labels))
 
+    def test_biogpt_sequence_classification_left_padding(self):
+        # Regression: under left padding the head must pool the last real token.
+        config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        config.num_labels = 3
+        config.pad_token_id = 0
+        model = BioGptForSequenceClassification(config)
+        model.to(torch_device)
+        model.eval()
+        real = input_dict["input_ids"][:1].clamp(min=1)
+        pad = torch.zeros((1, 3), dtype=real.dtype, device=torch_device)
+        input_ids = torch.cat([pad, real], dim=1)
+        attention_mask = input_ids.ne(config.pad_token_id).to(torch_device)
+        with torch.no_grad():
+            pooled_logits = model(input_ids, attention_mask=attention_mask).logits
+            hidden_states = model.biogpt(input_ids, attention_mask=attention_mask).last_hidden_state
+            per_position_logits = model.score(hidden_states)
+        last_real_index = input_ids.shape[1] - 1
+        torch.testing.assert_close(pooled_logits[0], per_position_logits[0, last_real_index])
+
 
 @require_torch
 class BioGptModelIntegrationTest(unittest.TestCase):


### PR DESCRIPTION

# What does this PR do?

`BioGptForSequenceClassification` is the last decoder classification head still using the legacy pooling index:

```python
sequence_length = (torch.ne(input_ids, self.config.pad_token_id).sum(-1) - 1)
pooled_logits = logits[torch.arange(batch_size), sequence_length]
```

`(num_non_pad - 1)` equals the index of the last real token only when padding is on the right. With **left padding** the real tokens are shifted to the end, so this selects a token in the front of the sequence and the head pools the wrong position. The classification logits and loss are then silently wrong, with no error or warning. Right padding is unaffected.

#35911 moved every other `ForSequenceClassification` decoder (gpt2, llama, ...) onto a left/right-padding-safe selection, but biogpt was missed. This PR brings biogpt in line by using the same block as gpt2:

```python
non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
token_indices = torch.arange(input_ids.shape[-1], device=logits.device, dtype=torch.int32)
last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
```

which takes the rightmost non-pad index and is correct for both padding sides. This is the full block from gpt2, so it also adds the same `raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")` guard for `pad_token_id is None` with `batch_size > 1` (previously biogpt silently pooled index `-1`); this matches every other decoder after #35911. The edit is in `modular_biogpt.py`, regenerated into `modeling_biogpt.py` with the modular converter.

biogpt is the only remaining model with this pattern (`grep "torch.ne(input_ids, self.config.pad_token_id).sum"` matches biogpt only).

<details>
<summary>Reproduction (CPU, fp32, no GPU)</summary>

The check stays inside a single forward to remove the position-embedding shift that left padding introduces: the head's `pooled_logits` should equal the per-position logits at the true last real token.

```python
import torch
from transformers import BioGptConfig, BioGptForSequenceClassification, set_seed

torch.set_grad_enabled(False)
cfg = BioGptConfig(vocab_size=100, hidden_size=32, num_hidden_layers=2,
                   num_attention_heads=2, intermediate_size=64, num_labels=3, pad_token_id=0)
set_seed(0)
model = BioGptForSequenceClassification(cfg).eval()

set_seed(1)
real = torch.randint(1, cfg.vocab_size, (1, 5))          # 5 real tokens
input_ids = torch.cat([torch.zeros(1, 3, dtype=torch.long), real], dim=1)  # 3 left pads
mask = (input_ids != 0).long()

pooled = model(input_ids, attention_mask=mask).logits     # head's pooled logits
hidden = model.biogpt(input_ids, attention_mask=mask).last_hidden_state
per_pos = model.score(hidden)                             # same-forward per-position logits

last_real = input_ids.shape[1] - 1                        # index 7
print("d(pooled, last_real) =", (pooled - per_pos[:, last_real]).abs().max().item())
```

Before fix (selects index 4, the buggy `num_non_pad - 1`):
```
d(pooled, last_real) = 0.23832...
```
After fix (selects index 7, the real last token):
```
d(pooled, last_real) = 0.0
```
gpt2 already returns `0.0` here; right padding returns `0.0` for biogpt before and after.

</details>

Added regression test `test_biogpt_sequence_classification_left_padding`: it asserts `pooled_logits` equals the last-real-token logits from the same forward. It fails on the current code and passes with the fix. Full `tests/models/biogpt/test_modeling_biogpt.py` passes.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Did you write any new necessary tests?

## Who can review?

cc @Rocketknight1
