### PR TITLE
fix(deepspeed): chunk ZeRO-3 missing-key param gather to avoid OOM

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4821,8 +4821,21 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             not_initialized_parameters = list(
                 {v for v in self.state_dict(keep_vars=True).values() if not getattr(v, "_is_hf_initialized", False)}
             )
-            with deepspeed.zero.GatheredParameters(not_initialized_parameters, modifier_rank=0):
-                self.initialize_weights()
+            # Gather in bounded chunks so a model-wide coalesced all-gather never re-materializes the whole
+            # parameter set on rank 0 (e.g. sparse MoE models with packed expert weights). See #46822.
+            gather_chunk_numel = 2_000_000_000  # ~a few GB in bf16
+            chunk, chunk_numel = [], 0
+            for param in not_initialized_parameters:
+                param_numel = param.ds_shape.numel() if hasattr(param, "ds_shape") else param.numel()
+                if chunk and chunk_numel + param_numel > gather_chunk_numel:
+                    with deepspeed.zero.GatheredParameters(chunk, modifier_rank=0):
+                        self.initialize_weights()
+                    chunk, chunk_numel = [], 0
+                chunk.append(param)
+                chunk_numel += param_numel
+            if chunk:
+                with deepspeed.zero.GatheredParameters(chunk, modifier_rank=0):
+                    self.initialize_weights()
         else:
             self.initialize_weights()
 


### PR DESCRIPTION
## Summary
- Fixes OOM during `from_pretrained` under DeepSpeed ZeRO-3 when many missing parameters need initialization (e.g. large sparse MoE models like MiniMax-M3).
- Instead of gathering all uninitialized parameters in one `GatheredParameters` context, gather them in bounded chunks so peak rank-0 memory stays bounded.

## Context
When loading large sparse MoE models under ZeRO-3, `_initialize_missing_keys` coalesced every uninitialized parameter into a single `GatheredParameters` all-gather. For models with packed expert weights this can re-materialize hundreds of GB on rank 0 and OOM.

## Test plan
- [x] Existing `test_init_zero3_missing_params` still validates missing-key initialization under ZeRO-3
- [ ] Manual repro from #46822 on multi-GPU with DeepSpeed ZeRO-3

Fixes #46822