### PR TITLE
Fix flash attention with StaticCache

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -668,9 +668,10 @@ def flash_attention_mask(
     if attention_mask is not None:
         # Here we need to slice from the right if using sliding or chunked (for full attention, this is equivalent to doing nothing)
         attention_mask = attention_mask[:, -kv_length:]
-        # We only return an actual mask if there is at least 1 padding token, otherwise we return `None` and use `is_causal` in FA2
-        # (note that the attention_mask is a boolean dtype here)
-        if attention_mask.all():
+        # We only return an actual mask if there is at least 1 padding token AND the length is the same as the kv_length (i.e. we
+        # do not use a StaticCache), otherwise we return `None` and use `is_causal` in FA2 (note that the attention_mask is a boolean
+        # dtype here)
+        if attention_mask.shape[1] == kv_length and attention_mask.all():
             attention_mask = None
 
     return attention_mask

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -668,9 +668,9 @@ def flash_attention_mask(
     if attention_mask is not None:
         # Here we need to slice from the right if using sliding or chunked (for full attention, this is equivalent to doing nothing)
         attention_mask = attention_mask[:, -kv_length:]
-        # We only return an actual mask if there is at least 1 padding token AND the length is the same as the kv_length (i.e. we
-        # do not use a StaticCache), otherwise we return `None` and use `is_causal` in FA2 (note that the attention_mask is a boolean
-        # dtype here)
+        # We only return an actual mask if there is at least 1 padding token AND the length is the same as the kv_length (it can only
+        # be smaller, if and only if we use a StaticCache, in which case we need a mask to properly slice k/v), otherwise we return
+        # `None` and use `is_causal` in FA2 (note that the attention_mask is a boolean dtype here)
         if attention_mask.shape[1] == kv_length and attention_mask.all():
             attention_mask = None
 

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -286,6 +286,7 @@ class LlamaIntegrationTest(unittest.TestCase):
             ep_generated_text = tokenizer.batch_decode(ep_generated_ids, skip_special_tokens=True)
             self.assertEqual(EXPECTED_TEXT_COMPLETION, ep_generated_text)
 
+    @pytest.mark.flash_attn_test
     @require_flash_attn
     def test_flash_with_static_cache(self):
         """Test that FA works correctly with a StaticCache"""

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -318,7 +318,7 @@ class LlamaIntegrationTest(unittest.TestCase):
                 (
                     "cuda",
                     8,
-                ): "The meaning of life is a complex and subjective question that has been debated by philosophers, theologians, scientists, and many others for centuries. There is no one definitive answer, as it can vary greatly from person to person, culture to culture, and even from one moment to another.\\n\\nThat being said, here are some possible perspectives on the meaning of life:\\n\\n1. **Biological perspective**: From a biological standpoint, the meaning of life can be seen as the survival and reproduction of the species."  # fmt: skip
+                ): "The question of the meaning of life is one of the most profound and debated topics in human history. It has been explored by philosophers, theologians, scientists, and many others across various cultures and disciplines"  # fmt: skip
             }
         )
         EXPECTED_TEXT = expected_text.get_expectation()

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -294,13 +294,13 @@ class LlamaIntegrationTest(unittest.TestCase):
         model = AutoModelForCausalLM.from_pretrained(model_name, device_map=torch_device, dtype=torch.bfloat16)
         tokenizer = AutoTokenizer.from_pretrained(model_name)
 
-        input_text = {"role": "user", "content": "What's tre meaning of life?"}
+        input_text = {"role": "user", "content": "What's the meaning of life?"}
         inputs = tokenizer.apply_chat_template(
             [input_text], tokenize=True, return_tensors="pt", add_generation_prompt=True
         ).to(model.device)
 
         out_sdpa = model.generate(**inputs, max_new_tokens=100, cache_implementation="static", do_sample=False)
-        output_text_sdpa = tokenizer.batch_decode(out_sdpa[0, inputs.input_ids.shape[1] :])
+        output_text_sdpa = tokenizer.batch_decode(out_sdpa[0, inputs.input_ids.shape[1] :])[0]
 
         # Now toggle FA and test again
         model.set_attn_implementation("flash_attention_2")
@@ -308,7 +308,7 @@ class LlamaIntegrationTest(unittest.TestCase):
         out_fa = model.generate(
             **inputs, max_new_tokens=100, cache_implementation="static", do_sample=False, return_dict_in_generate=True
         )
-        output_text_fa = tokenizer.batch_decode(out_fa.sequences[0, inputs.input_ids.shape[1] :])
+        output_text_fa = tokenizer.batch_decode(out_fa.sequences[0, inputs.input_ids.shape[1] :])[0]
 
         # Just to make sure
         self.assertTrue(all(isinstance(layer, StaticLayer) for layer in out_fa.past_key_values.layers))

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -318,7 +318,7 @@ class LlamaIntegrationTest(unittest.TestCase):
                 (
                     "cuda",
                     8,
-                ): "The question of the meaning of life is one of the most profound and debated topics in human history. It has been explored by philosophers, theologians, scientists, and many others across various cultures and disciplines"  # fmt: skip
+                ): "The question of the meaning of life is one of the most profound and debated topics in human history. It has been explored by philosophers, theologians, scientists, and many others across various cultures and disciplines. While there is no one definitive answer, here are some perspectives to consider:\n\n1. **Religious and spiritual perspectives**: Many religions and spiritual traditions offer their own answers to the meaning of life. For example, in Christianity, the meaning of life is often seen as serving God and preparing for eternal"  # fmt: skip
             }
         )
         EXPECTED_TEXT = expected_text.get_expectation()

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -22,6 +22,7 @@ from transformers.generation.configuration_utils import GenerationConfig
 from transformers.testing_utils import (
     Expectations,
     cleanup,
+    require_flash_attn,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -35,9 +36,11 @@ if is_torch_available():
     import torch
 
     from transformers import (
+        AutoModelForCausalLM,
         LlamaForCausalLM,
         LlamaModel,
         LlamaTokenizer,
+        StaticLayer,
     )
 
 
@@ -59,6 +62,7 @@ class LlamaModelTest(CausalLMModelTest, unittest.TestCase):
 
 
 @require_torch_accelerator
+@slow
 class LlamaIntegrationTest(unittest.TestCase):
     def setup(self):
         cleanup(torch_device, gc_collect=True)
@@ -70,7 +74,6 @@ class LlamaIntegrationTest(unittest.TestCase):
         # Investigate the root cause.
         cleanup(torch_device, gc_collect=True)
 
-    @slow
     def test_llama_3_1_hard(self):
         """
         An integration test for llama 3.1. It tests against a long output to ensure the subtle numerical differences
@@ -95,7 +98,6 @@ class LlamaIntegrationTest(unittest.TestCase):
         generated_text = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
         self.assertEqual(generated_text, EXPECTED_TEXT)
 
-    @slow
     def test_model_7b_logits_bf16(self):
         input_ids = [1, 306, 4658, 278, 6593, 310, 2834, 338]
 
@@ -140,7 +142,6 @@ class LlamaIntegrationTest(unittest.TestCase):
         actual_slice = out.logits[0, 0, :15].float()
         self.assertTrue(torch.allclose(expected_slice, actual_slice, atol=1e-2, rtol=1e-2))
 
-    @slow
     def test_model_7b_logits(self):
         input_ids = [1, 306, 4658, 278, 6593, 310, 2834, 338]
 
@@ -187,7 +188,6 @@ class LlamaIntegrationTest(unittest.TestCase):
             )
         )
 
-    @slow
     @require_torch_accelerator
     @pytest.mark.torch_compile_test
     def test_compile_static_cache(self):
@@ -224,7 +224,6 @@ class LlamaIntegrationTest(unittest.TestCase):
         static_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
         self.assertEqual(EXPECTED_TEXT_COMPLETION, static_text)
 
-    @slow
     @pytest.mark.torch_export_test
     def test_export_static_cache(self):
         from transformers.integrations.executorch import (
@@ -286,6 +285,47 @@ class LlamaIntegrationTest(unittest.TestCase):
             )
             ep_generated_text = tokenizer.batch_decode(ep_generated_ids, skip_special_tokens=True)
             self.assertEqual(EXPECTED_TEXT_COMPLETION, ep_generated_text)
+
+    @require_flash_attn
+    def test_flash_with_static_cache(self):
+        """Test that FA works correctly with a StaticCache"""
+        model_name = "meta-llama/Llama-3.2-3B-Instruct"
+
+        model = AutoModelForCausalLM.from_pretrained(model_name, device_map=torch_device, dtype=torch.bfloat16)
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+        input_text = {"role": "user", "content": "What's tre meaning of life?"}
+        inputs = tokenizer.apply_chat_template(
+            [input_text], tokenize=True, return_tensors="pt", add_generation_prompt=True
+        ).to(model.device)
+
+        out_sdpa = model.generate(**inputs, max_new_tokens=100, cache_implementation="static", do_sample=False)
+        output_text_sdpa = tokenizer.batch_decode(out_sdpa[0, inputs.input_ids.shape[1] :])
+
+        # Now toggle FA and test again
+        model.set_attn_implementation("flash_attention_2")
+
+        out_fa = model.generate(
+            **inputs, max_new_tokens=100, cache_implementation="static", do_sample=False, return_dict_in_generate=True
+        )
+        output_text_fa = tokenizer.batch_decode(out_fa.sequences[0, inputs.input_ids.shape[1] :])
+
+        # Just to make sure
+        self.assertTrue(all(isinstance(layer, StaticLayer) for layer in out_fa.past_key_values.layers))
+
+        expected_text = Expectations(
+            {
+                (
+                    "cuda",
+                    8,
+                ): "The meaning of life is a complex and subjective question that has been debated by philosophers, theologians, scientists, and many others for centuries. There is no one definitive answer, as it can vary greatly from person to person, culture to culture, and even from one moment to another.\\n\\nThat being said, here are some possible perspectives on the meaning of life:\\n\\n1. **Biological perspective**: From a biological standpoint, the meaning of life can be seen as the survival and reproduction of the species."  # fmt: skip
+            }
+        )
+        EXPECTED_TEXT = expected_text.get_expectation()
+
+        # Both output text should be the same, and equal to the reference
+        self.assertEqual(output_text_sdpa, output_text_fa)
+        self.assertEqual(output_text_fa, EXPECTED_TEXT)
 
 
 @slow


### PR DESCRIPTION
# What does this PR do?

Discovered by the @remi-or, FA was broken with flash and StaticCache because the mask is wrongly set as None, which means `is_causal` will be wrong as the k/v are padded