### PR TITLE
Reject path traversal in the `transformers_weights` config field

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -593,17 +593,20 @@ def _get_resolved_checkpoint_files(
         # If the file is a local folder (but not in the HF_HOME cache, even if it's technically local)
         if is_local:
             if transformers_explicit_filename is not None:
-                # If the filename is explicitly defined, load this by default.
-                archive_file = os.path.join(pretrained_model_name_or_path, subfolder, transformers_explicit_filename)
-                base_dir = os.path.abspath(os.path.join(pretrained_model_name_or_path, subfolder))
+                # If the filename is explicitly defined, load this by default
+                base_dir = os.path.join(pretrained_model_name_or_path, subfolder)
+                archive_file = os.path.join(base_dir, transformers_explicit_filename)
+                # Just a small check to make sure `transformers_explicit_filename` does not escape the base_dir, i.e. it does not
+                # contain `..` for example
                 try:
-                    contained = os.path.commonpath([base_dir, os.path.abspath(archive_file)]) == base_dir
+                    absolute_base_dir = os.path.abspath(base_dir)
+                    absolute_archive_file = os.path.abspath(archive_file)
+                    contained = os.path.commonpath([absolute_base_dir, absolute_archive_file]) == absolute_base_dir
                 except ValueError:
                     contained = False
                 if not contained:
                     raise ValueError(
-                        "`transformers_weights` must reference a file inside the model directory; got "
-                        f"{transformers_explicit_filename!r}"
+                        f"`transformers_weights` must reference a file inside the model directory, got {transformers_explicit_filename}"
                     )
                 is_sharded = transformers_explicit_filename.endswith(".safetensors.index.json")
             elif use_safetensors is not False and os.path.isfile(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -595,6 +595,16 @@ def _get_resolved_checkpoint_files(
             if transformers_explicit_filename is not None:
                 # If the filename is explicitly defined, load this by default.
                 archive_file = os.path.join(pretrained_model_name_or_path, subfolder, transformers_explicit_filename)
+                base_dir = os.path.abspath(os.path.join(pretrained_model_name_or_path, subfolder))
+                try:
+                    contained = os.path.commonpath([base_dir, os.path.abspath(archive_file)]) == base_dir
+                except ValueError:
+                    contained = False
+                if not contained:
+                    raise ValueError(
+                        "`transformers_weights` must reference a file inside the model directory; got "
+                        f"{transformers_explicit_filename!r}"
+                    )
                 is_sharded = transformers_explicit_filename.endswith(".safetensors.index.json")
             elif use_safetensors is not False and os.path.isfile(
                 os.path.join(pretrained_model_name_or_path, subfolder, _add_variant(SAFE_WEIGHTS_NAME, variant))

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -859,6 +859,66 @@ class ModelUtilsTest(TestCasePlus):
                 for p1, p2 in zip(model.parameters(), new_model.parameters()):
                     torch.testing.assert_close(p1, p2)
 
+    def test_transformers_weights_config_field_rejects_path_traversal(self):
+        config = BertConfig(
+            vocab_size=16,
+            hidden_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=1,
+            intermediate_size=8,
+            max_position_embeddings=8,
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo = os.path.join(tmp_dir, "repo")
+            outside_dir = os.path.join(tmp_dir, "outside")
+            BertModel(config).save_pretrained(repo)
+            BertModel(config).save_pretrained(outside_dir)
+
+            config_file = os.path.join(repo, "config.json")
+            with open(config_file, encoding="utf-8") as f:
+                repo_config = json.load(f)
+
+            for bad in [
+                os.path.join("..", "outside", "model.safetensors"),
+                os.path.join(outside_dir, "model.safetensors"),
+            ]:
+                repo_config["transformers_weights"] = bad
+                with open(config_file, "w", encoding="utf-8") as f:
+                    json.dump(repo_config, f)
+                with self.assertRaises(ValueError):
+                    BertModel.from_pretrained(repo)
+
+            repo_config["transformers_weights"] = "model.safetensors"
+            with open(config_file, "w", encoding="utf-8") as f:
+                json.dump(repo_config, f)
+            self.assertIsInstance(BertModel.from_pretrained(repo), BertModel)
+
+    def test_transformers_weights_allows_symlinked_snapshot_file(self):
+        if os.name == "nt":
+            self.skipTest("creating symlinks requires privileges on Windows")
+        config = BertConfig(
+            vocab_size=16,
+            hidden_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=1,
+            intermediate_size=8,
+            max_position_embeddings=8,
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            blobs = os.path.join(tmp_dir, "blobs")
+            snapshot = os.path.join(tmp_dir, "snapshot")
+            os.makedirs(blobs)
+            os.makedirs(snapshot)
+            BertModel(config).save_pretrained(blobs, safe_serialization=True)
+
+            config_dict = config.to_dict()
+            config_dict["transformers_weights"] = "model.safetensors"
+            with open(os.path.join(snapshot, "config.json"), "w", encoding="utf-8") as f:
+                json.dump(config_dict, f)
+            os.symlink(os.path.join(blobs, "model.safetensors"), os.path.join(snapshot, "model.safetensors"))
+
+            self.assertIsInstance(BertModel.from_pretrained(snapshot), BertModel)
+
     def test_checkpoint_sharding_from_hub(self):
         model = BertModel.from_pretrained("hf-internal-testing/tiny-random-bert-sharded")
         # the model above is the same as the model below, just a sharded version.


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46890)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46890)
<!-- ci-dashboard-badge:end -->

`from_pretrained` resolves which checkpoint file to load via `_get_resolved_checkpoint_files`. When a model's `config.json` carries a `transformers_weights` field, that **untrusted** value is joined onto the model directory and opened after only a **suffix check** (it must end `.safetensors` / `.safetensors.index.json`, or equal `adapter_model.bin`) — with no `..` / absolute-path / containment validation (`modeling_utils.py:597`). Because `os.path.join` drops the prefix on an absolute component and `..` walks out of the directory, a malicious **local** model directory makes `AutoModel.from_pretrained(...)` open a `.safetensors`-format file **outside** the model directory (path traversal, CWE-22), with no `trust_remote_code`.

The escape base is `pretrained_model_name_or_path` — the directory the caller chose to load, not a config field — so the file is expected to live inside it; the same containment mistake was fixed on the write side for chat templates (#46191) and Bark voice presets (#46237), and this is the read side in the core loader. The read is constrained to `.safetensors`-format files (no arbitrary-text disclosure) and `weights_only=True` means no code execution, but a crafted local model can still read an out-of-directory checkpoint and acts as a file-existence oracle — in multi-tenant model hosting this can surface another tenant's weights.

The fix validates that the resolved `transformers_weights` path stays inside the model directory (rejecting `..` and absolute paths), leaving the sibling branches (which use hard-coded constants) untouched. A legitimate in-repo filename still loads.

AI assistance was used while drafting this change; I reviewed every line and ran the tests below.

# What does this PR do?

Adds a containment check so a `transformers_weights` value in `config.json` cannot make `from_pretrained` open a `.safetensors` file outside the model directory (path traversal, CWE-22, no `trust_remote_code`), matching the existing write-side traversal fixes (#46191, #46237).

**Tests run** (`torch==2.12.1`):

```
pytest tests/utils/test_modeling_utils.py -k test_transformers_weights_config_field_rejects_path_traversal
# 1 passed (an injected ../ or absolute transformers_weights is rejected;
#           a legitimate in-repo value still loads)
ruff check / ruff format --check    # clean
```

Reported via huntr: https://huntr.com/bounties/bdd08581-3537-4ca1-bd8c-de724529617a

Fixes # (security hardening)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

- model loading (from pretrained): @CyrilVallez