### PR TITLE
fix(tokenization): prevent IndexError in apply_chat_template on empty conversation list

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -2069,7 +2069,7 @@ class ProcessorMixin(PushToHubMixin):
             else:
                 sampling_rate = 16_000
 
-        if isinstance(conversation, (list, tuple)) and (
+        if isinstance(conversation, (list, tuple)) and len(conversation) > 0 and (
             isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "content")
         ):
             is_batched = True

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -2069,8 +2069,10 @@ class ProcessorMixin(PushToHubMixin):
             else:
                 sampling_rate = 16_000
 
-        if isinstance(conversation, (list, tuple)) and len(conversation) > 0 and (
-            isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "content")
+        if (
+            isinstance(conversation, (list, tuple))
+            and len(conversation) > 0
+            and (isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "content"))
         ):
             is_batched = True
             conversations = conversation

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -1100,7 +1100,7 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
         if add_generation_prompt and continue_final_message:
             raise ValueError("Cannot use both `add_generation_prompt` and `continue_final_message`.")
 
-        if isinstance(conversation, (list, tuple)) and (
+        if isinstance(conversation, (list, tuple)) and len(conversation) > 0 and (
             isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
         ):
             conversations = conversation

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -1100,8 +1100,10 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
         if add_generation_prompt and continue_final_message:
             raise ValueError("Cannot use both `add_generation_prompt` and `continue_final_message`.")
 
-        if isinstance(conversation, (list, tuple)) and len(conversation) > 0 and (
-            isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
+        if (
+            isinstance(conversation, (list, tuple))
+            and len(conversation) > 0
+            and (isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages"))
         ):
             conversations = conversation
             is_batched = True

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3086,8 +3086,10 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
         chat_template = self.get_chat_template(chat_template, tools)
 
-        if isinstance(conversation, (list, tuple)) and len(conversation) > 0 and (
-            isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
+        if (
+            isinstance(conversation, (list, tuple))
+            and len(conversation) > 0
+            and (isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages"))
         ):
             conversations = conversation
             is_batched = True
@@ -3448,7 +3450,7 @@ def find_sentencepiece_model_file(pretrained_model_name_or_path, **kwargs):
             entries = hf_api().list_repo_tree(
                 repo_id=pretrained_model_name_or_path,
                 revision=kwargs.get("revision"),
-                path_in_repo=subfolder if subfolder else None,
+                path_in_repo=subfolder or None,
                 recursive=False,
                 token=kwargs.get("token"),
             )

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3086,7 +3086,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
         chat_template = self.get_chat_template(chat_template, tools)
 
-        if isinstance(conversation, (list, tuple)) and (
+        if isinstance(conversation, (list, tuple)) and len(conversation) > 0 and (
             isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
         ):
             conversations = conversation

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -324,6 +324,12 @@ class TokenizerUtilsTest(unittest.TestCase):
 
         self.assertEqual(whole_conversation_tokens, tokens)
 
+    def test_apply_chat_template_empty_conversation(self):
+        tokenizer = AutoTokenizer.from_pretrained("HuggingFaceH4/zephyr-7b-beta")
+        # Should not raise IndexError
+        tokens = tokenizer.apply_chat_template([], tokenize=True, return_dict=False)
+        self.assertEqual(tokens, [])
+
     def test_encode_message_raises_on_add_generation_prompt(self):
         tokenizer = AutoTokenizer.from_pretrained("HuggingFaceH4/zephyr-7b-beta")
         conversation = [


### PR DESCRIPTION
### What does this PR do?

Resolves #46752.

When calling `apply_chat_template` with an empty list (`[]`), the tokenization pipeline raises an `IndexError` because it attempts to check `isinstance(conversation[0], ...)` without validating if the list is populated.

This PR adds a `len(conversation) > 0` guard to prevent the crash in `tokenization_utils_base.py`, `processing_utils.py`, and `tokenization_mistral_common.py`. Also adds a regression test in `test_tokenization_utils.py`.

### Who can review?
@ArthurZucker @younesbelkada
