### PR TITLE
Fix mask when generating beyond sliding window

### DIFF
--- a/src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
@@ -133,6 +133,7 @@ class DiffusionGemmaGenerationConfig(GenerationConfig):
         # Parameters that control the cache
         self.cache_implementation: str | None = kwargs.pop("cache_implementation", None)
         self.cache_config: dict[str, Any] | None = kwargs.pop("cache_config", None)
+        self.disable_compile: str | None = kwargs.pop("disable_compile", None)
 
         # Special tokens that can be used at generation time
         self.bos_token_id: int | None = kwargs.pop("bos_token_id", None)
@@ -696,7 +697,7 @@ class DiffusionGemmaGenerationMixin:
             streamer.put(input_ids.cpu())
 
         # 0.f performance tuning
-        is_compiling = past_key_values is not None and past_key_values.is_compileable
+        is_compiling = past_key_values is not None and past_key_values.is_compileable and not generation_config.disable_compile
         if is_compiling:
             encoder_forward_after_prefill, decoder_forward, sampler, diffusion_stopping_criteria = (
                 self._compile_functions(sampler, diffusion_stopping_criteria)

--- a/src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
@@ -697,7 +697,9 @@ class DiffusionGemmaGenerationMixin:
             streamer.put(input_ids.cpu())
 
         # 0.f performance tuning
-        is_compiling = past_key_values is not None and past_key_values.is_compileable and not generation_config.disable_compile
+        is_compiling = (
+            past_key_values is not None and past_key_values.is_compileable and not generation_config.disable_compile
+        )
         if is_compiling:
             encoder_forward_after_prefill, decoder_forward, sampler, diffusion_stopping_criteria = (
                 self._compile_functions(sampler, diffusion_stopping_criteria)

--- a/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
@@ -1409,15 +1409,12 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
             kv_length, kv_offset = past_key_values.get_mask_sizes(q_length, layer_idx)
             kv_length += additional_kv_length  # Add current canvas length
 
-            # `StaticSlidingLayer` concatenates new key with cache when cache is full instead
-            # of rolling back. Thus the final length is `window+query-1`, not fixed-length
-            # `sliding_window`. Adding another `query_length` will result on mask shape mismatch
-            # see: https://github.com/huggingface/transformers/blob/e6f08cf2c4d9f07b59573948407cdc4a2815de7d/src/transformers/cache_utils.py#L536-L539
+            # StaticSlidingLayers cannot go beyond sliding window, even with `additional_kv_length`!
             if layer_pattern == "sliding_attention" and past_key_values.is_compileable:
                 layer_idx = past_key_values.is_sliding.index(True)
                 sliding_layer = past_key_values.layers[layer_idx]
-                if sliding_layer.cumulative_length_int >= sliding_layer.max_cache_len:
-                    kv_length = kv_length - additional_kv_length + 1
+                if kv_length >= sliding_layer.max_cache_len + additional_kv_length:
+                    kv_length = sliding_layer.max_cache_len + additional_kv_length
 
             mask_interface = ALL_MASK_ATTENTION_FUNCTIONS[config._attn_implementation]
             attention_mask = mask_interface(

--- a/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
@@ -1186,15 +1186,12 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
             kv_length, kv_offset = past_key_values.get_mask_sizes(q_length, layer_idx)
             kv_length += additional_kv_length  # Add current canvas length
 
-            # `StaticSlidingLayer` concatenates new key with cache when cache is full instead
-            # of rolling back. Thus the final length is `window+query-1`, not fixed-length
-            # `sliding_window`. Adding another `query_length` will result on mask shape mismatch
-            # see: https://github.com/huggingface/transformers/blob/e6f08cf2c4d9f07b59573948407cdc4a2815de7d/src/transformers/cache_utils.py#L536-L539
+            # StaticSlidingLayers cannot go beyond sliding window, even with `additional_kv_length`!
             if layer_pattern == "sliding_attention" and past_key_values.is_compileable:
                 layer_idx = past_key_values.is_sliding.index(True)
                 sliding_layer = past_key_values.layers[layer_idx]
-                if sliding_layer.cumulative_length_int >= sliding_layer.max_cache_len:
-                    kv_length = kv_length - additional_kv_length + 1
+                if kv_length >= sliding_layer.max_cache_len + additional_kv_length:
+                    kv_length = sliding_layer.max_cache_len + additional_kv_length
 
             mask_interface = ALL_MASK_ATTENTION_FUNCTIONS[config._attn_implementation]
             attention_mask = mask_interface(

--- a/tests/models/diffusion_gemma/test_modeling_diffusion_gemma.py
+++ b/tests/models/diffusion_gemma/test_modeling_diffusion_gemma.py
@@ -660,12 +660,21 @@ class DiffusionGemmaVisionText2TextModelTest(ModelTesterMixin, unittest.TestCase
     def test_generate_beyond_sliding_window(self, name, cache_implementation):
         """Tests that generate can run beyond the sliding window length"""
         config, model_inputs = self.model_tester.prepare_config_and_inputs_for_common()
-        config.text_config.sliding_window = 16
+        # Canvas length has to be much smaller than slidinng window to correctly check the mask
+        # and input-length has to be smaller than sliding length! We will check if mask is smaller
+        # than window, approaching the full cache length and goes beyond window length
+        # Input length is 25 in model tester, so we will set sliding window to 48 tokens
+        # After generating `max_new_tokens=32`, the final length will go beyond sliding windown
+        config.text_config.sliding_window = 48
         model = DiffusionGemmaForBlockDiffusion(config=config).to(torch_device).eval()
         model.generation_config.eos_token_id = None  # force generation up to `max_new_tokens`
 
         generation_outputs = model.generate(
-            **model_inputs, max_new_tokens=32, max_denoising_steps=2, disable_compile=True, cache_implementation=cache_implementation
+            **model_inputs,
+            max_new_tokens=32,
+            max_denoising_steps=2,
+            disable_compile=True,
+            cache_implementation=cache_implementation,
         )
         self.assertTrue(generation_outputs.sequences.shape[1] > config.text_config.sliding_window)
 

--- a/tests/models/diffusion_gemma/test_modeling_diffusion_gemma.py
+++ b/tests/models/diffusion_gemma/test_modeling_diffusion_gemma.py
@@ -665,7 +665,7 @@ class DiffusionGemmaVisionText2TextModelTest(ModelTesterMixin, unittest.TestCase
         model.generation_config.eos_token_id = None  # force generation up to `max_new_tokens`
 
         generation_outputs = model.generate(
-            **model_inputs, max_new_tokens=32, max_denoising_steps=2, cache_implementation=cache_implementation
+            **model_inputs, max_new_tokens=32, max_denoising_steps=2, disable_compile=True, cache_implementation=cache_implementation
         )
         self.assertTrue(generation_outputs.sequences.shape[1] > config.text_config.sliding_window)
 

--- a/tests/models/diffusion_gemma/test_modeling_diffusion_gemma.py
+++ b/tests/models/diffusion_gemma/test_modeling_diffusion_gemma.py
@@ -92,7 +92,7 @@ class DiffusionGemmaVisionText2TextModelTester:
         image_token_id=4,
         boi_token_id=5,
         eoi_token_id=6,
-        seq_length=25,
+        seq_length=25,  # See: `test_generate_beyond_sliding_window` before changing this value!
         self_conditioning_size=16,
         canvas_length=16,
         is_training=False,
@@ -660,11 +660,13 @@ class DiffusionGemmaVisionText2TextModelTest(ModelTesterMixin, unittest.TestCase
     def test_generate_beyond_sliding_window(self, name, cache_implementation):
         """Tests that generate can run beyond the sliding window length"""
         config, model_inputs = self.model_tester.prepare_config_and_inputs_for_common()
-        # Canvas length has to be much smaller than slidinng window to correctly check the mask
-        # and input-length has to be smaller than sliding length! We will check if mask is smaller
-        # than window, approaching the full cache length and goes beyond window length
+        # Canvas length has to be much smaller than sliding window to correctly check the mask
+        # and input-length has to be smaller than sliding length! We will check three cases:
+        # 1) input/mask is smaller than window
+        # 2) input length approaching full cache length
+        # 3) input length goes beyond window length
         # Input length is 25 in model tester, so we will set sliding window to 48 tokens
-        # After generating `max_new_tokens=32`, the final length will go beyond sliding windown
+        # After generating `max_new_tokens=32`, the final length will go beyond sliding window
         config.text_config.sliding_window = 48
         model = DiffusionGemmaForBlockDiffusion(config=config).to(torch_device).eval()
         model.generation_config.eos_token_id = None  # force generation up to `max_new_tokens`


### PR DESCRIPTION
# What does this PR do?


Slow test `test_generate_beyond_sliding_window` should have checked it. Found why it didn't fire and fixed the test, it was failing to compile on CI runners (fixed by disabling autocompile). And we had a "too long prefill length", so it didn't check when input slowly approaches max sliding length

cc @kashif 