### PR TITLE
[RT-DETR] Fix misplaced [-1] index in decoder projection when num_feature_levels > backbone outputs

### DIFF
--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1623,7 +1623,7 @@ class RTDetrModel(RTDetrPreTrainedModel):
         # Lowest resolution feature maps are obtained via 3x3 stride 2 convolutions on the final stage
         if self.config.num_feature_levels > len(sources):
             _len_sources = len(sources)
-            sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state)[-1])
+            sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state[-1]))
             for i in range(_len_sources + 1, self.config.num_feature_levels):
                 sources.append(self.decoder_input_proj[i](encoder_outputs.last_hidden_state[-1]))
 

--- a/src/transformers/models/rt_detr/modular_rt_detr.py
+++ b/src/transformers/models/rt_detr/modular_rt_detr.py
@@ -1862,7 +1862,7 @@ class RTDetrModel(RTDetrPreTrainedModel):
         # Lowest resolution feature maps are obtained via 3x3 stride 2 convolutions on the final stage
         if self.config.num_feature_levels > len(sources):
             _len_sources = len(sources)
-            sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state)[-1])
+            sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state[-1]))
             for i in range(_len_sources + 1, self.config.num_feature_levels):
                 sources.append(self.decoder_input_proj[i](encoder_outputs.last_hidden_state[-1]))
 


### PR DESCRIPTION
## What does this PR do?

Fixes a misplaced `[-1]` index in `RTDetrModel.forward` that causes a `TypeError` when `num_feature_levels` exceeds the number of backbone output feature maps.

Fixes #46832

## Root Cause

In the decoder input projection block, when `num_feature_levels > len(sources)`, the first extra feature level is constructed with:

```python
# BUG: [-1] indexes into the Conv2d output tensor, not the feature map list
sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state)[-1])
```

`encoder_outputs.last_hidden_state` is a **list** of feature-map tensors. The `[-1]` should select the last tensor from the list **before** passing it to the Conv2d projection — not **after**. The correct pattern already exists on the very next line:

```python
# CORRECT: [-1] selects from the list, then passes to Conv2d
sources.append(self.decoder_input_proj[i](encoder_outputs.last_hidden_state[-1]))
```

## Fix

Move the `[-1]` index inside the parentheses so it selects from the list before projection:

```diff
- sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state)[-1])
+ sources.append(self.decoder_input_proj[_len_sources](encoder_outputs.last_hidden_state[-1]))
```

Applied to both `modular_rt_detr.py` (source of truth) and `modeling_rt_detr.py` (generated).

## Reproduction

```python
import torch
from transformers import RTDetrConfig, RTDetrForObjectDetection

config = RTDetrConfig(num_feature_levels=4)  # > 3 backbone outputs
model = RTDetrForObjectDetection(config)
dummy = torch.randn(1, 3, 640, 640)

# Before fix: TypeError
# After fix: runs correctly
outputs = model(dummy)
```
