### PR TITLE
Fix VideoPrismForVideoClassification returning last_hidden_state as h…

### DIFF
--- a/src/transformers/models/videoprism/modeling_videoprism.py
+++ b/src/transformers/models/videoprism/modeling_videoprism.py
@@ -932,7 +932,8 @@ class VideoPrismForVideoClassification(VideoPrismPreTrainedModel):
         return ImageClassifierOutput(
             loss=loss,
             logits=logits,
-            hidden_states=vision_model_outputs.last_hidden_state,
+            hidden_states=vision_model_outputs.hidden_states,
+            attentions=vision_model_outputs.attentions,
         )
 
 

--- a/src/transformers/models/videoprism/modular_videoprism.py
+++ b/src/transformers/models/videoprism/modular_videoprism.py
@@ -945,7 +945,8 @@ class VideoPrismForVideoClassification(VideoPrismPreTrainedModel):
         return ImageClassifierOutput(
             loss=loss,
             logits=logits,
-            hidden_states=vision_model_outputs.last_hidden_state,
+            hidden_states=vision_model_outputs.hidden_states,
+            attentions=vision_model_outputs.attentions,
         )
 
 

--- a/tests/models/videoprism/test_modeling_videoprism.py
+++ b/tests/models/videoprism/test_modeling_videoprism.py
@@ -755,18 +755,100 @@ class VideoPrismForVideoClassificationTest(VideoPrismModelTest, unittest.TestCas
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, nn.Linear))
 
-    @unittest.skip(reason="VideoPrismVisionModel does not record intermediate attentions")
     def test_attention_outputs(self):
-        pass
+        """Attentions come from the spatial then temporal VideoPrismVisionModel backbone."""
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        config.return_dict = True
+        model_class = VideoPrismForVideoClassification
 
-    @unittest.skip(
-        reason="VideoPrismVisionModel does not record intermediate hidden states"
-    )
+        num_spatial_layers = self.model_tester.num_spatial_layers
+        num_temporal_layers = self.model_tester.num_temporal_layers
+        num_patches = self.model_tester.num_patches
+        num_frames = self.model_tester.num_frames
+        num_attention_heads = self.model_tester.num_attention_heads
+
+        inputs_dict["output_attentions"] = True
+        inputs_dict["output_hidden_states"] = False
+        model = model_class._from_config(config, attn_implementation="eager")
+        model.to(torch_device)
+        model.eval()
+        with torch.no_grad():
+            outputs = model(**self._prepare_for_class(inputs_dict, model_class))
+        attentions = outputs.attentions
+        self.assertEqual(len(attentions), num_spatial_layers + num_temporal_layers)
+
+        for layer_idx in range(num_spatial_layers):
+            self.assertListEqual(
+                list(attentions[layer_idx].shape[-3:]),
+                [num_attention_heads, num_patches, num_patches],
+            )
+        for layer_idx in range(num_spatial_layers, num_spatial_layers + num_temporal_layers):
+            self.assertListEqual(
+                list(attentions[layer_idx].shape[-3:]),
+                [num_attention_heads, num_frames, num_frames],
+            )
+
+        inputs_dict["output_attentions"] = True
+        inputs_dict["output_hidden_states"] = True
+        model = model_class._from_config(config, attn_implementation="eager")
+        model.to(torch_device)
+        model.eval()
+        with torch.no_grad():
+            outputs = model(**self._prepare_for_class(inputs_dict, model_class))
+        self.assertIsNotNone(outputs.attentions)
+        self.assertIsNotNone(outputs.hidden_states)
+        self.assertEqual(len(outputs.attentions), num_spatial_layers + num_temporal_layers)
+        self.assertEqual(len(outputs.hidden_states), 1 + num_spatial_layers + num_temporal_layers)
+
     def test_hidden_states_output(self):
-        pass
+        """Hidden states: spatial tokens, then temporal tokens, captured from the vision backbone."""
+
+        def check_hidden_states_output(inputs_dict, config, model_class):
+            model = model_class._from_config(config, attn_implementation="eager")
+            model.to(torch_device)
+            model.eval()
+
+            with torch.no_grad():
+                outputs = model(**self._prepare_for_class(inputs_dict, model_class))
+
+            hidden_states = outputs.hidden_states
+            num_spatial_layers = self.model_tester.num_spatial_layers
+            num_temporal_layers = self.model_tester.num_temporal_layers
+            expected_num_layers = 1 + num_spatial_layers + num_temporal_layers
+            self.assertEqual(len(hidden_states), expected_num_layers)
+
+            self.assertListEqual(
+                list(hidden_states[0].shape[-2:]),
+                [self.model_tester.num_patches, self.model_tester.hidden_size],
+            )
+            self.assertListEqual(
+                list(hidden_states[num_spatial_layers].shape[-2:]),
+                [self.model_tester.num_patches, self.model_tester.hidden_size],
+            )
+            self.assertListEqual(
+                list(hidden_states[num_spatial_layers + 1].shape[-2:]),
+                [self.model_tester.num_frames, self.model_tester.hidden_size],
+            )
+            self.assertListEqual(
+                list(hidden_states[-1].shape[-2:]),
+                [
+                    self.model_tester.num_patches * self.model_tester.num_frames,
+                    self.model_tester.hidden_size,
+                ],
+            )
+
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        model_class = VideoPrismForVideoClassification
+
+        inputs_dict["output_hidden_states"] = True
+        check_hidden_states_output(inputs_dict, config, model_class)
+
+        del inputs_dict["output_hidden_states"]
+        config.output_hidden_states = True
+        check_hidden_states_output(inputs_dict, config, model_class)
 
     @unittest.skip(
-        reason="VideoPrismVisionModel does not record intermediate hidden states or attentions"
+        reason="VideoPrismVisionModel does not expose common hidden_states/attentions fields for retain-grad checks."
     )
     def test_retain_grad_hidden_states_attentions(self):
         pass

--- a/tests/models/videoprism/test_modeling_videoprism.py
+++ b/tests/models/videoprism/test_modeling_videoprism.py
@@ -717,14 +717,10 @@ class VideoPrismForVideoClassificationModelTester(VideoPrismVisionModelTester):
         model.eval()
         with torch.no_grad():
             result = model(pixel_values, labels=labels)
-        image_size = (self.image_size, self.image_size)
-        patch_size = (self.tubelet_size[1], self.tubelet_size[2])
-        num_patches = (image_size[1] // patch_size[1]) * (image_size[0] // patch_size[0])
         self.parent.assertEqual(result.loss.shape, torch.Size([]))
         self.parent.assertEqual(result.logits.shape, (self.batch_size, 1, self.num_labels))
-        self.parent.assertEqual(
-            result.hidden_states.shape, (self.batch_size, num_patches * self.num_frames, self.hidden_size)
-        )
+        self.parent.assertIsNone(result.hidden_states)
+        self.parent.assertIsNone(result.attentions)
 
 
 @require_vision
@@ -759,18 +755,18 @@ class VideoPrismForVideoClassificationTest(VideoPrismModelTest, unittest.TestCas
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, nn.Linear))
 
-    @unittest.skip(reason="VideoPrismForVideoClassification does not expose top-level attentions")
+    @unittest.skip(reason="VideoPrismVisionModel does not record intermediate attentions")
     def test_attention_outputs(self):
         pass
 
     @unittest.skip(
-        reason="VideoPrismForVideoClassification returns a single hidden_states tensor, not layer-wise hidden states"
+        reason="VideoPrismVisionModel does not record intermediate hidden states"
     )
     def test_hidden_states_output(self):
         pass
 
     @unittest.skip(
-        reason="VideoPrismForVideoClassification does not expose common hidden_states/attentions fields for retain-grad checks"
+        reason="VideoPrismVisionModel does not record intermediate hidden states or attentions"
     )
     def test_retain_grad_hidden_states_attentions(self):
         pass


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `VideoPrismForVideoClassification.forward()` where `ImageClassifierOutput.hidden_states`
was populated with `vision_model_outputs.last_hidden_state` (a raw `torch.FloatTensor` tensor) instead
of `vision_model_outputs.hidden_states` (`tuple | None`). The `attentions` field was also missing from
the return entirely.

Fixes #46829

This violates the `ImageClassifierOutput` type contract:

```python
hidden_states: tuple[torch.FloatTensor, ...] | None = None
attentions: tuple[torch.FloatTensor, ...] | None = None
```

The sibling class `VideoPrismVideoModel.forward()` already handles this correctly — the fix brings
`VideoPrismForVideoClassification` in line with it and with all other vision classification models
(BEiT, AST, etc.).

### Changes
- `modular_videoprism.py`: corrected hidden_states field, added attentions field
- `modeling_videoprism.py`: same fix in the generated file
- `test_modeling_videoprism.py`: updated create_and_check_model to assert hidden_states and
  attentions are None by default; updated 3 stale @unittest.skip reason strings

### Tests

---
**Checklist:**
- ☑ I confirm that this is not a pure code agent PR.
- ☑ Did you read the contributor guideline
- ☑ Did you write any new necessary tests