### PR TITLE
Fix Xcodec2 attention to be non-causal.

### DIFF
--- a/src/transformers/models/xcodec2/modeling_xcodec2.py
+++ b/src/transformers/models/xcodec2/modeling_xcodec2.py
@@ -258,7 +258,7 @@ class Xcodec2Attention(nn.Module):
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
-        self.is_causal = True
+        self.is_causal = False
 
         self.q_proj = nn.Linear(
             config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
@@ -975,10 +975,6 @@ class Xcodec2Model(Xcodec2PreTrainedModel):
         self.quantizer = Xcodec2Quantizer(config)
         self.acoustic_decoder = Xcodec2Decoder(config)
 
-        # Get semantic encoder dtype for casting input features to avoid dtype mismatch
-        semantic_param = next(iter(self.semantic_encoder.parameters()), None)
-        self.semantic_dtype = semantic_param.dtype if semantic_param is not None else torch.float32
-
         self.post_init()
 
     @auto_docstring
@@ -1007,10 +1003,8 @@ class Xcodec2Model(Xcodec2PreTrainedModel):
 
         # Semantic embedding
         with torch.no_grad():
-            semantic_output = self.semantic_encoder(
-                input_features.to(self.semantic_dtype), attention_mask=input_features_mask
-            )
-        semantic_hidden_states = semantic_output.last_hidden_state.to(input_values.dtype).transpose(1, 2)
+            semantic_output = self.semantic_encoder(input_features, attention_mask=input_features_mask)
+        semantic_hidden_states = semantic_output.last_hidden_state.transpose(1, 2)
         semantic_hidden_states = self.semantic_adapter(semantic_hidden_states)
 
         # Acoustic embedding and concatenate

--- a/src/transformers/models/xcodec2/modular_xcodec2.py
+++ b/src/transformers/models/xcodec2/modular_xcodec2.py
@@ -193,6 +193,10 @@ class Xcodec2MLP(CLIPMLP):
 
 
 class Xcodec2Attention(LlamaAttention):
+    def __init__(self, config: Xcodec2Config, layer_idx: int):
+        super().__init__(config, layer_idx)
+        self.is_causal = False
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -635,10 +639,6 @@ class Xcodec2Model(Xcodec2PreTrainedModel):
         self.quantizer = Xcodec2Quantizer(config)
         self.acoustic_decoder = Xcodec2Decoder(config)
 
-        # Get semantic encoder dtype for casting input features to avoid dtype mismatch
-        semantic_param = next(iter(self.semantic_encoder.parameters()), None)
-        self.semantic_dtype = semantic_param.dtype if semantic_param is not None else torch.float32
-
         self.post_init()
 
     @auto_docstring
@@ -667,10 +667,8 @@ class Xcodec2Model(Xcodec2PreTrainedModel):
 
         # Semantic embedding
         with torch.no_grad():
-            semantic_output = self.semantic_encoder(
-                input_features.to(self.semantic_dtype), attention_mask=input_features_mask
-            )
-        semantic_hidden_states = semantic_output.last_hidden_state.to(input_values.dtype).transpose(1, 2)
+            semantic_output = self.semantic_encoder(input_features, attention_mask=input_features_mask)
+        semantic_hidden_states = semantic_output.last_hidden_state.transpose(1, 2)
         semantic_hidden_states = self.semantic_adapter(semantic_hidden_states)
 
         # Acoustic embedding and concatenate

--- a/tests/models/xcodec2/test_modeling_xcodec2.py
+++ b/tests/models/xcodec2/test_modeling_xcodec2.py
@@ -240,7 +240,7 @@ class Xcodec2IntegrationTest(unittest.TestCase):
 
             dec = model.decode(audio_codes=audio_codes).audio_values
             n_recon = len(exp_recon)
-            torch.testing.assert_close(dec.squeeze().cpu()[:n_recon], exp_recon, rtol=1e-3, atol=1e-3)
+            torch.testing.assert_close(dec.squeeze().cpu()[:n_recon], exp_recon, rtol=1e-6, atol=1e-6)
 
             # compare codec error
             codec_error = compute_rmse(inputs["input_values"], dec).item()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46963)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46963)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fix attention to non-causal.
And some better casting logic.

Here's a script for computing typical codec metrics (STOI, UTMOS) which could be adapted for other codecs: https://gist.github.com/ebezzam/2bd1ae4e602c9281394eddaf0db47640

Below are results, which better match those reported in the [paper](https://arxiv.org/pdf/2502.04128) (last row of Table 1).
```
# after non-causal fix
=== UTMOS v1 + STOI Results (Xcodec2 on LibriSpeech test-clean) ===

  [utmos_v1]
    mean        : 4.126076144207525
    std         : 0.30357224633025415
    min         : 2.1887624263763428
    max         : 4.5252885818481445
    n_samples   : 2620

  [stoi]
    mean        : 0.9185172467513849
    std         : 0.025973485735741188
    min         : 0.7102322578430176
    max         : 0.9643605351448059
    n_samples   : 2620

# before
=== UTMOS v1 + STOI Results (Xcodec2 on LibriSpeech test-clean) ===

  [utmos_v1]
    mean        : 3.3033667397408086
    std         : 0.4488575984272713
    min         : 1.3538525104522705
    max         : 4.418213367462158
    n_samples   : 2620

  [stoi]
    mean        : 0.8875954491719035
    std         : 0.030786942237932484
    min         : 0.6717123985290527
    max         : 0.9476659893989563
    n_samples   : 2620
```

<!-- ci-dashboard-recap:start -->

---

### CI recap

**Dashboard:** [View test results in Grafana](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46963)
**Latest run:** [28383088506](https://github.com/huggingface/transformers/actions/runs/28383088506)
**Result:** `success` | Grafana metrics are not available yet.

<!-- ci-dashboard-recap:end -->