### PR TITLE
Fix typo in `MusicgenForCausalLM.generate()`

### DIFF
--- a/src/transformers/models/musicgen/modeling_musicgen.py
+++ b/src/transformers/models/musicgen/modeling_musicgen.py
@@ -1019,11 +1019,11 @@ class MusicgenForCausalLM(MusicgenPreTrainedModel, GenerationMixin):
         # - `max_length`, prepared above, is used to determine the maximum cache length
         max_cache_length = generation_config.max_length - 1
         if (
-            input_ids_length.shape[1] != input_ids_length
+            input_ids.shape[1] != input_ids_length
             and model_input_name == "inputs_embeds"
             and not self.config.is_encoder_decoder
         ):
-            max_cache_length += input_ids_length.shape[1]
+            max_cache_length += input_ids.shape[1]
         self._prepare_cache_for_generation(
             generation_config,
             model_kwargs,

--- a/src/transformers/models/musicgen/modeling_musicgen.py
+++ b/src/transformers/models/musicgen/modeling_musicgen.py
@@ -1018,12 +1018,6 @@ class MusicgenForCausalLM(MusicgenPreTrainedModel, GenerationMixin):
         # - different models have a different cache name expected by the model (default = "past_key_values")
         # - `max_length`, prepared above, is used to determine the maximum cache length
         max_cache_length = generation_config.max_length - 1
-        if (
-            input_ids.shape[1] != input_ids_length
-            and model_input_name == "inputs_embeds"
-            and not self.config.is_encoder_decoder
-        ):
-            max_cache_length += input_ids.shape[1]
         self._prepare_cache_for_generation(
             generation_config,
             model_kwargs,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46974)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46974)
<!-- ci-dashboard-badge:end -->

`input_ids_length` is an `int` (the sequence length), not a tensor, so calling
`.shape[1]` on it makes `MusicgenForCausalLM.generate()` always raise
`AttributeError: 'int' object has no attribute 'shape'`. It should reference
`input_ids` instead, matching `generation/utils.py` and the already-correct
`musicgen_melody` copy.

```diff
-            input_ids_length.shape[1] != input_ids_length
+            input_ids.shape[1] != input_ids_length
             and model_input_name == "inputs_embeds"
             and not self.config.is_encoder_decoder
         ):
-            max_cache_length += input_ids_length.shape[1]
+            max_cache_length += input_ids.shape[1]
```

## Reproduction

```python
import torch
from transformers import MusicgenForConditionalGeneration

dec = MusicgenForConditionalGeneration.from_pretrained("facebook/musicgen-medium").decoder
pad = dec.config.pad_token_id
ids = torch.full((dec.config.num_codebooks, 8), pad, dtype=torch.long)
# before the fix: AttributeError: 'int' object has no attribute 'shape'
dec.generate(input_ids=ids, max_new_tokens=16, pad_token_id=pad,
             decoder_start_token_id=pad, num_return_sequences=1)
```