### PR TITLE
fix: cast q_offset/kv_offset to int in flex_attention_mask to prevent tensor-type mask shape errors

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -709,6 +709,9 @@ def flex_attention_mask(
         device (`torch.device` or `str`, optional):
             An optional device to create the mask on.
     """
+    # Ensure offsets are plain Python ints; callers may pass 0-dim tensors (e.g. from cache_position)
+    q_offset = int(q_offset)
+    kv_offset = int(kv_offset)
     # Potentially add the padding 2D mask
     if attention_mask is not None:
         # Older torch (2.5.x) cannot handle sequences not in multiples of 128 (default block size)


### PR DESCRIPTION
Fixes #46682

## What does this PR do?

When callers pass `q_offset` or `kv_offset` as a `torch.Tensor` (e.g. a 0-dim tensor from `cache_position`) to `flex_attention_mask`, the tensor type propagates into `add_offsets_to_mask_function` and `prepare_padding_mask`. Inside `add_offsets_to_mask_function`, the expression `q_idx + q_offset` returns a tensor instead of a plain int, which causes `create_block_mask`'s mask modulation function to return a tensor with an extra dimension, triggering a `ValueError` about the mask having more than 4 dimensions.

### Fix

Explicitly cast `q_offset` and `kv_offset` to `int` at the top of `flex_attention_mask`, before either value is used. This is safe because the type annotation already declares both as `int`, and any 0-dim tensor with an integer value converts cleanly via `int()`. The per-call-site workaround of `.item()` described in the issue is no longer needed.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests)?
- [x] Was this discussed/approved via a Github issue? Yes: #46682