### PR TITLE
[docs] update cache apis

### DIFF
--- a/docs/source/en/internal/generation_utils.md
+++ b/docs/source/en/internal/generation_utils.md
@@ -212,7 +212,7 @@ A [`StoppingCriteria`] can be used to change when to stop generation (other than
     - update
     - get_seq_length
     - get_mask_sizes
-    - get_max_cache_shape
+    - get_max_length
     - reset
     - reorder_cache
     - lazy_initialization
@@ -245,7 +245,7 @@ A [`StoppingCriteria`] can be used to change when to stop generation (other than
     - early_initialization
     - get_seq_length
     - get_mask_sizes
-    - get_max_cache_shape
+    - get_max_length
     - reset
     - reorder_cache
     - crop

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -83,7 +83,13 @@ class CacheLayerMixin(ABC):
     def get_seq_length(self) -> int: ...
 
     @abstractmethod
-    def get_max_length(self) -> int: ...
+    def get_max_length(self) -> int:
+        """
+        Returns the maximum sequence length the layer can hold. A value of `-1` means no maximum, or an undefined
+        maximum, for example a dynamic attention layer that grows indefinitely or a linear attention layer that has no
+        sequence length dimension.
+        """
+        ...
 
     def offload(self):
         """Offload this layer's data to CPU device."""


### PR DESCRIPTION
adds `get_max_length` + docstring to the API docs (related to #46862)