### PR TITLE
Fix AttributeError when window_size is set in TimesFm2_5ModelForPrediction

### DIFF
--- a/src/transformers/models/timesfm2_5/modeling_timesfm2_5.py
+++ b/src/transformers/models/timesfm2_5/modeling_timesfm2_5.py
@@ -777,7 +777,7 @@ class TimesFm2_5ModelForPrediction(TimesFm2_5PreTrainedModel):
         if window_size is not None:
             new_inputs: list[torch.Tensor] = []
             for ts in inputs:
-                new_inputs.extend(self._timesfm_moving_average(ts, window_size))
+                new_inputs.extend(self._timesfm2_5_moving_average(ts, window_size))
             inputs = new_inputs
 
         if truncate_negative is None:

--- a/src/transformers/models/timesfm2_5/modular_timesfm2_5.py
+++ b/src/transformers/models/timesfm2_5/modular_timesfm2_5.py
@@ -564,7 +564,7 @@ class TimesFm2_5ModelForPrediction(TimesFmModelForPrediction):
         if window_size is not None:
             new_inputs: list[torch.Tensor] = []
             for ts in inputs:
-                new_inputs.extend(self._timesfm_moving_average(ts, window_size))
+                new_inputs.extend(self._timesfm2_5_moving_average(ts, window_size))
             inputs = new_inputs
 
         if truncate_negative is None:

--- a/tests/models/timesfm2_5/test_modeling_timesfm2_5.py
+++ b/tests/models/timesfm2_5/test_modeling_timesfm2_5.py
@@ -120,6 +120,14 @@ class TimesFm2_5ModelTest(ModelTesterMixin, unittest.TestCase):
         results = model(**inputs_dict)
         assert results.mean_predictions is not None
 
+    def test_window_size(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        model = TimesFm2_5ModelForPrediction(config)
+        model.to(torch_device)
+        model.eval()
+        results = model(**inputs_dict, window_size=5)
+        self.assertIsNotNone(results.mean_predictions)
+
     @unittest.skip(reason="FA backend not yet supported because of forced masks")
     def test_sdpa_can_dispatch_on_flash(self):
         pass


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46973)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46973)
<!-- ci-dashboard-badge:end -->

This PR resolves issue #46821 where setting `window_size` in `TimesFm2_5ModelForPrediction.forward` raises an `AttributeError` due to calling `self._timesfm_moving_average` (which was renamed to `_timesfm2_5_moving_average` during modular conversion/refactoring).

### Changes
1. Updated the call site in `src/transformers/models/timesfm2_5/modular_timesfm2_5.py` to use `self._timesfm2_5_moving_average` instead of `self._timesfm_moving_average`.
2. Regenerated `src/transformers/models/timesfm2_5/modeling_timesfm2_5.py` by running `utils/checkers.py modular_conversion --fix`.
3. Added a new unit test `test_window_size` in `tests/models/timesfm2_5/test_modeling_timesfm2_5.py` to prevent regression.

<!-- ci-dashboard-recap:start -->

---

### CI recap

**Dashboard:** [View test results in Grafana](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46973)
**Latest run:** [28419394746](https://github.com/huggingface/transformers/actions/runs/28419394746)
**Result:** `success` | Grafana metrics are not available yet.

<!-- ci-dashboard-recap:end -->