### PR TITLE
Enhance return type annotation in apply_chat_template in processing_u…

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1975,7 +1975,7 @@ class ProcessorMixin(PushToHubMixin):
         load_audio_from_video: bool = False,
         processor_kwargs: dict | None = None,
         **kwargs,
-    ) -> "str | list[int] | list[list[int]] | np.ndarray | torch.Tensor | BatchFeature":
+) -> "str | list[str] | list[int] | list[list[int]] | np.ndarray | torch.Tensor | BatchFeature":
         """
         Similar to the `apply_chat_template` method on tokenizers, this method applies a Jinja template to input
         conversations to turn them into a single tokenizable string.

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1975,7 +1975,7 @@ class ProcessorMixin(PushToHubMixin):
         load_audio_from_video: bool = False,
         processor_kwargs: dict | None = None,
         **kwargs,
-    ) -> str:
+    ) -> "str | list[int] | list[list[int]] | np.ndarray | torch.Tensor | BatchFeature":
         """
         Similar to the `apply_chat_template` method on tokenizers, this method applies a Jinja template to input
         conversations to turn them into a single tokenizable string.


### PR DESCRIPTION
Update return type annotation for apply_chat_template to include multiple possible types. Currently the return type is str, but the function can return many types, tripping up PyLance or any type checking.