### PR TITLE
fix: normalize VLM processor image input handling across models

### DIFF
--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -574,6 +574,43 @@ def load_images(
         return load_image(images, timeout=timeout)
 
 
+def _normalize_images(
+    images: Union["PIL.Image.Image", np.ndarray, "torch.Tensor", str, list, tuple],
+    timeout: float | None = None,
+) -> list[list[Union["PIL.Image.Image", np.ndarray, "torch.Tensor"]]]:
+    """
+    Normalize image inputs to a consistent nested list format ``list[list[ImageInput]]``.
+    Handles single images, URLs, file paths, batched tensors, flat lists, and nested lists.
+    URLs and file paths are loaded via :func:`load_image` and returned as PIL Images.
+
+    Args:
+        images: A single image, URL string, file path, or (nested) list of images.
+        timeout: Timeout in seconds for URL requests.
+
+    Returns:
+        ``list[list[PIL.Image.Image | np.ndarray | torch.Tensor]]``: A nested list where
+        the outer list indexes batch items and the inner list indexes images per sample.
+    """
+    if isinstance(images, str):
+        return [[load_image(images, timeout=timeout)]]
+
+    if isinstance(images, (list, tuple)):
+        if len(images) == 0:
+            return []
+        if isinstance(images[0], (list, tuple)):
+            return [[load_image(img, timeout=timeout) if isinstance(img, str) else img for img in sublist] for sublist in images]
+        # Flat list: wrap in an outer list to form a single batch item
+        return [[load_image(img, timeout=timeout) if isinstance(img, str) else img for img in images]]
+
+    if is_valid_image(images):
+        return [[images]]
+
+    raise ValueError(
+        f"Invalid image input. Expected a PIL Image, numpy array, torch tensor, URL/path string, "
+        f"or (nested) list thereof. Got {type(images)}."
+    )
+
+
 def validate_preprocess_arguments(
     do_rescale: bool | None = None,
     rescale_factor: float | None = None,

--- a/src/transformers/models/llava_next/processing_llava_next.py
+++ b/src/transformers/models/llava_next/processing_llava_next.py
@@ -17,7 +17,7 @@ Processor class for LLaVa-NeXT.
 
 from ...feature_extraction_utils import BatchFeature
 from ...image_processing_utils import select_best_resolution
-from ...image_utils import ImageInput, SizeDict, get_image_size, to_numpy_array
+from ...image_utils import ImageInput, SizeDict, _normalize_images, get_image_size, to_numpy_array
 from ...processing_utils import (
     MultiModalData,
     ProcessingKwargs,
@@ -105,6 +105,7 @@ class LlavaNextProcessor(ProcessorMixin):
             **kwargs,
         )
         if images is not None:
+            images = _normalize_images(images)
             image_inputs = self.image_processor(images, **output_kwargs["images_kwargs"])
         else:
             image_inputs = {}

--- a/src/transformers/models/paligemma/processing_paligemma.py
+++ b/src/transformers/models/paligemma/processing_paligemma.py
@@ -18,7 +18,7 @@ Processor class for PaliGemma.
 import numpy as np
 
 from ...feature_extraction_utils import BatchFeature
-from ...image_utils import ImageInput, is_valid_image
+from ...image_utils import ImageInput, _normalize_images, is_valid_image
 from ...processing_utils import (
     MultiModalData,
     ProcessingKwargs,
@@ -162,6 +162,9 @@ class PaliGemmaProcessor(ProcessorMixin):
             )
             text = ""
 
+        # Normalize images: convert URLs/paths to PIL, ensure nested list format
+        images = _normalize_images(images)
+
         if _is_str_or_image(text):
             text = [text]
         elif isinstance(text, list) and _is_str_or_image(text[0]):
@@ -176,31 +179,19 @@ class PaliGemmaProcessor(ProcessorMixin):
                     "each text has and add special tokens."
                 )
 
-                if isinstance(text, list) and isinstance(images, list):
-                    if len(images) != len(text):
-                        raise ValueError(
-                            f"Received {len(images)} images for {len(text)} prompts. Each prompt should be associated with an image or list of images."
-                        )
+                if len(images) != len(text):
+                    raise ValueError(
+                        f"Received {len(images)} image groups for {len(text)} prompts. Each prompt should be associated with an image or list of images."
+                    )
 
-                # make a nested list of lists to be able to iterate over the images and text below
-                if is_valid_image(images):
-                    images = [[images]]
-                elif isinstance(images, (list, tuple)) and is_valid_image(images[0]):
-                    images = [[image] for image in images]
-                elif not (
-                    isinstance(images, (list, tuple))
-                    and isinstance(images[0], (list, tuple))
-                    and is_valid_image(images[0][0])
-                ):
-                    raise ValueError("images must be an image, list of images or list of list of images")
-
+                # images is already list[list[...]] after normalization
                 input_strings = [
                     build_string_from_input(
                         prompt=prompt,
                         bos_token=self.tokenizer.bos_token,
                         image_seq_len=self.image_seq_length,
                         image_token=IMAGE_TOKEN,
-                        num_images=len(image_list) if isinstance(image_list, list) else 1,
+                        num_images=len(image_list),
                     )
                     for prompt, image_list in zip(text, images)
                 ]

--- a/src/transformers/models/pixtral/processing_pixtral.py
+++ b/src/transformers/models/pixtral/processing_pixtral.py
@@ -18,7 +18,7 @@ Processor class for Pixtral.
 import numpy as np
 
 from ...feature_extraction_utils import BatchFeature
-from ...image_utils import ImageInput, is_valid_image
+from ...image_utils import ImageInput, _normalize_images
 from ...processing_utils import (
     MultiModalData,
     ProcessingKwargs,
@@ -47,16 +47,6 @@ class PixtralProcessorKwargs(ProcessingKwargs, total=False):
             "return_tensors": "pt",
         },
     }
-
-
-# Copied from transformers.models.idefics2.processing_idefics2.is_url
-def is_url(val) -> bool:
-    return isinstance(val, str) and val.startswith("http")
-
-
-# Copied from transformers.models.idefics2.processing_idefics2.is_image_or_image_url
-def is_image_or_image_url(elem):
-    return is_url(elem) or is_valid_image(elem)
 
 
 @auto_docstring
@@ -129,6 +119,7 @@ class PixtralProcessor(ProcessorMixin):
         patch_size = self.patch_size * self.spatial_merge_size
 
         if images is not None:
+            images = _normalize_images(images)
             output_kwargs["images_kwargs"]["patch_size"] = patch_size
             image_inputs = self.image_processor(images, **output_kwargs["images_kwargs"])
         else:


### PR DESCRIPTION
Resolves #34545

Standardizes image input handling across VLM processors by adding URL loading, PIL Image support, and consistent nested/batched list handling. Added a `_normalize_images` utility in `image_utils.py` to reduce duplication.

## Changes

- **`image_utils.py`**: Added `_normalize_images()` utility that normalizes image inputs (URLs, paths, PIL, numpy, torch tensors, nested lists) into a consistent `list[list[...]]` format, loading URLs/paths via `load_image`.
- **`processing_paligemma.py`**: Fixed crash when passing URL strings or file paths by normalizing images before validation. Simplified the image structure logic since normalization guarantees a consistent format.
- **`processing_pixtral.py`**: Added explicit URL/image loading via `_normalize_images`. Removed unused `is_url`/`is_image_or_image_url` helper functions that were copied from Idefics2 but never used.
- **`processing_llava_next.py`**: Added explicit URL/image loading via `_normalize_images` for consistency with other processors.

## Processors not requiring changes

- **LlavaProcessor** / **Qwen2VLProcessor**: Use the base `ProcessorMixin.__call__` which already calls `fetch_images` via `prepare_inputs_layout`.
- **Idefics2Processor**: Already handles URLs via `load_image` in its custom `__call__`.
- **Idefics3Processor**: Already calls `self.image_processor.fetch_images(images)` in its `prepare_inputs_layout`.

Signed-off-by: KartavyaDikshit <kartavyaniraj.dikshit2021@vitstudent.ac.in>