### PR TITLE
Avoid NumPy 2.0 `__array__` copy-keyword deprecation in `create_mm_token_type_ids`

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -925,6 +925,9 @@ class ProcessorMixin(PushToHubMixin):
         """
         mm_token_type_ids = []
         for tokenizer_input in input_ids:
+            # Convert tensor rows to a list so `np.array` avoids NumPy 2.0's `__array__` copy-keyword deprecation.
+            if not isinstance(tokenizer_input, list):
+                tokenizer_input = tokenizer_input.tolist()
             tokenizer_input = np.array(tokenizer_input)
             mm_token_types = np.zeros_like(tokenizer_input)
             mm_token_types[np.isin(tokenizer_input, self.image_token_ids)] = 1


### PR DESCRIPTION
`ProcessorMixin.create_mm_token_type_ids` does `np.array(tokenizer_input)` on each row of `input_ids`. Several processors (e.g. Qwen2.5-VL, Gemma4) call it with `input_ids` already as a tensor, and `np.array(tensor)` triggers NumPy 2.0's deprecation because torch's `__array__` does not accept the `copy` keyword. This fires once per example, flooding logs in any VLM workload (e.g. SFT over an image dataset). (Processors that pass a plain list, e.g. Gemma3, are unaffected.)

Fix: convert non-list rows to a plain list (`.tolist()`) before `np.array(...)`, so the `__array__` path is never taken. Output is unchanged.

## MRE

```python
import warnings, numpy as np, torch

warnings.simplefilter("error", DeprecationWarning)
np.array(torch.tensor([1, 2, 3]))
# DeprecationWarning: __array__ implementation doesn't accept a copy keyword, ...
```

In practice it is reached via a VLM processor that passes tensor `input_ids` to `create_mm_token_type_ids`:

```python
import warnings
from PIL import Image
from transformers import AutoProcessor

warnings.simplefilter("error", DeprecationWarning)
img = Image.new("RGB", (32, 32))
proc = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration")
proc(text="<|vision_start|><|image_pad|><|vision_end|> hi", images=img, return_tensors="pt")
```

```
Traceback (most recent call last):
  File "/fsx/qgallouedec/transformers/repro.py", line 8, in <module>
    proc(text="<|vision_start|><|image_pad|><|vision_end|> hi", images=img, return_tensors="pt")
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx/qgallouedec/transformers/src/transformers/processing_utils.py", line 693, in __call__
    text_inputs["mm_token_type_ids"] = self.create_mm_token_type_ids(text_inputs["input_ids"])
                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx/qgallouedec/transformers/src/transformers/processing_utils.py", line 928, in create_mm_token_type_ids
    tokenizer_input = np.array(tokenizer_input)
DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword
Segmentation fault (core dumped)
```
