### PR TITLE
nemotron_asr_streaming: set _supports_flex_attn to False

### DIFF
--- a/src/transformers/models/nemotron_asr_streaming/modeling_nemotron_asr_streaming.py
+++ b/src/transformers/models/nemotron_asr_streaming/modeling_nemotron_asr_streaming.py
@@ -818,7 +818,8 @@ class NemotronAsrStreamingPreTrainedModel(PreTrainedModel):
     _no_split_modules = ["NemotronAsrStreamingEncoderBlock"]
     _supports_flat_attention_mask = True
     _supports_sdpa = True
-    _supports_flex_attn = True
+    # flex attention is incompatible as this model uses a float attention mask (relative position bias) across the board
+    _supports_flex_attn = False
 
     # TODO: @eustlb, add support when flash attention supports custom attention bias
     _supports_flash_attn = False

--- a/src/transformers/models/nemotron_asr_streaming/modular_nemotron_asr_streaming.py
+++ b/src/transformers/models/nemotron_asr_streaming/modular_nemotron_asr_streaming.py
@@ -998,6 +998,8 @@ class NemotronAsrStreamingEncoderBlock(ParakeetEncoderBlock):
 @auto_docstring
 class NemotronAsrStreamingPreTrainedModel(ParakeetPreTrainedModel):
     config: NemotronAsrStreamingConfig
+    # flex attention is incompatible as this model uses a float attention mask (relative position bias) across the board
+    _supports_flex_attn = False
 
     def _get_subsampling_output_length(self, input_lengths: torch.Tensor):
         encoder_config = getattr(self.config, "encoder_config", self.config)


### PR DESCRIPTION
It returns error AttributeError: 'BlockMask' object has no attribute 'dtype' when running test case `tests/models/nemotron_asr_streaming/test_modeling_nemotron_asr_streaming.py::NemotronAsrStreamingEncoderModelTest::test_flex_attention_with_grads`, it seems to be a similar case like https://github.com/huggingface/transformers/pull/42802: `_supports_flex_attn` should be set to False. Pls help review, thx! @vasqu 