### PR TITLE
QwenVL model conversion

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -645,11 +645,7 @@ def _build_checkpoint_conversion_mapping():
             ),
         ],
         "Qwen2VLModel": [
-            WeightRenaming(source_patterns=r"^model\.layers", target_patterns="model.language_model.layers"),
-            WeightRenaming(source_patterns=r"^model\.norm", target_patterns="model.language_model.norm"),
-            WeightRenaming(
-                source_patterns=r"^model\.embed_tokens", target_patterns="model.language_model.embed_tokens"
-            ),
+            PrefixChange(prefix_to_add="language_model", model_prefix="model"),
         ],
         "Qwen2VLForConditionalGeneration": [
             WeightRenaming(source_patterns=r"^visual", target_patterns="model.visual"),

--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -647,7 +647,9 @@ def _build_checkpoint_conversion_mapping():
         "Qwen2VLModel": [
             WeightRenaming(source_patterns=r"^model\.layers", target_patterns="model.language_model.layers"),
             WeightRenaming(source_patterns=r"^model\.norm", target_patterns="model.language_model.norm"),
-            WeightRenaming(source_patterns=r"^model\.embed_tokens", target_patterns="model.language_model.embed_tokens"),
+            WeightRenaming(
+                source_patterns=r"^model\.embed_tokens", target_patterns="model.language_model.embed_tokens"
+            ),
         ],
         "Qwen2VLForConditionalGeneration": [
             WeightRenaming(source_patterns=r"^visual", target_patterns="model.visual"),

--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -120,6 +120,7 @@ _MODEL_TO_CONVERSION_PATTERN = {
     "MusicFlamingoModel": "Qwen2AudioModel",
     "GraniteSpeechPlusModel": "GraniteSpeechModel",
     "MaskFormerDetrDecoder": "DetrModel",
+    "Qwen2_5_VLModel": "Qwen2VLModel",
     "Qwen2_5_VLForConditionalGeneration": "Qwen2VLForConditionalGeneration",
     # ViT-style vision models (old HuggingFace checkpoint format → new modular format)
     "ASTModel": "ViTModel",
@@ -642,6 +643,11 @@ def _build_checkpoint_conversion_mapping():
                 source_patterns=r"^model(?!(\.visual|\.projector|\.language_model))",
                 target_patterns="model.language_model",
             ),
+        ],
+        "Qwen2VLModel": [
+            WeightRenaming(source_patterns=r"^model\.layers", target_patterns="model.language_model.layers"),
+            WeightRenaming(source_patterns=r"^model\.norm", target_patterns="model.language_model.norm"),
+            WeightRenaming(source_patterns=r"^model\.embed_tokens", target_patterns="model.language_model.embed_tokens"),
         ],
         "Qwen2VLForConditionalGeneration": [
             WeightRenaming(source_patterns=r"^visual", target_patterns="model.visual"),

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -357,6 +357,7 @@ MODEL_MAPPING_NAMES = OrderedDict(
         ("ovis2", "Ovis2Model"),
         ("owlv2", "Owlv2Model"),
         ("owlvit", "OwlViTModel"),
+        ("paddleocr_vl", "PaddleOCRVLModel"),
         ("paligemma", "PaliGemmaModel"),
         ("parakeet_ctc", "ParakeetForCTC"),
         ("parakeet_encoder", "ParakeetEncoder"),

--- a/tests/models/colqwen2/test_modeling_colqwen2.py
+++ b/tests/models/colqwen2/test_modeling_colqwen2.py
@@ -267,6 +267,12 @@ class ColQwen2ForRetrievalModelTest(ModelTesterMixin, unittest.TestCase):
 
             self.assertIsInstance(outputs, ColQwen2ForRetrievalOutput)
 
+    @unittest.skip(
+        reason="Conversions applied to underlying VLM saved in legacy format. Colqwen2 doesn't match any of those regexes!"
+    )
+    def test_reverse_loading_mapping(self, **kwargs):
+        pass
+
     @unittest.skip(reason="Some undefined behavior encountered with test versions of Qwen2-VL. Skip for now.")
     def test_model_parallelism(self):
         pass

--- a/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
@@ -204,6 +204,9 @@ class Qwen2_5_VLModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Test
     def test_config(self):
         self.config_tester.run_common_tests()
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
     def test_mismatching_num_image_tokens(self):
         """
         Tests that VLMs through an error with explicit message saying what is wrong

--- a/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
@@ -196,6 +196,9 @@ class Qwen2VLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     def test_config(self):
         self.config_tester.run_common_tests()
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
     def test_mismatching_num_image_tokens(self):
         """
         Tests that VLMs through an error with explicit message saying what is wrong


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46881)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46881)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Loading a base qwen vl doesn't work on `main`, I don't know when the conversion got lost for it. Checked with the below script that loading and re-loading works fine

```python
from transformers import AutoModelForMultimodalLM, AutoModel, ColQwen2ForRetrieval

model = AutoModelForMultimodalLM.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", device_map="cuda")
model.save_pretrained("tmp_qwen")
model = AutoModelForMultimodalLM.from_pretrained("tmp_qwen", device_map="cuda")

base_model = AutoModel.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", device_map="cuda")
base_model.save_pretrained("tmp_qwen_base")
base_model = AutoModel.from_pretrained("tmp_qwen_base", device_map="cuda")

ret = ColQwen2ForRetrieval.from_pretrained("vidore/colqwen2-v1.0-hf", device_map="cuda")
ret.save_pretrained("tmp_colqwen")
ret = ColQwen2ForRetrieval.from_pretrained("tmp_colqwen", device_map="cuda")


```

<!-- ci-dashboard-recap:start -->

---

### CI recap

**Dashboard:** [View test results in Grafana](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46881)
**Latest run:** [28430645169:1](https://github.com/huggingface/transformers/actions/runs/28430645169)
**Result:** `success` | **Jobs:** 14 | **Tests:** 49,790 | **Failures:** 0 | **Duration:** 16h 32m

<!-- ci-dashboard-recap:end -->