### PR TITLE
Fix typo in MiniMax M3 VL documentation

### DIFF
--- a/docs/source/en/model_doc/minimax_m3_vl.md
+++ b/docs/source/en/model_doc/minimax_m3_vl.md
@@ -32,7 +32,7 @@ Every layer is GQA (`num_key_value_heads = 4`) with per-head QK-norm and **parti
 `rotary_dim`. `config.layer_types[i]` then picks `"full_attention"` (dense causal) or
 `"minimax_m3_sparse"`, where a [`MiniMaxM3VLIndexer`] decides, per query, which block of keys the main attention may see.
 
-The indexer scores every key, then **max-poolsthose per-key scores into blocks of `index_block_size` keys**, so selection happens at the granularity of a *block
+The indexer scores every key, then **max-pools the per-key scores into blocks of `index_block_size` keys**, so selection happens at the granularity of a *block
 of keys*: per query it keeps the top-`index_topk_blocks` key blocks plus the always-on `index_local_blocks`
 local-window block (under block-level causality), broadcasts the per-block `0`/`-inf` choice back onto every key in
 the block. The result is a `[B, 1, S_q, S_k]` additive bias summed onto the causal mask. 


### PR DESCRIPTION
# What does this PR do?

This PR fixes a typo in the MiniMax-M3-VL documentation.

The phrase:

"max-poolsthose per-key scores"

has been corrected to:

"max-pools the per-key scores"

This improves readability and clarity of the documentation.
