### PR TITLE
Migrate ALBERT task heads to self.loss_function and add ForMultipleChoiceLoss

### DIFF
--- a/src/transformers/loss/loss_utils.py
+++ b/src/transformers/loss/loss_utils.py
@@ -146,6 +146,13 @@ def ForTokenClassification(logits: torch.Tensor, labels, config, **kwargs):
     return fixed_cross_entropy(logits, labels, **kwargs)
 
 
+def ForMultipleChoiceLoss(labels: torch.Tensor, pooled_logits: torch.Tensor, **kwargs) -> torch.Tensor:
+    # pooled_logits is already [batch_size, num_choices] — no reshape needed
+    # labels is [batch_size] — index of the correct choice
+    labels = labels.to(pooled_logits.device)
+    return fixed_cross_entropy(pooled_logits, labels, **kwargs)
+
+
 def ForSemanticSegmentationLoss(
     logits: torch.Tensor,
     labels: torch.Tensor,
@@ -179,6 +186,7 @@ LOSS_MAPPING = {
     "ForVideoClassification": ForSequenceClassificationLoss,
     "ForAudioClassification": ForSequenceClassificationLoss,
     "ForTokenClassification": ForTokenClassification,
+    "ForMultipleChoice": ForMultipleChoiceLoss,
     "ForSegmentation": ForSegmentationLoss,
     "ForObjectDetection": ForObjectDetectionLoss,
     "ForConditionalGeneration": ForCausalLMLoss,

--- a/src/transformers/models/albert/modeling_albert.py
+++ b/src/transformers/models/albert/modeling_albert.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 
 import torch
 from torch import nn
-from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
+from torch.nn import CrossEntropyLoss
 
 from ... import initialization as init
 from ...activations import ACT2FN
@@ -646,8 +646,7 @@ class AlbertForMaskedLM(AlbertPreTrainedModel):
 
         masked_lm_loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            masked_lm_loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), labels.view(-1))
+            masked_lm_loss = self.loss_function(logits=prediction_scores, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
 
         return MaskedLMOutput(
             loss=masked_lm_loss,
@@ -711,26 +710,7 @@ class AlbertForSequenceClassification(AlbertPreTrainedModel):
 
         loss = None
         if labels is not None:
-            if self.config.problem_type is None:
-                if self.num_labels == 1:
-                    self.config.problem_type = "regression"
-                elif self.num_labels > 1 and (labels.dtype == torch.long or labels.dtype == torch.int):
-                    self.config.problem_type = "single_label_classification"
-                else:
-                    self.config.problem_type = "multi_label_classification"
-
-            if self.config.problem_type == "regression":
-                loss_fct = MSELoss()
-                if self.num_labels == 1:
-                    loss = loss_fct(logits.squeeze(), labels.squeeze())
-                else:
-                    loss = loss_fct(logits, labels)
-            elif self.config.problem_type == "single_label_classification":
-                loss_fct = CrossEntropyLoss()
-                loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
-            elif self.config.problem_type == "multi_label_classification":
-                loss_fct = BCEWithLogitsLoss()
-                loss = loss_fct(logits, labels)
+            loss = self.loss_function(labels=labels, pooled_logits=logits, config=self.config, **kwargs)
 
         return SequenceClassifierOutput(
             loss=loss,
@@ -791,8 +771,7 @@ class AlbertForTokenClassification(AlbertPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
+            loss = self.loss_function(logits=logits, labels=labels, config=self.config, **kwargs)
 
         return TokenClassifierOutput(
             loss=loss,
@@ -846,20 +825,13 @@ class AlbertForQuestionAnswering(AlbertPreTrainedModel):
 
         total_loss = None
         if start_positions is not None and end_positions is not None:
-            # If we are on multi-GPU, split add a dimension
-            if len(start_positions.size()) > 1:
-                start_positions = start_positions.squeeze(-1)
-            if len(end_positions.size()) > 1:
-                end_positions = end_positions.squeeze(-1)
-            # sometimes the start/end positions are outside our model inputs, we ignore these terms
-            ignored_index = start_logits.size(1)
-            start_positions = start_positions.clamp(0, ignored_index)
-            end_positions = end_positions.clamp(0, ignored_index)
-
-            loss_fct = CrossEntropyLoss(ignore_index=ignored_index)
-            start_loss = loss_fct(start_logits, start_positions)
-            end_loss = loss_fct(end_logits, end_positions)
-            total_loss = (start_loss + end_loss) / 2
+            total_loss = self.loss_function(
+                start_logits=start_logits,
+                end_logits=end_logits,
+                start_positions=start_positions,
+                end_positions=end_positions,
+                **kwargs,
+            )
 
         return QuestionAnsweringModelOutput(
             loss=total_loss,
@@ -953,8 +925,7 @@ class AlbertForMultipleChoice(AlbertPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            loss = loss_fct(reshaped_logits, labels)
+            loss = self.loss_function(labels=labels, pooled_logits=reshaped_logits, config=self.config, **kwargs)
 
         return MultipleChoiceModelOutput(
             loss=loss,

--- a/src/transformers/models/albert/modeling_albert.py
+++ b/src/transformers/models/albert/modeling_albert.py
@@ -646,7 +646,9 @@ class AlbertForMaskedLM(AlbertPreTrainedModel):
 
         masked_lm_loss = None
         if labels is not None:
-            masked_lm_loss = self.loss_function(logits=prediction_scores, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+            masked_lm_loss = self.loss_function(
+                logits=prediction_scores, labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return MaskedLMOutput(
             loss=masked_lm_loss,


### PR DESCRIPTION
Hey @ArthurZucker,

Continuing the `loss_function` refactor for ALBERT.

I migrated all the standard task heads (`AlbertForMaskedLM`, `AlbertForSequenceClassification`, `AlbertForTokenClassification`, `AlbertForQuestionAnswering`, and `AlbertForMultipleChoice`) to use `self.loss_function`. The hardcoded loss imports are also removed since they aren't used inline anymore.

One thing I noticed while doing this: `ForMultipleChoice` was actually missing from `LOSS_MAPPING` in `loss_utils.py`. If a model tried to use it, it would silently fall back to `ForCausalLMLoss` which expects different arguments and tensor shapes. I went ahead and added a dedicated `ForMultipleChoiceLoss` helper that cleanly computes cross-entropy over the `[batch_size, num_choices]` logits without any extra reshaping, and registered it in the mapping.

Note: I left `AlbertForPreTraining` alone since it combines MLM and SOP losses in the same forward pass and doesn't map perfectly to the single output helper pattern.

All tests are passing locally. Let me know if anything needs to be tweaked!
