### PR TITLE
Fix loss alignment and Trainer token counting for encoder decoder models

### DIFF
--- a/src/transformers/models/moonshine/modeling_moonshine.py
+++ b/src/transformers/models/moonshine/modeling_moonshine.py
@@ -24,7 +24,6 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
-from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
@@ -912,6 +911,10 @@ class MoonshineForConditionalGeneration(MoonshinePreTrainedModel, GenerationMixi
         'Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel.'
         ```"""
 
+        # `shift_labels` is consumed here (the decoder inputs are already right-shifted), so pop it before the
+        # inner model call rather than letting it flow down through `**kwargs`.
+        shift_labels = kwargs.pop("shift_labels", None)
+
         if labels is not None:
             if decoder_input_ids is None and decoder_inputs_embeds is None:
                 decoder_input_ids = shift_tokens_right(
@@ -934,8 +937,17 @@ class MoonshineForConditionalGeneration(MoonshinePreTrainedModel, GenerationMixi
 
         loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
+            # `decoder_input_ids` are right-shifted from `labels`, so the logits are already aligned with the
+            # targets: pass them as `shift_labels` (with `labels=None`) so `ForCausalLMLoss` does not shift a
+            # second time, and route through `self.loss_function` so the grad-accumulation
+            # `num_items_in_batch` normalization is honored.
+            loss = self.loss_function(
+                logits=logits,
+                labels=None,
+                vocab_size=self.config.vocab_size,
+                shift_labels=shift_labels if shift_labels is not None else labels,
+                **kwargs,
+            )
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/moonshine/modular_moonshine.py
+++ b/src/transformers/models/moonshine/modular_moonshine.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 from huggingface_hub.dataclasses import strict
-from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
@@ -751,6 +750,10 @@ class MoonshineForConditionalGeneration(MoonshinePreTrainedModel, GenerationMixi
         'Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel.'
         ```"""
 
+        # `shift_labels` is consumed here (the decoder inputs are already right-shifted), so pop it before the
+        # inner model call rather than letting it flow down through `**kwargs`.
+        shift_labels = kwargs.pop("shift_labels", None)
+
         if labels is not None:
             if decoder_input_ids is None and decoder_inputs_embeds is None:
                 decoder_input_ids = shift_tokens_right(
@@ -773,8 +776,17 @@ class MoonshineForConditionalGeneration(MoonshinePreTrainedModel, GenerationMixi
 
         loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
+            # `decoder_input_ids` are right-shifted from `labels`, so the logits are already aligned with the
+            # targets: pass them as `shift_labels` (with `labels=None`) so `ForCausalLMLoss` does not shift a
+            # second time, and route through `self.loss_function` so the grad-accumulation
+            # `num_items_in_batch` normalization is honored.
+            loss = self.loss_function(
+                logits=logits,
+                labels=None,
+                vocab_size=self.config.vocab_size,
+                shift_labels=shift_labels if shift_labels is not None else labels,
+                **kwargs,
+            )
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
@@ -25,7 +25,6 @@ from typing import Optional
 import torch
 import torch.nn as nn
 from torch import Tensor
-from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
@@ -1076,6 +1075,10 @@ class MoonshineStreamingForConditionalGeneration(MoonshineStreamingPreTrainedMod
         'Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel.'
         ```"""
 
+        # `shift_labels` is consumed here (the decoder inputs are already right-shifted), so pop it before the
+        # inner model call rather than letting it flow down through `**kwargs`.
+        shift_labels = kwargs.pop("shift_labels", None)
+
         if labels is not None:
             if decoder_input_ids is None and decoder_inputs_embeds is None:
                 decoder_input_ids = shift_tokens_right(
@@ -1098,8 +1101,17 @@ class MoonshineStreamingForConditionalGeneration(MoonshineStreamingPreTrainedMod
 
         loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
+            # `decoder_input_ids` are right-shifted from `labels`, so the logits are already aligned with the
+            # targets: pass them as `shift_labels` (with `labels=None`) so `ForCausalLMLoss` does not shift a
+            # second time, and route through `self.loss_function` so the grad-accumulation
+            # `num_items_in_batch` normalization is honored.
+            loss = self.loss_function(
+                logits=logits,
+                labels=None,
+                vocab_size=self.config.vocab_size,
+                shift_labels=shift_labels if shift_labels is not None else labels,
+                **kwargs,
+            )
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/pp_formulanet/modeling_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/modeling_pp_formulanet.py
@@ -1082,6 +1082,10 @@ class PPFormulaNetForConditionalGeneration(PPFormulaNetPreTrainedModel, Generati
         >>> print(result)
         ['\\zeta_{0}(\\nu)=-\\frac{\\nu\\varrho^{-2\\nu}}{\\pi}\\int_{\\mu}^{\\infty}d\\omega\\int_{C_{+}}d z\\frac{2z^{2}}{(z^{2}+\\omega^{2})^{\\nu+1}}\\breve{\\Psi}(\\omega;z)e^{i\\epsilon z}\\quad,']
         ```"""
+        # `shift_labels` is consumed by the loss below (the decoder inputs are already right-shifted), so pop it
+        # before the inner model call rather than letting it flow down through `**kwargs`.
+        shift_labels = kwargs.pop("shift_labels", None)
+
         outputs = self.model(
             input_ids=input_ids,
             pixel_values=pixel_values,
@@ -1103,8 +1107,14 @@ class PPFormulaNetForConditionalGeneration(PPFormulaNetPreTrainedModel, Generati
 
         loss = None
         if labels is not None:
+            # Encoder-decoder logits are position-aligned with the targets, so pass them as `shift_labels`
+            # (with `labels=None`) to stop `ForCausalLMLoss` shifting them a second time.
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+                logits=logits,
+                labels=None,
+                vocab_size=self.config.text_config.vocab_size,
+                shift_labels=shift_labels if shift_labels is not None else labels,
+                **kwargs,
             )
 
         return Seq2SeqLMOutput(

--- a/src/transformers/models/pp_formulanet/modular_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/modular_pp_formulanet.py
@@ -467,6 +467,10 @@ class PPFormulaNetForConditionalGeneration(Florence2ForConditionalGeneration):
         >>> print(result)
         ['\\zeta_{0}(\\nu)=-\\frac{\\nu\\varrho^{-2\\nu}}{\\pi}\\int_{\\mu}^{\\infty}d\\omega\\int_{C_{+}}d z\\frac{2z^{2}}{(z^{2}+\\omega^{2})^{\\nu+1}}\\breve{\\Psi}(\\omega;z)e^{i\\epsilon z}\\quad,']
         ```"""
+        # `shift_labels` is consumed by the loss below (the decoder inputs are already right-shifted), so pop it
+        # before the inner model call rather than letting it flow down through `**kwargs`.
+        shift_labels = kwargs.pop("shift_labels", None)
+
         outputs = self.model(
             input_ids=input_ids,
             pixel_values=pixel_values,
@@ -488,8 +492,14 @@ class PPFormulaNetForConditionalGeneration(Florence2ForConditionalGeneration):
 
         loss = None
         if labels is not None:
+            # Encoder-decoder logits are position-aligned with the targets, so pass them as `shift_labels`
+            # (with `labels=None`) to stop `ForCausalLMLoss` shifting them a second time.
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+                logits=logits,
+                labels=None,
+                vocab_size=self.config.text_config.vocab_size,
+                shift_labels=shift_labels if shift_labels is not None else labels,
+                **kwargs,
             )
 
         return Seq2SeqLMOutput(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -517,8 +517,13 @@ class Trainer:
         # each row is never a prediction target. The valid-prediction count used by `num_items_in_batch` must therefore
         # be taken over `labels[..., 1:]`, not the full label tensor. Inspect the actual loss function via
         # LOSS_MAPPING so model-specific loss_types that route to ForCausalLMLoss (e.g. CsmForConditionalGeneration)
-        # are caught too.
-        self._loss_shifts_labels = LOSS_MAPPING.get(getattr(model_to_inspect, "loss_type", None)) is ForCausalLMLoss
+        # are caught too. Encoder-decoder models are excluded: their loss is aligned with unshifted targets (usually
+        # because they feed right-shifted `decoder_input_ids` to the decoder), so every non-`-100` label is a
+        # prediction target and the decoder-only `labels[..., 1:]` counting rule must not apply -- it would
+        # under-count and over-scale the loss.
+        self._loss_shifts_labels = LOSS_MAPPING.get(
+            getattr(model_to_inspect, "loss_type", None)
+        ) is ForCausalLMLoss and not getattr(getattr(model_to_inspect, "config", None), "is_encoder_decoder", False)
 
         if self.args.label_smoothing_factor != 0:
             if getattr(self.model.config, "problem_type", None) == "multi_label_classification":

--- a/tests/models/dia/test_modeling_dia.py
+++ b/tests/models/dia/test_modeling_dia.py
@@ -231,6 +231,10 @@ class DiaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
         self.config_tester = ConfigTester(self, has_text_modality=False, config_class=DiaConfig)
         self.skip_non_greedy_generate()
 
+    @unittest.skip(reason="Dia flattens codebook channels into the batch dim; logits do not match 2D `labels`")
+    def test_encoder_decoder_loss_no_double_shift(self):
+        pass
+
     def prepare_config_and_inputs_for_generate(self, batch_size=2):
         # DIA should not have a `None` eos token id because it uses certain LogitsProcessors
         # so we overwrite preparation

--- a/tests/models/moonshine/test_modeling_moonshine.py
+++ b/tests/models/moonshine/test_modeling_moonshine.py
@@ -30,12 +30,14 @@ from ...test_pipeline_mixin import PipelineTesterMixin
 
 if is_torch_available():
     import torch
+    from torch.nn import CrossEntropyLoss
 
     from transformers import (
         AutoProcessor,
         MoonshineForConditionalGeneration,
         MoonshineModel,
     )
+    from transformers.models.moonshine.modeling_moonshine import MoonshineEncoderModelOutput
 
 from datasets import load_dataset
 
@@ -153,10 +155,6 @@ class MoonshineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
 
     def test_training_loss_no_double_shift(self):
         # forward shifts labels into decoder_input_ids, so loss must be plain CE against the labels (no second shift)
-        from torch.nn import CrossEntropyLoss
-
-        from transformers.models.moonshine.modeling_moonshine import MoonshineEncoderModelOutput
-
         config = self.model_tester.get_config()
         config.pad_token_id = self.model_tester.pad_token_id
         model = MoonshineForConditionalGeneration(config).to(torch_device).eval()
@@ -178,10 +176,30 @@ class MoonshineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
             return CrossEntropyLoss()(logits[..., :-1, :].reshape(-1, vocab_size), lbl[..., 1:].reshape(-1))
 
         for lbl in (labels, padded):
+            # Moonshine is the only model here that moves off a plain `CrossEntropyLoss` onto the shared
+            # `self.loss_function`, so it also needs to start honoring `num_items_in_batch`: the loss is a
+            # summed cross-entropy divided by that count, so passing the true count reproduces the aligned
+            # mean cross-entropy, and doubling the count must halve the loss. A plain `CrossEntropyLoss`
+            # (mean over tokens) would ignore the count and leave both losses unchanged.
+            n = int((lbl != -100).sum())
             with torch.no_grad():
-                out = model(encoder_outputs=encoder_outputs, labels=lbl, use_cache=False)
+                out = model(encoder_outputs=encoder_outputs, labels=lbl, num_items_in_batch=n, use_cache=False)
+                loss_2n = model(
+                    encoder_outputs=encoder_outputs, labels=lbl, num_items_in_batch=2 * n, use_cache=False
+                ).loss
             self.assertTrue(torch.allclose(out.loss, aligned_ce(out.logits, lbl)))
             self.assertFalse(torch.allclose(out.loss, double_shift_ce(out.logits, lbl)))
+            self.assertTrue(torch.allclose(out.loss, 2 * loss_2n))
+
+        # A caller supplied `shift_labels` is popped out of `kwargs` and used verbatim, rather than colliding
+        # with the one `forward` derives from `labels`.
+        caller_shift_labels = labels.roll(shifts=1, dims=1)
+        with torch.no_grad():
+            out = model(
+                encoder_outputs=encoder_outputs, labels=labels, shift_labels=caller_shift_labels, use_cache=False
+            )
+        self.assertTrue(torch.allclose(out.loss, aligned_ce(out.logits, caller_shift_labels)))
+        self.assertFalse(torch.allclose(out.loss, aligned_ce(out.logits, labels)))
 
     def test_attention_outputs(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/models/prophetnet/test_modeling_prophetnet.py
+++ b/tests/models/prophetnet/test_modeling_prophetnet.py
@@ -817,6 +817,10 @@ class ProphetNetModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTeste
     test_resize_embeddings = False
     is_encoder_decoder = True
 
+    @unittest.skip(reason="ProphetNet's loss is NLL over n-gram streams, not one cross-entropy over the logits")
+    def test_encoder_decoder_loss_no_double_shift(self):
+        pass
+
     # TODO: Fix the failed tests
     def is_pipeline_test_to_skip(
         self,

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -80,6 +80,7 @@ from transformers.models.auto.modeling_auto import (
     MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING_NAMES,
     MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES,
     MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES,
+    MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES,
     MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING_NAMES,
     MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING_NAMES,
     MODEL_MAPPING_NAMES,
@@ -1733,6 +1734,127 @@ class ModelTesterMixin(ExportTesterMixin):
                                     self.assertTrue(
                                         v.grad is not None, f"{k} in {model_class.__name__} has no gradient!"
                                     )
+
+    def test_encoder_decoder_loss_no_double_shift(self):
+        """
+        Encoder-decoder LM heads are fed right-shifted ``decoder_input_ids``, so their logits are already
+        position-aligned with the targets: the training loss must be the cross-entropy against ``labels``
+        directly. If it shifts a second time (e.g. by routing through ``ForCausalLMLoss`` without passing
+        ``shift_labels``) the model trains against ``labels[..., 1:]`` -- an off-by-one in the loss.
+
+        The right-shifted ``decoder_input_ids`` are built and supplied here, so every model is driven the same
+        way regardless of how its own ``forward`` would have derived them.
+
+        The oracle compares the *gradient* of the reported loss w.r.t. ``output.logits`` against the gradients
+        of the aligned and of the shifted cross-entropy. Gradients carry the target positions, so they stay
+        decisive even where the two loss values coincide numerically -- which happens whenever a tester's
+        initialization makes the logits near-uniform (the T5-family testers set ``initializer_factor=0.002``).
+
+        Scope: encoder-decoder models built on ``ModelTesterMixin`` whose ``forward`` owns the loss. The
+        ``EncoderDecoderModel`` / ``VisionEncoderDecoderModel`` / ``SpeechEncoderDecoderModel`` wrappers are
+        covered by separate ``EncoderDecoderMixin`` test suites; those wrapper models' ``forward`` already
+        computes an aligned cross-entropy independently of the decoder, so they cannot hit this path.
+        """
+        # Class-based applicability gate first: this oracle needs a sequence-to-sequence LM head with one logit
+        # vector per label token. Decide from `all_model_classes` alone -- some testers have no `get_config`, so
+        # the config is not touched until after this gate.
+        seq2seq_lm_names = [
+            *get_values(MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES),
+            *get_values(MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES),
+            *get_values(MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES),
+        ]
+        seq2seq_lm_classes = [c for c in self.all_model_classes if c.__name__ in seq2seq_lm_names]
+        if not seq2seq_lm_classes:
+            self.skipTest(reason="No sequence-to-sequence language modeling head to check")
+
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        if not config.is_encoder_decoder:
+            self.skipTest(reason="Model is not an encoder-decoder")
+
+        vocab_size = config.get_text_config(decoder=True).vocab_size
+        # Targets are >= 2 tokens long so that `labels[..., 1:]` is non-empty and the two oracles differ.
+        tester_decoder_input_ids = inputs_dict.get("decoder_input_ids")
+        seq_len = (
+            tester_decoder_input_ids.shape[-1]
+            if isinstance(tester_decoder_input_ids, torch.Tensor)
+            else getattr(self.model_tester, "decoder_seq_length", getattr(self.model_tester, "seq_length", 2)) or 2
+        )
+        seq_len = max(2, seq_len)
+        set_seed(42)
+        labels = torch.randint(3, vocab_size, (self.model_tester.batch_size, seq_len), device=torch_device)
+
+        for model_class in seq2seq_lm_classes:
+            with self.subTest(model_class.__name__):
+                # Deep-copy per class so nothing below mutates the shared config across iterations.
+                model_config = copy.deepcopy(config)
+                model_config.use_cache = False
+                model_config.return_dict = True
+                text_config = model_config.get_text_config(decoder=True)
+                pad_fallback = getattr(self.model_tester, "pad_token_id", None) or 0
+                for cfg in (model_config, text_config):
+                    if getattr(cfg, "pad_token_id", None) is None:
+                        # A pad id is still read while building decoder masks, and some models take it from the
+                        # top config while others take it from the decoder text config.
+                        cfg.pad_token_id = pad_fallback
+
+                # The first decoder token moves the logits but cannot change which cross-entropy the reported
+                # loss matches, so any in-vocabulary id will do. Use the model's own start id when the tester
+                # sets one and 0 otherwise, since several testers leave `decoder_start_token_id` unset. The
+                # range check is defensive: it keeps an id past the tester's vocabulary from failing in an
+                # embedding lookup before the alignment assertions run.
+                start_token_id = getattr(model_config, "decoder_start_token_id", None)
+                if not isinstance(start_token_id, int) or not 0 <= start_token_id < vocab_size:
+                    start_token_id = 0
+                decoder_input_ids = labels.roll(shifts=1, dims=1)
+                decoder_input_ids[:, 0] = start_token_id
+
+                inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=False)
+                # Replace the tester's decoder inputs with targets the model cannot have derived differently:
+                # `decoder_input_ids` is `labels` right-shifted, so the logits are aligned with `labels`.
+                inputs.pop("decoder_attention_mask", None)
+                inputs["decoder_input_ids"] = decoder_input_ids
+                inputs["labels"] = labels
+
+                model = model_class(model_config).to(torch_device).eval()
+                # No `torch.no_grad()`: the oracle below differentiates the reported loss w.r.t. the logits.
+                output = model(**inputs)
+
+                logits = output.logits
+                vocab = logits.shape[-1]
+                float_logits = logits.float()
+                aligned = nn.functional.cross_entropy(float_logits.reshape(-1, vocab), labels.reshape(-1))
+                double_shifted = nn.functional.cross_entropy(
+                    float_logits[:, :-1, :].reshape(-1, vocab), labels[:, 1:].reshape(-1)
+                )
+                # The three gradients are taken from graphs that share nodes, so keep the graph alive until the
+                # last one. `allow_unused` turns "the loss does not depend on `output.logits`" into a readable
+                # failure instead of an autograd error.
+                grad_reported = torch.autograd.grad(output.loss, logits, retain_graph=True, allow_unused=True)[0]
+                self.assertIsNotNone(
+                    grad_reported,
+                    msg=f"{model_class.__name__}: the reported loss is not a function of `output.logits`",
+                )
+                grad_aligned = torch.autograd.grad(aligned, logits, retain_graph=True)[0]
+                grad_shifted = torch.autograd.grad(double_shifted, logits)[0]
+                # Guard the oracle: if both targets produce the same gradient the assertions below are vacuous.
+                self.assertFalse(
+                    torch.allclose(grad_aligned, grad_shifted),
+                    msg=(
+                        f"{model_class.__name__}: the aligned and shifted gradients are indistinguishable "
+                        f"(vacuous oracle)"
+                    ),
+                )
+                self.assertTrue(
+                    torch.allclose(grad_reported, grad_aligned),
+                    msg=f"{model_class.__name__}: training loss is not the cross-entropy against `labels`",
+                )
+                self.assertFalse(
+                    torch.allclose(grad_reported, grad_shifted),
+                    msg=(
+                        f"{model_class.__name__}: training loss is the cross-entropy against `labels[..., 1:]`. "
+                        f"`decoder_input_ids` are already right-shifted, so the loss must not shift `labels` again."
+                    ),
+                )
 
     def test_training(self):
         if not self.model_tester.is_training:

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -32,6 +32,8 @@ from transformers import (
     AutoModelForCausalLM,
     AutoModelForSequenceClassification,
     AutoTokenizer,
+    BartConfig,
+    BartForConditionalGeneration,
     BitsAndBytesConfig,
     DataCollatorForLanguageModeling,
     EarlyStoppingCallback,
@@ -46,7 +48,7 @@ from transformers import (
     logging,
 )
 from transformers.integrations import activate_neftune
-from transformers.loss.loss_utils import ForCausalLMLoss
+from transformers.loss.loss_utils import LOSS_MAPPING, ForCausalLMLoss
 from transformers.testing_utils import (
     CaptureLogger,
     LoggingLevel,
@@ -391,6 +393,47 @@ class TrainerGradientAccumulationTest(TestCasePlus, TrainerIntegrationCommon):
             self.assertFalse(trainer._loss_shifts_labels)
 
             # 5 valid + 8 valid = 13 (no shift).
+            batch_samples = [
+                {"labels": torch.tensor([[1, 2, 3, 4, 5, -100, -100, -100]])},
+                {"labels": torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])},
+            ]
+            num_items = trainer._get_num_items_in_batch(batch_samples, torch.device("cpu"))
+            self.assertEqual(int(num_items), 13)
+
+    @require_torch_non_multi_accelerator
+    def test_num_items_in_batch_encoder_decoder(self):
+        """
+        Encoder-decoder LM heads compute their loss against unshifted `labels` -- their logits are aligned with
+        the targets (typically by right-shifting the decoder inputs), so the loss must not shift again. Their
+        class-name-inferred `loss_type` still maps to ForCausalLMLoss, which would drive the Trainer to count over
+        `labels[..., 1:]` and over-scale the loss; `_get_num_items_in_batch` must instead count the full label
+        tensor whenever `config.is_encoder_decoder`. Bart probes exactly that (`loss_type` -> ForCausalLMLoss,
+        `is_encoder_decoder` True) combination -- though Bart's own forward computes the aligned loss with
+        `CrossEntropyLoss` rather than routing through `ForCausalLMLoss`.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = BartConfig(
+                vocab_size=64,
+                d_model=16,
+                encoder_layers=1,
+                decoder_layers=1,
+                encoder_attention_heads=1,
+                decoder_attention_heads=1,
+                encoder_ffn_dim=16,
+                decoder_ffn_dim=16,
+                max_position_embeddings=32,
+            )
+            model = BartForConditionalGeneration(config)
+            # loss_type routes to ForCausalLMLoss, but the model is encoder-decoder -> the count must NOT shift.
+            self.assertIs(LOSS_MAPPING.get(model.loss_type), ForCausalLMLoss)
+            self.assertTrue(model.config.is_encoder_decoder)
+            trainer = Trainer(
+                model=model,
+                args=TrainingArguments(output_dir=tmp_dir, per_device_train_batch_size=2),
+            )
+            self.assertFalse(trainer._loss_shifts_labels)
+
+            # 5 valid + 8 valid = 13, counted in full (no shift).
             batch_samples = [
                 {"labels": torch.tensor([[1, 2, 3, 4, 5, -100, -100, -100]])},
                 {"labels": torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])},


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46903)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46903)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Encoder decoder models build `decoder_input_ids` by right shifting the target with
`shift_tokens_right`, so the logits already line up with `labels`. Two related bugs get this
alignment wrong.

1. Double shifted training loss. When such a model computes its loss through `self.loss_function`
   (which uses `ForCausalLMLoss`) without passing `shift_labels`, the labels are shifted a second
   time to `labels[..., 1:]`. The model then trains against `labels[..., 1:]` instead of `labels`,
   which is an off by one. PPFormulaNet had this bug, and Moonshine had it before #46784.

2. Trainer token undercount. `Trainer._loss_shifts_labels` assumed that any `ForCausalLMLoss` head
   counts `num_items_in_batch` over `labels[..., 1:]`. For encoder decoder heads every label that is
   not `-100` is a real target, so this counts one target position too few per sequence and scales
   the gradient accumulation loss up. For example, if 8 targets are counted as 6, the loss is
   multiplied by about 8/6, which is roughly 1.33x.

## Changes

1. `trainer.py`. `_loss_shifts_labels` now also requires `config.is_encoder_decoder` to be false.
   Decoder only heads keep the old behavior, and encoder decoder heads count every valid label. This
   corrects the `num_items_in_batch` normalization for PPFormulaNet and, through the Moonshine change
   below, for Moonshine and MoonshineStreaming. It also corrects Florence2 and CohereASR, whose model
   fixes already landed upstream, so those files do not need any further change here.

2. `pp_formulanet`. The loss now goes through `self.loss_function` with `labels=None` and the aligned
   targets passed as `shift_labels`. `shift_labels` is popped from `kwargs` before the inner model call,
   so a caller supplied value is honoured, does not collide with the derived one, and does not leak into
   the inner model. The edit is in `modular_pp_formulanet.py` and the `modeling` file is regenerated.

3. `moonshine` and `moonshine_streaming`. These now use the same form instead of a plain
   `CrossEntropyLoss` that ignored `num_items_in_batch`. Both `modeling` files are regenerated from the
   modulars and the unused import is removed.

Only the training loss changes, and only when `labels` are passed. Logits and `generate()` are
unchanged, and `-100` stays ignored.

This is the existing coordinated PR for this work. The wider scope was approved by @zucchini-nlp in
this comment: https://github.com/huggingface/transformers/pull/46903#discussion_r3490715527. No
duplicate PR is being opened.

Fixes #46901.

## Test

A new generic test `test_encoder_decoder_loss_no_double_shift` in `tests/test_modeling_common.py`
covers `ModelTesterMixin` sequence to sequence language model heads whose `forward` owns the loss. It
feeds fresh labels of length at least 2, supplies `decoder_input_ids` built by right shifting those
labels, and asserts that the gradient of the reported loss with respect to `output.logits` matches the
gradient of a cross entropy against `labels` and not against `labels[..., 1:]`. The gradient comparison
stays decisive on testers whose initialization makes the logits near uniform. There are no per model
branches in it. Dia and ProphetNet skip it in their own testers, since Dia flattens codebook channels
into the batch dimension and ProphetNet computes loss over n gram prediction streams. Trainer counting
is covered by a Bart encoder decoder test in `tests/trainer/test_trainer.py`, and Moonshine's move onto
the shared loss is covered in its own loss test. The existing `test_num_items_in_batch_causal_lm` and
`test_num_items_in_batch_non_causal_lm` still pass.

Commands run locally, rebased on `origin/main` bb3ffb9703:

```bash
make typing            # 2 checks passed
make style             # 4 checks passed
git diff --check       # clean

python utils/check_modular_conversion.py --files \
  src/transformers/models/moonshine/modular_moonshine.py \
  src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py \
  src/transformers/models/pp_formulanet/modular_pp_formulanet.py
#   clean

rg --files tests/models -g 'test_modeling*.py' -0 | \
  xargs -0 env PYTHONPATH=src python -m pytest \
    -k test_encoder_decoder_loss_no_double_shift -q
#   38 passed, 568 skipped, 38 subtests passed

python -m pytest tests/trainer/test_trainer.py -k "num_items_in_batch and not grad_norm"
#   3 passed

python -m pytest tests/models/pp_formulanet/test_modeling_pp_formulanet.py
#   113 passed, 147 skipped, 686 subtests passed

python -m pytest tests/models/moonshine/test_modeling_moonshine.py \
                 tests/models/moonshine_streaming/test_modeling_moonshine_streaming.py
#   195 passed, 237 skipped, 2672 subtests passed
```

## Note

AI assistance was used while preparing this change; I have reviewed every line and run the tests.

