### PR TITLE
fix: resolve issue #17283

### DIFF
--- a/src/transformers/pipelines/pt_utils.py
+++ b/src/transformers/pipelines/pt_utils.py
@@ -123,6 +123,17 @@ class PipelineIterator(IterableDataset):
             return self.loader_batch_item()
 
         # We're out of items within a batch
+        # Clean up previous batch data to free memory, especially past_key_values
+        # which can be very large and cause OOM when accumulated across batches.
+        if self._loader_batch_data is not None:
+            if isinstance(self._loader_batch_data, dict) or hasattr(self._loader_batch_data, "items"):
+                for k in list(getattr(self._loader_batch_data, "keys", lambda: [])()
+                              if hasattr(self._loader_batch_data, "keys")
+                              else self._loader_batch_data.keys()):
+                    if k == "past_key_values":
+                        del self._loader_batch_data[k]
+            self._loader_batch_data = None
+
         item = next(self.iterator)
         processed = self.infer(item, **self.params)
         # We now have a batch of "inferred things".

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -402,6 +402,19 @@ class TextGenerationPipeline(Pipeline):
 
         output = self.model.generate(input_ids=input_ids, attention_mask=attention_mask, **generate_kwargs)
 
+        # Clear past_key_values immediately after generation to free GPU memory.
+        # past_key_values are not needed by the pipeline and can be very large,
+        # especially during batch inference where they accumulate and cause OOM errors.
+        if isinstance(output, ModelOutput):
+            if hasattr(output, "past_key_values") and output.past_key_values is not None:
+                del output["past_key_values"]
+            # Clear any extra tensors that are not needed
+            for extra_key in ["cache_position", "encoder_outputs"]:
+                if hasattr(output, extra_key):
+                    del output[extra_key]
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
         if isinstance(output, ModelOutput):
             generated_sequence = output.sequences
             other_outputs = {k: v for k, v in output.items() if k not in {"sequences", "past_key_values"}}


### PR DESCRIPTION
Resolves #17283

Fixed pipeline batch inference memory spike by properly releasing intermediate tensors during batch processing.

Signed-off-by: KartavyaDikshit <kartavyaniraj.dikshit2021@vitstudent.ac.in>