### PR TITLE
Fix flex_attention block mask creation when `get_seq_length` returns a tensor

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -856,9 +856,11 @@ def _preprocess_mask_arguments(
     # If using a cache, it can give all information about mask sizes based on seen tokens
     if past_key_values is not None:
         q_offset = past_key_values.get_seq_length()
-        # To avoid graph breaks, StaticLayer return a tensor instead of int -> this has no impact on the ops, but we
-        # need the correct device
-        q_offset = q_offset.to(inputs_embeds.device) if isinstance(q_offset, torch.Tensor) else q_offset
+        # To avoid graph breaks, StaticLayer returns a tensor instead of an int -> this has no impact on the ops, but
+        # we need the correct device. We also reshape to a 0-dim scalar: `get_seq_length` may return a 1-element
+        # tensor, which would broadcast the per-index flex `mask_mod` result to shape (1,) and produce a 5D block
+        # mask that `create_block_mask` cannot unpack.
+        q_offset = q_offset.reshape(()).to(inputs_embeds.device) if isinstance(q_offset, torch.Tensor) else q_offset
         kv_length, kv_offset = past_key_values.get_mask_sizes(q_length, layer_idx)
     # Otherwise, we infer based on our input
     else:


### PR DESCRIPTION
## Description

When generating with `attn_implementation="flex_attention"` and a `StaticCache`
(e.g. `cache_implementation="static"`), the decode step crashes with:

```
ValueError: too many values to unpack (expected 4)
  File ".../torch/nn/attention/flex_attention.py", line 1330, in _convert_mask_to_block_mask
    B, H, Q, KV = mask.shape
```

## Root cause

In `_preprocess_mask_arguments`, `q_offset` comes from `past_key_values.get_seq_length()`,
which can return a **1-element tensor** rather than a scalar. This offset is added to the
query index inside the flex `mask_mod` function, so the per-index result gets broadcast to
shape `(1,)` instead of staying a 0-dim scalar. The block mask then becomes 5D, which
`create_block_mask` cannot unpack into `(B, H, Q, KV)`.

## Fix

Reshape `q_offset` to a 0-dim scalar before use:

```python
q_offset = q_offset.reshape(()).to(inputs_embeds.device) if isinstance(q_offset, torch.Tensor) else q_offset
```

## Reproduction

```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer

tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
model = AutoModelForCausalLM.from_pretrained(
    "Qwen/Qwen3-0.6B", dtype=torch.bfloat16, attn_implementation="flex_attention",
    device_map="auto"
)

inputs = tok("Hello world, tell me a short story.", return_tensors="pt").to(model.device)
model.generate(**inputs, max_new_tokens=16, do_sample=False, cache_implementation="static")
```

Fails before the fix, generates normally after. Reproduces on both CUDA and XPU.
