### PR TITLE
Fix `BlockMask` crash in CTRL flex-attention generation

### DIFF
--- a/src/transformers/models/ctrl/modeling_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_ctrl.py
@@ -300,7 +300,7 @@ class CTRLModel(CTRLPreTrainedModel):
         else:
             token_type_embeds = 0
 
-        if attention_mask is not None and attention_mask.ndim < 4:
+        if attention_mask is not None and isinstance(attention_mask, torch.Tensor) and attention_mask.ndim < 4:
             attention_mask = attention_mask.view(batch_size, -1)
 
         causal_mask = create_causal_mask(


### PR DESCRIPTION
## Problem

Generating with `Salesforce/ctrl` under compiled flex-attention crashes:

```
AttributeError: 'BlockMask' object has no attribute 'ndim'
```

at `CTRLModel.forward` (`models/ctrl/modeling_ctrl.py`).

## Reproduction

```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer

model_id = "Salesforce/ctrl"
tokenizer = AutoTokenizer.from_pretrained(model_id)
model = AutoModelForCausalLM.from_pretrained(
    model_id, attn_implementation="flex_attention", device_map="auto"
)
model.generation_config.cache_implementation = "static"  # compileable cache -> BlockMask path

inputs = tokenizer("Today the weather is", return_tensors="pt").to(model.device)
outputs = model.generate(**inputs, max_new_tokens=16)  # crashes before this fix
print(tokenizer.decode(outputs[0], skip_special_tokens=True))
```

## Cause

`CTRLModel.forward` reshapes `attention_mask` with an unconditional `.ndim` check:

```python
if attention_mask is not None and attention_mask.ndim < 4:
    attention_mask = attention_mask.view(batch_size, -1)
```

In compiled flex-attention generation, `prepare_inputs_for_generation` pre-builds a
`BlockMask` (via `create_masks_for_generate`) and passes it as `attention_mask`.
`BlockMask` exposes `.shape` but not `.ndim`, so the check raises. The reshape is
only meant for 2D padding tensors; `create_causal_mask` already handles a 4D
`Tensor`/`BlockMask` downstream.

## Fix

Only reshape real tensors, letting `BlockMask` (and any 4D mask) pass through
unchanged. Mirrors the existing `doge` / `deepseek_v4` guard; `torch` is already
imported.

```python
if attention_mask is not None and isinstance(attention_mask, torch.Tensor) and attention_mask.ndim < 4:
    attention_mask = attention_mask.view(batch_size, -1)
```

## Validation

Benchmark suite on `Salesforce/ctrl` (causal-lm, level 1). Before: flex config
crashed (exit 1). After: all 4 configs pass (eager / FA2 / flex / FA2+CB), exit 0.

## Note

`models/gpt2/modeling_gpt2.py` has the identical latent bug; not touched here, can
be addressed in a follow-up.
