### PR TITLE
Fix RagTokenizer attribute delegation

### DIFF
--- a/src/transformers/models/rag/tokenization_rag.py
+++ b/src/transformers/models/rag/tokenization_rag.py
@@ -58,6 +58,15 @@ class RagTokenizer:
     def __call__(self, *args, **kwargs):
         return self.current_tokenizer(*args, **kwargs)
 
+    def __getattr__(self, name):
+        current_tokenizer = self.__dict__.get("current_tokenizer", None)
+        if current_tokenizer is not None:
+            try:
+                return getattr(current_tokenizer, name)
+            except AttributeError:
+                pass
+        raise AttributeError(f"{self.__class__.__name__} has no attribute {name}")
+
     def batch_decode(self, *args, **kwargs):
         return self.generator.batch_decode(*args, **kwargs)
 

--- a/tests/models/rag/test_tokenization_rag.py
+++ b/tests/models/rag/test_tokenization_rag.py
@@ -121,6 +121,23 @@ class RagTokenizerTest(TestCase):
         self.assertIsInstance(new_rag_tokenizer.generator, RobertaTokenizer)
         self.assertEqual(new_rag_tokenizer.generator.get_vocab(), rag_tokenizer.generator.get_vocab())
 
+    @require_tokenizers
+    def test_delegates_missing_attributes_to_current_tokenizer(self):
+        rag_tokenizer = RagTokenizer(question_encoder=self.get_dpr_tokenizer(), generator=self.get_bart_tokenizer())
+
+        input_text = "want lowest"
+        self.assertEqual(rag_tokenizer.encode(input_text), rag_tokenizer.question_encoder.encode(input_text))
+
+        rag_tokenizer.question_encoder.patch_token = "<patch>"
+        rag_tokenizer.question_encoder.patch_token_id = 42
+        self.assertEqual(rag_tokenizer.patch_token, "<patch>")
+        self.assertEqual(rag_tokenizer.patch_token_id, 42)
+        self.assertFalse(hasattr(rag_tokenizer, "missing_tokenizer_attribute"))
+
+        target_text = "lower"
+        rag_tokenizer._switch_to_target_mode()
+        self.assertEqual(rag_tokenizer.encode(target_text), rag_tokenizer.generator.encode(target_text))
+
     @slow
     def test_pretrained_token_nq_tokenizer(self):
         tokenizer = RagTokenizer.from_pretrained("facebook/rag-token-nq")


### PR DESCRIPTION
# What does this PR do?

Fixes #35532.

This PR updates `RagTokenizer` so that missing tokenizer attributes and methods are delegated to the active `current_tokenizer`.

Previously, `RagTokenizer.__call__`, `decode`, and `batch_decode` were forwarded, but other tokenizer APIs such as `encode`, `patch_token`, and `patch_token_id` were not available through the wrapper. This caused `AttributeError` even though the active underlying tokenizer supported those attributes.

The change adds a guarded `__getattr__` implementation that looks up missing attributes on `current_tokenizer`. This keeps the existing input/target tokenizer switching behavior while making `RagTokenizer` behave more like the tokenizer it wraps.

A regression test was added to check:

- `RagTokenizer.encode(...)` delegates to the question encoder in input mode
- tokenizer attributes like `patch_token` and `patch_token_id` are accessible through the wrapper
- missing attributes still behave correctly with `hasattr`
- `encode(...)` delegates to the generator after switching to target mode

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, **we ask that new users do not submit pure code agent PRs** at this time. You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this repeatedly or maliciously.

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

I used an AI coding assistant while drafting this change. I reviewed the issue, source changes, tests, and final diff before submitting.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.

Issue: #35532

- [x] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?

No documentation update needed; this is a small tokenizer wrapper behavior fix.

- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

Added `RagTokenizerTest::test_delegates_missing_attributes_to_current_tokenizer`.

## Tests

```text
PYTHONPATH=src python -m pytest -q -p no:cacheprovider tests/models/rag/test_tokenization_rag.py -k "delegates_missing_attributes_to_current_tokenizer or save_load_pretrained_with_saved_config"
# Passed 3 consecutive runs locally.

PYTHONPATH=src python -m pytest -q -p no:cacheprovider tests/models/rag/test_tokenization_rag.py
# 2 passed, 2 skipped locally. Slow pretrained RAG tests were skipped.

python -m ruff check src/transformers/models/rag/tokenization_rag.py tests/models/rag/test_tokenization_rag.py
python -m ruff format --check src/transformers/models/rag/tokenization_rag.py tests/models/rag/test_tokenization_rag.py
git diff --check origin/main...HEAD -- src/transformers/models/rag/tokenization_rag.py tests/models/rag/test_tokenization_rag.py
```