### PR TITLE
[fix][whisper]: fix max_new_tokens handling

### DIFF
--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -1929,7 +1929,7 @@ class WhisperGenerationMixin(GenerationMixin):
                 f"so that their combined length is less than {self.config.max_target_positions}."
             )
 
-        num_initial_tokens = min(config.max_target_positions // 2 - 1, decoder_input_ids.shape[-1] - 1)
+        num_initial_tokens = min(config.max_target_positions // 2 - 1, decoder_input_ids.shape[-1])
 
         # Make sure we don't get larger than `max_length`
         if generation_config.max_length is not None and generation_config.max_new_tokens is None:
@@ -1937,6 +1937,7 @@ class WhisperGenerationMixin(GenerationMixin):
             logger.info(
                 f"Increase max_length from {generation_config.max_length} to {max_length} since input is conditioned on previous segment."
             )
+            generation_config.max_length = max_length
         elif (
             generation_config.max_new_tokens is not None
             and generation_config.max_new_tokens + decoder_input_ids.shape[-1] > config.max_target_positions


### PR DESCRIPTION
# What does this PR do?

PR #44130 changed how the generation loop enforces `max_length`: it is now the strict total decoder length (forced/initial tokens + generated content), whereas the old `cache_position` based approach effectively didn't count one position.

  Whisper prepends forced decoder tokens before the transcript (`[<|startoftranscript|>, <|lang|>, <|transcribe|>, <|notimestamps|>]`). So when a user passes `max_length=20` they mean "20 content tokens," and `_set_max_new_tokens_and_length` is supposed to inflate the limit to leave room for that forced prefix. Two defects broke this:

  1. The compensation was computed but discarded.
  The function computed `max_length = min(generation_config.max_length + num_initial_tokens, …)` but a refactor #30018 dropped the line that wrote it back. That refactor
  reworked `_set_max_new_tokens_and_length` from returning a kwargs dict (which set `kwargs["max_length"]`) to mutating `generation_config` in place. The max_new_tokens branch got its in-place replacement, but the max_length branch's equivalent (generation_config.max_length = max_length) was never carried over. It became dead code, harmless under the old loop, actively harmful once #44130 made max_length strict.

  2. An off-by-one hidden in num_initial_tokens.
  The compensation used `decoder_input_ids.shape[-1] - 1`. That -1 existed to cancel the old loop's free (uncounted) position, so the net inflation still came out to the full prefix length. PR #44130 removed that quirk, so the -1 now under-counts the prefix by one, leaving the output one token short even after re-adding the assignment.

TD;DR: #30018 planted latent dead code, #44130 activated it

Fixes:
- `test_modeling_whisper.py::WhisperModelIntegrationTests::test_tiny_generation`
- `test_modeling_whisper.py::WhisperModelIntegrationTests::test_tiny_en_generation`

