### PR TITLE
Remove default dtype in FusedRMSNormGated modules

### DIFF
--- a/src/transformers/models/olmo_hybrid/modeling_olmo_hybrid.py
+++ b/src/transformers/models/olmo_hybrid/modeling_olmo_hybrid.py
@@ -706,7 +706,6 @@ class OlmoHybridGatedDeltaNet(nn.Module):
             else FusedRMSNormGated(
                 self.head_v_dim,
                 eps=1e-5,
-                dtype=config.dtype if config.dtype is not None else torch.get_default_dtype(),
             )
         )
 

--- a/src/transformers/models/olmo_hybrid/modular_olmo_hybrid.py
+++ b/src/transformers/models/olmo_hybrid/modular_olmo_hybrid.py
@@ -520,7 +520,6 @@ class OlmoHybridGatedDeltaNet(nn.Module):
             else FusedRMSNormGated(
                 self.head_v_dim,
                 eps=1e-5,
-                dtype=config.dtype if config.dtype is not None else torch.get_default_dtype(),
             )
         )
 

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -412,7 +412,6 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 self.head_v_dim,
                 eps=self.layer_norm_epsilon,
                 activation=self.activation,
-                dtype=config.dtype if config.dtype is not None else torch.get_default_dtype(),
             )
         )
 

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -409,7 +409,6 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                 self.head_v_dim,
                 eps=self.layer_norm_epsilon,
                 activation=self.activation,
-                dtype=config.dtype if config.dtype is not None else torch.get_default_dtype(),
             )
         )
 

--- a/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modeling_qwen3_next.py
@@ -543,7 +543,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 self.head_v_dim,
                 eps=self.layer_norm_epsilon,
                 activation=self.activation,
-                dtype=config.dtype if config.dtype is not None else torch.get_default_dtype(),
             )
         )
 

--- a/src/transformers/models/qwen3_next/modular_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modular_qwen3_next.py
@@ -384,7 +384,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 self.head_v_dim,
                 eps=self.layer_norm_epsilon,
                 activation=self.activation,
-                dtype=config.dtype if config.dtype is not None else torch.get_default_dtype(),
             )
         )
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46953)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46953)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Follow-up of https://github.com/huggingface/transformers/pull/46817. As mentionned, device and dtype should never be explicit in module instantiation.
cc @vasqu

<!-- ci-dashboard-recap:start -->

---

### CI recap

**Dashboard:** [View test results in Grafana](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46953)
**Latest run:** [28350254198:1](https://github.com/huggingface/transformers/actions/runs/28350254198)
**Result:** `success` | **Jobs:** 2 | **Tests:** 13 | **Failures:** 0 | **Duration:** 1m 10s

<!-- ci-dashboard-recap:end -->