### PR TITLE
Fix prompt lookup decoding crash when no EOS token is configured

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1135,11 +1135,12 @@ class PromptLookupCandidateGenerator(CandidateGenerator):
                     # remove remaining candidate ids if an "eos" token is found, otherwise the target model may
                     # accept eos and the rest as valid, thus not stopping generation after "eos"
                     # NOTE: below code is written based on the fact that assisted decoding supports only bs=1
-                    mask = torch.isin(chosen_ids, self.eos_token_id)
-                    match_indices_eos = torch.nonzero(mask)
-                    if match_indices_eos.numel() > 0:
-                        first_eos_index = match_indices_eos[0].item()
-                        chosen_ids = chosen_ids[:first_eos_index]
+                    if self.eos_token_id is not None:
+                        mask = torch.isin(chosen_ids, self.eos_token_id)
+                        match_indices_eos = torch.nonzero(mask)
+                        if match_indices_eos.numel() > 0:
+                            first_eos_index = match_indices_eos[0].item()
+                            chosen_ids = chosen_ids[:first_eos_index]
                     break
             if match_found:
                 break

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -920,6 +920,25 @@ class GenerationTesterMixin:
         self.assertTrue(output_prompt_lookup.shape[-1] == 10)
 
     @pytest.mark.generate
+    def test_prompt_lookup_decoding_no_eos_token(self):
+        # Same setup as test_prompt_lookup_decoding_stops_at_eos, but with no EOS in effect
+        # (eos_token_id=None, e.g. open-ended generation). The EOS-cropping branch must be skipped
+        # rather than running torch.isin(chosen_ids, None), which raises a TypeError.
+
+        input_ids = torch.randint(1, 50, (1, 10), device=torch_device)  # generate inputs in range from 1-50
+        arbitrary_ngram = 51  # arbitrary OOV unigram to force a deterministic match, as in the test above
+        input_ids[:, 3] = arbitrary_ngram  # earlier occurrence; its continuation is what gets proposed
+        input_ids[:, -1] = arbitrary_ngram  # put arbitrary_ngram in the end for the necessary match to happen
+
+        candidate_generator = PromptLookupCandidateGenerator(
+            eos_token_id=None, num_output_tokens=4, max_matching_ngram_size=1
+        )
+        output_prompt_lookup = candidate_generator.get_candidates(input_ids)[0]
+
+        # With no EOS to stop at, PLD proposes all num_output_tokens continuation tokens (10 + 4)
+        self.assertTrue(output_prompt_lookup.shape[-1] == 14)
+
+    @pytest.mark.generate
     def test_left_padding_compatibility(
         self, unpadded_custom_inputs: dict | None = None, padded_custom_inputs: dict | None = None
     ):

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -920,25 +920,6 @@ class GenerationTesterMixin:
         self.assertTrue(output_prompt_lookup.shape[-1] == 10)
 
     @pytest.mark.generate
-    def test_prompt_lookup_decoding_no_eos_token(self):
-        # Same setup as test_prompt_lookup_decoding_stops_at_eos, but with no EOS in effect
-        # (eos_token_id=None, e.g. open-ended generation). The EOS-cropping branch must be skipped
-        # rather than running torch.isin(chosen_ids, None), which raises a TypeError.
-
-        input_ids = torch.randint(1, 50, (1, 10), device=torch_device)  # generate inputs in range from 1-50
-        arbitrary_ngram = 51  # arbitrary OOV unigram to force a deterministic match, as in the test above
-        input_ids[:, 3] = arbitrary_ngram  # earlier occurrence; its continuation is what gets proposed
-        input_ids[:, -1] = arbitrary_ngram  # put arbitrary_ngram in the end for the necessary match to happen
-
-        candidate_generator = PromptLookupCandidateGenerator(
-            eos_token_id=None, num_output_tokens=4, max_matching_ngram_size=1
-        )
-        output_prompt_lookup = candidate_generator.get_candidates(input_ids)[0]
-
-        # With no EOS to stop at, PLD proposes all num_output_tokens continuation tokens (10 + 4)
-        self.assertTrue(output_prompt_lookup.shape[-1] == 14)
-
-    @pytest.mark.generate
     def test_left_padding_compatibility(
         self, unpadded_custom_inputs: dict | None = None, padded_custom_inputs: dict | None = None
     ):
@@ -3821,6 +3802,24 @@ class GenerationIntegrationTests(unittest.TestCase):
         self.assertTrue(model.generation_config.bos_token_id == gen_output[0, 0])
         self.assertTrue(test_bos_id == gen_output[0, 0])
         self.assertTrue(generation_config.bos_token_id is None)
+
+    def test_prompt_lookup_decoding_no_eos_token(self):
+        # Same setup as test_prompt_lookup_decoding_stops_at_eos, but with no EOS in effect
+        # (eos_token_id=None, e.g. open-ended generation). The EOS-cropping branch must be skipped
+        # rather than running torch.isin(chosen_ids, None), which raises a TypeError.
+
+        input_ids = torch.randint(1, 50, (1, 10), device=torch_device)  # generate inputs in range from 1-50
+        arbitrary_ngram = 51  # arbitrary OOV unigram, as in test_prompt_lookup_decoding_stops_at_eos
+        input_ids[:, 3] = arbitrary_ngram  # earlier occurrence; its continuation is what gets proposed
+        input_ids[:, -1] = arbitrary_ngram  # put arbitrary_ngram in the end for the necessary match to happen
+
+        candidate_generator = PromptLookupCandidateGenerator(
+            eos_token_id=None, num_output_tokens=4, max_matching_ngram_size=1
+        )
+        output_prompt_lookup = candidate_generator.get_candidates(input_ids)[0]
+
+        # With no EOS to stop at, PLD proposes all num_output_tokens continuation tokens (10 + 4)
+        self.assertTrue(output_prompt_lookup.shape[-1] == 14)
 
     def test_speculative_decoding_equals_regular_decoding(self):
         draft_name = "double7/vicuna-68m"


### PR DESCRIPTION

# What does this PR do?

Prompt lookup decoding (`prompt_lookup_num_tokens=N`) crashes with a `TypeError` whenever no EOS token is in effect, e.g. open-ended generation with `eos_token_id=None`, or a base checkpoint with no `eos_token_id`:

```python
import torch
from transformers import AutoModelForCausalLM

model = AutoModelForCausalLM.from_pretrained("HuggingFaceTB/SmolLM2-360M-Instruct").eval()
model.generation_config.pad_token_id = 0

# Trailing ngram repeats earlier in the input, so prompt lookup finds a match.
ids = torch.tensor([[5, 6, 7, 8, 9, 10, 11, 7, 8]])
model.generate(ids, attention_mask=torch.ones_like(ids), max_new_tokens=15,
               prompt_lookup_num_tokens=3, eos_token_id=None)
# TypeError: isin() received an invalid combination of arguments - got (Tensor, NoneType), ...
```

**Bug:** once an ngram match is found, `PromptLookupCandidateGenerator.get_candidates` runs `torch.isin(chosen_ids, self.eos_token_id)` to crop the candidate at the first EOS, but `self.eos_token_id` is `None` when no EOS is set. `eos_token_id=None` is not refilled from the config, so a normal `generate` call reaches this.

**Fix:** wrap the EOS-cropping block in `if self.eos_token_id is not None:`. This is the same guard already used for the same tensor in `SinglePositionMultiTokenCandidateGenerator`, and matches how `AssistedCandidateGenerator` normalizes a missing EOS. Behaviour is unchanged when an EOS is set; with no EOS the crop is skipped (there is nothing to stop at).

<details>
<summary>Reproduction and verification</summary>

The snippet above raises `TypeError` on `main` and returns normally with this PR. Reverting only the source change reproduces the crash; restoring it fixes it.

Regression test `tests/generation/test_utils.py::test_prompt_lookup_decoding_no_eos_token` (next to `test_prompt_lookup_decoding_stops_at_eos`) constructs `PromptLookupCandidateGenerator(eos_token_id=None, ...)`, feeds an input that forces a match, and asserts `get_candidates` returns the continuation instead of raising. It fails with `TypeError` at `candidate_generator.py:1138` without the fix and passes with it.

No regressions: `tests/generation/test_candidate_generator.py` (13 passed) and the llama `prompt_lookup`/`assisted`/`speculative` candidate-generation tests (6 passed).

Env: transformers `main` (5.13.0.dev0), torch 2.8.0+cu128, Python 3.12, Linux x86_64.
</details>

cc @zucchini-nlp
