### PR TITLE
Update EvalPrediction annotations for batch_eval_metrics

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -212,10 +212,10 @@ class EvalPrediction:
     Evaluation output (always contains labels), to be used to compute metrics.
 
     Parameters:
-        predictions (`np.ndarray`): Predictions of the model.
-        label_ids (`np.ndarray`): Targets to be matched.
+        predictions (`np.ndarray` or `torch.Tensor`): Predictions of the model.
+        label_ids (`np.ndarray` or `torch.Tensor`): Targets to be matched.
         inputs (`np.ndarray`, *optional*): Input data passed to the model.
-        losses (`np.ndarray`, *optional*): Loss values computed during evaluation.
+        losses (`np.ndarray` or `torch.Tensor`, *optional*): Loss values computed during evaluation.
     """
 
     def __init__(

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -220,10 +220,10 @@ class EvalPrediction:
 
     def __init__(
         self,
-        predictions: np.ndarray | tuple[np.ndarray],
-        label_ids: np.ndarray | tuple[np.ndarray],
+        predictions: np.ndarray | torch.Tensor | tuple[np.ndarray] | tuple[torch.Tensor],
+        label_ids: np.ndarray | torch.Tensor | tuple[np.ndarray] | tuple[torch.Tensor],
         inputs: np.ndarray | tuple[np.ndarray] | None = None,
-        losses: np.ndarray | tuple[np.ndarray] | None = None,
+        losses: np.ndarray | torch.Tensor | tuple[np.ndarray] | tuple[torch.Tensor] | None = None,
     ):
         self.predictions = predictions
         self.label_ids = label_ids


### PR DESCRIPTION
# What does this PR do?

Fixes #46656.

This PR updates the `EvalPrediction` type annotations and documentation to reflect the runtime behavior when `batch_eval_metrics=True`.

In this code path, `predictions`, `label_ids`, and `losses` may be passed to `EvalPrediction` as `torch.Tensor`s before being converted to NumPy arrays. However, the current annotations and documentation only specify `np.ndarray`.

This PR updates the affected type annotations and documentation to include `torch.Tensor`, making them consistent with the existing runtime behavior. `inputs` is left unchanged since it represents the batch yielded by the dataloader and is outside the scope of this issue.
