### PR TITLE
fix: convert Tensor q_offset/kv_offset to int in flex_attention_mask

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -709,6 +709,16 @@ def flex_attention_mask(
         device (`torch.device` or `str`, optional):
             An optional device to create the mask on.
     """
+    # Ensure offsets are plain Python ints. Callers may pass scalar Tensors
+    # (e.g. from cache_position[0] or StaticLayerCache.get_seq_length()), which
+    # propagate into the mask_mod closure and add an extra batch dimension to
+    # every per-index result, producing a 5D BlockMask that create_block_mask
+    # cannot unpack (raises "too many values to unpack (expected 4)"). See #46682.
+    if isinstance(q_offset, torch.Tensor):
+        q_offset = q_offset.item()
+    if isinstance(kv_offset, torch.Tensor):
+        kv_offset = kv_offset.item()
+
     # Potentially add the padding 2D mask
     if attention_mask is not None:
         # Older torch (2.5.x) cannot handle sequences not in multiples of 128 (default block size)


### PR DESCRIPTION
## Summary
- When `q_offset` or `kv_offset` arrive as scalar `torch.Tensor` objects (e.g. from `cache_position[0]` or `StaticLayerCache.get_seq_length()`), they get captured by the `inner_mask` closure inside `add_offsets_to_mask_function()`. Adding a plain int to a scalar Tensor returns a Tensor instead of a scalar, so the boolean mask result has shape `(1,)` instead of being a scalar bool. This extra dimension propagates through `create_block_mask`, producing a 5D `BlockMask` that crashes with `ValueError: too many values to unpack (expected 4)`.
- The fix calls `.item()` on Tensor offsets at the `flex_attention_mask()` boundary, converting them to native Python ints before they enter the closure.

## Test plan
- [x] Traced the call chain: `create_causal_mask` -> `flex_attention_mask` -> `add_offsets_to_mask_function` -> `create_block_mask`
- [x] Confirmed `_preprocess_mask_arguments` reshapes to 0-dim Tensor but does not convert to int
- [x] Verified `.item()` is the correct conversion (matches the reporter's confirmed workaround)

Fixes #46682

🤖 Generated with [Claude Code](https://claude.com/claude-code)