### PR TITLE
Fix dtype cast in TimesFM 2.5 ResidualBlock for quantized weights

### DIFF
--- a/src/transformers/models/timesfm2_5/modeling_timesfm2_5.py
+++ b/src/transformers/models/timesfm2_5/modeling_timesfm2_5.py
@@ -106,8 +106,11 @@ class TimesFm2_5ResidualBlock(nn.Module):
         use_bias = use_bias if use_bias is not None else config.use_bias
 
     def forward(self, x):
-        # Align activations to block parameter dtype for mixed precision stability
-        x = x.to(self.input_layer.weight.dtype)
+        # Only cast inputs when the block weights are floating point. Under quantization
+        # (e.g. bitsandbytes 4/8-bit) `input_layer.weight.dtype` is an integer type, and
+        # casting the float inputs to it would silently truncate them (e.g. 0.73 -> 0).
+        if (target_dtype := self.input_layer.weight.dtype).is_floating_point:
+            x = x.to(target_dtype)
         hidden = self.input_layer(x)
         hidden = self.activation(hidden)
         output = self.output_layer(hidden)

--- a/src/transformers/models/timesfm2_5/modular_timesfm2_5.py
+++ b/src/transformers/models/timesfm2_5/modular_timesfm2_5.py
@@ -158,8 +158,11 @@ class TimesFm2_5ResidualBlock(TimesFmResidualBlock):
         self.activation = ACT2FN[config.activation]
 
     def forward(self, x):
-        # Align activations to block parameter dtype for mixed precision stability
-        x = x.to(self.input_layer.weight.dtype)
+        # Only cast inputs when the block weights are floating point. Under quantization
+        # (e.g. bitsandbytes 4/8-bit) `input_layer.weight.dtype` is an integer type, and
+        # casting the float inputs to it would silently truncate them (e.g. 0.73 -> 0).
+        if (target_dtype := self.input_layer.weight.dtype).is_floating_point:
+            x = x.to(target_dtype)
         return super().forward(x)
 
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46942&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46942) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46942&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46942)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`TimesFm2_5ResidualBlock.forward` unconditionally casts its float input to the block's weight dtype:

```python
x = x.to(self.input_layer.weight.dtype)
```

`input_layer` is an `nn.Linear`, and this block is used as the model's input projection (`input_ff_layer`), so the **raw float time-series inputs** flow through it. When the model is loaded with quantization (e.g. `bitsandbytes` 4/8-bit), `input_layer.weight.dtype` is an **integer** type (e.g. `uint8`). Casting the float inputs to an int dtype silently truncates them to zeros (`0.73 -> 0`), so the model produces garbage outputs with no error or warning.

The fix only casts when the weight dtype is floating point, preserving the original mixed-precision behavior while skipping the destructive cast under quantization:

```python
if (target_dtype := self.input_layer.weight.dtype).is_floating_point:
    x = x.to(target_dtype)
```

This is the same pattern already applied to the multimodal embedders in `gemma4_unified` (#46904) and `gemma4` (#46933).

Both `modular_timesfm2_5.py` and the generated `modeling_timesfm2_5.py` are updated to stay in sync.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. (Same class of bug as #46904 / #46933.)
- [ ] Did you make sure to update the documentation with your changes? N/A.
- [ ] Did you write any new necessary tests? Follows the precedent of #46904/#46933 (dtype-safety guard, no new test).

## Who can review?

@kashif @SunMarc