### PR TITLE
fix(tokenization): guard against IndexError when apply_chat_template …

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3086,8 +3086,10 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
         chat_template = self.get_chat_template(chat_template, tools)
 
-        if isinstance(conversation, (list, tuple)) and conversation and (
-            isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
+        if (
+            isinstance(conversation, (list, tuple))
+            and conversation
+            and (isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages"))
         ):
             conversations = conversation
             is_batched = True

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3086,7 +3086,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
         chat_template = self.get_chat_template(chat_template, tools)
 
-        if isinstance(conversation, (list, tuple)) and (
+        if isinstance(conversation, (list, tuple)) and conversation and (
             isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
         ):
             conversations = conversation


### PR DESCRIPTION
When `apply_chat_template` is called with an empty list `[]`, line 3089 tries to access `conversation[0]` without first checking if the list is empty:

```python
if isinstance(conversation, (list, tuple)) and (
    isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
):
```

This raises `IndexError: list index out of range`.

**Fix:** add `conversation and` before accessing `conversation[0]`, so Python's short-circuit evaluation prevents the index access on empty sequences.

**Reproduction:**
```python
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-1.5B-Instruct")
tokenizer.apply_chat_template([], tokenize=False)  # IndexError before fix, returns "" after
```

Fixes #46752.