### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/github-script@v9.0.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const wr = context.payload.workflow_run;


### PR DESCRIPTION
## Summary

Pin all unpinned GitHub Actions to immutable full-length commit SHAs.

**Why:** Mutable tags (`@v3`, `@main`, etc.) can be silently redirected to malicious commits. SHA-pinning ensures the exact reviewed code runs in CI.

**Changes:** 1 reference(s) across 1 workflow file(s). Each retains its version tag as an inline comment.

**References:**
- [GitHub: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [OpenSSF Scorecard: Pinned-Dependencies](https://securityscorecards.dev)

*Automated security hardening PR.*