### PR TITLE
fix(tokenization): guard against IndexError when apply_chat_template …

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3086,7 +3086,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
         chat_template = self.get_chat_template(chat_template, tools)
 
-        if isinstance(conversation, (list, tuple)) and (
+        if isinstance(conversation, (list, tuple)) and len(conversation) > 0 and (
             isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
         ):
             conversations = conversation


### PR DESCRIPTION
Fixes #46752

## What does this PR do?

`apply_chat_template` crashes with an `IndexError` when `conversation=[]` (an empty list) is passed.

**Root cause:** In `tokenization_utils_base.py` around line 3089, the code accesses `conversation[0]` without first checking that the list is non-empty:

```python
# Before (buggy):
if isinstance(conversation, (list, tuple)) and (
    isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
):
```

**Fix:** Add a `len(conversation) > 0` guard before accessing the first element:

```python
# After (fixed):
if isinstance(conversation, (list, tuple)) and len(conversation) > 0 and (
    isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
):
```

This is the minimal, safe fix: an empty conversation simply falls through to the `else` branch (`conversations = [conversation]`, `is_batched = False`), which is the correct behavior.

## Reproduction

```python
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-1.5B-Instruct")

# Before: raises IndexError: list index out of range
# After: returns ""
tokenizer.apply_chat_template([], tokenize=False)
```

Also reproduced on `google/gemma-2-2b-it`.

- [ ] I confirm that this is not a pure code agent PR.