### PR TITLE
Reject assisted generation for LFM2 and LFM2-MoE (set _is_stateful)

### DIFF
--- a/src/transformers/models/lfm2/modeling_lfm2.py
+++ b/src/transformers/models/lfm2/modeling_lfm2.py
@@ -476,6 +476,7 @@ class Lfm2PreTrainedModel(PreTrainedModel):
         "hidden_states": Lfm2DecoderLayer,
         "attentions": Lfm2Attention,
     }
+    _is_stateful = True
 
 
 @auto_docstring

--- a/src/transformers/models/lfm2/modular_lfm2.py
+++ b/src/transformers/models/lfm2/modular_lfm2.py
@@ -297,6 +297,7 @@ class Lfm2DecoderLayer(GradientCheckpointingLayer):
 
 class Lfm2PreTrainedModel(LlamaPreTrainedModel):
     _can_compile_fullgraph = False
+    _is_stateful = True
 
 
 class Lfm2Model(LlamaModel):

--- a/src/transformers/models/lfm2_moe/modeling_lfm2_moe.py
+++ b/src/transformers/models/lfm2_moe/modeling_lfm2_moe.py
@@ -556,6 +556,7 @@ class Lfm2MoePreTrainedModel(PreTrainedModel):
         "hidden_states": Lfm2MoeDecoderLayer,
         "attentions": Lfm2MoeAttention,
     }
+    _is_stateful = True
 
     @torch.no_grad()
     def _init_weights(self, module):

--- a/src/transformers/models/lfm2_moe/modular_lfm2_moe.py
+++ b/src/transformers/models/lfm2_moe/modular_lfm2_moe.py
@@ -130,6 +130,7 @@ class Lfm2MoeDecoderLayer(Lfm2DecoderLayer):
 
 class Lfm2MoePreTrainedModel(LlamaPreTrainedModel):
     _can_compile_fullgraph = False  # uses a non-compilable cache class
+    _is_stateful = True
 
     @torch.no_grad()
     def _init_weights(self, module):

--- a/tests/models/lfm2/test_modeling_lfm2.py
+++ b/tests/models/lfm2/test_modeling_lfm2.py
@@ -54,6 +54,15 @@ class Lfm2ModelTest(CausalLMModelTest, unittest.TestCase):
     def _get_conv_state_shape(self, batch_size: int, config):
         return (batch_size, config.hidden_size, config.conv_L_cache)
 
+    def test_assisted_generation_rejected_as_stateful(self):
+        """LFM2 is a conv/attention hybrid (stateful), so assisted / prompt-lookup decoding must be rejected with
+        a clear error instead of silently producing wrong text (it cannot roll back its conv state)."""
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        model = Lfm2ForCausalLM(config).to(torch_device).eval()
+        input_ids = inputs_dict["input_ids"][:1]  # batch size 1, so prompt lookup would otherwise run
+        with self.assertRaisesRegex(ValueError, "stateful"):
+            model.generate(input_ids, max_new_tokens=3, do_sample=False, prompt_lookup_num_tokens=2)
+
     def test_attention_outputs(self):
         """Lfm2Moe alternates between attention and short-conv layers."""
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/models/lfm2_moe/test_modeling_lfm2_moe.py
+++ b/tests/models/lfm2_moe/test_modeling_lfm2_moe.py
@@ -72,6 +72,15 @@ class Lfm2MoeModelTest(CausalLMModelTest, unittest.TestCase):
     def _get_conv_state_shape(self, batch_size: int, config):
         return (batch_size, config.hidden_size, config.conv_L_cache)
 
+    def test_assisted_generation_rejected_as_stateful(self):
+        """Lfm2Moe is a conv/attention hybrid (stateful), so assisted / prompt-lookup decoding must be rejected
+        with a clear error instead of silently producing wrong text (it cannot roll back its conv state)."""
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        model = Lfm2MoeForCausalLM(config).to(torch_device).eval()
+        input_ids = inputs_dict["input_ids"][:1]  # batch size 1, so prompt lookup would otherwise run
+        with self.assertRaisesRegex(ValueError, "stateful"):
+            model.generate(input_ids, max_new_tokens=3, do_sample=False, prompt_lookup_num_tokens=2)
+
     def test_attention_outputs(self):
         """Lfm2Moe alternates between attention and short-conv layers."""
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION

# What does this PR do?

LFM2 and LFM2-MoE are conv/attention hybrids that keep recurrent conv state, but they inherited the default `_is_stateful = False` from Llama. Assisted and prompt-lookup decoding are therefore not rejected for them, and because their conv state cannot be rolled back during speculative verification, they silently produce tokens that diverge from greedy instead of raising the clear error the other stateful models raise:

```
ValueError: assisted generation is not supported with stateful models, such as Lfm2ForCausalLM
```

Speculative decoding is supposed to be lossless (token-identical to greedy), so silently diverging is a correctness bug. This PR sets `_is_stateful = True` on both models so the existing guard rejects assisted/prompt-lookup decoding cleanly. (This does not add speculative-decoding support for LFM2, which would require rolling back the conv cache; it makes the unsupported path fail loudly instead of silently.)

<details>
<summary>Reproduction (real LFM2-1.2B, fp32) and before/after</summary>

```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer

tok = AutoTokenizer.from_pretrained("LiquidAI/LFM2-1.2B")
m = AutoModelForCausalLM.from_pretrained("LiquidAI/LFM2-1.2B", dtype=torch.float32).eval()
ids = tok("The capital of France is Paris, and the capital of Germany is", return_tensors="pt").input_ids

greedy = m.generate(ids, max_new_tokens=40, do_sample=False)
lookup = m.generate(ids, max_new_tokens=40, do_sample=False, prompt_lookup_num_tokens=2)
```

Before this PR `_is_stateful` is `False`, greedy is deterministic, but `prompt_lookup` diverges from greedy at every `prompt_lookup_num_tokens` with completely different tokens (fp32, so not a tie). After this PR `prompt_lookup` (and any `assistant_model`) raises the `ValueError` above, matching the other stateful hybrids (Falcon-H1, Qwen3.5, mamba2, ...).

</details>

A regression test is added for each model (`Lfm2ModelTest` / `Lfm2MoeModelTest` `::test_assisted_generation_rejected_as_stateful`), asserting prompt-lookup decoding raises a stateful-model error. Each fails on `main` (decoding silently runs) and passes with this fix. The `lfm2` model test file passes (137 passed, 122 skipped); `ruff` is clean. The fix edits the modular files and regenerates the modeling files.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@Cyrilvallez
