### PR TITLE
Allow PEFT quantized models with non-trainable quantizers

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -120,6 +120,7 @@ def validate_quantization_for_training(model):
     _is_model_quantized_and_qat_trainable = getattr(model, "hf_quantizer", None) is not None and getattr(
         model.hf_quantizer, "is_qat_trainable", False
     )
+    _is_peft = _is_peft_model(model)
 
     # Filter out quantized + compiled models
     if _is_quantized_and_base_model and hasattr(model, "_orig_mod"):
@@ -128,13 +129,13 @@ def validate_quantization_for_training(model):
         )
 
     # At this stage the model is already loaded
-    if _is_quantized_and_base_model and not _is_peft_model(model) and not _is_model_quantized_and_qat_trainable:
+    if _is_quantized_and_base_model and not _is_peft and not _is_model_quantized_and_qat_trainable:
         raise ValueError(
             "You cannot perform fine-tuning on purely quantized models. Please attach trainable adapters on top of"
             " the quantized model to correctly perform fine-tuning. Please see: https://huggingface.co/docs/transformers/peft"
             " for more details"
         )
-    elif _is_quantized_and_base_model and not _quantization_method_supports_training:
+    elif _is_quantized_and_base_model and not _is_peft and not _quantization_method_supports_training:
         raise ValueError(
             f"The model you are trying to fine-tune is quantized with {model.hf_quantizer.quantization_config.quant_method}"
             " but that quantization method do not support training. Please open an issue on GitHub: https://github.com/huggingface/transformers"

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -21,6 +21,7 @@ import math
 import os
 import tempfile
 from functools import partial
+from types import SimpleNamespace
 
 import datasets
 import numpy as np
@@ -69,6 +70,8 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
+from transformers.trainer_utils import validate_quantization_for_training
+from transformers.utils.quantization_config import QuantizationMethod
 
 from .trainer_test_utils import (
     ATOL,
@@ -914,6 +917,41 @@ class TrainerIntegrationPrerunTest(TestCasePlus, TrainerIntegrationCommon):
             trainer.args.seed = 314
             trainer.train()
             self.check_trained_model(trainer.model, alternate_seed=True)
+
+
+# ---------------------------------------------------------------------------
+# Quantized training validation tests
+# ---------------------------------------------------------------------------
+
+
+@require_torch
+class TrainerQuantizationValidationTest(TestCasePlus):
+    def test_non_peft_quantized_model_with_non_trainable_quantizer_raises(self):
+        model = GPT2LMHeadModel(GPT2Config(n_layer=1, n_head=2, n_embd=32, vocab_size=100))
+        model.is_quantized = True
+        model.hf_quantizer = SimpleNamespace(
+            is_trainable=False,
+            is_qat_trainable=False,
+            quantization_config=SimpleNamespace(quant_method=QuantizationMethod.FP8),
+        )
+
+        with self.assertRaises(ValueError):
+            validate_quantization_for_training(model)
+
+    @require_peft
+    def test_peft_quantized_model_with_non_trainable_quantizer_is_allowed(self):
+        from peft import LoraConfig, get_peft_model
+
+        model = GPT2LMHeadModel(GPT2Config(n_layer=1, n_head=2, n_embd=32, vocab_size=100))
+        model.is_quantized = True
+        model.hf_quantizer = SimpleNamespace(
+            is_trainable=False,
+            is_qat_trainable=False,
+            quantization_config=SimpleNamespace(quant_method=QuantizationMethod.FP8),
+        )
+        model = get_peft_model(model, LoraConfig(target_modules=["c_attn"], task_type="CAUSAL_LM"))
+
+        validate_quantization_for_training(model)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46964)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46964)
<!-- ci-dashboard-badge:end -->

Fixes #46736.

This updates `validate_quantization_for_training` so PEFT-wrapped quantized models are consistently exempted from the non-trainable quantized base model guards.

The existing logic already skipped PEFT models for the "purely quantized model" check, but the following "quantization method does not support training" branch still rejected them. That blocks LoRA adapter fine-tuning flows created with `get_peft_model(...)`, even though the quantized base model itself is not being trained.

The change keeps the existing error for non-PEFT quantized base models and adds tests for both paths.

Tests:
```
python -m pytest tests/trainer/test_trainer.py -k "non_peft_quantized_model_with_non_trainable_quantizer_raises or peft_quantized_model_with_non_trainable_quantizer_is_allowed"
```

<!-- ci-dashboard-recap:start -->

---

### CI recap

**Dashboard:** [View test results in Grafana](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46964)
**Latest run:** [28390211132:2](https://github.com/huggingface/transformers/actions/runs/28390211132)
**Result:** `failure` | **Jobs:** 14 | **Tests:** 67,159 | **Failures:** 67 | **Duration:** 12h 25m

<!-- ci-dashboard-recap:end -->