### PR TITLE
Switch decorator order

### DIFF
--- a/tests/models/chameleon/test_modeling_chameleon.py
+++ b/tests/models/chameleon/test_modeling_chameleon.py
@@ -232,8 +232,8 @@ class ChameleonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_batching_equivalence(self):
         pass
 
-    @unittest.skip("Skip get_image_features tests as those are tested via ChameleonVision2SeqModelTest instead")
     @parameterized.expand([True, False, None])
+    @unittest.skip("Skip get_image_features tests as those are tested via ChameleonVision2SeqModelTest instead")
     def test_get_image_features_output(self, return_dict: bool | None):
         pass
 

--- a/tests/models/fsmt/test_modeling_fsmt.py
+++ b/tests/models/fsmt/test_modeling_fsmt.py
@@ -303,8 +303,8 @@ class FSMTModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     def test_assisted_decoding_sample(self):
         pass
 
-    @unittest.skip(reason="Can't do assisted decoding and not worth fixing")
     @parameterized.expand([("random",), ("same",)])
+    @unittest.skip(reason="Can't do assisted decoding and not worth fixing")
     def test_assisted_decoding_matches_greedy_search(self, assistant_type):
         pass
 

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -292,8 +292,8 @@ class Gemma4Audio2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unittes
     def test_get_image_features_attentions(self):
         pass
 
-    @unittest.skip("The tester has no image in input dict")
     @parameterized.expand([True, False, None])
+    @unittest.skip("The tester has no image in input dict")
     def test_get_image_features_output(self, return_dict: bool | None):
         pass
 
@@ -305,8 +305,8 @@ class Gemma4Audio2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unittes
     def test_get_video_features_attentions(self):
         pass
 
-    @unittest.skip("The tester has no videos in input dict")
     @parameterized.expand([True, False, None])
+    @unittest.skip("The tester has no videos in input dict")
     def test_get_video_features_output(self, return_dict: bool | None):
         pass
 
@@ -514,8 +514,8 @@ class Gemma4Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
     def test_get_audio_features_attentions(self):
         pass
 
-    @unittest.skip("The tester has no audios in input dict")
     @parameterized.expand([True, False, None])
+    @unittest.skip("The tester has no audios in input dict")
     def test_get_audio_features_output(self, return_dict: bool | None):
         pass
 
@@ -527,8 +527,8 @@ class Gemma4Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
     def test_get_video_features_attentions(self):
         pass
 
-    @unittest.skip("The tester has no videos in input dict")
     @parameterized.expand([True, False, None])
+    @unittest.skip("The tester has no videos in input dict")
     def test_get_video_features_output(self, return_dict: bool | None):
         pass
 

--- a/tests/models/glm_moe_dsa/test_modeling_glm_moe_dsa.py
+++ b/tests/models/glm_moe_dsa/test_modeling_glm_moe_dsa.py
@@ -147,8 +147,8 @@ class GlmMoeDsaModelTest(CausalLMModelTest, unittest.TestCase):
     def test_flash_attn_2_inference_equivalence_right_padding(self):
         self.skipTest(reason="Qwen2Moe flash attention does not support right padding")
 
-    @unittest.skip("DSA indexer mask shape mismatch with assisted decoding")
     @parameterized.expand([("random",), ("same",)])
+    @unittest.skip("DSA indexer mask shape mismatch with assisted decoding")
     def test_assisted_decoding_matches_greedy_search(self, assistant_type):
         pass
 

--- a/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
@@ -166,8 +166,8 @@ class Qwen3OmniMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         for k in out_dict:
             self.assertIsInstance(out_dict[k], return_tensor_to_type[return_tensors])
 
-    @unittest.skip("Skipping but this one is important, should be fixed ASAP")
     @parameterized.expand([(1, "pt"), (2, "pt")])
+    @unittest.skip("Skipping but this one is important, should be fixed ASAP")
     def test_apply_chat_template_image(self, batch_size: int, return_tensors: str):
         pass
 

--- a/tests/models/xlstm/test_modeling_xlstm.py
+++ b/tests/models/xlstm/test_modeling_xlstm.py
@@ -170,8 +170,8 @@ class xLSTMModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     def test_generate_without_input_ids(self):
         pass
 
-    @unittest.skip(reason="xLSTM cache slicing test case is an edge case")
     @parameterized.expand([("greedy", 1), ("beam search", 2)])
+    @unittest.skip(reason="xLSTM cache slicing test case is an edge case")
     def test_generate_from_inputs_embeds(self, _, num_beams):
         pass
 


### PR DESCRIPTION
# What does this PR do?

As per the title. For proepr skip, `skip` must be AFTER `parameterized.expand` (currently, they appear as PASSED, because the body of the test is then only `pass`)