### PR TITLE
docs(conditional_detr): fix num_queries default in docstring (100 -> 300)

### DIFF
--- a/src/transformers/models/conditional_detr/configuration_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/configuration_conditional_detr.py
@@ -25,7 +25,7 @@ from ..auto import AutoConfig
 @strict
 class ConditionalDetrConfig(PreTrainedConfig):
     r"""
-    num_queries (`int`, *optional*, defaults to 100):
+    num_queries (`int`, *optional*, defaults to 300):
         Number of object queries, i.e. detection slots. This is the maximal number of objects
         [`ConditionalDetrModel`] can detect in a single image. For COCO, we recommend 100 queries.
     auxiliary_loss (`bool`, *optional*, defaults to `False`):


### PR DESCRIPTION
The `num_queries` docstring in `ConditionalDetrConfig` says it "defaults to 100", but the actual class attribute is `num_queries: int = 300`. The `100` is a leftover copy from vanilla DETR; Conditional DETR uses 300 object queries (matching the `microsoft/conditional-detr-resnet-50` checkpoint), and the `300` default has been stable across releases. This corrects the documented default to 300.