### PR TITLE
fix(mps): remove float64 casts in MusicFlamingo and UDOP that break Apple Silicon MPS

### DIFF
--- a/src/transformers/models/musicflamingo/modeling_musicflamingo.py
+++ b/src/transformers/models/musicflamingo/modeling_musicflamingo.py
@@ -181,8 +181,6 @@ def rotate_half(x):
 
 
 def apply_rotary_time_emb(hidden_states, cos, sin):
-    original_dtype = hidden_states.dtype
-    hidden_states = hidden_states.to(torch.float64)
     cos = cos.to(hidden_states)
     sin = sin.to(hidden_states)
     rot_dim = cos.shape[-1]
@@ -190,7 +188,7 @@ def apply_rotary_time_emb(hidden_states, cos, sin):
     passthrough = hidden_states[..., rot_dim:]
     rotated = hidden_states[..., :rot_dim]
     rotated = (rotated * cos) + (rotate_half(rotated) * sin)
-    return torch.cat((rotated, passthrough), dim=-1).to(original_dtype)
+    return torch.cat((rotated, passthrough), dim=-1)
 
 
 @auto_docstring(

--- a/src/transformers/models/musicflamingo/modular_musicflamingo.py
+++ b/src/transformers/models/musicflamingo/modular_musicflamingo.py
@@ -166,8 +166,6 @@ def rotate_half(x):
 
 
 def apply_rotary_time_emb(hidden_states, cos, sin):
-    original_dtype = hidden_states.dtype
-    hidden_states = hidden_states.to(torch.float64)
     cos = cos.to(hidden_states)
     sin = sin.to(hidden_states)
     rot_dim = cos.shape[-1]
@@ -175,7 +173,7 @@ def apply_rotary_time_emb(hidden_states, cos, sin):
     passthrough = hidden_states[..., rot_dim:]
     rotated = hidden_states[..., :rot_dim]
     rotated = (rotated * cos) + (rotate_half(rotated) * sin)
-    return torch.cat((rotated, passthrough), dim=-1).to(original_dtype)
+    return torch.cat((rotated, passthrough), dim=-1)
 
 
 class MusicFlamingoRotaryEmbedding(MoonshineRotaryEmbedding):

--- a/src/transformers/models/udop/modeling_udop.py
+++ b/src/transformers/models/udop/modeling_udop.py
@@ -160,8 +160,7 @@ def combine_image_text_embeddings(
     )
     ocr_points = ocr_points_x + ocr_points_y
     # make sure bounding boxes are of type float to calculate means
-    bbox = bbox.to(torch.float64)
-    target_seg = (bbox.mean(-1) == 0.0) | (bbox.mean(-1) == 1.0)
+    target_seg = (bbox.float().mean(-1) == 0.0) | (bbox.float().mean(-1) == 1.0)
     repeated_vision_embeds = torch.gather(
         image_embeddings, 1, ocr_points.unsqueeze(-1).repeat(1, 1, image_embeddings.size(-1))
     )

--- a/tests/models/musicflamingo/test_modeling_musicflamingo.py
+++ b/tests/models/musicflamingo/test_modeling_musicflamingo.py
@@ -43,6 +43,8 @@ from ...test_modeling_common import ids_tensor
 if is_torch_available():
     import torch
 
+    from transformers.models.musicflamingo.modeling_musicflamingo import apply_rotary_time_emb
+
 
 class MusicFlamingoModelTester(ALMModelTester):
     """
@@ -146,6 +148,16 @@ class MusicFlamingoForConditionalGenerationModelTest(ALMModelTest, unittest.Test
 
         inferred = model._build_audio_timestamps(input_ids, post_lengths, max_post_length)
         torch.testing.assert_close(inferred, audio_timestamps)
+
+    def test_apply_rotary_time_emb_preserves_dtype(self):
+        # Verifies that apply_rotary_time_emb does not upcast to float64, which would fail on MPS.
+        batch, seq, dim = 2, 4, 8
+        hidden_states = torch.randn(batch, seq, dim, dtype=torch.float32, device=torch_device)
+        cos = torch.randn(batch, seq, dim // 2, dtype=torch.float32, device=torch_device)
+        sin = torch.randn(batch, seq, dim // 2, dtype=torch.float32, device=torch_device)
+        out = apply_rotary_time_emb(hidden_states, cos, sin)
+        self.assertEqual(out.dtype, torch.float32)
+        self.assertEqual(out.shape, hidden_states.shape)
 
     @unittest.skip(
         reason="This test does not apply to MusicFlamingo since High-level inputs_embeds corresponding to audio tokens are replaced when input features are provided."

--- a/tests/models/udop/test_modeling_udop.py
+++ b/tests/models/udop/test_modeling_udop.py
@@ -41,6 +41,7 @@ if is_torch_available():
     import torch.nn.functional as F
 
     from transformers import UdopEncoderModel, UdopForConditionalGeneration, UdopModel, UdopProcessor
+    from transformers.models.udop.modeling_udop import combine_image_text_embeddings
 
 
 class UdopModelTester:
@@ -404,6 +405,19 @@ class UdopModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     @unittest.skip(reason="TODO: Fix me @joao")
     def test_generate_without_input_ids(self):
         pass
+
+    def test_combine_image_text_embeddings_no_float64(self):
+        # combine_image_text_embeddings previously cast bbox to float64, which fails on MPS.
+        # Verify that the function runs with float32 inputs and produces a finite result.
+        num_patches, batch_size, seq_len, hidden_size = 14, 2, 4, 32
+        image_embeddings = torch.randn(batch_size, num_patches * num_patches, hidden_size, device=torch_device)
+        inputs_embeds = torch.zeros(batch_size, seq_len, hidden_size, device=torch_device)
+        # Use all-zero bboxes to exercise the target_seg mask.
+        bbox = torch.zeros(batch_size, seq_len, 4, device=torch_device)
+        result, _, _ = combine_image_text_embeddings(
+            image_embeddings, inputs_embeds, bbox, visual_bbox=None, num_patches=num_patches
+        )
+        self.assertFalse(torch.any(result.isnan()))
 
 
 class UdopEncoderOnlyModelTester:


### PR DESCRIPTION
## What does this PR do?

Fixes #46723.

`torch.float64` is not supported on Apple Silicon MPS devices — any `.to(torch.float64)` call on an MPS tensor raises:
```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.
```

Two functions unconditionally upcasted to float64 before performing computation, causing all MusicFlamingo and UDOP inference to fail on MPS:

### `apply_rotary_time_emb` (MusicFlamingo)

```python
# Before — broken on MPS
hidden_states = hidden_states.to(torch.float64)
...
return torch.cat((rotated, passthrough), dim=-1).to(original_dtype)
```

The result was immediately cast back to `original_dtype`, so the float64 upcast gave no precision benefit for float32/bfloat16 models. Removed it entirely.  `modeling_musicflamingo.py` regenerated from the modular file with `utils/check_modular_conversion.py --fix`.

### `combine_image_text_embeddings` (UDOP)

```python
# Before — broken on MPS
bbox = bbox.to(torch.float64)
target_seg = (bbox.mean(-1) == 0.0) | (bbox.mean(-1) == 1.0)
```

The float64 was only needed for two exact comparisons against 0.0 and 1.0. Float32 is perfectly sufficient for these comparisons (bboxes that are exactly 0 or 1 are represented exactly in float32). Replaced with `.float()`.

## Tests

Added a unit test for each fix:
- `MusicFlamingoForConditionalGenerationModelTest::test_apply_rotary_time_emb_preserves_dtype` — verifies output dtype matches float32 input (no float64 upcast)
- `UdopModelTest::test_combine_image_text_embeddings_no_float64` — verifies the function runs without float64 and produces finite results

```
pytest tests/models/musicflamingo/test_modeling_musicflamingo.py::MusicFlamingoForConditionalGenerationModelTest::test_apply_rotary_time_emb_preserves_dtype tests/models/udop/test_modeling_udop.py::UdopModelTest::test_combine_image_text_embeddings_no_float64 -v
# 2 passed
```

## Coordination

- Addresses issue #46723 (opened by the community; no active PR existed — a commenter said "I'll be sending a PR momentarily" 10+ days ago but no PR appeared)
- Checked for duplicate PRs with `gh pr list --repo huggingface/transformers --state open --search "46723 in:body"` — none found
- AI assistance was used to draft this PR; changes reviewed and tested by the human submitter