### PR TITLE
Fix failure revealed by Pytest v9

### DIFF
--- a/src/transformers/models/glmasr/modeling_glmasr.py
+++ b/src/transformers/models/glmasr/modeling_glmasr.py
@@ -520,7 +520,7 @@ class GlmAsrCausalLMOutputWithPast(ModelOutput):
     """
 )
 class GlmAsrForConditionalGeneration(GlmAsrPreTrainedModel, GenerationMixin):
-    _keep_in_fp32_modules_strict = ["embed_positions"]
+    _keep_in_fp32_modules_strict = None
     _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
 
     def __init__(self, config):

--- a/src/transformers/models/glmasr/modular_glmasr.py
+++ b/src/transformers/models/glmasr/modular_glmasr.py
@@ -375,6 +375,7 @@ class GlmAsrModel(AudioFlamingo3Model):
     """
 )
 class GlmAsrForConditionalGeneration(AudioFlamingo3ForConditionalGeneration):
+    _keep_in_fp32_modules_strict = None
     _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
 
     def __init__(self, config):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46954)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46954)
<!-- ci-dashboard-badge:end -->

[!NOTE]
this fix was generated with the help of AI. But I carefully reviewed it and I fully endorse all the content.

## The Issue
The test `tests/models/glmasr/test_modeling_glmasr` fails with pytest v9 or with `pip install pytest-subtests`.

Specifically, `GlmAsrForConditionalGenerationModelTest.test_keep_in_fp32_modules_exist` fails with:
`AssertionError: False is not true : ['embed_positions'] were specified in the _keep_in_fp32_modules_strict list, but are not part of the modules in GlmAsrForConditionalGeneration`

## pytest v9 and `subTest`
Pytest v9 natively supports `unittest.TestCase.subTest()`.
Without proper support, failures inside `subTest` were simply accumulated, and **silently ignored by pytest**.
Pytest v9 (or `pip install pytest-subtests`) correctly detects and reports these failures.

## Root Cause
`GlmAsrForConditionalGeneration` inherits from `AudioFlamingo3ForConditionalGeneration`,
but its `GlmAsrEncoder` does not use `embed_positions`, unlike `AudioFlamingo3Encoder`.
Therefore, `embed_positions` is not present in the model's state dict, and the check fails.

<!-- ci-dashboard-recap:start -->

---

### CI recap

**Dashboard:** [View test results in Grafana](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46954)
**Latest run:** [28358743771](https://github.com/huggingface/transformers/actions/runs/28358743771)
**Result:** `success` | Grafana metrics are not available yet.

<!-- ci-dashboard-recap:end -->