### PR TITLE
Fix BitNet packed-weight unpacking dtype (`F.linear` dtype mismatch)

### DIFF
--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -399,6 +399,11 @@ class BitNetDeserialize:
                 actual_out = weight.shape[0]
                 if actual_out * VALUES_PER_ITEM == expected_out:
                     needs_unpacking = True
+                    # Unpack into the module's compute dtype, not the packed uint8 dtype,
+                    # otherwise the ternary weights stay uint8 and F.linear fails with a
+                    # dtype mismatch (e.g. BFloat16 != unsigned char).
+                    if hasattr(module, "weight_scale"):
+                        target_dtype = module.weight_scale.dtype
         if needs_unpacking:
             weight_uint8 = weight.to(torch.uint8)
             weight = unpack_weights(weight_uint8, dtype=target_dtype)

--- a/tests/quantization/bitnet_integration/test_bitnet.py
+++ b/tests/quantization/bitnet_integration/test_bitnet.py
@@ -71,6 +71,59 @@ class BitNetPackedWeightsTest(unittest.TestCase):
         self.assertEqual(result["weight"].shape, (out_features, in_features))
         self.assertTrue(torch.equal(result["weight"], original))
 
+    def test_unpack_packed_weights_uint8_checkpoint(self):
+        """
+        Regression test for a dtype mismatch when loading offline/autobitlinear checkpoints.
+
+        A real safetensors checkpoint stores the packed BitNet weights as ``uint8``. The
+        deserializer must unpack them into the module's compute dtype (``weight_scale.dtype``),
+        otherwise the ternary weights stay ``uint8`` and ``F.linear`` crashes with
+        "expected mat1 and mat2 to have the same dtype, but got: BFloat16 != unsigned char".
+        """
+        import torch.nn.functional as F
+
+        from transformers.integrations.bitnet import (
+            VALUES_PER_ITEM,
+            AutoBitLinear,
+            BitNetDeserialize,
+            pack_weights,
+        )
+
+        out_features = 128
+        in_features = 64
+        compute_dtype = torch.bfloat16
+
+        class SimpleModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = AutoBitLinear(
+                    in_features=in_features, out_features=out_features, bias=False, dtype=compute_dtype
+                )
+
+        model = SimpleModel()
+        # The module's compute dtype is carried by weight_scale (here bfloat16).
+        self.assertEqual(model.linear.weight_scale.dtype, compute_dtype)
+
+        original = torch.randint(-1, 2, (out_features, in_features)).to(compute_dtype)
+        # As stored in a real safetensors checkpoint: packed ternary weights kept as uint8.
+        packed = pack_weights(original.clone().float()).to(torch.uint8)
+        self.assertEqual(packed.dtype, torch.uint8)
+        self.assertEqual(packed.shape[0], out_features // VALUES_PER_ITEM)
+
+        deserializer = BitNetDeserialize(hf_quantizer=None)
+        result = deserializer.convert({"weight": packed}, model=model, full_layer_name="linear.weight")["weight"]
+
+        # The unpacked weight must use the compute dtype, not the packed uint8 dtype.
+        self.assertEqual(result.dtype, compute_dtype)
+        self.assertNotEqual(result.dtype, torch.uint8)
+        self.assertEqual(result.shape, (out_features, in_features))
+        self.assertTrue(torch.equal(result, original))
+
+        # The original crash happened here: F.linear against a bfloat16 activation.
+        activation = torch.randn(2, in_features, dtype=compute_dtype)
+        output = F.linear(activation, result)
+        self.assertEqual(output.dtype, compute_dtype)
+
 
 @require_torch_accelerator
 class BitNetQuantConfigTest(unittest.TestCase):


### PR DESCRIPTION
## Problem

Loading `microsoft/bitnet-b1.58-2B-4T` in `bfloat16` and running a forward pass crashes:

```
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: BFloat16 != unsigned char
```

## Reproduction

```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer

model_id = "microsoft/bitnet-b1.58-2B-4T"
tokenizer = AutoTokenizer.from_pretrained(model_id)
model = AutoModelForCausalLM.from_pretrained(model_id, dtype=torch.bfloat16).to("cuda")

messages = [
    {"role": "system", "content": "You are a helpful AI assistant."},
    {"role": "user", "content": "How are you?"},
]
prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
outputs = model.generate(**inputs, max_new_tokens=32)  # crashes before this fix
print(tokenizer.decode(outputs[0][inputs["input_ids"].shape[-1]:], skip_special_tokens=True))
```

## Cause

For `autobitlinear`/`offline` checkpoints, weights are unpacked in
`BitNetDeserialize.convert` via `unpack_weights(weight_uint8, dtype=target_dtype)`.
`target_dtype` was taken from the *packed* tensor (`uint8`), so the unpacked weights
stayed `uint8`. `AutoBitLinear.forward` then calls `F.linear` without re-casting,
giving the `bfloat16 != uint8` mismatch.

## Fix

Unpack into the module's compute dtype (`weight_scale.dtype`):

```python
if actual_out * VALUES_PER_ITEM == expected_out:
    needs_unpacking = True
    if hasattr(module, "weight_scale"):
        target_dtype = module.weight_scale.dtype
```

## Validation

With the fix, the model loads and generates coherent text:

```
I'm an AI, so I don't have feelings, but I'm here and ready to help you! How can I assist you today?
```
