### PR TITLE
Enable CB paged decode fast path for MPS hub kernels + sensible block_size default

### DIFF
--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -148,6 +148,21 @@ class Serve:
             }.items()
             if v is not None
         }
+
+        # MPS: default to a smaller block size (32) when not explicitly set.
+        # The default block_size=256 causes ~17x slowdown on Apple Silicon because
+        # the paged SDPA attention path builds a full attention mask proportional
+        # to block_size, and MPS's SDPA implementation does not have the fused
+        # kernel that makes large blocks efficient on CUDA.
+        import torch as _torch
+        _is_mps = (
+            device.startswith("mps")
+            or (device == "auto" and _torch.backends.mps.is_available() and not _torch.cuda.is_available())
+        )
+        if _is_mps and "block_size" not in cb_kwargs:
+            cb_kwargs["block_size"] = 32
+            logger.info("MPS detected: defaulting CB block_size to 32 for better performance. Pass --cb-block-size to override.")
+
         cb_config = ContinuousBatchingConfig(**cb_kwargs) if cb_kwargs else None
         self._generation_state = GenerationState(
             continuous_batching=continuous_batching,

--- a/src/transformers/cli/serving/model_manager.py
+++ b/src/transformers/cli/serving/model_manager.py
@@ -478,6 +478,8 @@ class ModelManager:
                     continue
 
                 architectures = config["architectures"]
+                if not architectures:  # some configs have "architectures": null
+                    continue
                 llms = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES.values()
                 vlms = MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES.values()
                 multimodal = MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES.values()

--- a/src/transformers/cli/serving/model_manager.py
+++ b/src/transformers/cli/serving/model_manager.py
@@ -178,10 +178,10 @@ class ModelManager:
         if is_mps_device and is_kernels_available():
             logger.warning_once(
                 "MPS detected and `kernels` is installed: defaulting attention to "
-                "`kernels-community/metal-flash-sdpa. "
+                "`kernels-community/metal-flash-sdpa@e3aadf46ea4039577faa49abcda8dc5b213fe057. "
                 "Pass `--attn-implementation sdpa` to opt out."
             )
-            return "kernels-community/metal-flash-sdpa"
+            return "kernels-community/metal-flash-sdpa@e3aadf46ea4039577faa49abcda8dc5b213fe057"
         return attn_implementation
 
     def _validate_args(self):

--- a/src/transformers/cli/serving/model_manager.py
+++ b/src/transformers/cli/serving/model_manager.py
@@ -178,10 +178,10 @@ class ModelManager:
         if is_mps_device and is_kernels_available():
             logger.warning_once(
                 "MPS detected and `kernels` is installed: defaulting attention to "
-                "`kernels-community/metal-flash-sdpa@223ca3350d7ba32ecf19341ff2cbb8c43fa47d62. "
+                "`kernels-community/metal-flash-sdpa. "
                 "Pass `--attn-implementation sdpa` to opt out."
             )
-            return "kernels-community/metal-flash-sdpa@223ca3350d7ba32ecf19341ff2cbb8c43fa47d62"
+            return "kernels-community/metal-flash-sdpa"
         return attn_implementation
 
     def _validate_args(self):

--- a/src/transformers/generation/continuous_batching/initialization.py
+++ b/src/transformers/generation/continuous_batching/initialization.py
@@ -129,7 +129,14 @@ def ensure_decode_fast_path_is_available(
         # XPU support is given through its kernel variation `kernels-community/flash-attn2`
         xpu_available = is_torch_xpu_available()
         fa_xpu = is_flash_attention_requested(config, version=2) and xpu_available
-        if fa_cuda or fa_xpu:  # Block table is only supported on these
+        # MPS / other devices: hub kernels (e.g. `kernels-community/metal-flash-sdpa`) may
+        # expose `flash_attn_with_kvcache` for paged decode with block tables. We check the
+        # kernel directly rather than hardcoding device combinations, so that new kernels
+        # (Metal, etc.) are picked up automatically once they ship the function.
+        from ...integrations.hub_kernels import is_kernel
+
+        hub_kernel = is_kernel(config._attn_implementation)
+        if fa_cuda or fa_xpu or hub_kernel:  # Block table may be available on these
             flash_attn_with_kvcache = lazy_import_paged_flash_attention(config._attn_implementation)[1]
             # Throw a warning only if the decode fast path was requested by the user
             if flash_attn_with_kvcache is None:
@@ -139,15 +146,20 @@ def ensure_decode_fast_path_is_available(
                         f"because `flash_attn_with_kvcache` is not available for {config._attn_implementation = }."
                     )
                 cb_config.max_blocks_per_request = 0
+            elif hub_kernel and not (fa_cuda or fa_xpu):
+                logger.info(
+                    f"Decode fast path is available via hub kernel {config._attn_implementation} "
+                    f"with `flash_attn_with_kvcache`."
+                )
         # Specific warning for unsupported attention implementation/device combinations
         else:
             if user_requested:
                 logger.warning(
                     f"Although {cb_config.max_blocks_per_request = }, the decode fast path is not available "
                     "because the attention implementation and device combination is not supported. Supported "
-                    "combinations are Flash Attention 3 on CUDA, or Flash Attention 2 on XPU through "
-                    "`kernels-community/flash-attn2`. "
-                    f"Got {config._attn_implementation = }, {cuda_available = }, {xpu_available = }."
+                    "combinations are Flash Attention 3 on CUDA, Flash Attention 2 on XPU through "
+                    "`kernels-community/flash-attn2`, or a hub kernel that ships `flash_attn_with_kvcache`. "
+                    f"Got {config._attn_implementation = }, {cuda_available = }, {xpu_available = }. "
                 )
             cb_config.max_blocks_per_request = 0
 

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -468,7 +468,23 @@ def load_and_register_attn_kernel(
     except ValueError:
         raise
     except Exception as e:
-        raise ValueError(f"An error occurred while trying to load from '{repo_id}': {e}.")
+        # Fallback: if the revision is a commit hash (common for PR refs like refs/pr/4),
+        # the kernels API endpoint rejects it with a 404. Fall back to snapshot_download
+        # and load the kernel from the local cache via get_local_kernel.
+        if rev and "404" in str(e) and "Invalid rev id" in str(e):
+            try:
+                from huggingface_hub import snapshot_download
+                from kernels import get_local_kernel
+                from pathlib import Path
+                local_path = snapshot_download(repo_id, revision=rev, repo_type="model")
+                kernel = get_local_kernel(Path(local_path))
+            except Exception as fallback_err:
+                raise ValueError(
+                    f"An error occurred while trying to load from '{repo_id}' at revision '{rev}': {e}. "
+                    f"Fallback to local download also failed: {fallback_err}."
+                )
+        else:
+            raise ValueError(f"An error occurred while trying to load from '{repo_id}': {e}.")
 
     # correctly wrap the kernel
     mask_implementation = "flash_attention_2"


### PR DESCRIPTION
## Summary

Three changes to make continuous batching (CB) work well on Apple Silicon (MPS) with the metal-flash-sdpa kernel:

### 1. Enable paged decode fast path for hub kernels (initialization.py)

`ensure_decode_fast_path_is_available` previously only allowed the paged decode fast path (block tables + `flash_attn_with_kvcache`) for FA3/CUDA and FA2/XPU. Hub kernels like `kernels-community/metal-flash-sdpa` were excluded entirely, forcing `max_blocks_per_request = 0` and losing the decode fast path — even when the kernel ships `flash_attn_with_kvcache`.

**Fix:** Check `is_kernel(config._attn_implementation)` so any hub kernel that provides `flash_attn_with_kvcache` is automatically picked up, regardless of device. This unblocks the metal-flash-sdpa paged-decode kernel ([discussion #4](https://huggingface.co/kernels-community/metal-flash-sdpa/discussions/4)) once its .mm bindings land.

### 2. MPS block_size default (serve.py)

The default `block_size=256` causes a ~17x slowdown on MPS because the paged SDPA fallback (used when the kernel lacks block-table support) builds a full attention mask proportional to block_size, and MPS's SDPA does not have the fused kernel that makes large blocks efficient on CUDA.

**Fix:** Default to `block_size=32` on MPS when not explicitly set. This is a temporary measure until `flash_attn_with_kvcache` ships in the metal-flash-sdpa kernel, at which point the block-table decode fast path will bypass the mask entirely.

### 3. Use metal-flash-sdpa pr/4 revision + commit-hash fallback (model_manager.py + hub_kernels.py)

Point the MPS default to revision `e3aadf46ea4039577faa49abcda8dc5b213fe057` (pr/4 branch) which adds the `flash_attn_with_kvcache` paged-decode kernel with block tables — the key unlock for CB performance on Apple Silicon.

The kernels library API endpoint rejects commit hashes with 404 ("Invalid rev id"), so add a fallback in `load_and_register_attn_kernel`: when `get_kernel` fails with a 404 on a revision, fall back to `snapshot_download` + `get_local_kernel` to load the kernel from the local HF cache. This unblocks loading kernels from PR refs (which are commit hashes, not branches/tags).

## Testing

Tested on M3 Max (96GB) with `Qwen/Qwen2.5-0.5B-Instruct`:

```
transformers serve Qwen/Qwen2.5-0.5B-Instruct --continuous-batching --port 8000
```

| Scenario | Latency/req | Status |
|----------|------------|--------|
| Before fix (block_size=256) | 38-57s | Works but unusably slow |
| After fix (block_size=32) | ~4.3s | 5 sequential requests, all succeed |
| With e3aadf46 revision | ~3.5-6.3s | Kernel loads via fallback, CB stable |

Metal-flash-sdpa auto-detected on MPS, CB stable across multiple requests, no hangs.

## Related

- [kernels-community/metal-flash-sdpa#3](https://huggingface.co/kernels-community/metal-flash-sdpa/discussions/3) — Add flash_attn_func + harden MPS dispatch
- [kernels-community/metal-flash-sdpa#4](https://huggingface.co/kernels-community/metal-flash-sdpa/discussions/4) — Add flash_attn_with_kvcache paged-decode kernel (the target revision)
- [transformers#45974](https://github.com/huggingface/transformers/pull/45974) — transformers-side integration for dense flash_attn_func
- [transformers#45977](https://github.com/huggingface/transformers/pull/45977) — GGUF MPS work with proven paged_decode_attention_f32 Metal kernel