### PR TITLE
[Docs] Fix full disk offloading docs

### DIFF
--- a/docs/source/en/models.md
+++ b/docs/source/en/models.md
@@ -213,19 +213,20 @@ model = AutoModelForCausalLM.from_pretrained(
 )
 ```
 
-Set every device budget to `0` to offload the entire model to disk. `max_memory` only overrides the devices you name, so cap each GPU and the CPU to push every weight to disk.
+Set `max_memory={}` to specify that no gpu or cpu memory is available and to force offloading the entire model to disk.
 
 ```py
 model = AutoModelForCausalLM.from_pretrained(
     "google/gemma-7b",
     device_map="auto",
-    max_memory={0: 0, "cpu": 0},
+    max_memory={},
     offload_folder="./offload",
 )
 ```
 
 > [!NOTE]
 > Disk offloading trades memory for speed. Reading weights from disk on every forward pass is slower than reading from CPU or GPU memory.
+> Fully disk offloading requires `accelerate>1.14.0`
 
 ### Model data type
 


### PR DESCRIPTION
## Purpose ##
* Fix incorrect documentation which states that `max_memory={}` does not trigger full disk offloading
* Document `accelerate>1.14.0` requirement for full disk offloading

## Testing ##
The code below demonstrates that full disk offloading does indeed occur when `max_memory={}`
```python3
from transformers import AutoModelForCausalLM

# Load model with full disk offload
model = AutoModelForCausalLM.from_pretrained(
    "google/gemma-7b",
    device_map="auto",
    max_memory={},
    offload_folder="./offload_folder",
)

assert model.hf_device_map == {"": "disk"}
assert model.model.layers[0].self_attn.q_proj.weight.device.type == "meta"
```

## Suggested Reviewers ##
@stevhliu @SunMarc 