### PR TITLE
Fix variable-length linear attention in Qwen3.5/Qwen3-Next

### DIFF
--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -34,7 +34,11 @@ from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
 from ...integrations import use_kernel_forward_from_hub
 from ...masking_utils import create_causal_mask
-from ...modeling_flash_attention_utils import FlashAttentionKwargs
+from ...modeling_flash_attention_utils import (
+    FlashAttentionKwargs,
+    _is_packed_sequence,
+    prepare_fa_kwargs_from_position_ids,
+)
 from ...modeling_layers import (
     GenericForSequenceClassification,
     GenericForTokenClassification,
@@ -244,6 +248,32 @@ def l2norm(x: torch.FloatTensor, dim: int = -1, eps: float = 1e-6):
     return x * inv_norm
 
 
+def seq_idx_from_cu_seqlens(cu_seqlens):
+    """Build the per-token sequence index `(1, total_len)` that `causal_conv1d_fn` uses to keep packed
+    sequences separated, from cumulative sequence lengths."""
+    return torch.repeat_interleave(
+        torch.arange(cu_seqlens.numel() - 1, device=cu_seqlens.device, dtype=torch.int32),
+        cu_seqlens.diff(),
+    ).unsqueeze(0)
+
+
+def causal_conv1d_packed_torch(conv1d, hidden_states, cu_seqlens):
+    """Torch fallback for the short causal conv that does not leak across packed-sequence boundaries.
+
+    `hidden_states` is `(batch, conv_dim, seq_len)`. When `cu_seqlens` is given, each packed sub-sequence
+    is convolved independently (zero left-context), matching what the fused kernel does via `seq_idx`.
+    """
+    seq_len = hidden_states.shape[-1]
+    if cu_seqlens is None:
+        return F.silu(conv1d(hidden_states)[:, :, :seq_len])
+    bounds = cu_seqlens.tolist()
+    segments = [
+        F.silu(conv1d(hidden_states[:, :, start:end])[:, :, : end - start])
+        for start, end in zip(bounds[:-1], bounds[1:])
+    ]
+    return torch.cat(segments, dim=-1)
+
+
 def torch_chunk_gated_delta_rule(
     query,
     key,
@@ -254,8 +284,31 @@ def torch_chunk_gated_delta_rule(
     initial_state=None,
     output_final_state=False,
     use_qk_l2norm_in_kernel=False,
+    cu_seqlens=None,
     **kwargs,
 ):
+    # Variable-length / packed inputs: `cu_seqlens` marks the boundaries of the sequences packed
+    # into the (single) batch row. Process each sub-sequence independently so that neither attention
+    # nor the recurrent state leaks across sequence boundaries (the FLA kernel does this internally,
+    # but the torch fallback would otherwise run the recurrence straight through the boundaries).
+    if cu_seqlens is not None:
+        cu_seqlens = cu_seqlens.tolist()
+        outputs = [
+            torch_chunk_gated_delta_rule(
+                query[:, start:end],
+                key[:, start:end],
+                value[:, start:end],
+                g[:, start:end],
+                beta[:, start:end],
+                chunk_size=chunk_size,
+                initial_state=None,
+                output_final_state=False,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            )[0]
+            for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:])
+        ]
+        return torch.cat(outputs, dim=1), None
+
     initial_dtype = query.dtype
     if use_qk_l2norm_in_kernel:
         query = l2norm(query, dim=-1, eps=1e-6)
@@ -487,16 +540,21 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             if cache_params is not None:
                 new_conv_state = F.pad(mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1], 0))
                 cache_params.update_conv_state(new_conv_state, self.layer_idx)
+            # Packed sequences: keep the causal conv from mixing tokens across sequence boundaries.
+            cu_seqlens = None if use_precomputed_states else kwargs.get("cu_seq_lens_q")
             if self.causal_conv1d_fn is not None:
+                seq_idx = kwargs.get("seq_idx")
+                if seq_idx is None and cu_seqlens is not None:
+                    seq_idx = seq_idx_from_cu_seqlens(cu_seqlens)
                 mixed_qkv = self.causal_conv1d_fn(
                     x=mixed_qkv,
                     weight=self.conv1d.weight.squeeze(1),
                     bias=self.conv1d.bias,
                     activation=self.activation,
-                    seq_idx=kwargs.get("seq_idx"),
+                    seq_idx=seq_idx,
                 )
             else:
-                mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, : mixed_qkv.shape[-1]])
+                mixed_qkv = causal_conv1d_packed_torch(self.conv1d, mixed_qkv, cu_seqlens)
             if use_precomputed_states:
                 mixed_qkv = mixed_qkv[:, :, -seq_len:]
 
@@ -1136,6 +1194,23 @@ class Qwen3_5ModelOutputWithPast(BaseModelOutputWithPast):
     rope_deltas: torch.LongTensor | None = None
 
 
+def maybe_set_cu_seqlens_for_packing(position_ids, batch_size, kwargs):
+    """Derive cumulative sequence lengths from packed `position_ids` for the linear-attention path.
+
+    The gated-delta-net kernels need `cu_seqlens` to know where each packed sequence starts and ends.
+    Mirroring the standard Flash-Attention path, recover them from packed `position_ids` so that callers
+    only need to pass `position_ids` (as for every other model) rather than explicit `cu_seq_lens_*`.
+    No-op when sequences are not packed or when the varlen kwargs were already provided.
+    """
+    if kwargs.get("cu_seq_lens_q") is not None or not _is_packed_sequence(position_ids, batch_size):
+        return
+    (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(position_ids)
+    kwargs["cu_seq_lens_q"] = cu_seq_lens_q
+    kwargs["cu_seq_lens_k"] = cu_seq_lens_k
+    kwargs["max_length_q"] = max_length_q
+    kwargs["max_length_k"] = max_length_k
+
+
 class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
     config: Qwen3_5TextConfig
 
@@ -1186,6 +1261,10 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
             position_ids = position_ids[1:]
         else:
             text_position_ids = None
+
+        # Recover packed-sequence boundaries from `position_ids` so the linear-attention layers do not
+        # leak state across sequences when only `position_ids` is passed (the standard packing interface).
+        maybe_set_cu_seqlens_for_packing(text_position_ids, inputs_embeds.shape[0], kwargs)
 
         causal_mask = create_causal_mask(
             config=self.config,

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -46,6 +46,9 @@ from ..qwen3_next.modeling_qwen3_next import (
     Qwen3NextPreTrainedModel,
     Qwen3NextRMSNorm,
     apply_mask_to_padding_states,
+    causal_conv1d_packed_torch,
+    maybe_set_cu_seqlens_for_packing,
+    seq_idx_from_cu_seqlens,
 )
 from ..qwen3_vl.configuration_qwen3_vl import Qwen3VLConfig, Qwen3VLVisionConfig
 from ..qwen3_vl.modeling_qwen3_vl import (
@@ -262,16 +265,21 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
             if cache_params is not None:
                 new_conv_state = F.pad(mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1], 0))
                 cache_params.update_conv_state(new_conv_state, self.layer_idx)
+            # Packed sequences: keep the causal conv from mixing tokens across sequence boundaries.
+            cu_seqlens = None if use_precomputed_states else kwargs.get("cu_seq_lens_q")
             if self.causal_conv1d_fn is not None:
+                seq_idx = kwargs.get("seq_idx")
+                if seq_idx is None and cu_seqlens is not None:
+                    seq_idx = seq_idx_from_cu_seqlens(cu_seqlens)
                 mixed_qkv = self.causal_conv1d_fn(
                     x=mixed_qkv,
                     weight=self.conv1d.weight.squeeze(1),
                     bias=self.conv1d.bias,
                     activation=self.activation,
-                    seq_idx=kwargs.get("seq_idx"),
+                    seq_idx=seq_idx,
                 )
             else:
-                mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, : mixed_qkv.shape[-1]])
+                mixed_qkv = causal_conv1d_packed_torch(self.conv1d, mixed_qkv, cu_seqlens)
             if use_precomputed_states:
                 mixed_qkv = mixed_qkv[:, :, -seq_len:]
 
@@ -529,6 +537,10 @@ class Qwen3_5TextModel(Qwen3NextModel):
             position_ids = position_ids[1:]
         else:
             text_position_ids = None
+
+        # Recover packed-sequence boundaries from `position_ids` so the linear-attention layers do not
+        # leak state across sequences when only `position_ids` is passed (the standard packing interface).
+        maybe_set_cu_seqlens_for_packing(text_position_ids, inputs_embeds.shape[0], kwargs)
 
         causal_mask = create_causal_mask(
             config=self.config,

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -34,7 +34,11 @@ from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
 from ...integrations import use_experts_implementation, use_kernel_forward_from_hub
 from ...masking_utils import create_causal_mask
-from ...modeling_flash_attention_utils import FlashAttentionKwargs
+from ...modeling_flash_attention_utils import (
+    FlashAttentionKwargs,
+    _is_packed_sequence,
+    prepare_fa_kwargs_from_position_ids,
+)
 from ...modeling_layers import GradientCheckpointingLayer
 from ...modeling_outputs import (
     BaseModelOutputWithPast,
@@ -241,6 +245,32 @@ def l2norm(x: torch.FloatTensor, dim: int = -1, eps: float = 1e-6):
     return x * inv_norm
 
 
+def seq_idx_from_cu_seqlens(cu_seqlens):
+    """Build the per-token sequence index `(1, total_len)` that `causal_conv1d_fn` uses to keep packed
+    sequences separated, from cumulative sequence lengths."""
+    return torch.repeat_interleave(
+        torch.arange(cu_seqlens.numel() - 1, device=cu_seqlens.device, dtype=torch.int32),
+        cu_seqlens.diff(),
+    ).unsqueeze(0)
+
+
+def causal_conv1d_packed_torch(conv1d, hidden_states, cu_seqlens):
+    """Torch fallback for the short causal conv that does not leak across packed-sequence boundaries.
+
+    `hidden_states` is `(batch, conv_dim, seq_len)`. When `cu_seqlens` is given, each packed sub-sequence
+    is convolved independently (zero left-context), matching what the fused kernel does via `seq_idx`.
+    """
+    seq_len = hidden_states.shape[-1]
+    if cu_seqlens is None:
+        return F.silu(conv1d(hidden_states)[:, :, :seq_len])
+    bounds = cu_seqlens.tolist()
+    segments = [
+        F.silu(conv1d(hidden_states[:, :, start:end])[:, :, : end - start])
+        for start, end in zip(bounds[:-1], bounds[1:])
+    ]
+    return torch.cat(segments, dim=-1)
+
+
 def torch_chunk_gated_delta_rule(
     query,
     key,
@@ -251,8 +281,31 @@ def torch_chunk_gated_delta_rule(
     initial_state=None,
     output_final_state=False,
     use_qk_l2norm_in_kernel=False,
+    cu_seqlens=None,
     **kwargs,
 ):
+    # Variable-length / packed inputs: `cu_seqlens` marks the boundaries of the sequences packed
+    # into the (single) batch row. Process each sub-sequence independently so that neither attention
+    # nor the recurrent state leaks across sequence boundaries (the FLA kernel does this internally,
+    # but the torch fallback would otherwise run the recurrence straight through the boundaries).
+    if cu_seqlens is not None:
+        cu_seqlens = cu_seqlens.tolist()
+        outputs = [
+            torch_chunk_gated_delta_rule(
+                query[:, start:end],
+                key[:, start:end],
+                value[:, start:end],
+                g[:, start:end],
+                beta[:, start:end],
+                chunk_size=chunk_size,
+                initial_state=None,
+                output_final_state=False,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            )[0]
+            for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:])
+        ]
+        return torch.cat(outputs, dim=1), None
+
     initial_dtype = query.dtype
     if use_qk_l2norm_in_kernel:
         query = l2norm(query, dim=-1, eps=1e-6)
@@ -484,16 +537,21 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             if cache_params is not None:
                 new_conv_state = F.pad(mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1], 0))
                 cache_params.update_conv_state(new_conv_state, self.layer_idx)
+            # Packed sequences: keep the causal conv from mixing tokens across sequence boundaries.
+            cu_seqlens = None if use_precomputed_states else kwargs.get("cu_seq_lens_q")
             if self.causal_conv1d_fn is not None:
+                seq_idx = kwargs.get("seq_idx")
+                if seq_idx is None and cu_seqlens is not None:
+                    seq_idx = seq_idx_from_cu_seqlens(cu_seqlens)
                 mixed_qkv = self.causal_conv1d_fn(
                     x=mixed_qkv,
                     weight=self.conv1d.weight.squeeze(1),
                     bias=self.conv1d.bias,
                     activation=self.activation,
-                    seq_idx=kwargs.get("seq_idx"),
+                    seq_idx=seq_idx,
                 )
             else:
-                mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, : mixed_qkv.shape[-1]])
+                mixed_qkv = causal_conv1d_packed_torch(self.conv1d, mixed_qkv, cu_seqlens)
             if use_precomputed_states:
                 mixed_qkv = mixed_qkv[:, :, -seq_len:]
 
@@ -1240,6 +1298,23 @@ class Qwen3_5MoeCausalLMOutputWithPast(CausalLMOutputWithPast):
     aux_loss: torch.FloatTensor | None = None
 
 
+def maybe_set_cu_seqlens_for_packing(position_ids, batch_size, kwargs):
+    """Derive cumulative sequence lengths from packed `position_ids` for the linear-attention path.
+
+    The gated-delta-net kernels need `cu_seqlens` to know where each packed sequence starts and ends.
+    Mirroring the standard Flash-Attention path, recover them from packed `position_ids` so that callers
+    only need to pass `position_ids` (as for every other model) rather than explicit `cu_seq_lens_*`.
+    No-op when sequences are not packed or when the varlen kwargs were already provided.
+    """
+    if kwargs.get("cu_seq_lens_q") is not None or not _is_packed_sequence(position_ids, batch_size):
+        return
+    (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(position_ids)
+    kwargs["cu_seq_lens_q"] = cu_seq_lens_q
+    kwargs["cu_seq_lens_k"] = cu_seq_lens_k
+    kwargs["max_length_q"] = max_length_q
+    kwargs["max_length_k"] = max_length_k
+
+
 class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
     config: Qwen3_5MoeTextConfig
 
@@ -1290,6 +1365,10 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
             position_ids = position_ids[1:]
         else:
             text_position_ids = None
+
+        # Recover packed-sequence boundaries from `position_ids` so the linear-attention layers do not
+        # leak state across sequences when only `position_ids` is passed (the standard packing interface).
+        maybe_set_cu_seqlens_for_packing(text_position_ids, inputs_embeds.shape[0], kwargs)
 
         causal_mask = create_causal_mask(
             config=self.config,

--- a/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modeling_qwen3_next.py
@@ -31,7 +31,11 @@ from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
 from ...integrations import use_experts_implementation
 from ...masking_utils import create_causal_mask
-from ...modeling_flash_attention_utils import FlashAttentionKwargs
+from ...modeling_flash_attention_utils import (
+    FlashAttentionKwargs,
+    _is_packed_sequence,
+    prepare_fa_kwargs_from_position_ids,
+)
 from ...modeling_layers import (
     GenericForQuestionAnswering,
     GenericForSequenceClassification,
@@ -370,6 +374,32 @@ def l2norm(x: torch.FloatTensor, dim: int = -1, eps: float = 1e-6):
     return x * inv_norm
 
 
+def seq_idx_from_cu_seqlens(cu_seqlens):
+    """Build the per-token sequence index `(1, total_len)` that `causal_conv1d_fn` uses to keep packed
+    sequences separated, from cumulative sequence lengths."""
+    return torch.repeat_interleave(
+        torch.arange(cu_seqlens.numel() - 1, device=cu_seqlens.device, dtype=torch.int32),
+        cu_seqlens.diff(),
+    ).unsqueeze(0)
+
+
+def causal_conv1d_packed_torch(conv1d, hidden_states, cu_seqlens):
+    """Torch fallback for the short causal conv that does not leak across packed-sequence boundaries.
+
+    `hidden_states` is `(batch, conv_dim, seq_len)`. When `cu_seqlens` is given, each packed sub-sequence
+    is convolved independently (zero left-context), matching what the fused kernel does via `seq_idx`.
+    """
+    seq_len = hidden_states.shape[-1]
+    if cu_seqlens is None:
+        return F.silu(conv1d(hidden_states)[:, :, :seq_len])
+    bounds = cu_seqlens.tolist()
+    segments = [
+        F.silu(conv1d(hidden_states[:, :, start:end])[:, :, : end - start])
+        for start, end in zip(bounds[:-1], bounds[1:])
+    ]
+    return torch.cat(segments, dim=-1)
+
+
 def torch_chunk_gated_delta_rule(
     query,
     key,
@@ -380,8 +410,31 @@ def torch_chunk_gated_delta_rule(
     initial_state=None,
     output_final_state=False,
     use_qk_l2norm_in_kernel=False,
+    cu_seqlens=None,
     **kwargs,
 ):
+    # Variable-length / packed inputs: `cu_seqlens` marks the boundaries of the sequences packed
+    # into the (single) batch row. Process each sub-sequence independently so that neither attention
+    # nor the recurrent state leaks across sequence boundaries (the FLA kernel does this internally,
+    # but the torch fallback would otherwise run the recurrence straight through the boundaries).
+    if cu_seqlens is not None:
+        cu_seqlens = cu_seqlens.tolist()
+        outputs = [
+            torch_chunk_gated_delta_rule(
+                query[:, start:end],
+                key[:, start:end],
+                value[:, start:end],
+                g[:, start:end],
+                beta[:, start:end],
+                chunk_size=chunk_size,
+                initial_state=None,
+                output_final_state=False,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            )[0]
+            for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:])
+        ]
+        return torch.cat(outputs, dim=1), None
+
     initial_dtype = query.dtype
     if use_qk_l2norm_in_kernel:
         query = l2norm(query, dim=-1, eps=1e-6)
@@ -641,16 +694,21 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             if cache_params is not None:
                 new_conv_state = F.pad(mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1], 0))
                 cache_params.update_conv_state(new_conv_state, self.layer_idx)
+            # Packed sequences: keep the causal conv from mixing tokens across sequence boundaries.
+            cu_seqlens = None if use_precomputed_states else kwargs.get("cu_seq_lens_q")
             if self.causal_conv1d_fn is not None:
+                seq_idx = kwargs.get("seq_idx")
+                if seq_idx is None and cu_seqlens is not None:
+                    seq_idx = seq_idx_from_cu_seqlens(cu_seqlens)
                 mixed_qkv = self.causal_conv1d_fn(
                     x=mixed_qkv,
                     weight=self.conv1d.weight.squeeze(1),
                     bias=self.conv1d.bias,
                     activation=self.activation,
-                    seq_idx=kwargs.get("seq_idx"),
+                    seq_idx=seq_idx,
                 )
             else:
-                mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, : mixed_qkv.shape[-1]])
+                mixed_qkv = causal_conv1d_packed_torch(self.conv1d, mixed_qkv, cu_seqlens)
             if use_precomputed_states:
                 mixed_qkv = mixed_qkv[:, :, -seq_len:]
 
@@ -915,6 +973,23 @@ class Qwen3NextPreTrainedModel(PreTrainedModel):
             init.normal_(module.gate.weight, mean=0.0, std=self.config.initializer_range)
 
 
+def maybe_set_cu_seqlens_for_packing(position_ids, batch_size, kwargs):
+    """Derive cumulative sequence lengths from packed `position_ids` for the linear-attention path.
+
+    The gated-delta-net kernels need `cu_seqlens` to know where each packed sequence starts and ends.
+    Mirroring the standard Flash-Attention path, recover them from packed `position_ids` so that callers
+    only need to pass `position_ids` (as for every other model) rather than explicit `cu_seq_lens_*`.
+    No-op when sequences are not packed or when the varlen kwargs were already provided.
+    """
+    if kwargs.get("cu_seq_lens_q") is not None or not _is_packed_sequence(position_ids, batch_size):
+        return
+    (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(position_ids)
+    kwargs["cu_seq_lens_q"] = cu_seq_lens_q
+    kwargs["cu_seq_lens_k"] = cu_seq_lens_k
+    kwargs["max_length_q"] = max_length_q
+    kwargs["max_length_k"] = max_length_k
+
+
 class Qwen3NextModel(Qwen3NextPreTrainedModel):
     def __init__(self, config: Qwen3NextConfig):
         super().__init__(config)
@@ -954,6 +1029,10 @@ class Qwen3NextModel(Qwen3NextPreTrainedModel):
             past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
             position_ids = position_ids.unsqueeze(0)
+
+        # Recover packed-sequence boundaries from `position_ids` so the linear-attention layers do not
+        # leak state across sequences when only `position_ids` is passed (the standard packing interface).
+        maybe_set_cu_seqlens_for_packing(position_ids, inputs_embeds.shape[0], kwargs)
 
         causal_mask = create_causal_mask(
             config=self.config,

--- a/src/transformers/models/qwen3_next/modular_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modular_qwen3_next.py
@@ -24,7 +24,11 @@ from ... import initialization as init
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...masking_utils import create_causal_mask
-from ...modeling_flash_attention_utils import FlashAttentionKwargs
+from ...modeling_flash_attention_utils import (
+    FlashAttentionKwargs,
+    _is_packed_sequence,
+    prepare_fa_kwargs_from_position_ids,
+)
 from ...modeling_outputs import MoeCausalLMOutputWithPast, MoeModelOutputWithPast
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
@@ -211,6 +215,49 @@ def l2norm(x: torch.FloatTensor, dim: int = -1, eps: float = 1e-6):
     return x * inv_norm
 
 
+def maybe_set_cu_seqlens_for_packing(position_ids, batch_size, kwargs):
+    """Derive cumulative sequence lengths from packed `position_ids` for the linear-attention path.
+
+    The gated-delta-net kernels need `cu_seqlens` to know where each packed sequence starts and ends.
+    Mirroring the standard Flash-Attention path, recover them from packed `position_ids` so that callers
+    only need to pass `position_ids` (as for every other model) rather than explicit `cu_seq_lens_*`.
+    No-op when sequences are not packed or when the varlen kwargs were already provided.
+    """
+    if kwargs.get("cu_seq_lens_q") is not None or not _is_packed_sequence(position_ids, batch_size):
+        return
+    (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(position_ids)
+    kwargs["cu_seq_lens_q"] = cu_seq_lens_q
+    kwargs["cu_seq_lens_k"] = cu_seq_lens_k
+    kwargs["max_length_q"] = max_length_q
+    kwargs["max_length_k"] = max_length_k
+
+
+def seq_idx_from_cu_seqlens(cu_seqlens):
+    """Build the per-token sequence index `(1, total_len)` that `causal_conv1d_fn` uses to keep packed
+    sequences separated, from cumulative sequence lengths."""
+    return torch.repeat_interleave(
+        torch.arange(cu_seqlens.numel() - 1, device=cu_seqlens.device, dtype=torch.int32),
+        cu_seqlens.diff(),
+    ).unsqueeze(0)
+
+
+def causal_conv1d_packed_torch(conv1d, hidden_states, cu_seqlens):
+    """Torch fallback for the short causal conv that does not leak across packed-sequence boundaries.
+
+    `hidden_states` is `(batch, conv_dim, seq_len)`. When `cu_seqlens` is given, each packed sub-sequence
+    is convolved independently (zero left-context), matching what the fused kernel does via `seq_idx`.
+    """
+    seq_len = hidden_states.shape[-1]
+    if cu_seqlens is None:
+        return F.silu(conv1d(hidden_states)[:, :, :seq_len])
+    bounds = cu_seqlens.tolist()
+    segments = [
+        F.silu(conv1d(hidden_states[:, :, start:end])[:, :, : end - start])
+        for start, end in zip(bounds[:-1], bounds[1:])
+    ]
+    return torch.cat(segments, dim=-1)
+
+
 def torch_chunk_gated_delta_rule(
     query,
     key,
@@ -221,8 +268,31 @@ def torch_chunk_gated_delta_rule(
     initial_state=None,
     output_final_state=False,
     use_qk_l2norm_in_kernel=False,
+    cu_seqlens=None,
     **kwargs,
 ):
+    # Variable-length / packed inputs: `cu_seqlens` marks the boundaries of the sequences packed
+    # into the (single) batch row. Process each sub-sequence independently so that neither attention
+    # nor the recurrent state leaks across sequence boundaries (the FLA kernel does this internally,
+    # but the torch fallback would otherwise run the recurrence straight through the boundaries).
+    if cu_seqlens is not None:
+        cu_seqlens = cu_seqlens.tolist()
+        outputs = [
+            torch_chunk_gated_delta_rule(
+                query[:, start:end],
+                key[:, start:end],
+                value[:, start:end],
+                g[:, start:end],
+                beta[:, start:end],
+                chunk_size=chunk_size,
+                initial_state=None,
+                output_final_state=False,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            )[0]
+            for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:])
+        ]
+        return torch.cat(outputs, dim=1), None
+
     initial_dtype = query.dtype
     if use_qk_l2norm_in_kernel:
         query = l2norm(query, dim=-1, eps=1e-6)
@@ -482,16 +552,21 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             if cache_params is not None:
                 new_conv_state = F.pad(mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1], 0))
                 cache_params.update_conv_state(new_conv_state, self.layer_idx)
+            # Packed sequences: keep the causal conv from mixing tokens across sequence boundaries.
+            cu_seqlens = None if use_precomputed_states else kwargs.get("cu_seq_lens_q")
             if self.causal_conv1d_fn is not None:
+                seq_idx = kwargs.get("seq_idx")
+                if seq_idx is None and cu_seqlens is not None:
+                    seq_idx = seq_idx_from_cu_seqlens(cu_seqlens)
                 mixed_qkv = self.causal_conv1d_fn(
                     x=mixed_qkv,
                     weight=self.conv1d.weight.squeeze(1),
                     bias=self.conv1d.bias,
                     activation=self.activation,
-                    seq_idx=kwargs.get("seq_idx"),
+                    seq_idx=seq_idx,
                 )
             else:
-                mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, : mixed_qkv.shape[-1]])
+                mixed_qkv = causal_conv1d_packed_torch(self.conv1d, mixed_qkv, cu_seqlens)
             if use_precomputed_states:
                 mixed_qkv = mixed_qkv[:, :, -seq_len:]
 
@@ -712,6 +787,10 @@ class Qwen3NextModel(Qwen3NextPreTrainedModel):
             past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
             position_ids = position_ids.unsqueeze(0)
+
+        # Recover packed-sequence boundaries from `position_ids` so the linear-attention layers do not
+        # leak state across sequences when only `position_ids` is passed (the standard packing interface).
+        maybe_set_cu_seqlens_for_packing(position_ids, inputs_embeds.shape[0], kwargs)
 
         causal_mask = create_causal_mask(
             config=self.config,


### PR DESCRIPTION
# What does this PR do?

Fixes #46851 

Fixes the silent miscomputation of Qwen3.5 linear attention on packed / variable-length inputs.

`Qwen3_5GatedDeltaNet` only recovered packed-sequence boundaries from an explicit `cu_seq_lens_q` kwarg and never derived them from `position_ids`. Since downstream packages (e.g. Verl) assume the same interface as every other HF model (pass `position_ids`, boundaries are inferred), `Qwen3.5` silently produced incorrect results, with no error, whenever `cu_seqlens` was omitted. On top of that, the torch fallbacks (the chunked gated-delta-rule kernel and the short causal conv) ignored `cu_seqlens` entirely, so results were wrong even when the kwargs were passed and the FLA/causal-conv kernels weren't installed.

There were three cross-boundary leaks in the gated-delta net, this PR closes all of them:

1. Boundary derivation: `maybe_set_cu_seqlens_for_packing` recovers `cu_seq_lens`/`max_length` from packed `position_ids` in the text model forward when packing is detected and they weren't supplied, mirroring the standard Flash-Attention path (_is_packed_sequence / prepare_fa_kwargs_from_position_ids). Passing `position_ids` alone now works, like other models.
2. Chunked delta-rule torch fallback: `torch_chunk_gated_delta_rule` now processes each packed sub-sequence independently so neither attention nor the recurrent state leaks across boundaries.
3. Causal conv: `seq_idx_from_cu_seqlens` feeds the fused causal_conv1d_fn, and causal_conv1d_packed_torch convolves each sub-sequence independently in the torch fallback, so the kernel window can't mix tokens across boundaries.

Everything lives in the shared `modular_qwen3_next.py` / `modular_qwen3_5.py`, so the fix also covers Qwen3-Next and Qwen3.5-MoE.


## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

@vasqu @ArthurZucker