### PR TITLE
Rework some old cache getters/properties

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -397,17 +397,17 @@ class StaticLayer(CacheLayerMixin):
         prefill itself ends up in a compiled region (with chunked prefill for instance).
         """
         self.dtype, self.device = key_states.dtype, key_states.device
-        self.max_batch_size, self.num_heads = key_states.shape[:2]
+        self.batch_size, self.num_heads = key_states.shape[:2]
         self.v_head_dim = value_states.shape[-1]
         self.k_head_dim = key_states.shape[-1]
 
         self.keys = torch.zeros(
-            (self.max_batch_size, self.num_heads, self.max_cache_len, self.k_head_dim),
+            (self.batch_size, self.num_heads, self.max_cache_len, self.k_head_dim),
             dtype=self.dtype,
             device=self.device,
         )
         self.values = torch.zeros(
-            (self.max_batch_size, self.num_heads, self.max_cache_len, self.v_head_dim),
+            (self.batch_size, self.num_heads, self.max_cache_len, self.v_head_dim),
             dtype=self.dtype,
             device=self.device,
         )
@@ -620,9 +620,9 @@ class StaticIndexedLayer(StaticLayer):
 
     def lazy_initialization_indexer(self, indexer_key_states: torch.Tensor) -> None:
         self.indexer_dtype, self.indexer_device = indexer_key_states.dtype, indexer_key_states.device
-        max_batch_size, _, index_head_dim = indexer_key_states.shape
+        batch_size, _, index_head_dim = indexer_key_states.shape
         self.indexer_keys = torch.zeros(
-            (max_batch_size, self.max_cache_len, index_head_dim),
+            (batch_size, self.max_cache_len, index_head_dim),
             dtype=self.indexer_dtype,
             device=self.indexer_device,
         )
@@ -934,7 +934,7 @@ class LinearAttentionLayer(LinearAttentionCacheLayerMixin):
         if conv_states is not None:
             self.dtype, self.device = conv_states.dtype, conv_states.device
             # Even if prefill is larfer/shorter than the conv_size, the tensor is always either padded or truncated
-            self.max_batch_size, self.conv_kernel_size = conv_states.shape[0], conv_states.shape[-1]
+            self.batch_size, self.conv_kernel_size = conv_states.shape[0], conv_states.shape[-1]
             # The shape is always static, so we init as such
             self.conv_states = torch.zeros_like(conv_states, dtype=self.dtype, device=self.device)
             # Mark as static address to be able to use cudagraphs
@@ -1398,11 +1398,11 @@ class Cache:
             self.layers[layer_idx].batch_select_indices(indices)
 
     @property
-    def max_batch_size(self) -> int:
-        """Return the maximum batch size of the cache"""
-        values = [layer.max_batch_size for layer in self.layers]
+    def batch_size(self) -> int:
+        """Return the batch size of the cache"""
+        values = [layer.batch_size for layer in self.layers]
         if len(set(values)) > 1:
-            raise ValueError(f"Max batch size is not consistent across layers: {values}")
+            raise ValueError(f"The batch size is not consistent across layers: {values}")
         return values[0]
 
     @property
@@ -1446,6 +1446,13 @@ class Cache:
             "`max_cache_len` is deprecated, and will be removed in version 5.16. Please use `get_max_length()` instead"
         )
         return self.get_max_length()
+
+    @property
+    def max_batch_size(self) -> int:
+        logger.warning_once(
+            "`max_batch_size` is deprecated, and will be removed in version 5.16. Please use the simpler `batch_size` instead"
+        )
+        return self.batch_size
 
 
 class DynamicCache(Cache):

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -83,7 +83,7 @@ class CacheLayerMixin(ABC):
     def get_seq_length(self) -> int: ...
 
     @abstractmethod
-    def get_max_cache_shape(self) -> int: ...
+    def get_max_length(self) -> int: ...
 
     def offload(self):
         """Offload this layer's data to CPU device."""
@@ -115,6 +115,12 @@ class CacheLayerMixin(ABC):
         if self.get_seq_length() > 0:
             self.keys = self.keys.index_select(0, beam_idx.to(self.keys.device))
             self.values = self.values.index_select(0, beam_idx.to(self.values.device))
+
+    def get_max_cache_shape(self) -> int:
+        logger.warning(
+            "`get_max_cache_shape` is deprecated, and will be removed in version 5.16. Please use `get_max_length` instead"
+        )
+        return self.get_max_length()
 
 
 class DynamicLayer(CacheLayerMixin):
@@ -167,7 +173,7 @@ class DynamicLayer(CacheLayerMixin):
             return 0
         return self.keys.shape[-2]
 
-    def get_max_cache_shape(self) -> int:
+    def get_max_length(self) -> int:
         """Returns the maximum sequence length of the cache object. DynamicLayer does not have a maximum length."""
         return -1
 
@@ -267,7 +273,7 @@ class DynamicSlidingWindowLayer(DynamicLayer):
         """Returns the sequence length of the cached states."""
         return self.cumulative_length
 
-    def get_max_cache_shape(self) -> int:
+    def get_max_length(self) -> int:
         """Return the maximum cache shape of the cache"""
         return self.sliding_window
 
@@ -462,7 +468,7 @@ class StaticLayer(CacheLayerMixin):
         """Returns the sequence length of the cached states."""
         return self.cumulative_length if self.is_initialized else 0
 
-    def get_max_cache_shape(self) -> int:
+    def get_max_length(self) -> int:
         """Return the maximum cache shape of the cache"""
         return self.max_cache_len
 
@@ -912,6 +918,10 @@ class LinearAttentionCacheLayerMixin(ABC):
         # We don't crop the linear attention cache, so simply do nothing here
         pass
 
+    def get_max_length(self) -> int:
+        # LinearAttention layer have no sequence length dimension, so simply return -1 here
+        return -1
+
 
 class LinearAttentionLayer(LinearAttentionCacheLayerMixin):
     def __init__(self, config: PreTrainedConfig | None = None):
@@ -1093,6 +1103,14 @@ class Cache:
 
     def __repr__(self):
         return f"{self.__class__.__name__}(layers={self.layers})"
+
+    def __len__(self):
+        """
+        This value corresponds to the number of layers in the model.
+        """
+        # Note: for DynamicCache, layers are initialized lazily, so this will not be accurate before the first
+        # forward through all the layers
+        return len(self.layers)
 
     def prefetch(self, layer_idx: int, only_non_sliding: bool = True):
         """
@@ -1282,6 +1300,22 @@ class Cache:
 
         return self.layers[layer_idx].get_seq_length()
 
+    def get_max_length(self, layer_idx: int | None = None) -> int:
+        """
+        Returns the maximum length of the cache. If `layer_idx` is not provided (default), this returns the maximum
+        accross all layers. Otherwise, return the maximum supported value for the given layer.
+        A value of `-1` means no maximum, or undefined maximum, e.g. for dynamic attention layers that can grow indefinitely,
+        or linear attention layer that do not have a sequence length dimension.
+        """
+        # For DynamicCache, where the layers are created at runtime
+        if layer_idx is not None and layer_idx >= len(self.layers):
+            return -1
+
+        if layer_idx is None:
+            return max(layer.get_max_length() for layer in self.layers)
+        else:
+            return self.layers[layer_idx].get_max_length()
+
     def has_previous_state(self, layer_idx: int | None = None) -> bool:
         """Returns whether the LinearAttention layer at index `layer_idx` has previous state or not."""
         if layer_idx is not None and layer_idx >= len(self.layers):
@@ -1338,14 +1372,6 @@ class Cache:
 
         return self.layers[layer_idx].get_mask_sizes(query_length)
 
-    def get_max_cache_shape(self, layer_idx: int = 0) -> int:
-        """Returns maximum sequence length of the cache object. Dynamic caches do not have a maximum length."""
-        # For DynamicCache, where the layers are created at runtime -> if it was not yet created, return -1
-        # as DynamicLayer does
-        if layer_idx >= len(self.layers):
-            return -1
-        return self.layers[layer_idx].get_max_cache_shape()
-
     def reset(self):
         """Recursively reset all layers tensors"""
         for layer_idx in range(len(self.layers)):
@@ -1380,13 +1406,6 @@ class Cache:
         return values[0]
 
     @property
-    def max_cache_len(self) -> int:
-        """Return the maximum cache length of the cache"""
-        # Linear attention layers have no `max_cache_len`; skip them so a hybrid cache reports its attention layers'.
-        values = [layer.max_cache_len for layer in self.layers if hasattr(layer, "max_cache_len")]
-        return max(values) if values else 0
-
-    @property
     def is_compileable(self) -> bool:
         """Return whether the cache is compilable"""
         # For DynamicCache dispatching the layers lazily (otherwise, all([]) is True)
@@ -1415,13 +1434,18 @@ class Cache:
             for layer in self.layers
         ]
 
-    def __len__(self):
-        """
-        This value corresponds to the number of layers in the model.
-        """
-        # Note: for DynamicCache, layers are initialized lazily, so this will not be accurate before the first
-        # forward through all the layers
-        return len(self.layers)
+    def get_max_cache_shape(self, layer_idx: int = 0) -> int:
+        logger.warning_once(
+            "`get_max_cache_shape` is deprecated, and will be removed in version 5.16. Please use `get_max_length` instead"
+        )
+        return self.get_max_length(layer_idx)
+
+    @property
+    def max_cache_len(self) -> int:
+        logger.warning_once(
+            "`max_cache_len` is deprecated, and will be removed in version 5.16. Please use `get_max_length()` instead"
+        )
+        return self.get_max_length()
 
 
 class DynamicCache(Cache):
@@ -1766,6 +1790,10 @@ class EncoderDecoderCache(Cache):
         """Returns the sequence length of the cached states. A layer index can be optionally passed."""
         return self.self_attention_cache.get_seq_length(layer_idx)
 
+    def get_max_length(self, layer_idx: int | None = None) -> int:
+        """Returns the maximum sequence length (i.e. max capacity) of the cache object"""
+        return self.self_attention_cache.get_max_length(layer_idx)
+
     def reset(self):
         self.self_attention_cache.reset()
         self.cross_attention_cache.reset()
@@ -1808,10 +1836,6 @@ class EncoderDecoderCache(Cache):
         self.self_attention_cache.batch_select_indices(indices)
         self.cross_attention_cache.batch_select_indices(indices)
 
-    def get_max_cache_shape(self) -> int:
-        """Returns the maximum sequence length (i.e. max capacity) of the cache object"""
-        return self.self_attention_cache.get_max_cache_shape()
-
     def get_mask_sizes(self, query_length: int, layer_idx: int) -> tuple[int, int]:
         return self.self_attention_cache.get_mask_sizes(query_length, layer_idx)
 
@@ -1822,6 +1846,12 @@ class EncoderDecoderCache(Cache):
     @property
     def is_compileable(self) -> bool:
         return self.self_attention_cache.is_compileable
+
+    def get_max_cache_shape(self, layer_idx: int = 0) -> int:
+        logger.warning_once(
+            "`get_max_cache_shape` is deprecated, and will be removed in version 5.16. Please use `get_max_length` instead"
+        )
+        return self.get_max_length(layer_idx)
 
 
 # Deprecated alias: SlidingWindowCache was removed in transformers v5. StaticCache is the replacement.

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1830,7 +1830,7 @@ class GenerationMixin(ContinuousMixin):
         need_new_cache = (
             cache_to_check is None
             or cache_to_check.offloading != offload_cache
-            or cache_to_check.max_batch_size != batch_size
+            or cache_to_check.batch_size != batch_size
             or cache_to_check.get_max_length() < max_cache_len
         )
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1831,14 +1831,14 @@ class GenerationMixin(ContinuousMixin):
             cache_to_check is None
             or cache_to_check.offloading != offload_cache
             or cache_to_check.max_batch_size != batch_size
-            or cache_to_check.max_cache_len < max_cache_len
+            or cache_to_check.get_max_length() < max_cache_len
         )
 
         encoder_decoder_cache = getattr(self, "_cache", None)
         if isinstance(encoder_decoder_cache, EncoderDecoderCache):
             need_new_cache = (
                 need_new_cache
-                or encoder_decoder_cache.cross_attention_cache.max_cache_len
+                or encoder_decoder_cache.cross_attention_cache.get_max_length()
                 != model_kwargs["encoder_outputs"][0].shape[1]
             )
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -593,7 +593,7 @@ class BloomForCausalLM(BloomPreTrainedModel, GenerationMixin):
         # This part differs from other models because BLOOM needs a 2D mask to construct alibi tensor
         # The only difference is the usage of 2D instead of 4D mask, but the shape will be static
         if isinstance(past_key_values, StaticCache) and attention_mask is not None:
-            target_length = past_key_values.get_max_cache_shape()
+            target_length = past_key_values.get_max_length()
             batch_size, seq_length = attention_mask.shape
             diff = target_length - seq_length
 

--- a/src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
@@ -1147,7 +1147,7 @@ class DiffusionGemmaGenerationMixin:
             cache_to_check is None
             or cache_to_check.offloading != offload_cache
             or cache_to_check.max_batch_size != batch_size
-            or cache_to_check.max_cache_len < max_length
+            or cache_to_check.get_max_length() < max_length
         )
 
         if need_new_cache:

--- a/src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
@@ -1146,7 +1146,7 @@ class DiffusionGemmaGenerationMixin:
         need_new_cache = (
             cache_to_check is None
             or cache_to_check.offloading != offload_cache
-            or cache_to_check.max_batch_size != batch_size
+            or cache_to_check.batch_size != batch_size
             or cache_to_check.get_max_length() < max_length
         )
 

--- a/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
@@ -1413,8 +1413,8 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
             if layer_pattern == "sliding_attention" and past_key_values.is_compileable:
                 layer_idx = past_key_values.is_sliding.index(True)
                 sliding_layer = past_key_values.layers[layer_idx]
-                if kv_length >= sliding_layer.max_cache_len + additional_kv_length:
-                    kv_length = sliding_layer.max_cache_len + additional_kv_length
+                if kv_length >= sliding_layer.get_max_length() + additional_kv_length:
+                    kv_length = sliding_layer.get_max_length() + additional_kv_length
 
             mask_interface = ALL_MASK_ATTENTION_FUNCTIONS[config._attn_implementation]
             attention_mask = mask_interface(

--- a/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modular_diffusion_gemma.py
@@ -1190,8 +1190,8 @@ class DiffusionGemmaDecoderModel(DiffusionGemmaPreTrainedModel):
             if layer_pattern == "sliding_attention" and past_key_values.is_compileable:
                 layer_idx = past_key_values.is_sliding.index(True)
                 sliding_layer = past_key_values.layers[layer_idx]
-                if kv_length >= sliding_layer.max_cache_len + additional_kv_length:
-                    kv_length = sliding_layer.max_cache_len + additional_kv_length
+                if kv_length >= sliding_layer.get_max_length() + additional_kv_length:
+                    kv_length = sliding_layer.get_max_length() + additional_kv_length
 
             mask_interface = ALL_MASK_ATTENTION_FUNCTIONS[config._attn_implementation]
             attention_mask = mask_interface(

--- a/src/transformers/models/voxtral_realtime/modeling_voxtral_realtime.py
+++ b/src/transformers/models/voxtral_realtime/modeling_voxtral_realtime.py
@@ -1230,7 +1230,7 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralRealtimePreTrainedModel, Ge
             not hasattr(self, "_encoder_cache")
             or cache_to_check.offloading != offload_cache
             or cache_to_check.max_batch_size != batch_size
-            or cache_to_check.max_cache_len < max_cache_len
+            or cache_to_check.get_max_length() < max_cache_len
         )
 
         if need_new_cache:

--- a/src/transformers/models/voxtral_realtime/modeling_voxtral_realtime.py
+++ b/src/transformers/models/voxtral_realtime/modeling_voxtral_realtime.py
@@ -1229,7 +1229,7 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralRealtimePreTrainedModel, Ge
         need_new_cache = (
             not hasattr(self, "_encoder_cache")
             or cache_to_check.offloading != offload_cache
-            or cache_to_check.max_batch_size != batch_size
+            or cache_to_check.batch_size != batch_size
             or cache_to_check.get_max_length() < max_cache_len
         )
 

--- a/src/transformers/models/voxtral_realtime/modular_voxtral_realtime.py
+++ b/src/transformers/models/voxtral_realtime/modular_voxtral_realtime.py
@@ -836,7 +836,7 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralRealtimePreTrainedModel, Ge
         need_new_cache = (
             not hasattr(self, "_encoder_cache")
             or cache_to_check.offloading != offload_cache
-            or cache_to_check.max_batch_size != batch_size
+            or cache_to_check.batch_size != batch_size
             or cache_to_check.get_max_length() < max_cache_len
         )
 

--- a/src/transformers/models/voxtral_realtime/modular_voxtral_realtime.py
+++ b/src/transformers/models/voxtral_realtime/modular_voxtral_realtime.py
@@ -837,7 +837,7 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralRealtimePreTrainedModel, Ge
             not hasattr(self, "_encoder_cache")
             or cache_to_check.offloading != offload_cache
             or cache_to_check.max_batch_size != batch_size
-            or cache_to_check.max_cache_len < max_cache_len
+            or cache_to_check.get_max_length() < max_cache_len
         )
 
         if need_new_cache:

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2486,9 +2486,7 @@ class GenerationTesterMixin:
             else:
                 model_input_length = prompt_length + generated_length
             query_length = (
-                prompt_length + generated_length
-                if not has_static_cache
-                else decoder_past_key_values.get_max_cache_shape()
+                prompt_length + generated_length if not has_static_cache else decoder_past_key_values.get_max_length()
             )
 
             expected_shape = (

--- a/tests/models/dia/test_modeling_dia.py
+++ b/tests/models/dia/test_modeling_dia.py
@@ -336,9 +336,7 @@ class DiaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
             else:
                 model_input_length = prompt_length + generated_length
             query_length = (
-                prompt_length + generated_length
-                if not has_static_cache
-                else decoder_past_key_values.get_max_cache_shape()
+                prompt_length + generated_length if not has_static_cache else decoder_past_key_values.get_max_length()
             )
 
             expected_shape = (

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -150,7 +150,7 @@ class CacheTest(unittest.TestCase):
         config = LlamaConfig(num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=2, hidden_size=32)
         config.layer_types = ["full_attention", "linear_attention"]
         cache = StaticCache(config=config, max_cache_len=8)
-        self.assertEqual(cache.max_cache_len, 8)
+        self.assertEqual(cache.get_max_length(), 8)
 
     @require_torch_accelerator
     def test_offloaded_cache_prefetches_across_linear_attention_layers(self):
@@ -586,7 +586,7 @@ class CacheHardIntegrationTest(unittest.TestCase):
             return_dict_in_generate=True,
         )
         self.assertIsInstance(out.past_key_values, StaticCache)
-        self.assertEqual(out.past_key_values.max_cache_len, requested_max_cache_len)
+        self.assertEqual(out.past_key_values.get_max_length(), requested_max_cache_len)
 
     def test_chunked_prefill_initializes_static_cache_eagerly(self):
         """


### PR DESCRIPTION
# What does this PR do?

As per the title. Some of those old APIs for max sequence length and batch size were quite misleading and badly named. `get_max_cache_shape` and `max_cache_len` were more or less doing the same, but with different names -> `get_max_length` is a better API IMO, as it relates to the similar `get_seq_length` for max/current length respectively. `max_batch_size` is very misleading as well IMO, as the Cache will be changed anyway anytime the batch sizes changes. E.g. a StaticCache with batch size 8 will be changed to a StaticCache of batch size 2 if we use a new sequence of batch 8 -> 2, instead of using a larger cache that would be sliced (it will require re-compilation, but will save a lot of compute, so I still think this is overall the best approach)