### PR TITLE
[docs] Fix grammar in BLIP visual question answering example

### DIFF
--- a/docs/source/en/model_doc/blip.md
+++ b/docs/source/en/model_doc/blip.md
@@ -27,7 +27,7 @@ You can find all the original BLIP checkpoints under the [BLIP](https://huggingf
 >
 > Click on the BLIP models in the right sidebar for more examples of how to apply BLIP to different vision language tasks.
 
-The example below demonstrates how to visual question answering with [`Pipeline`] or the [`AutoModel`] class.
+The example below demonstrates how to perform visual question answering with [Pipeline] or the [AutoModel] class.
 
 <hfoptions id="usage">
 <hfoption id="Pipeline">


### PR DESCRIPTION
This PR fixes a small grammar issue in the BLIP documentation.

Changes:
- Replaced "how to visual question answering" with "how to perform visual question answering"

No functional changes.