### PR TITLE
Fix secondary rate limit when downloading artifacts in slack report

### DIFF
--- a/.github/workflows/slack-report.yml
+++ b/.github/workflows/slack-report.yml
@@ -65,11 +65,14 @@ jobs:
           ref: ${{ (github.event_name == 'issue_comment' || github.event_name == 'pull_request_target') && 'main' || (inputs.commit_sha || github.sha) }}
           persist-credentials: false
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      # Use a forked version of download-artifact with chunk-delay to avoid secondary rate limits
+      # when downloading many artifacts (e.g. ~1000 test reports).
+      - uses: ydshieh/download-artifact@034d574170fc2fbcc74842d25304666dad52f1ad
         env:
           ACTIONS_ARTIFACT_MAX_ARTIFACT_COUNT: 2000
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          chunk-delay: 1000
 
       - name: Prepare some setup values
         run: |


### PR DESCRIPTION
## Summary

- Switches `download-artifact` to a forked version ([ydshieh/download-artifact@rate_limit_friendly](https://github.com/ydshieh/download-artifact/pull/1)) that adds a `chunk-delay` input
- Sets `chunk-delay: 1000` (1 second between each batch of 5 downloads) to avoid GitHub secondary rate limit errors when downloading ~1000 test report artifacts

## Context

The slack reporting job downloads all artifacts from a workflow run (can be ~1000). Without throttling, all downloads fire in rapid succession and hit GitHub's secondary rate limit (`RequestError: You have exceeded a secondary rate limit`). The forked action fixes this by deferring promise creation so the delay is correctly applied between batches.