### PR TITLE
Fix RT-DETR extra feature-level projection indexing (#46832)

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1971,8 +1971,12 @@ class GenerationMixin(ContinuousMixin):
             # with a longer prompt or a larger `max_new_tokens` (up to that ceiling) reuse the same cache instead of
             # triggering a reallocation (and a `torch.compile` recompilation). Without it, the cache is sized to the
             # current call's `max_length` only. See #46424.
-            if generation_config.max_cache_len is not None:
-                max_cache_length = max(max_cache_length, generation_config.max_cache_len)
+            # Honor both `generation_config.max_cache_len` and the documented `cache_config["max_cache_len"]` path.
+            configured_max_cache_len = generation_config.max_cache_len
+            if configured_max_cache_len is None and generation_config.cache_config is not None:
+                configured_max_cache_len = generation_config.cache_config.get("max_cache_len")
+            if configured_max_cache_len is not None:
+                max_cache_length = max(max_cache_length, configured_max_cache_len)
             cache_batch_size = max(generation_config.num_beams, generation_config.num_return_sequences) * batch_size
             model_kwargs[cache_name] = self._prepare_static_cache(
                 cache_implementation=generation_config.cache_implementation,

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1623,7 +1623,7 @@ class RTDetrModel(RTDetrPreTrainedModel):
         # Lowest resolution feature maps are obtained via 3x3 stride 2 convolutions on the final stage
         if self.config.num_feature_levels > len(sources):
             _len_sources = len(sources)
-            sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state)[-1])
+            sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state[-1]))
             for i in range(_len_sources + 1, self.config.num_feature_levels):
                 sources.append(self.decoder_input_proj[i](encoder_outputs.last_hidden_state[-1]))
 

--- a/src/transformers/models/rt_detr/modular_rt_detr.py
+++ b/src/transformers/models/rt_detr/modular_rt_detr.py
@@ -1862,7 +1862,7 @@ class RTDetrModel(RTDetrPreTrainedModel):
         # Lowest resolution feature maps are obtained via 3x3 stride 2 convolutions on the final stage
         if self.config.num_feature_levels > len(sources):
             _len_sources = len(sources)
-            sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state)[-1])
+            sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state[-1]))
             for i in range(_len_sources + 1, self.config.num_feature_levels):
                 sources.append(self.decoder_input_proj[i](encoder_outputs.last_hidden_state[-1]))
 


### PR DESCRIPTION
## Summary

Fixes a latent crash in RT-DETR when `num_feature_levels` is set higher than the number of backbone output levels (e.g. 4 vs default 3).

### Bug (#46832)

In `RTDetrModel.forward`, the first extra decoder projection incorrectly indexed the **output** of `decoder_input_proj` with `[-1]` instead of selecting the last backbone feature map **before** the projection:

```python
# before (TypeError: conv2d received a list of tensors)
sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state)[-1])

# after (matches the correct pattern used in the next loop iteration)
sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state[-1]))
```

Default configs (`num_feature_levels` equal to backbone depth) are unaffected.

### Secondary fix (#46424)

Documented `generation_config.cache_config["max_cache_len"]` is now honored on the static-cache path (in addition to top-level `generation_config.max_cache_len`), so users can pin `StaticCache` size via either API and avoid realloc/`torch.compile` recompiles across generate calls.

## Test plan

- [x] Code review: extra-level branch now mirrors the already-correct `for i in range(...)` loop body
- [ ] Run RT-DETR repro from #46832:
  ```python
  import torch
  from transformers import RTDetrConfig, RTDetrForObjectDetection

  config = RTDetrConfig(num_feature_levels=4, num_labels=80, image_size=640)
  model = RTDetrForObjectDetection(config).eval()
  with torch.no_grad():
      outputs = model(pixel_values=torch.rand(1, 3, 640, 640))  # should not raise
  ```
- [ ] Confirm default `RTDetrConfig()` forward still works
- [ ] Optional: verify `generate(..., cache_implementation="static", cache_config={"max_cache_len": 2048})` sizes static cache to >= 2048

Fixes #46832
Related #46424