### PR TITLE
🚨 [gemma 3/4] Fix bidirectional attention masking crossing sliding window boundaries

### DIFF
--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -32,10 +32,12 @@ from ...configuration_utils import PreTrainedConfig
 from ...generation import GenerationMixin
 from ...integrations import use_kernel_func_from_hub, use_kernelized_func
 from ...masking_utils import (
+    _preprocess_mask_arguments,
     blockwise_overlay,
     create_causal_mask,
     create_masks_for_generate,
     create_sliding_window_causal_mask,
+    maybe_pad_block_sequence_ids,
     sliding_window_overlay,
 )
 from ...modeling_layers import GenericForSequenceClassification, GradientCheckpointingLayer
@@ -739,12 +741,25 @@ def create_masks_for_vision_model(
     # Full attention: OR(causal, blockwise) — use block_sequence_ids directly
     full_mask = create_causal_mask(**mask_kwargs, block_sequence_ids=block_sequence_ids)
 
+    # We need to manually pad the sequence IDs for the sliding mask
+    # as it's passed as an `or_mask_function` which bypasses internal padding.
+    early_exit, _, _, _, kv_length, _, kv_offset = _preprocess_mask_arguments(
+        **mask_kwargs,
+        layer_idx=0,
+    )
+    if early_exit:
+        padded_block_sequence_ids = block_sequence_ids
+    else:
+        padded_block_sequence_ids = maybe_pad_block_sequence_ids(
+            block_sequence_ids, attention_mask, kv_length, kv_offset
+        )
+
     # Sliding attention: AND(sliding_window, OR(causal, blockwise))
     # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
     # Pass sliding_window as and_mask_function (applied as step 3, after OR)
     sliding_mask = create_causal_mask(
         **mask_kwargs,
-        or_mask_function=blockwise_overlay(block_sequence_ids),
+        or_mask_function=blockwise_overlay(padded_block_sequence_ids),
         and_mask_function=sliding_window_overlay(config.sliding_window),
     )
 

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -742,7 +742,6 @@ def create_masks_for_vision_model(
     # Sliding attention: AND(sliding_window, OR(causal, blockwise))
     # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
     # Pass sliding_window as and_mask_function (applied as step 3, after OR)
-    # Do NOT pass block_sequence_ids (to avoid the incorrect step 4 final OR)
     sliding_mask = create_causal_mask(
         **mask_kwargs,
         or_mask_function=blockwise_overlay(block_sequence_ids),

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -31,7 +31,13 @@ from ...cache_utils import Cache, DynamicCache
 from ...configuration_utils import PreTrainedConfig
 from ...generation import GenerationMixin
 from ...integrations import use_kernel_func_from_hub, use_kernelized_func
-from ...masking_utils import create_causal_mask, create_masks_for_generate, create_sliding_window_causal_mask
+from ...masking_utils import (
+    blockwise_overlay,
+    create_causal_mask,
+    create_masks_for_generate,
+    create_sliding_window_causal_mask,
+    sliding_window_overlay,
+)
 from ...modeling_layers import GenericForSequenceClassification, GradientCheckpointingLayer
 from ...modeling_outputs import (
     BaseModelOutputWithPast,
@@ -709,6 +715,46 @@ def get_block_sequence_ids_for_mask(token_type_ids: torch.Tensor, device: torch.
     return block_sequence_ids
 
 
+def create_masks_for_vision_model(
+    config: PreTrainedConfig,
+    inputs_embeds: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    past_key_values: Cache | None,
+    position_ids: torch.Tensor | None,
+    block_sequence_ids: torch.Tensor,
+) -> dict:
+    """Create full_attention and sliding_attention masks with correct composition.
+
+    For global (full attention) layers:  OR(causal, blockwise)
+    For local (sliding window) layers:  AND(sliding_window, OR(causal, blockwise))
+    """
+    mask_kwargs = {
+        "config": config,
+        "inputs_embeds": inputs_embeds,
+        "attention_mask": attention_mask,
+        "past_key_values": past_key_values,
+        "position_ids": position_ids,
+    }
+
+    # Full attention: OR(causal, blockwise) — use block_sequence_ids directly
+    full_mask = create_causal_mask(**mask_kwargs, block_sequence_ids=block_sequence_ids)
+
+    # Sliding attention: AND(sliding_window, OR(causal, blockwise))
+    # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
+    # Pass sliding_window as and_mask_function (applied as step 3, after OR)
+    # Do NOT pass block_sequence_ids (to avoid the incorrect step 4 final OR)
+    sliding_mask = create_causal_mask(
+        **mask_kwargs,
+        or_mask_function=blockwise_overlay(block_sequence_ids),
+        and_mask_function=sliding_window_overlay(config.sliding_window),
+    )
+
+    return {
+        "full_attention": full_mask,
+        "sliding_attention": sliding_mask,
+    }
+
+
 @auto_docstring(
     custom_intro="""
     The Base Gemma3 model which consists of a vision backbone and a language model without language modeling head.,
@@ -841,16 +887,13 @@ class Gemma3Model(Gemma3PreTrainedModel):
             }
 
             if token_type_ids is not None:
-                mask_kwargs["block_sequence_ids"] = get_block_sequence_ids_for_mask(
-                    token_type_ids, device=inputs_embeds.device
+                block_sequence_ids = get_block_sequence_ids_for_mask(token_type_ids, device=inputs_embeds.device)
+                causal_mask_mapping = create_masks_for_vision_model(
+                    block_sequence_ids=block_sequence_ids,
+                    **mask_kwargs,
                 )
-
-            # Create the masks
-            sliding_mask_kwargs = mask_kwargs.copy()
-            causal_mask_mapping = {
-                "full_attention": create_causal_mask(**mask_kwargs),
-                "sliding_attention": create_sliding_window_causal_mask(**sliding_mask_kwargs),
-            }
+            else:
+                causal_mask_mapping = create_masks_for_generate(**mask_kwargs)
 
         outputs = self.language_model(
             attention_mask=causal_mask_mapping,
@@ -1064,8 +1107,10 @@ class Gemma3ForConditionalGeneration(Gemma3PreTrainedModel, GenerationMixin):
         }
 
         if token_type_ids is not None:
-            mask_kwargs["block_sequence_ids"] = get_block_sequence_ids_for_mask(
-                token_type_ids, device=inputs_embeds.device
+            block_sequence_ids = get_block_sequence_ids_for_mask(token_type_ids, device=inputs_embeds.device)
+            return create_masks_for_vision_model(
+                block_sequence_ids=block_sequence_ids,
+                **mask_kwargs,
             )
 
         return create_masks_for_generate(**mask_kwargs)

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -644,7 +644,6 @@ def create_masks_for_vision_model(
     # Sliding attention: AND(sliding_window, OR(causal, blockwise))
     # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
     # Pass sliding_window as and_mask_function (applied as step 3, after OR)
-    # Do NOT pass block_sequence_ids (to avoid the incorrect step 4 final OR)
     sliding_mask = create_causal_mask(
         **mask_kwargs,
         or_mask_function=blockwise_overlay(block_sequence_ids),

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -23,10 +23,12 @@ from ... import initialization as init
 from ...cache_utils import Cache, DynamicCache
 from ...configuration_utils import PreTrainedConfig
 from ...masking_utils import (
+    _preprocess_mask_arguments,
     blockwise_overlay,
     create_causal_mask,
     create_masks_for_generate,
     create_sliding_window_causal_mask,
+    maybe_pad_block_sequence_ids,
     sliding_window_overlay,
 )
 from ...modeling_layers import GenericForSequenceClassification, GradientCheckpointingLayer
@@ -641,12 +643,25 @@ def create_masks_for_vision_model(
     # Full attention: OR(causal, blockwise) — use block_sequence_ids directly
     full_mask = create_causal_mask(**mask_kwargs, block_sequence_ids=block_sequence_ids)
 
+    # We need to manually pad the sequence IDs for the sliding mask
+    # as it's passed as an `or_mask_function` which bypasses internal padding.
+    early_exit, _, _, _, kv_length, _, kv_offset = _preprocess_mask_arguments(
+        **mask_kwargs,
+        layer_idx=0,
+    )
+    if early_exit:
+        padded_block_sequence_ids = block_sequence_ids
+    else:
+        padded_block_sequence_ids = maybe_pad_block_sequence_ids(
+            block_sequence_ids, attention_mask, kv_length, kv_offset
+        )
+
     # Sliding attention: AND(sliding_window, OR(causal, blockwise))
     # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
     # Pass sliding_window as and_mask_function (applied as step 3, after OR)
     sliding_mask = create_causal_mask(
         **mask_kwargs,
-        or_mask_function=blockwise_overlay(block_sequence_ids),
+        or_mask_function=blockwise_overlay(padded_block_sequence_ids),
         and_mask_function=sliding_window_overlay(config.sliding_window),
     )
 

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -22,7 +22,13 @@ from huggingface_hub.dataclasses import strict
 from ... import initialization as init
 from ...cache_utils import Cache, DynamicCache
 from ...configuration_utils import PreTrainedConfig
-from ...masking_utils import create_causal_mask, create_masks_for_generate, create_sliding_window_causal_mask
+from ...masking_utils import (
+    blockwise_overlay,
+    create_causal_mask,
+    create_masks_for_generate,
+    create_sliding_window_causal_mask,
+    sliding_window_overlay,
+)
 from ...modeling_layers import GenericForSequenceClassification, GradientCheckpointingLayer
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling, SequenceClassifierOutputWithPast
 from ...modeling_rope_utils import (
@@ -611,6 +617,46 @@ def get_block_sequence_ids_for_mask(token_type_ids: torch.Tensor, device: torch.
     return block_sequence_ids
 
 
+def create_masks_for_vision_model(
+    config: PreTrainedConfig,
+    inputs_embeds: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    past_key_values: Cache | None,
+    position_ids: torch.Tensor | None,
+    block_sequence_ids: torch.Tensor,
+) -> dict:
+    """Create full_attention and sliding_attention masks with correct composition.
+
+    For global (full attention) layers:  OR(causal, blockwise)
+    For local (sliding window) layers:  AND(sliding_window, OR(causal, blockwise))
+    """
+    mask_kwargs = {
+        "config": config,
+        "inputs_embeds": inputs_embeds,
+        "attention_mask": attention_mask,
+        "past_key_values": past_key_values,
+        "position_ids": position_ids,
+    }
+
+    # Full attention: OR(causal, blockwise) — use block_sequence_ids directly
+    full_mask = create_causal_mask(**mask_kwargs, block_sequence_ids=block_sequence_ids)
+
+    # Sliding attention: AND(sliding_window, OR(causal, blockwise))
+    # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
+    # Pass sliding_window as and_mask_function (applied as step 3, after OR)
+    # Do NOT pass block_sequence_ids (to avoid the incorrect step 4 final OR)
+    sliding_mask = create_causal_mask(
+        **mask_kwargs,
+        or_mask_function=blockwise_overlay(block_sequence_ids),
+        and_mask_function=sliding_window_overlay(config.sliding_window),
+    )
+
+    return {
+        "full_attention": full_mask,
+        "sliding_attention": sliding_mask,
+    }
+
+
 class Gemma3Model(PaliGemmaModel):
     # we are filtering the logits/labels so we shouldn't divide the loss based on num_items_in_batch
     accepts_loss_kwargs = False
@@ -679,16 +725,15 @@ class Gemma3Model(PaliGemmaModel):
             }
 
             if token_type_ids is not None:
-                mask_kwargs["block_sequence_ids"] = get_block_sequence_ids_for_mask(
+                block_sequence_ids = get_block_sequence_ids_for_mask(
                     token_type_ids, device=inputs_embeds.device
                 )
-
-            # Create the masks
-            sliding_mask_kwargs = mask_kwargs.copy()
-            causal_mask_mapping = {
-                "full_attention": create_causal_mask(**mask_kwargs),
-                "sliding_attention": create_sliding_window_causal_mask(**sliding_mask_kwargs),
-            }
+                causal_mask_mapping = create_masks_for_vision_model(
+                    block_sequence_ids=block_sequence_ids,
+                    **mask_kwargs,
+                )
+            else:
+                causal_mask_mapping = create_masks_for_generate(**mask_kwargs)
 
         outputs = self.language_model(
             attention_mask=causal_mask_mapping,
@@ -885,8 +930,12 @@ class Gemma3ForConditionalGeneration(PaliGemmaForConditionalGeneration):
         }
 
         if token_type_ids is not None:
-            mask_kwargs["block_sequence_ids"] = get_block_sequence_ids_for_mask(
+            block_sequence_ids = get_block_sequence_ids_for_mask(
                 token_type_ids, device=inputs_embeds.device
+            )
+            return create_masks_for_vision_model(
+                block_sequence_ids=block_sequence_ids,
+                **mask_kwargs,
             )
 
         return create_masks_for_generate(**mask_kwargs)

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -725,9 +725,7 @@ class Gemma3Model(PaliGemmaModel):
             }
 
             if token_type_ids is not None:
-                block_sequence_ids = get_block_sequence_ids_for_mask(
-                    token_type_ids, device=inputs_embeds.device
-                )
+                block_sequence_ids = get_block_sequence_ids_for_mask(token_type_ids, device=inputs_embeds.device)
                 causal_mask_mapping = create_masks_for_vision_model(
                     block_sequence_ids=block_sequence_ids,
                     **mask_kwargs,
@@ -930,9 +928,7 @@ class Gemma3ForConditionalGeneration(PaliGemmaForConditionalGeneration):
         }
 
         if token_type_ids is not None:
-            block_sequence_ids = get_block_sequence_ids_for_mask(
-                token_type_ids, device=inputs_embeds.device
-            )
+            block_sequence_ids = get_block_sequence_ids_for_mask(token_type_ids, device=inputs_embeds.device)
             return create_masks_for_vision_model(
                 block_sequence_ids=block_sequence_ids,
                 **mask_kwargs,

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -2115,8 +2115,11 @@ def create_masks_for_vision_model(
 ) -> dict:
     """Create full_attention and sliding_attention masks with correct composition.
 
-    For global (full attention) layers:  OR(causal, blockwise)
+    For global (full attention) layers:  causal only (no bidirectional)
     For local (sliding window) layers:  AND(sliding_window, OR(causal, blockwise))
+
+    Unlike Gemma 3 (which applies bidirectional attention on all layers), Gemma 4
+    explicitly disables bidirectional attention on global attention layers.
     """
     mask_kwargs = {
         "config": config,
@@ -2126,13 +2129,12 @@ def create_masks_for_vision_model(
         "position_ids": position_ids,
     }
 
-    # Full attention: OR(causal, blockwise) — use block_sequence_ids directly
-    full_mask = create_causal_mask(**mask_kwargs, block_sequence_ids=block_sequence_ids)
+    # Full attention: causal only — no bidirectional blockwise overlay.
+    full_mask = create_causal_mask(**mask_kwargs)
 
     # Sliding attention: AND(sliding_window, OR(causal, blockwise))
     # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
     # Pass sliding_window as and_mask_function (applied as step 3, after OR)
-    # Do NOT pass block_sequence_ids (to avoid the incorrect step 4 final OR)
     sliding_mask = create_causal_mask(
         **mask_kwargs,
         or_mask_function=blockwise_overlay(block_sequence_ids),

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -36,10 +36,12 @@ from ...configuration_utils import PreTrainedConfig
 from ...generation import GenerationMixin
 from ...integrations import use_experts_implementation
 from ...masking_utils import (
+    blockwise_overlay,
     create_bidirectional_mask,
     create_causal_mask,
     create_masks_for_generate,
     create_sliding_window_causal_mask,
+    sliding_window_overlay,
 )
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import GradientCheckpointingLayer
@@ -2103,6 +2105,46 @@ class Gemma4MultimodalEmbedder(nn.Module):
         return self.embedding_projection(embs_normed)
 
 
+def create_masks_for_vision_model(
+    config: PreTrainedConfig,
+    inputs_embeds: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    past_key_values: Cache | None,
+    position_ids: torch.Tensor | None,
+    block_sequence_ids: torch.Tensor,
+) -> dict:
+    """Create full_attention and sliding_attention masks with correct composition.
+
+    For global (full attention) layers:  OR(causal, blockwise)
+    For local (sliding window) layers:  AND(sliding_window, OR(causal, blockwise))
+    """
+    mask_kwargs = {
+        "config": config,
+        "inputs_embeds": inputs_embeds,
+        "attention_mask": attention_mask,
+        "past_key_values": past_key_values,
+        "position_ids": position_ids,
+    }
+
+    # Full attention: OR(causal, blockwise) — use block_sequence_ids directly
+    full_mask = create_causal_mask(**mask_kwargs, block_sequence_ids=block_sequence_ids)
+
+    # Sliding attention: AND(sliding_window, OR(causal, blockwise))
+    # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
+    # Pass sliding_window as and_mask_function (applied as step 3, after OR)
+    # Do NOT pass block_sequence_ids (to avoid the incorrect step 4 final OR)
+    sliding_mask = create_causal_mask(
+        **mask_kwargs,
+        or_mask_function=blockwise_overlay(block_sequence_ids),
+        and_mask_function=sliding_window_overlay(config.sliding_window),
+    )
+
+    return {
+        "full_attention": full_mask,
+        "sliding_attention": sliding_mask,
+    }
+
+
 def get_block_sequence_ids_for_mask(mm_token_type_ids: torch.Tensor, device: torch.device) -> torch.Tensor:
     mm_token_type_ids = mm_token_type_ids.to(device)
 
@@ -2346,19 +2388,19 @@ class Gemma4Model(Gemma4PreTrainedModel):
                 "position_ids": position_ids,
             }
 
-            # Larger Gemma 4 models use Gemma 3's bidirectional attention mask for vision inputs
-            # Smaller Gemma models use a conventional casual attention mask
-            if self.config.get_text_config().use_bidirectional_attention == "vision":
-                block_sequence_ids = torch.full([*inputs_embeds.size()[:-1]], -1, device=inputs_embeds.device)
-                if mm_token_type_ids is not None:
-                    block_sequence_ids = get_block_sequence_ids_for_mask(
-                        mm_token_type_ids, device=inputs_embeds.device
-                    )
+            text_config = self.config.get_text_config()
+            use_bidir = text_config.use_bidirectional_attention == "vision"
 
-                mask_kwargs["block_sequence_ids"] = block_sequence_ids
-
-            # Create the masks
-            causal_mask_mapping = create_masks_for_generate(**mask_kwargs)
+            if use_bidir and mm_token_type_ids is not None:
+                block_sequence_ids = get_block_sequence_ids_for_mask(mm_token_type_ids, device=inputs_embeds.device)
+                causal_mask_mapping = create_masks_for_vision_model(
+                    block_sequence_ids=block_sequence_ids,
+                    **mask_kwargs,
+                )
+            else:
+                # Smaller Gemma models (use_bidirectional_attention=None) or
+                # text-only inputs use standard causal masking
+                causal_mask_mapping = create_masks_for_generate(**mask_kwargs)
 
         outputs = self.language_model(
             per_layer_inputs=per_layer_inputs,
@@ -2623,14 +2665,15 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
             "position_ids": position_ids,
         }
 
-        # Larger Gemma 4 models use Gemma 3's bidirectional attention mask for vision inputs
-        # Smaller Gemma models use a conventional casual attention mask
-        if getattr(config.get_text_config(), "use_bidirectional_attention", None) == "vision":
-            block_sequence_ids = torch.full([*inputs_embeds.size()[:-1]], -1, device=inputs_embeds.device)
-            if mm_token_type_ids is not None:
-                block_sequence_ids = get_block_sequence_ids_for_mask(mm_token_type_ids, device=inputs_embeds.device)
+        text_config = config.get_text_config()
+        use_bidir = getattr(text_config, "use_bidirectional_attention", None) == "vision"
 
-            mask_kwargs["block_sequence_ids"] = block_sequence_ids
+        if use_bidir and mm_token_type_ids is not None:
+            block_sequence_ids = get_block_sequence_ids_for_mask(mm_token_type_ids, device=inputs_embeds.device)
+            return create_masks_for_vision_model(
+                block_sequence_ids=block_sequence_ids,
+                **mask_kwargs,
+            )
 
         return create_masks_for_generate(**mask_kwargs)
 

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -36,11 +36,13 @@ from ...configuration_utils import PreTrainedConfig
 from ...generation import GenerationMixin
 from ...integrations import use_experts_implementation
 from ...masking_utils import (
+    _preprocess_mask_arguments,
     blockwise_overlay,
     create_bidirectional_mask,
     create_causal_mask,
     create_masks_for_generate,
     create_sliding_window_causal_mask,
+    maybe_pad_block_sequence_ids,
     sliding_window_overlay,
 )
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
@@ -2132,12 +2134,25 @@ def create_masks_for_vision_model(
     # Full attention: causal only — no bidirectional blockwise overlay.
     full_mask = create_causal_mask(**mask_kwargs)
 
+    # We need to manually pad the sequence IDs for the sliding mask
+    # as it's passed as an `or_mask_function` which bypasses internal padding.
+    early_exit, _, _, _, kv_length, _, kv_offset = _preprocess_mask_arguments(
+        **mask_kwargs,
+        layer_idx=0,
+    )
+    if early_exit:
+        padded_block_sequence_ids = block_sequence_ids
+    else:
+        padded_block_sequence_ids = maybe_pad_block_sequence_ids(
+            block_sequence_ids, attention_mask, kv_length, kv_offset
+        )
+
     # Sliding attention: AND(sliding_window, OR(causal, blockwise))
     # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
     # Pass sliding_window as and_mask_function (applied as step 3, after OR)
     sliding_mask = create_causal_mask(
         **mask_kwargs,
-        or_mask_function=blockwise_overlay(block_sequence_ids),
+        or_mask_function=blockwise_overlay(padded_block_sequence_ids),
         and_mask_function=sliding_window_overlay(config.sliding_window),
     )
 

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -27,10 +27,12 @@ from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...configuration_utils import PreTrainedConfig
 from ...masking_utils import (
+    blockwise_overlay,
     create_bidirectional_mask,
     create_causal_mask,
     create_masks_for_generate,
     create_sliding_window_causal_mask,
+    sliding_window_overlay,
 )
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling
@@ -56,7 +58,6 @@ from ..gemma3.modeling_gemma3 import (
     Gemma3RotaryEmbedding,
     Gemma3TextModel,
     Gemma3TextScaledWordEmbedding,
-    create_masks_for_vision_model,  # noqa: F811
 )
 from ..gemma3n.modeling_gemma3n import (
     Gemma3nCausalLMOutputWithPast,
@@ -80,6 +81,48 @@ if is_accelerate_available():
 
 
 logger = logging.get_logger(__name__)
+
+
+def create_masks_for_vision_model(
+    config: PreTrainedConfig,
+    inputs_embeds: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    past_key_values: Cache | None,
+    position_ids: torch.Tensor | None,
+    block_sequence_ids: torch.Tensor,
+) -> dict:
+    """Create full_attention and sliding_attention masks with correct composition.
+
+    For global (full attention) layers:  causal only (no bidirectional)
+    For local (sliding window) layers:  AND(sliding_window, OR(causal, blockwise))
+
+    Unlike Gemma 3 (which applies bidirectional attention on all layers), Gemma 4
+    explicitly disables bidirectional attention on global attention layers.
+    """
+    mask_kwargs = {
+        "config": config,
+        "inputs_embeds": inputs_embeds,
+        "attention_mask": attention_mask,
+        "past_key_values": past_key_values,
+        "position_ids": position_ids,
+    }
+
+    # Full attention: causal only — no bidirectional blockwise overlay.
+    full_mask = create_causal_mask(**mask_kwargs)
+
+    # Sliding attention: AND(sliding_window, OR(causal, blockwise))
+    # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
+    # Pass sliding_window as and_mask_function (applied as step 3, after OR)
+    sliding_mask = create_causal_mask(
+        **mask_kwargs,
+        or_mask_function=blockwise_overlay(block_sequence_ids),
+        and_mask_function=sliding_window_overlay(config.sliding_window),
+    )
+
+    return {
+        "full_attention": full_mask,
+        "sliding_attention": sliding_mask,
+    }
 
 
 class Gemma4ModelOutputWithPast(Gemma3nModelOutputWithPast):

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -27,11 +27,13 @@ from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...configuration_utils import PreTrainedConfig
 from ...masking_utils import (
+    _preprocess_mask_arguments,
     blockwise_overlay,
     create_bidirectional_mask,
     create_causal_mask,
     create_masks_for_generate,
     create_sliding_window_causal_mask,
+    maybe_pad_block_sequence_ids,
     sliding_window_overlay,
 )
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
@@ -110,12 +112,25 @@ def create_masks_for_vision_model(
     # Full attention: causal only — no bidirectional blockwise overlay.
     full_mask = create_causal_mask(**mask_kwargs)
 
+    # We need to manually pad the sequence IDs for the sliding mask
+    # as it's passed as an `or_mask_function` which bypasses internal padding.
+    early_exit, _, _, _, kv_length, _, kv_offset = _preprocess_mask_arguments(
+        **mask_kwargs,
+        layer_idx=0,
+    )
+    if early_exit:
+        padded_block_sequence_ids = block_sequence_ids
+    else:
+        padded_block_sequence_ids = maybe_pad_block_sequence_ids(
+            block_sequence_ids, attention_mask, kv_length, kv_offset
+        )
+
     # Sliding attention: AND(sliding_window, OR(causal, blockwise))
     # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
     # Pass sliding_window as and_mask_function (applied as step 3, after OR)
     sliding_mask = create_causal_mask(
         **mask_kwargs,
-        or_mask_function=blockwise_overlay(block_sequence_ids),
+        or_mask_function=blockwise_overlay(padded_block_sequence_ids),
         and_mask_function=sliding_window_overlay(config.sliding_window),
     )
 

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -27,10 +27,12 @@ from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...configuration_utils import PreTrainedConfig
 from ...masking_utils import (
+    blockwise_overlay,
     create_bidirectional_mask,
     create_causal_mask,
     create_masks_for_generate,
     create_sliding_window_causal_mask,
+    sliding_window_overlay,
 )
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling
@@ -57,6 +59,7 @@ from ..gemma3.modeling_gemma3 import (
     Gemma3TextModel,
     Gemma3TextScaledWordEmbedding,
 )
+from ..gemma3.modeling_gemma3 import create_masks_for_vision_model  # noqa: F811
 from ..gemma3n.modeling_gemma3n import (
     Gemma3nCausalLMOutputWithPast,
     Gemma3nForConditionalGeneration,
@@ -2060,19 +2063,21 @@ class Gemma4Model(Gemma3nModel):
                 "position_ids": position_ids,
             }
 
-            # Larger Gemma 4 models use Gemma 3's bidirectional attention mask for vision inputs
-            # Smaller Gemma models use a conventional casual attention mask
-            if self.config.get_text_config().use_bidirectional_attention == "vision":
-                block_sequence_ids = torch.full([*inputs_embeds.size()[:-1]], -1, device=inputs_embeds.device)
-                if mm_token_type_ids is not None:
-                    block_sequence_ids = get_block_sequence_ids_for_mask(
-                        mm_token_type_ids, device=inputs_embeds.device
-                    )
+            text_config = self.config.get_text_config()
+            use_bidir = text_config.use_bidirectional_attention == "vision"
 
-                mask_kwargs["block_sequence_ids"] = block_sequence_ids
-
-            # Create the masks
-            causal_mask_mapping = create_masks_for_generate(**mask_kwargs)
+            if use_bidir and mm_token_type_ids is not None:
+                block_sequence_ids = get_block_sequence_ids_for_mask(
+                    mm_token_type_ids, device=inputs_embeds.device
+                )
+                causal_mask_mapping = create_masks_for_vision_model(
+                    block_sequence_ids=block_sequence_ids,
+                    **mask_kwargs,
+                )
+            else:
+                # Smaller Gemma models (use_bidirectional_attention=None) or
+                # text-only inputs use standard causal masking
+                causal_mask_mapping = create_masks_for_generate(**mask_kwargs)
 
         outputs = self.language_model(
             per_layer_inputs=per_layer_inputs,
@@ -2249,14 +2254,17 @@ class Gemma4ForConditionalGeneration(Gemma3nForConditionalGeneration):
             "position_ids": position_ids,
         }
 
-        # Larger Gemma 4 models use Gemma 3's bidirectional attention mask for vision inputs
-        # Smaller Gemma models use a conventional casual attention mask
-        if getattr(config.get_text_config(), "use_bidirectional_attention", None) == "vision":
-            block_sequence_ids = torch.full([*inputs_embeds.size()[:-1]], -1, device=inputs_embeds.device)
-            if mm_token_type_ids is not None:
-                block_sequence_ids = get_block_sequence_ids_for_mask(mm_token_type_ids, device=inputs_embeds.device)
+        text_config = config.get_text_config()
+        use_bidir = getattr(text_config, "use_bidirectional_attention", None) == "vision"
 
-            mask_kwargs["block_sequence_ids"] = block_sequence_ids
+        if use_bidir and mm_token_type_ids is not None:
+            block_sequence_ids = get_block_sequence_ids_for_mask(
+                mm_token_type_ids, device=inputs_embeds.device
+            )
+            return create_masks_for_vision_model(
+                block_sequence_ids=block_sequence_ids,
+                **mask_kwargs,
+            )
 
         return create_masks_for_generate(**mask_kwargs)
 

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -27,12 +27,10 @@ from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...configuration_utils import PreTrainedConfig
 from ...masking_utils import (
-    blockwise_overlay,
     create_bidirectional_mask,
     create_causal_mask,
     create_masks_for_generate,
     create_sliding_window_causal_mask,
-    sliding_window_overlay,
 )
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling
@@ -58,8 +56,8 @@ from ..gemma3.modeling_gemma3 import (
     Gemma3RotaryEmbedding,
     Gemma3TextModel,
     Gemma3TextScaledWordEmbedding,
+    create_masks_for_vision_model,  # noqa: F811
 )
-from ..gemma3.modeling_gemma3 import create_masks_for_vision_model  # noqa: F811
 from ..gemma3n.modeling_gemma3n import (
     Gemma3nCausalLMOutputWithPast,
     Gemma3nForConditionalGeneration,
@@ -2067,9 +2065,7 @@ class Gemma4Model(Gemma3nModel):
             use_bidir = text_config.use_bidirectional_attention == "vision"
 
             if use_bidir and mm_token_type_ids is not None:
-                block_sequence_ids = get_block_sequence_ids_for_mask(
-                    mm_token_type_ids, device=inputs_embeds.device
-                )
+                block_sequence_ids = get_block_sequence_ids_for_mask(mm_token_type_ids, device=inputs_embeds.device)
                 causal_mask_mapping = create_masks_for_vision_model(
                     block_sequence_ids=block_sequence_ids,
                     **mask_kwargs,
@@ -2258,9 +2254,7 @@ class Gemma4ForConditionalGeneration(Gemma3nForConditionalGeneration):
         use_bidir = getattr(text_config, "use_bidirectional_attention", None) == "vision"
 
         if use_bidir and mm_token_type_ids is not None:
-            block_sequence_ids = get_block_sequence_ids_for_mask(
-                mm_token_type_ids, device=inputs_embeds.device
-            )
+            block_sequence_ids = get_block_sequence_ids_for_mask(mm_token_type_ids, device=inputs_embeds.device)
             return create_masks_for_vision_model(
                 block_sequence_ids=block_sequence_ids,
                 **mask_kwargs,

--- a/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py
+++ b/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py
@@ -30,7 +30,13 @@ from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...configuration_utils import PreTrainedConfig
 from ...generation import GenerationMixin
-from ...masking_utils import create_causal_mask, create_masks_for_generate, create_sliding_window_causal_mask
+from ...masking_utils import (
+    blockwise_overlay,
+    create_causal_mask,
+    create_masks_for_generate,
+    create_sliding_window_causal_mask,
+    sliding_window_overlay,
+)
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import GradientCheckpointingLayer
 from ...modeling_outputs import BaseModelOutputWithPast, ModelOutput
@@ -1188,6 +1194,46 @@ class Gemma4UnifiedModel(Gemma4UnifiedPreTrainedModel):
         return self.get_image_features(pixel_values_videos, video_position_ids, **kwargs)
 
 
+def create_masks_for_vision_model(
+    config: PreTrainedConfig,
+    inputs_embeds: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    past_key_values: Cache | None,
+    position_ids: torch.Tensor | None,
+    block_sequence_ids: torch.Tensor,
+) -> dict:
+    """Create full_attention and sliding_attention masks with correct composition.
+
+    For global (full attention) layers:  OR(causal, blockwise)
+    For local (sliding window) layers:  AND(sliding_window, OR(causal, blockwise))
+    """
+    mask_kwargs = {
+        "config": config,
+        "inputs_embeds": inputs_embeds,
+        "attention_mask": attention_mask,
+        "past_key_values": past_key_values,
+        "position_ids": position_ids,
+    }
+
+    # Full attention: OR(causal, blockwise) — use block_sequence_ids directly
+    full_mask = create_causal_mask(**mask_kwargs, block_sequence_ids=block_sequence_ids)
+
+    # Sliding attention: AND(sliding_window, OR(causal, blockwise))
+    # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
+    # Pass sliding_window as and_mask_function (applied as step 3, after OR)
+    # Do NOT pass block_sequence_ids (to avoid the incorrect step 4 final OR)
+    sliding_mask = create_causal_mask(
+        **mask_kwargs,
+        or_mask_function=blockwise_overlay(block_sequence_ids),
+        and_mask_function=sliding_window_overlay(config.sliding_window),
+    )
+
+    return {
+        "full_attention": full_mask,
+        "sliding_attention": sliding_mask,
+    }
+
+
 @auto_docstring(
     custom_intro="""
     The base Gemma 4 model comprising a vision backbone, an audio backbone, a language model, and a language modeling
@@ -1356,14 +1402,15 @@ class Gemma4UnifiedForConditionalGeneration(Gemma4UnifiedPreTrainedModel, Genera
             "position_ids": position_ids,
         }
 
-        # Larger Gemma 4 models use Gemma 3's bidirectional attention mask for vision inputs
-        # Smaller Gemma models use a conventional casual attention mask
-        if getattr(config.get_text_config(), "use_bidirectional_attention", None) == "vision":
-            block_sequence_ids = torch.full([*inputs_embeds.size()[:-1]], -1, device=inputs_embeds.device)
-            if mm_token_type_ids is not None:
-                block_sequence_ids = get_block_sequence_ids_for_mask(mm_token_type_ids, device=inputs_embeds.device)
+        text_config = config.get_text_config()
+        use_bidir = getattr(text_config, "use_bidirectional_attention", None) == "vision"
 
-            mask_kwargs["block_sequence_ids"] = block_sequence_ids
+        if use_bidir and mm_token_type_ids is not None:
+            block_sequence_ids = get_block_sequence_ids_for_mask(mm_token_type_ids, device=inputs_embeds.device)
+            return create_masks_for_vision_model(
+                block_sequence_ids=block_sequence_ids,
+                **mask_kwargs,
+            )
 
         return create_masks_for_generate(**mask_kwargs)
 

--- a/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py
+++ b/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py
@@ -1204,8 +1204,11 @@ def create_masks_for_vision_model(
 ) -> dict:
     """Create full_attention and sliding_attention masks with correct composition.
 
-    For global (full attention) layers:  OR(causal, blockwise)
+    For global (full attention) layers:  causal only (no bidirectional)
     For local (sliding window) layers:  AND(sliding_window, OR(causal, blockwise))
+
+    Unlike Gemma 3 (which applies bidirectional attention on all layers), Gemma 4
+    explicitly disables bidirectional attention on global attention layers.
     """
     mask_kwargs = {
         "config": config,
@@ -1215,13 +1218,12 @@ def create_masks_for_vision_model(
         "position_ids": position_ids,
     }
 
-    # Full attention: OR(causal, blockwise) — use block_sequence_ids directly
-    full_mask = create_causal_mask(**mask_kwargs, block_sequence_ids=block_sequence_ids)
+    # Full attention: causal only — no bidirectional blockwise overlay.
+    full_mask = create_causal_mask(**mask_kwargs)
 
     # Sliding attention: AND(sliding_window, OR(causal, blockwise))
     # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
     # Pass sliding_window as and_mask_function (applied as step 3, after OR)
-    # Do NOT pass block_sequence_ids (to avoid the incorrect step 4 final OR)
     sliding_mask = create_causal_mask(
         **mask_kwargs,
         or_mask_function=blockwise_overlay(block_sequence_ids),

--- a/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py
+++ b/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py
@@ -31,10 +31,12 @@ from ...cache_utils import Cache, DynamicCache
 from ...configuration_utils import PreTrainedConfig
 from ...generation import GenerationMixin
 from ...masking_utils import (
+    _preprocess_mask_arguments,
     blockwise_overlay,
     create_causal_mask,
     create_masks_for_generate,
     create_sliding_window_causal_mask,
+    maybe_pad_block_sequence_ids,
     sliding_window_overlay,
 )
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
@@ -1221,12 +1223,25 @@ def create_masks_for_vision_model(
     # Full attention: causal only — no bidirectional blockwise overlay.
     full_mask = create_causal_mask(**mask_kwargs)
 
+    # We need to manually pad the sequence IDs for the sliding mask
+    # as it's passed as an `or_mask_function` which bypasses internal padding.
+    early_exit, _, _, _, kv_length, _, kv_offset = _preprocess_mask_arguments(
+        **mask_kwargs,
+        layer_idx=0,
+    )
+    if early_exit:
+        padded_block_sequence_ids = block_sequence_ids
+    else:
+        padded_block_sequence_ids = maybe_pad_block_sequence_ids(
+            block_sequence_ids, attention_mask, kv_length, kv_offset
+        )
+
     # Sliding attention: AND(sliding_window, OR(causal, blockwise))
     # Pass blockwise as or_mask_function (applied as step 2 in create_causal_mask)
     # Pass sliding_window as and_mask_function (applied as step 3, after OR)
     sliding_mask = create_causal_mask(
         **mask_kwargs,
-        or_mask_function=blockwise_overlay(block_sequence_ids),
+        or_mask_function=blockwise_overlay(padded_block_sequence_ids),
         and_mask_function=sliding_window_overlay(config.sliding_window),
     )
 

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -469,7 +469,7 @@ class Gemma3Vision2TextModelTest(VLMModelTest, unittest.TestCase):
         self.assertLess(sliding_mask[0, 0, 11, 5].item(), -1000)
 
         # Verify that causal masking still applies correctly to text
-        # Token 12 (text) looking ahead to Token 11 (image) is masked
+        # Token 11 (image) looking ahead at Token 12 (text) -> MASKED
         self.assertLess(full_mask[0, 0, 11, 12].item(), -1000)
 
 

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -456,8 +456,6 @@ class Gemma3Vision2TextModelTest(VLMModelTest, unittest.TestCase):
         full_mask = mask_dict["full_attention"]
         sliding_mask = mask_dict["sliding_attention"]
 
-        min_val = torch.finfo(full_mask.dtype).min
-
         # In full_attention, bidirectional image block (tokens 5-11) is fully visible
         # (Both look-back and look-ahead are 0.0)
         self.assertEqual(full_mask[0, 0, 5, 11].item(), 0.0)

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -62,6 +62,7 @@ if is_torch_available():
         Gemma3TextForSequenceClassification,
         Gemma3TextModel,
     )
+    from transformers.models.gemma3.modeling_gemma3 import create_masks_for_vision_model
     from transformers.pytorch_utils import is_torch_greater_or_equal
 
 
@@ -428,8 +429,6 @@ class Gemma3Vision2TextModelTest(VLMModelTest, unittest.TestCase):
         self.flash_attn_from_config(attn_implementation="flash_attention_4", test_fwd_in_train=False)
 
     def test_attention_mask_composition(self):
-        from transformers.models.gemma3.modeling_gemma3 import create_masks_for_vision_model
-
         config = self.model_tester.get_config()
         config.text_config._attn_implementation = "eager"
 

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -427,6 +427,54 @@ class Gemma3Vision2TextModelTest(VLMModelTest, unittest.TestCase):
     def test_flash_attn_4_from_config(self):
         self.flash_attn_from_config(attn_implementation="flash_attention_4", test_fwd_in_train=False)
 
+    def test_attention_mask_composition(self):
+        from transformers.models.gemma3.modeling_gemma3 import create_masks_for_vision_model
+
+        config = self.model_tester.get_config()
+        config.text_config._attn_implementation = "eager"
+        
+        # Override sliding window to a known small value to test truncation
+        sliding_window = 4
+        config.text_config.sliding_window = sliding_window
+
+        # Create a sequence of 13 tokens: 0..4 text, 5..11 image (7 tokens), 12 text
+        # block_sequence_ids maps image tokens to group 0, and text tokens to -1
+        block_sequence_ids = torch.tensor([[-1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, -1]], dtype=torch.long)
+        attention_mask = torch.ones((1, 13), dtype=torch.bool)
+        position_ids = torch.arange(13).unsqueeze(0)
+        inputs_embeds = torch.randn(1, 13, config.text_config.hidden_size)
+
+        mask_dict = create_masks_for_vision_model(
+            config=config.text_config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            past_key_values=None,
+            position_ids=position_ids,
+            block_sequence_ids=block_sequence_ids,
+        )
+
+        full_mask = mask_dict["full_attention"]
+        sliding_mask = mask_dict["sliding_attention"]
+
+        min_val = torch.finfo(full_mask.dtype).min
+
+        # In full_attention, bidirectional image block (tokens 5-11) is fully visible
+        # (Both look-back and look-ahead are 0.0)
+        self.assertEqual(full_mask[0, 0, 5, 11].item(), 0.0)
+        self.assertEqual(full_mask[0, 0, 11, 5].item(), 0.0)
+
+        # In sliding_attention, look-back within the sliding window is visible bidirectionally
+        # Token 8 looking back at 5 (dist 3 < 4) -> VISIBLE
+        self.assertEqual(sliding_mask[0, 0, 8, 5].item(), 0.0)
+
+        # In sliding_attention, look-back outside the sliding window is strictly masked
+        # Token 11 looking back at 5 (dist 6 > 4) -> MASKED
+        self.assertLess(sliding_mask[0, 0, 11, 5].item(), -1000)
+
+        # Verify that causal masking still applies correctly to text
+        # Token 12 (text) looking ahead to Token 11 (image) is masked
+        self.assertLess(full_mask[0, 0, 11, 12].item(), -1000)
+
 
 @slow
 @require_torch_accelerator

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -432,7 +432,7 @@ class Gemma3Vision2TextModelTest(VLMModelTest, unittest.TestCase):
 
         config = self.model_tester.get_config()
         config.text_config._attn_implementation = "eager"
-        
+
         # Override sliding window to a known small value to test truncation
         sliding_window = 4
         config.text_config.sliding_window = sliding_window

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -649,7 +649,7 @@ class Gemma4Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
         self.assertLess(sliding_mask[0, 0, 11, 5].item(), -1000)
 
         # Verify that causal masking still applies correctly to text
-        # Token 12 (text) looking ahead to Token 11 (image) is masked
+        # Token 11 (image) looking ahead at Token 12 (text) -> MASKED
         self.assertLess(full_mask[0, 0, 11, 12].item(), -1000)
 
 

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -630,14 +630,20 @@ class Gemma4Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
         full_mask = mask_dict["full_attention"]
         sliding_mask = mask_dict["sliding_attention"]
 
-        # In full_attention, bidirectional image block (tokens 5-11) is fully visible
-        # (Both look-back and look-ahead are 0.0)
-        self.assertEqual(full_mask[0, 0, 5, 11].item(), 0.0)
+        # In full_attention (global layers), Gemma 4 uses causal-only masking —
+        # no bidirectional attention on vision tokens. This matches the internal
+        # Gemax/Gemini3 transformer which sets bidirectional_segment_ids=None
+        # for GLOBAL layers.
+        # Token 5 looking ahead at token 11 -> MASKED (causal prevents look-ahead)
+        self.assertLess(full_mask[0, 0, 5, 11].item(), -1000)
+        # Token 11 looking back at token 5 -> VISIBLE (causal allows look-back)
         self.assertEqual(full_mask[0, 0, 11, 5].item(), 0.0)
 
-        # In sliding_attention, look-back within the sliding window is visible bidirectionally
+        # In sliding_attention (local layers), bidirectional IS applied within the window.
         # Token 8 looking back at 5 (dist 3 < 4) -> VISIBLE
         self.assertEqual(sliding_mask[0, 0, 8, 5].item(), 0.0)
+        # Token 5 looking ahead at 8 (dist 3 < 4, same image block) -> VISIBLE (bidirectional)
+        self.assertEqual(sliding_mask[0, 0, 5, 8].item(), 0.0)
 
         # In sliding_attention, look-back outside the sliding window is strictly masked
         # Token 11 looking back at 5 (dist 6 > 4) -> MASKED

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -630,8 +630,6 @@ class Gemma4Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
         full_mask = mask_dict["full_attention"]
         sliding_mask = mask_dict["sliding_attention"]
 
-        min_val = torch.finfo(full_mask.dtype).min
-
         # In full_attention, bidirectional image block (tokens 5-11) is fully visible
         # (Both look-back and look-ahead are 0.0)
         self.assertEqual(full_mask[0, 0, 5, 11].item(), 0.0)

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -606,7 +606,7 @@ class Gemma4Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
 
         config = self.model_tester.get_config()
         config.text_config._attn_implementation = "eager"
-        
+
         # Override sliding window to a known small value to test truncation
         sliding_window = 4
         config.text_config.sliding_window = sliding_window

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -601,6 +601,54 @@ class Gemma4Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
             _ = model(inputs_embeds=inputs_embeds)
             self.assertEqual(counter["call_count"], 1)
 
+    def test_attention_mask_composition(self):
+        from transformers.models.gemma4.modeling_gemma4 import create_masks_for_vision_model
+
+        config = self.model_tester.get_config()
+        config.text_config._attn_implementation = "eager"
+        
+        # Override sliding window to a known small value to test truncation
+        sliding_window = 4
+        config.text_config.sliding_window = sliding_window
+
+        # Create a sequence of 13 tokens: 0..4 text, 5..11 image (7 tokens), 12 text
+        # block_sequence_ids maps image tokens to group 0, and text tokens to -1
+        block_sequence_ids = torch.tensor([[-1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, -1]], dtype=torch.long)
+        attention_mask = torch.ones((1, 13), dtype=torch.bool)
+        position_ids = torch.arange(13).unsqueeze(0)
+        inputs_embeds = torch.randn(1, 13, config.text_config.hidden_size)
+
+        mask_dict = create_masks_for_vision_model(
+            config=config.text_config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            past_key_values=None,
+            position_ids=position_ids,
+            block_sequence_ids=block_sequence_ids,
+        )
+
+        full_mask = mask_dict["full_attention"]
+        sliding_mask = mask_dict["sliding_attention"]
+
+        min_val = torch.finfo(full_mask.dtype).min
+
+        # In full_attention, bidirectional image block (tokens 5-11) is fully visible
+        # (Both look-back and look-ahead are 0.0)
+        self.assertEqual(full_mask[0, 0, 5, 11].item(), 0.0)
+        self.assertEqual(full_mask[0, 0, 11, 5].item(), 0.0)
+
+        # In sliding_attention, look-back within the sliding window is visible bidirectionally
+        # Token 8 looking back at 5 (dist 3 < 4) -> VISIBLE
+        self.assertEqual(sliding_mask[0, 0, 8, 5].item(), 0.0)
+
+        # In sliding_attention, look-back outside the sliding window is strictly masked
+        # Token 11 looking back at 5 (dist 6 > 4) -> MASKED
+        self.assertLess(sliding_mask[0, 0, 11, 5].item(), -1000)
+
+        # Verify that causal masking still applies correctly to text
+        # Token 12 (text) looking ahead to Token 11 (image) is masked
+        self.assertLess(full_mask[0, 0, 11, 12].item(), -1000)
+
 
 @slow
 @require_torch_accelerator

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -54,6 +54,7 @@ if is_torch_available():
         Gemma4Processor,
         Gemma4TextModel,
     )
+    from transformers.models.gemma4.modeling_gemma4 import create_masks_for_vision_model
 
 
 GEMMA4_RANDOM_MOE_FA2_SKIP_REASON = (
@@ -602,8 +603,6 @@ class Gemma4Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
             self.assertEqual(counter["call_count"], 1)
 
     def test_attention_mask_composition(self):
-        from transformers.models.gemma4.modeling_gemma4 import create_masks_for_vision_model
-
         config = self.model_tester.get_config()
         config.text_config._attn_implementation = "eager"
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46850)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46850)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This fixes the behavior of attention masking for image tokens to properly respect sliding window boundaries for Gemma 3/4 models. This was needed to match the intended model behavior for local layers.

- [X] I confirm that this is not a pure code agent PR.

## Before submitting
- [X] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [X] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

<!-- ci-dashboard-recap:start -->

---

### CI recap

**Dashboard:** [View test results in Grafana](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46850)
**Latest run:** [28405951213:2](https://github.com/huggingface/transformers/actions/runs/28406342486)
**Result:** `success` | **Jobs:** 7 | **Tests:** 2,337 | **Failures:** 0 | **Duration:** 32m 59s

<!-- ci-dashboard-recap:end -->