### PR TITLE
[docs] continuous batching (offloading behavior, max batch tokens, block size minimum)

### DIFF
--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -231,6 +231,14 @@ outputs = model.generate_batch(
 )
 ```
 
+### KV cache block size
+
+`block_size` sets how many tokens each KV cache block holds. It must be at least 4, and `generate_batch` raises a `ValueError` for any smaller value. The cache reserves two extra blocks for padding and sentinel bookkeeping, so very small blocks spend a large fraction of memory on this fixed overhead. Larger blocks cut bookkeeping but waste space when a sequence doesn't fill its last block. The default of 256 matches the `flash_attn_with_kvcache` decode kernel and works well in most cases. Keep `block_size` well above the minimum for an efficient cache.
+
+```py
+cb_config = ContinuousBatchingConfig(block_size=128)
+```
+
 ### Batch and scheduling limits
 
 `max_requests_per_batch` caps how many requests run in a single forward pass. The model produces a logits tensor sized by the number of batch tokens and the vocabulary size, and it's cast to `fp32` for sampling, which doubles the footprint. Each request only needs one next-token prediction, so a smaller cap keeps this tensor smaller and avoids out-of-memory errors on prefill-heavy batches with large vocabularies. By default it's set to the number of prompts submitted, with a fallback of 1024, then capped to fit `max_batch_tokens` and `num_blocks`.

--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -197,11 +197,12 @@ for chunk in manager.request_id_iter(request_id="streamed"):
 
 [`ContinuousBatchingConfig`] controls the KV cache, scheduling, CUDA graphs, memory usage, and more. Pass it alongside [`GenerationConfig`] to customize continuous batching.
 
-By default, `num_blocks` and `max_batch_tokens` are inferred automatically from available GPU memory. Use the table below to help you pick the appropriate features.
+By default, `max_batch_tokens` is `8192`, bounded by available GPU memory and never below `256`, while `num_blocks` fills the remaining memory. Use the table below to help you pick the appropriate features.
 
 | Feature | Memory | Throughput | Latency |
 |---|---|---|---|
 | `max_memory_percent` / `block_size` | ✓ controls KV budget | | |
+| `max_batch_tokens` | ↑ larger input buffers | ✓ bigger prefill batches | ✓ TTFT when prefill-bound |
 | `scheduler` | | ✓ scheduling policy | ✓ TTFT |
 | CUDA graphs | ↑ graph storage | ✓ less dispatch overhead | ✓ |
 | Async batching | ↑ ~2× I/O buffers | ✓ overlaps CPU/GPU | |
@@ -237,6 +238,18 @@ outputs = model.generate_batch(
 
 ```py
 cb_config = ContinuousBatchingConfig(block_size=128)
+```
+
+### Prefill batch size
+
+`max_batch_tokens` sets the token budget for a single forward pass, the maximum number of query tokens the model processes at once. A larger budget packs more prompt tokens into each prefill, which raises prefill throughput and lowers time-to-first-token on prompt-heavy workloads. The scheduler splits prompts that exceed the budget across steps. See [chunked prefill](./continuous_batching_architecture#chunked-prefill) for how oversized prompts are handled.
+
+By default, `max_batch_tokens` is `8192`. The value is bounded by available GPU memory so the per-batch input tensors don't crowd out the KV cache, and it never falls below `256`. On a GPU with little free memory, the bound lowers it below `8192`.
+
+`max_batch_tokens` and `num_blocks` draw from the same memory budget, so they trade off against each other. A larger token budget allocates bigger input buffers and leaves fewer KV cache blocks for concurrent or long requests. Raise `max_batch_tokens` to push prefill throughput when you have more memory available, and lower it to free memory for more KV blocks or to avoid out-of-memory errors.
+
+```py
+cb_config = ContinuousBatchingConfig(max_batch_tokens=16384)
 ```
 
 ### Batch and scheduling limits
@@ -285,7 +298,6 @@ cb_config = ContinuousBatchingConfig(
     use_cuda_graph=True,
     q_padding_interval_size=64,
     kv_padding_interval_size=16384,
-    max_cached_graphs=32,
 )
 ```
 

--- a/docs/source/en/continuous_batching_architecture.md
+++ b/docs/source/en/continuous_batching_architecture.md
@@ -131,7 +131,7 @@ Freed blocks aren't wiped and they stay "initialized" with their content and has
 
 ### Soft reset
 
-If the KV cache fills completely during a long session, because requests are generating very long outputs, the manager triggers offloading rather than crashing. It selects the oldest active request (or the newest, if a previous soft reset already blocked new requests from joining), appends its generated tokens to its original prompt, frees its cache blocks, and adds it back to the queue.
+A soft reset is the fallback path for [offloading](#offloading). When the manager can't copy a request's KV cache to the CPU swap pool, because CPU offloading is disabled or the pool is full, it soft resets the request instead. It appends the request's generated tokens to its original prompt, frees its cache blocks, and adds it back to the queue. The [Offloading](#offloading) section covers which requests are chosen.
 
 When the cache has space again, the request resumes from where it left off with its generation history encoded in the prompt.
 
@@ -169,11 +169,16 @@ Async batching requires CUDA graphs to be active, since graph replay provides th
 
 ## Offloading
 
-Requests that generate very long outputs can fill the KV cache during long sessions. The manager evicts one active request instead of crashing. It selects the oldest active request, or the newest if a previous eviction already blocked new requests from joining.
+Requests that generate long outputs can grow until the KV cache has no room to allocate the next block. Rather than crash, the manager offloads active requests back to the waiting queue to free blocks for the requests that remain.
 
-When `cpu_offload_space` is greater than `0.0`, the manager first tries to copy the evicted request's KV cache blocks to a pre-allocated pinned CPU buffer. The request moves back to the waiting queue. After GPU cache space becomes available, the manager copies the blocks back to the GPU and resumes the request without recomputing its prompt and generated tokens.
+Offloading is demand-driven. The scheduler reports the *stalled* requests, the active requests that failed to allocate the blocks they need, along with how many blocks each one demands. The manager offloads the fewest requests needed to free enough blocks to cover that demand. It offloads newest first, so requests already scheduled into the current batch keep their cache, and the last remaining active request is never offloaded.
 
-If CPU offloading is disabled or the CPU swap pool is full, the manager falls back to a soft reset. A soft reset appends the generated tokens to the original prompt, frees the request's cache blocks, and adds the request back to the queue. After the cache has space, the request resumes with its generation history encoded in the prompt.
+Two situations trigger offloading.
+
+- A batch is scheduled, but some active requests stalled. The manager offloads enough of the stalled requests that the next batch can allocate blocks for the rest.
+- The cache is full and no batch can be scheduled at all. The manager offloads requests and retries scheduling in a loop within the same step, until a batch fits or no request can be offloaded. It no longer waits for the next forward pass to recover.
+
+An offloaded request takes one of two paths. When `cpu_offload_space` is greater than `0.0`, the manager copies the request's KV cache blocks to a pre-allocated pinned CPU buffer, batching every request that fits the swap pool into a single transfer. After GPU cache space becomes available, the manager copies the blocks back to the GPU and resumes the request without recomputing its prompt and generated tokens. Requests that don't fit the pool, or every offloaded request when CPU offloading is disabled, fall back to a [soft reset](#soft-reset).
 
 ## Next steps
 

--- a/docs/source/en/continuous_batching_architecture.md
+++ b/docs/source/en/continuous_batching_architecture.md
@@ -98,6 +98,8 @@ Paged KV cache (num_blocks × block_size tokens per block)
 
 A page holds the key/value state for one token in one layer. A block is a span of `block_size` pages (default 256) and is the unit of allocation. Blocks are allocated per layer group. Layers within a group share a block ID, which keeps bookkeeping uniform for mixed-attention models.
 
+The cache reserves two extra blocks on top of `num_blocks` for padding tokens to read from and write to, plus a sentinel index for sliding window groups. This reservation requires `block_size` to be at least 4, so the manager rejects smaller values.
+
 ### Cache sizing
 
 The manager infers the number of blocks at startup from free GPU memory. The manager solves an equation that accounts for KV tensors, attention masks, activations, and bookkeeping indices, then sizes the pool to fit inside `max_memory_percent` (default 0.9) of the available memory.

--- a/docs/source/en/continuous_batching_architecture.md
+++ b/docs/source/en/continuous_batching_architecture.md
@@ -145,7 +145,7 @@ Because the batch shapes change every step, the continuous batching system handl
 
 1. Query lengths are padded to the nearest multiple of `q_padding_interval_size`.
 2. KV lengths are padded to the nearest multiple of `kv_padding_interval_size`.
-3. Recorded graphs are stored in an LRU cache of up to `max_cached_graphs` entries.
+3. Recorded graphs are stored in a cache.
 
 When a batch's padded shape matches a cached graph, the graph replays without any CPU dispatch. New shapes trigger a new graph capture.
 


### PR DESCRIPTION
Adds docs for several recent continuous batching PRs (#46765, #46712, #46587):

- New section for `max_batch_tokens`,  the trade off and when to raise or lower it
- New section explaining `block_size`
- Reframe soft reset as the fallback path for offloading
- Describe new offloading behavior (demand-drive, newest first-eviction with batched CPU transfers)