### PR TITLE
Remove deprecated training args and `is_fast` property

### DIFF
--- a/docs/source/en/tasks/instance_segmentation.md
+++ b/docs/source/en/tasks/instance_segmentation.md
@@ -298,7 +298,7 @@ With the data, model, and metrics ready, set up training. A few important notes 
 ...     learning_rate=1e-4,
 ...     weight_decay=1e-4,
 ...     lr_scheduler_type="cosine",
-...     warmup_ratio=0.1,
+...     warmup_steps=0.1,
 ...     fp16=True,
 ...     dataloader_num_workers=4,
 ...     eval_strategy="epoch",

--- a/src/transformers/image_processing_backends.py
+++ b/src/transformers/image_processing_backends.py
@@ -91,19 +91,6 @@ class TorchvisionBackend(BaseImageProcessor):
         self._set_attributes(**kwargs)
 
     @property
-    def is_fast(self) -> bool:
-        """
-        `bool`: Whether or not this image processor is using the fast (Torchvision) backend.
-        The `is_fast` property is deprecated and will be removed in v5.3 of Transformers.
-        Use the `backend` attribute instead (e.g., `processor.backend == "torchvision"`).
-        """
-        logger.warning_once(
-            "The `is_fast` property is deprecated and will be removed in v5.3 of Transformers. "
-            "Use the `backend` attribute instead (e.g., `processor.backend == 'torchvision'`)."
-        )
-        return True
-
-    @property
     def backend(self) -> str:
         """
         `str`: The backend used by this image processor.
@@ -432,19 +419,6 @@ class PilBackend(BaseImageProcessor):
     def __init__(self, **kwargs: Unpack[ImagesKwargs]):
         super().__init__(**kwargs)
         self._set_attributes(**kwargs)
-
-    @property
-    def is_fast(self) -> bool:
-        """
-        `bool`: Whether or not this image processor is using the fast (Torchvision) backend.
-        The `is_fast` property is deprecated and will be removed in v5.3 of Transformers.
-        Use the `backend` attribute instead (e.g., `processor.backend == "torchvision"`).
-        """
-        logger.warning_once(
-            "The `is_fast` property is deprecated and will be removed in v5.3 of Transformers. "
-            "Use the `backend` attribute instead (e.g., `processor.backend == 'torchvision'`)."
-        )
-        return False
 
     @property
     def backend(self) -> str:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1439,19 +1439,6 @@ class TrainingArguments:
         },
     )
 
-    # --- Deprecated / Internal ---
-    warmup_ratio: float | None = field(
-        default=None,
-        metadata={
-            "help": "This argument is deprecated and will be removed in v5.2. Use `warmup_steps` instead as it also works with float values."
-        },
-    )
-    logging_dir: str | None = field(
-        default=None,
-        metadata={
-            "help": "Deprecated and will be removed in v5.2. Set env var `TENSORBOARD_LOGGING_DIR` instead. TensorBoard log directory."
-        },
-    )
     local_rank: int = field(
         default=-1,
         metadata={
@@ -1483,15 +1470,6 @@ class TrainingArguments:
 
         if self.disable_tqdm is None:
             self.disable_tqdm = logger.getEffectiveLevel() > logging.WARN
-
-        if self.warmup_ratio is not None:
-            logger.warning("warmup_ratio is deprecated and will be removed in v5.2. Use `warmup_steps` instead.")
-            self.warmup_steps = self.warmup_ratio
-
-        if self.logging_dir is not None:
-            logger.warning(
-                "`logging_dir` is deprecated and will be removed in v5.2. Please set `TENSORBOARD_LOGGING_DIR` instead."
-            )
 
         if isinstance(self.include_num_input_tokens_seen, bool):
             self.include_num_input_tokens_seen = "all" if self.include_num_input_tokens_seen else "no"
@@ -2579,7 +2557,6 @@ class TrainingArguments:
         num_epochs: float = 3.0,
         max_steps: int = -1,
         warmup_steps: float = 0,
-        warmup_ratio: float | None = None,
     ):
         """
         A method that regroups all arguments linked to the learning rate scheduler and its hyperparameters.
@@ -2611,10 +2588,6 @@ class TrainingArguments:
         0.05
         ```
         """
-        if warmup_ratio is not None:
-            logger.warning("warmup_ratio is deprecated and will be removed in v5.2 . Use `warmup_steps` instead.")
-            warmup_steps = warmup_ratio
-
         self.lr_scheduler_type = SchedulerType(name)
         self.num_train_epochs = num_epochs
         self.max_steps = max_steps


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46917)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46917)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Removes overdue deprecations:
- Deprecated `TrainingArguments` fields `warmup_ratio` and `logging_dir` (plus their `__post_init__` migration logic and the `warmup_ratio` arg in `set_lr_scheduler`). Docs updated to use `warmup_steps` (which accepts a float ratio).
- Deprecated `is_fast` property from image processing backends (superseded by the `backend` attribute).

- [x] I confirm that this is not a pure code agent PR.

## Who can review?

trainer: @SunMarc