### PR TITLE
Fix broken internal links in model documentation

### DIFF
--- a/docs/source/en/model_doc/bert-generation.md
+++ b/docs/source/en/model_doc/bert-generation.md
@@ -52,7 +52,7 @@ print(tokenizer.decode(outputs[0]))
 
 Quantization reduces the memory burden of large models by representing the weights in a lower precision. Refer to the [Quantization](../quantization/overview) overview for more available quantization backends.
 
-The example below uses [BitsAndBytesConfig](../quantizationbitsandbytes) to quantize the weights to 4-bit.
+The example below uses [BitsAndBytesConfig](../quantization/bitsandbytes) to quantize the weights to 4-bit.
 
 ```python
 import torch

--- a/docs/source/en/model_doc/instructblip.md
+++ b/docs/source/en/model_doc/instructblip.md
@@ -24,7 +24,7 @@ specific language governing permissions and limitations under the License.
 ## Overview
 
 The InstructBLIP model was proposed in [InstructBLIP: Towards General-purpose Vision-Language Models with Instruction Tuning](https://huggingface.co/papers/2305.06500) by Wenliang Dai, Junnan Li, Dongxu Li, Anthony Meng Huat Tiong, Junqi Zhao, Weisheng Wang, Boyang Li, Pascale Fung, Steven Hoi.
-InstructBLIP leverages the [BLIP-2](blip2) architecture for visual instruction tuning.
+InstructBLIP leverages the [BLIP-2](blip-2) architecture for visual instruction tuning.
 
 The abstract from the paper is the following:
 
@@ -40,7 +40,7 @@ The original code can be found [here](https://github.com/salesforce/LAVIS/tree/m
 
 ## Usage tips
 
-InstructBLIP uses the same architecture as [BLIP-2](blip2) with a tiny but important difference: it also feeds the text prompt (instruction) to the Q-Former.
+InstructBLIP uses the same architecture as [BLIP-2](blip-2) with a tiny but important difference: it also feeds the text prompt (instruction) to the Q-Former.
 
 > [!NOTE]
 > BLIP models after release v4.46 will raise warnings about adding `processor.num_query_tokens = {{num_query_tokens}}` and expand model embeddings layer to add special `<image>` token. It is strongly recommended to add the attributes to the processor if you own the model checkpoint, or open a PR if it is not owned by you. Adding these attributes means that BLIP will add the number of query tokens required per image and expand the text with as many `<image>` placeholders as there will be query tokens. Usually it is around 500 tokens per image, so make sure that the text is not truncated as otherwise there will be failure when merging the embeddings.

--- a/docs/source/en/model_doc/led.md
+++ b/docs/source/en/model_doc/led.md
@@ -18,7 +18,7 @@ rendered properly in your Markdown viewer.
 
 # LED
 
-[Longformer-Encoder-Decoder (LED)](https://huggingface.co/papers/2004.05150) is an encoder-decoder  transformer model for sequence-to-sequence tasks like summarization. It extends [Longformer](.longformer), an encoder-only model designed to handle long inputs, by adding a decoder layer. The decoder uses full self-attention on the encoded tokens and previously decoded locations. Because of Longformer's linear self-attention mechanism, LED is more efficient than standard encoder-decoder models when processing long sequences.
+[Longformer-Encoder-Decoder (LED)](https://huggingface.co/papers/2004.05150) is an encoder-decoder  transformer model for sequence-to-sequence tasks like summarization. It extends [Longformer](longformer), an encoder-only model designed to handle long inputs, by adding a decoder layer. The decoder uses full self-attention on the encoded tokens and previously decoded locations. Because of Longformer's linear self-attention mechanism, LED is more efficient than standard encoder-decoder models when processing long sequences.
 
 You can find all the original [LED] checkpoints under the [Ai2](https://huggingface.co/allenai/models?search=led) organization.
 

--- a/docs/source/en/model_doc/opt.md
+++ b/docs/source/en/model_doc/opt.md
@@ -69,7 +69,7 @@ tokenizer.batch_decode(generated_ids)[0]
 
 Quantization reduces the memory burden of large models by representing the weights in a lower precision. Refer to the [Quantization](../quantization/overview) overview for more available quantization backends.
 
-The example below uses [bitsandbytes](..quantization/bitsandbytes) to quantize the weights to 8-bits.
+The example below uses [bitsandbytes](../quantization/bitsandbytes) to quantize the weights to 8-bits.
 
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig


### PR DESCRIPTION
What does this PR do?
Several model doc pages link to internal pages with malformed paths that resolve to 404s in the built docs:

bert-generation: ../quantizationbitsandbytes (missing slash)
opt: ..quantization/bitsandbytes (missing slash)
led: .longformer (stray leading dot)
instructblip (×2): blip2 → the page is blip-2
Repointed each to its existing target file, matching the ../quantization/overview convention already used on the same pages. Docs-only change, no code or behavior affected.

Fixes # (no tracking issue — self-found documentation defects)

Code Agent Policy
I confirm that this is not a pure code agent PR.
Before submitting
 This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
 Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
 Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
 Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
 Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?
Who can review?
Documentation: @stevhliu