### PR TITLE
Fix expanded dim in the cache's cumulative length

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -378,7 +378,7 @@ class StaticLayer(CacheLayerMixin):
         super().__init__()
         self.max_cache_len = max_cache_len
         # Very important that it's a tensor here, to avoid recompiling when we update it and use it to create positions
-        self.cumulative_length = torch.tensor([0], dtype=int)
+        self.cumulative_length = torch.tensor(0, dtype=int)
 
     def lazy_initialization(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
         """
@@ -610,7 +610,7 @@ class StaticIndexedLayer(StaticLayer):
         self.is_indexer_initialized: bool = False
         # The indexer update runs independently of (and after) the main K/V `update` in the attention
         # forward, so it tracks its own cumulative length rather than reusing `self.cumulative_length`.
-        self.indexer_cumulative_length = torch.tensor([0], dtype=int)
+        self.indexer_cumulative_length = torch.tensor(0, dtype=int)
 
     def lazy_initialization_indexer(self, indexer_key_states: torch.Tensor) -> None:
         self.indexer_dtype, self.indexer_device = indexer_key_states.dtype, indexer_key_states.device

--- a/src/transformers/integrations/executorch.py
+++ b/src/transformers/integrations/executorch.py
@@ -588,7 +588,7 @@ class TorchExportableModuleWithStaticCache(torch.nn.Module):
         # as otherwise it's mutated in-place indefinitely - we cannot call reset in-between the `generate` as the program was
         # already exported)
         for layer in self.static_cache.layers:
-            layer.cumulative_length.copy_(cache_position[0:1])
+            layer.cumulative_length.copy_(cache_position[0])
 
         past_key_values = self.static_cache
 
@@ -756,7 +756,7 @@ class TorchExportableModuleWithHybridCache(torch.nn.Module):
         # as otherwise it's mutated in-place indefinitely - we cannot call reset in-between the `generate` as the program was
         # already exported)
         for layer in self.cache.layers:
-            layer.cumulative_length.copy_(cache_position[0:1])
+            layer.cumulative_length.copy_(cache_position[0])
 
         # Forward pass with the model
         outputs = self.model(
@@ -894,7 +894,7 @@ class Seq2SeqLMDecoderExportableModuleWithStaticCache(torch.nn.Module):
         # as otherwise it's mutated in-place indefinitely - we cannot call reset in-between the `generate` as the program was
         # already exported)
         for layer in self.static_cache.layers:
-            layer.cumulative_length.copy_(cache_position[0:1])
+            layer.cumulative_length.copy_(cache_position[0])
 
         # Get outputs from decoder
         outputs = self.decoder(

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -857,10 +857,8 @@ def _preprocess_mask_arguments(
     if past_key_values is not None:
         q_offset = past_key_values.get_seq_length()
         # To avoid graph breaks, StaticLayer returns a tensor instead of an int -> this has no impact on the ops, but
-        # we need the correct device. We also reshape to a 0-dim scalar: `get_seq_length` may return a 1-element
-        # tensor, which would broadcast the per-index flex `mask_mod` result to shape (1,) and produce a 5D block
-        # mask that `create_block_mask` cannot unpack.
-        q_offset = q_offset.reshape(()).to(inputs_embeds.device) if isinstance(q_offset, torch.Tensor) else q_offset
+        # we need the correct device
+        q_offset = q_offset.to(inputs_embeds.device) if isinstance(q_offset, torch.Tensor) else q_offset
         kv_length, kv_offset = past_key_values.get_mask_sizes(q_length, layer_idx)
     # Otherwise, we infer based on our input
     else:


### PR DESCRIPTION
# What does this PR do?

As per the title. Follow-up to https://github.com/huggingface/transformers/pull/46802. Rather than reshaping when creating the mask, I believe it makes more sense to never use the added dim, i.e. use `cumulative_length` as a scalar tensor all the time, closer to a full python int.
Note that I made sure that it does not break our compile pipeline, both for StaticLayer and StaticSlidingWindowLayer.