### PR TITLE
Fix CohereASR training loss double shift

### DIFF
--- a/src/transformers/models/cohere_asr/modeling_cohere_asr.py
+++ b/src/transformers/models/cohere_asr/modeling_cohere_asr.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
+from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
@@ -637,7 +638,8 @@ class CohereAsrForConditionalGeneration(CohereAsrPreTrainedModel, GenerationMixi
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
+            loss_fct = CrossEntropyLoss()
+            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/cohere_asr/modular_cohere_asr.py
+++ b/src/transformers/models/cohere_asr/modular_cohere_asr.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
+from torch.nn import CrossEntropyLoss
 
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
 from ...generation import GenerationMixin
@@ -500,7 +501,8 @@ class CohereAsrForConditionalGeneration(MoonshineForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
+            loss_fct = CrossEntropyLoss()
+            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/tests/models/cohere_asr/test_modeling_cohere_asr.py
+++ b/tests/models/cohere_asr/test_modeling_cohere_asr.py
@@ -15,6 +15,7 @@
 import copy
 import math
 import unittest
+from types import SimpleNamespace
 
 from transformers import AutoProcessor, CohereAsrConfig, CohereAsrForConditionalGeneration, is_torch_available
 from transformers.audio_utils import load_audio
@@ -178,6 +179,42 @@ class CohereAsrModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_reverse_loading_mapping(self):
         # proj_out conversion only applies to ForConditionalGeneration, not the base model
         super().test_reverse_loading_mapping(skip_base_model=True)
+
+    def test_training_loss_no_double_shift(self):
+        # forward shifts labels into decoder_input_ids, so loss must be
+        # plain CE against the labels (no second shift)
+        from torch.nn import CrossEntropyLoss
+
+        config = self.model_tester.get_config()
+        config.pad_token_id = self.model_tester.pad_token_id
+        model = CohereAsrForConditionalGeneration(config).to(torch_device).eval()
+        vocab_size = config.vocab_size
+
+        torch.manual_seed(0)
+        bsz, enc_len, dec_len = 2, 10, 6
+        enc_hidden = torch.randn(bsz, enc_len, config.hidden_size, device=torch_device)
+        encoder_outputs = SimpleNamespace(
+            last_hidden_state=enc_hidden,
+            attention_mask=None,
+            hidden_states=None,
+            attentions=None,
+        )
+        labels = torch.randint(3, vocab_size, (bsz, dec_len), device=torch_device)
+        padded = labels.clone()
+        padded[0, -1] = -100
+        padded[1, -2:] = -100
+
+        def aligned_ce(logits, lbl):
+            return CrossEntropyLoss()(logits.reshape(-1, vocab_size), lbl.reshape(-1))
+
+        def double_shift_ce(logits, lbl):
+            return CrossEntropyLoss()(logits[..., :-1, :].reshape(-1, vocab_size), lbl[..., 1:].reshape(-1))
+
+        for lbl in (labels, padded):
+            with torch.no_grad():
+                out = model(encoder_outputs=encoder_outputs, labels=lbl, use_cache=False)
+            self.assertTrue(torch.allclose(out.loss, aligned_ce(out.logits, lbl)))
+            self.assertFalse(torch.allclose(out.loss, double_shift_ce(out.logits, lbl)))
 
     # Copied from tests.models.moonshine_streaming.test_modeling_moonshine_streaming.MoonshineStreamingModelTest.test_resize_tokens_embeddings
     def test_resize_tokens_embeddings(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46947)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46947)
<!-- ci-dashboard-badge:end -->

## Summary

CohereASR right-shifts `labels` into `decoder_input_ids`, then used `self.loss_function` (`ForCausalLMLoss`) to compute the training loss. That loss shifts labels internally again, so training targets were effectively `labels[..., 1:]`.

This switches CohereASR to a plain `CrossEntropyLoss`, matching the Moonshine fix and seq2seq models that already align decoder inputs from labels before computing loss.

Fixes #46894.

## Tests

- `PYTHONPATH=src /tmp/transformers-pr-venv/bin/python -m pytest tests/models/cohere_asr/test_modeling_cohere_asr.py::CohereAsrModelTest::test_training_loss_no_double_shift -q`

<!-- ci-dashboard-recap:start -->

---

### CI recap

**Dashboard:** [View test results in Grafana](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46947)
**Latest run:** [28335138925](https://github.com/huggingface/transformers/actions/runs/28335138925)
**Result:** `success` | Grafana metrics are not available yet.

<!-- ci-dashboard-recap:end -->