### PR TITLE
fix: prevent IndexError in apply_chat_template with empty conversation list

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3086,7 +3086,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
         chat_template = self.get_chat_template(chat_template, tools)
 
-        if isinstance(conversation, (list, tuple)) and (
+        if isinstance(conversation, (list, tuple)) and len(conversation) > 0 and (
             isinstance(conversation[0], (list, tuple)) or hasattr(conversation[0], "messages")
         ):
             conversations = conversation


### PR DESCRIPTION
## Fix

Fixes #46752

### Problem

`apply_chat_template` crashes with `IndexError: list index out of range` when passed an empty list:

```python
tokenizer.apply_chat_template([], tokenize=False)
# IndexError: list index out of range
```

### Solution

Add a `len(conversation) > 0` guard before accessing `conversation[0]` in `tokenization_utils_base.py` line 3089.

### Changes

- `src/transformers/tokenization_utils_base.py`: Added length check before accessing `conversation[0]`

### Testing

- Empty list no longer raises `IndexError`
- Normal conversation lists continue to work correctly