### PR TITLE
Fix Gemma4 closed thinking block detection in serve

### DIFF
--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -286,7 +286,7 @@ def get_reasoning_config(processor, model: "PreTrainedModel", input_ids=None) ->
         schema = _DEFAULT_THINKING_TOKENS["schema"]
     config: dict = {"start_ids": start_ids, "end_id": end_id, "schema": schema}
     if input_ids is not None:
-        config["start_in_thinking"] = _starts_in_thinking(input_ids, start_ids)
+        config["start_in_thinking"] = _starts_in_thinking(input_ids, start_ids, end_id)
     return config
 
 
@@ -310,7 +310,7 @@ def parse_reasoning(processor, generated_ids, content: str, reasoning_config: di
     return content, None
 
 
-def _starts_in_thinking(input_ids, start_ids: list[int]) -> bool:
+def _starts_in_thinking(input_ids, start_ids: list[int], end_id: int) -> bool:
     """True if the rendered prompt ends with an unclosed thinking block.
 
     Some reasoning-model chat templates prefill the thinking opener as the final
@@ -328,6 +328,10 @@ def _starts_in_thinking(input_ids, start_ids: list[int]) -> bool:
         if len(input_ids) != 1:
             return False
         input_ids = input_ids[0]
+    # Some templates prefill an empty thinking block and immediately close it
+    # (e.g. Gemma 4 renders ``<|channel>thought\n<channel|>`` when thinking is disabled).
+    if input_ids and input_ids[-1] == end_id:
+        return False
     n = len(start_ids)
     # Match start_ids at the tail, allowing up to one trailing token (e.g. "\n").
     for trailing in (0, 1):

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -37,6 +37,7 @@ from transformers.cli.serving.utils import (
     BaseHandler,
     GenerationState,
     Modality,
+    _starts_in_thinking,
     get_tool_call_config,
     parse_tool_calls,
 )
@@ -318,6 +319,18 @@ class TestProcessorInputsFromMessages(unittest.TestCase):
                 self.assertEqual(len(result[0]["content"]), 2)
                 video_item = result[0]["content"][0]
                 self.assertEqual(video_item, {"type": "video", "url": video_src})
+
+
+class TestReasoningUtils(unittest.TestCase):
+    def test_starts_in_thinking_rejects_already_closed_block(self):
+        start_ids = [100, 45518, 107]
+        end_id = 101
+
+        self.assertTrue(_starts_in_thinking([1, *start_ids], start_ids, end_id))
+        self.assertTrue(_starts_in_thinking([1, *start_ids, 198], start_ids, end_id))
+
+        # Gemma 4 can render an empty, already closed thinking block when thinking is disabled.
+        self.assertFalse(_starts_in_thinking([1, *start_ids, end_id], start_ids, end_id))
 
 
 class TestGenerativeModelList(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

Fixes #46561.

This PR fixes Gemma 4 reasoning detection in `transformers serve` when thinking is disabled.

Gemma 4 can render an empty thinking block that is immediately closed in the prompt. The previous `_starts_in_thinking` logic only checked whether the prompt ended near the thinking start token, so it could incorrectly treat the following generated text as `reasoning_content`.

This change passes the thinking end token into `_starts_in_thinking` and returns `False` when the prompt already ends with the thinking end token.

## Tests

```bash
.venv/bin/python -m pytest tests/cli/test_serve.py::TestReasoningUtils::test_starts_in_thinking_rejects_already_closed_block -q
ruff check src/transformers/cli/serving/utils.py tests/cli/test_serve.py
ruff format --check src/transformers/cli/serving/utils.py tests/cli/test_serve.py
git diff --check