### PR TITLE
Raise a loud error for missing prefix

### DIFF
--- a/docs/source/en/chat_response_parsing.md
+++ b/docs/source/en/chat_response_parsing.md
@@ -58,6 +58,11 @@ prompt to understand the message. All of the prefix before the final turn is dis
 at a time. We just need the prefix to ensure we're seeing the entire final message, and not miss any prefilled
 fields!
 
+Because a missing prefix can silently mis-parse a prefilled message, `prefix` is required when parsing with a
+new-style `response_template`: omitting it raises an error. In the rare case where you are sure the generation
+already contains the complete message and no prefix context is needed, pass `prefix=""` (or an empty list of
+token ids) to opt out explicitly.
+
 If the tokenizer has no response template set, `parse_response` will raise an error. We're working on adding
 templates to more models as quickly as we can!
 

--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -216,7 +216,7 @@ def parse_tool_calls(processor, generated_ids, schema: dict) -> list[dict] | Non
 
     Returns a list of ``{"name": str, "arguments": str}`` dicts, or ``None`` if none found.
     """
-    parsed = processor.parse_response(generated_ids, schema)
+    parsed = processor.parse_response(generated_ids, schema, prefix="")
     # The new response_template path returns a dict like {"tool_calls": [...]}; unwrap.
     if isinstance(parsed, dict) and "tool_calls" in parsed:
         parsed = parsed["tool_calls"]

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -2251,7 +2251,7 @@ class ProcessorMixin(PushToHubMixin):
             schema (`Union[list, dict]`, *optional*):
                 A response template (preferred, new-style) or legacy response schema dict. If not provided, the
                 tokenizer's `response_template` or `response_schema` attribute is used (in that order).
-            prefix (`str`, token ids, 1D/2D tensor, or a list of these, *optional*):
+            prefix (`str`, token ids, 1D/2D tensor, or a list of these):
                 The prompt that came before generation. Many chat templates pre-write part of the message, so
                 this is needed to parse correctly. For a batched `response`, pass either a single prefix
                 (broadcast to every item) or one prefix per item. Only supported with new-style templates.

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3374,7 +3374,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
                 A response template (preferred, new-style) or legacy response schema dict that indicates the
                 expected output format and how parsing should be performed. If not provided, the tokenizer's
                 `response_template` or `response_schema` attribute will be used (in that order).
-            prefix (`str`, token ids, 1D/2D tensor, or a list of these, *optional*):
+            prefix (`str`, token ids, 1D/2D tensor, or a list of these):
                 The prompt that came before generation. This is necessary because many chat templates
                 pre-write part of the message, so we need to see the prompt to parse correctly. For a batched
                 `response`, pass either a single prefix (broadcast to every item) or one prefix per item.
@@ -3405,6 +3405,13 @@ class PreTrainedTokenizerBase(PushToHubMixin):
             raise ValueError(
                 "`prefix=` is only supported with new-style `response_template` specs, not legacy `response_schema`."
             )
+        if prefix is None and use_new_template:
+            raise ValueError(
+                "`parse_response` requires `prefix=` (the prompt that came before generation) when parsing with a "
+                "new-style `response_template`, because chat templates often pre-write part of the assistant message "
+                "(e.g. an opening `<think>` tag) that the parser must see to parse correctly. If you're sure you "
+                "don't need the prefix, you can pass an empty string or list."
+            )
 
         if isinstance(response, str):
             responses, batched = [response], False
@@ -3415,11 +3422,16 @@ class PreTrainedTokenizerBase(PushToHubMixin):
             responses, batched = ([decoded], False) if isinstance(decoded, str) else (decoded, True)
 
         if prefix is None:
+            # Reachable only on the legacy path (new-style + None already raised above); `prefixes` is
+            # unused by `recursive_parse`, so the placeholder is harmless.
             prefixes: list[str | None] = [None] * len(responses)
         else:
             if isinstance(prefix, str):
                 prefix_texts, prefix_batched = [prefix], False
-            elif isinstance(prefix, (list, tuple)) and (not prefix or isinstance(prefix[0], str)):
+            elif isinstance(prefix, (list, tuple)) and not prefix:
+                # An empty list is the explicit opt-out (no prefix context); broadcast "" to every response.
+                prefix_texts, prefix_batched = [""], False
+            elif isinstance(prefix, (list, tuple)) and isinstance(prefix[0], str):
                 prefix_texts, prefix_batched = list(prefix), True
             else:
                 decoded = self.decode(prefix)
@@ -3450,11 +3462,11 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         parsing a streamed response. Uses the tokenizer's `response_template` attribute unless
         overridden.
 
-        When `prefix` is passed (as a string, list of token ids, or 1D tensor), the stream is
-        initialized in the state implied by the chat-prompt context (right-truncated past the
-        spec's `start_anchor`). Generated chunks fed via `stream.feed()` are then classified
-        correctly even when the chat template emitted assistant-turn content (e.g., `<think>\\n`)
-        that the model continues from."""
+        `prefix` (a string, list of token ids, or 1D tensor) is required: the stream is initialized in
+        the state implied by the chat-prompt context (right-truncated past the spec's `start_anchor`), so
+        generated chunks fed via `stream.feed()` are classified correctly even when the chat template
+        emitted assistant-turn content (e.g., `<think>\\n`) that the model continues from. Omitting it
+        raises; if the stream truly starts from a clean assistant turn, pass `prefix=""` to opt out."""
         template = response_template if response_template is not None else getattr(self, "response_template", None)
         if template is None:
             raise AttributeError(

--- a/src/transformers/utils/chat_parsing/response_parser.py
+++ b/src/transformers/utils/chat_parsing/response_parser.py
@@ -59,6 +59,13 @@ class ResponseParser:
 
     def __init__(self, response_template: dict | ResponseTemplate, prefix: str | None = None):
         self._spec = load_response_template(response_template)
+        if prefix is None:
+            raise ValueError(
+                "`ResponseParser`/`parse_response` requires `prefix` (the chat prompt sent to the model before "
+                "generation), because chat templates often pre-write part of the assistant message (e.g. an "
+                "opening `<think>` tag) that the parser must see to parse the output correctly. If the generation "
+                'already contains the complete message, pass `prefix=""` to opt out explicitly.'
+            )
         self._buffer: str = ""
         self._pos: int = 0
         self._output: dict[str, Any] = dict(self._spec.defaults)

--- a/tests/utils/test_chat_parsing.py
+++ b/tests/utils/test_chat_parsing.py
@@ -198,7 +198,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
                 }
             ],
         }
-        self.assertEqual(tokenizer.parse_response(model_out), expected)
+        self.assertEqual(tokenizer.parse_response(model_out, prefix=""), expected)
 
     def test_token_id_inputs(self):
         tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
@@ -208,9 +208,9 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             '<|START_ACTION|>[\n    {"tool_call_id": "0", "tool_name": "simple_tool", '
             '"parameters": {"temperature_format": "Celsius"}}\n]<|END_ACTION|><|END_OF_TURN_TOKEN|>'
         )
-        parsed = tokenizer.parse_response(model_out)
+        parsed = tokenizer.parse_response(model_out, prefix="")
         tokenized = tokenizer(model_out).input_ids
-        self.assertEqual(tokenizer.parse_response(tokenized), parsed)
+        self.assertEqual(tokenizer.parse_response(tokenized, prefix=""), parsed)
 
     def test_batched_response(self):
         """A batch of responses (list of strings or list of token-id sequences) returns one parsed
@@ -227,16 +227,16 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             '<|START_ACTION|>[\n    {"tool_call_id": "0", "tool_name": "tool_b", '
             '"parameters": {"y": "2"}}\n]<|END_ACTION|><|END_OF_TURN_TOKEN|>'
         )
-        single_a = tokenizer.parse_response(out_a)
-        single_b = tokenizer.parse_response(out_b)
+        single_a = tokenizer.parse_response(out_a, prefix="")
+        single_b = tokenizer.parse_response(out_b, prefix="")
         self.assertNotEqual(single_a, single_b)
         # A list of strings is parsed as a batch, one dict per item.
-        self.assertEqual(tokenizer.parse_response([out_a, out_b]), [single_a, single_b])
+        self.assertEqual(tokenizer.parse_response([out_a, out_b], prefix=""), [single_a, single_b])
         # Batched token-id input (list of token-id sequences) parses the same way.
         ids = [tokenizer(out_a).input_ids, tokenizer(out_b).input_ids]
-        self.assertEqual(tokenizer.parse_response(ids), [single_a, single_b])
+        self.assertEqual(tokenizer.parse_response(ids, prefix=""), [single_a, single_b])
         # A single-item batch returns a one-element list, not a bare dict.
-        self.assertEqual(tokenizer.parse_response([out_a]), [single_a])
+        self.assertEqual(tokenizer.parse_response([out_a], prefix=""), [single_a])
 
     def test_explicit_template_schema_detection(self):
         """An explicit new-style template passed as `schema=` is routed to the response-template
@@ -248,11 +248,13 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             '<|START_ACTION|>[\n    {"tool_call_id": "0", "tool_name": "simple_tool", '
             '"parameters": {"temperature_format": "Celsius"}}\n]<|END_ACTION|><|END_OF_TURN_TOKEN|>'
         )
-        expected = parse_response(model_out, cohere_template)
+        expected = parse_response(model_out, cohere_template, prefix="")
         # Detected via the canonical `version` marker...
-        self.assertEqual(tokenizer.parse_response(model_out, schema={"version": 1, **cohere_template}), expected)
+        self.assertEqual(
+            tokenizer.parse_response(model_out, schema={"version": 1, **cohere_template}, prefix=""), expected
+        )
         # ...and via `fields` when the template omits `version`.
-        self.assertEqual(tokenizer.parse_response(model_out, schema=cohere_template), expected)
+        self.assertEqual(tokenizer.parse_response(model_out, schema=cohere_template, prefix=""), expected)
 
     def test_cohere(self):
         model_out = (
@@ -261,7 +263,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             '"parameters": {"temperature_format": "Celsius"}}\n]<|END_ACTION|><|END_OF_TURN_TOKEN|>'
         )
         self.assertEqual(
-            parse_response(model_out, cohere_template),
+            parse_response(model_out, cohere_template, prefix=""),
             {
                 "role": "assistant",
                 "thinking": "I should call a tool.",
@@ -286,7 +288,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             '<tool_call>\n{"name": "get_current_temperature", "arguments": {"location": "Paris"}}\n</tool_call>\n</s>'
         )
         self.assertEqual(
-            parse_response(model_out, ernie_template),
+            parse_response(model_out, ernie_template, prefix=""),
             {
                 "role": "assistant",
                 "thinking": (
@@ -320,7 +322,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             "have!\n</response>\n</s>"
         )
         self.assertEqual(
-            parse_response(model_out, ernie_template),
+            parse_response(model_out, ernie_template, prefix=""),
             {
                 "role": "assistant",
                 "content": (
@@ -352,7 +354,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             'to=functions.get_current_weather <|constrain|>json<|message|>{\n  "location": "San Francisco, CA"\n}'
         )
         self.assertEqual(
-            parse_response(model_out, gpt_oss_template),
+            parse_response(model_out, gpt_oss_template, prefix=""),
             {
                 "role": "assistant",
                 "thinking": (
@@ -380,7 +382,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             "<|end|><|start|>assistant<|channel|>final<|message|>2"
         )
         self.assertEqual(
-            parse_response(model_out, gpt_oss_template),
+            parse_response(model_out, gpt_oss_template, prefix=""),
             {
                 "role": "assistant",
                 "content": "2",
@@ -400,7 +402,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             'just want to chat, feel free to let me know!"}}</tool_call>'
         )
         self.assertEqual(
-            parse_response(model_out, smollm_template),
+            parse_response(model_out, smollm_template, prefix=""),
             {
                 "role": "assistant",
                 "thinking": (
@@ -431,7 +433,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
     def test_smollm_tool_call_no_thinking(self):
         model_out = '<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>'
         self.assertEqual(
-            parse_response(model_out, smollm_template),
+            parse_response(model_out, smollm_template, prefix=""),
             {
                 "role": "assistant",
                 "tool_calls": [
@@ -449,7 +451,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             "Some content about gravity goes here but I'm cutting it off to make this shorter!"
         )
         self.assertEqual(
-            parse_response(model_out, smollm_template),
+            parse_response(model_out, smollm_template, prefix=""),
             {
                 "role": "assistant",
                 "content": "Some content about gravity goes here but I'm cutting it off to make this shorter!",
@@ -469,7 +471,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             "<parameter=temp_units>\ncelsius\n</parameter>\n</function>\n</tool_call>"
         )
         self.assertEqual(
-            parse_response(model_out, qwen3_template),
+            parse_response(model_out, qwen3_template, prefix=""),
             {
                 "role": "assistant",
                 "tool_calls": [
@@ -495,7 +497,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             'unit:<|"|>celsius<|"|>}<tool_call|><|tool_response>'
         )
         self.assertEqual(
-            parse_response(model_out, gemma4_template),
+            parse_response(model_out, gemma4_template, prefix=""),
             {
                 "role": "assistant",
                 "thinking": (
@@ -522,7 +524,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             'struct_value:{foo:<|"|>bar<|"|>}}<tool_call|>'
         )
         self.assertEqual(
-            parse_response(model_out, gemma4_template),
+            parse_response(model_out, gemma4_template, prefix=""),
             {
                 "role": "assistant",
                 "thinking": "Let me call the tool.",
@@ -559,7 +561,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             },
         }
         with self.assertRaises(ValueError) as cm:
-            parse_response("no response here", template_spec)
+            parse_response("no response here", template_spec, prefix="")
         self.assertIn("content", str(cm.exception))
 
     def test_int_content_parser(self):
@@ -574,7 +576,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
                 },
             },
         }
-        self.assertEqual(parse_response("<n>42</n>", template_spec), {"role": "assistant", "count": 42})
+        self.assertEqual(parse_response("<n>42</n>", template_spec, prefix=""), {"role": "assistant", "count": 42})
 
     def test_kv_lines_parser(self):
         template_spec = {
@@ -589,7 +591,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             },
         }
         self.assertEqual(
-            parse_response("<meta>name: alice\nage: 30</meta>", template_spec),
+            parse_response("<meta>name: alice\nage: 30</meta>", template_spec, prefix=""),
             {"role": "assistant", "metadata": {"name": "alice", "age": "30"}},
         )
 
@@ -678,7 +680,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
         }
         for opener, closer in (("<a>", "</a>"), ("<bb>", "</bb>"), ("<a>", "</bb>")):
             self.assertEqual(
-                parse_response(f"{opener}hi{closer}", template_spec),
+                parse_response(f"{opener}hi{closer}", template_spec, prefix=""),
                 {"role": "assistant", "x": "hi"},
             )
 
@@ -694,7 +696,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
                 "content": {"close": ["<turn|>", "<|tool_response>", "<eos>"], "content": "text"},
             },
         }
-        parser = ResponseParser(template_spec)
+        parser = ResponseParser(template_spec, prefix="")
         plain = "x" * 32
         flushed: list[str] = []
         for ch in parser.feed(plain):
@@ -714,7 +716,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
                 "x": {"open": "<x>", "close": ["END", "ENDX"], "content": "text"},
             },
         }
-        parser = ResponseParser(template_spec)
+        parser = ResponseParser(template_spec, prefix="")
         # "<x>hiEND" mid-stream: don't commit the close yet — "ENDX" might be coming.
         events = parser.feed("<x>hiEND")
         self.assertEqual([e for e in events if e["type"] == "region_close"], [])
@@ -734,7 +736,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
                 "fields": {"x": {"open": bad_open, "close": "</x>", "content": "text"}},
             }
             with self.assertRaises(ValueError):
-                parse_response("<x>hi</x>", spec)
+                parse_response("<x>hi</x>", spec, prefix="")
 
     def test_field_without_close_runs_to_end_of_stream(self):
         """A field with no `close`/`close_pattern` stays open until end-of-stream, capturing
@@ -745,7 +747,7 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             "fields": {"content": {"open": "<resp>", "content": "text"}},
         }
         self.assertEqual(
-            parse_response("<resp>hello world", spec),
+            parse_response("<resp>hello world", spec, prefix=""),
             {"role": "assistant", "content": "hello world"},
         )
 
@@ -836,10 +838,10 @@ class ResponseEventStreamTest(unittest.TestCase):
         output must equal the whole-string parse. Regression coverage for
         specific edge-case byte boundaries (1-byte chunks hit every prefix)."""
         for name, tmpl, text in _STREAMING_FIXTURES:
-            expected = parse_response(text, tmpl)
+            expected = parse_response(text, tmpl, prefix="")
             for step in (1, 2, 3, 5, 7, 13, 31):
                 with self.subTest(fixture=name, step=step):
-                    streamer = ResponseParser(tmpl)
+                    streamer = ResponseParser(tmpl, prefix="")
                     for chunk in _chunk_fixed(text, step):
                         streamer.feed(chunk)
                     message, _ = streamer.finalize()
@@ -851,10 +853,10 @@ class ResponseEventStreamTest(unittest.TestCase):
         reproduce."""
         rng = random.Random(0xC0DE_5EED)
         for name, tmpl, text in _STREAMING_FIXTURES:
-            expected = parse_response(text, tmpl)
+            expected = parse_response(text, tmpl, prefix="")
             for trial in range(30):
                 with self.subTest(fixture=name, trial=trial):
-                    streamer = ResponseParser(tmpl)
+                    streamer = ResponseParser(tmpl, prefix="")
                     for chunk in _chunk_random(text, rng):
                         streamer.feed(chunk)
                     message, _ = streamer.finalize()
@@ -871,7 +873,7 @@ class ResponseEventStreamTest(unittest.TestCase):
         for name, tmpl, text in _STREAMING_FIXTURES:
             for trial in range(10):
                 with self.subTest(fixture=name, trial=trial):
-                    streamer = ResponseParser(tmpl)
+                    streamer = ResponseParser(tmpl, prefix="")
                     all_events: list[dict] = []
                     for chunk in _chunk_random(text, rng):
                         all_events.extend(streamer.feed(chunk))
@@ -910,7 +912,7 @@ class ResponseEventStreamTest(unittest.TestCase):
         is delivered only in region_close."""
         # Single representative case with a long text region and a JSON region.
         text = _STREAMING_FIXTURES[0][2]  # cohere fixture
-        streamer = ResponseParser(cohere_template)
+        streamer = ResponseParser(cohere_template, prefix="")
         events: list[dict] = []
         for ch in text:  # 1-byte chunks hit the most anchor boundaries
             events.extend(streamer.feed(ch))
@@ -969,7 +971,7 @@ class ResponseEventStreamTest(unittest.TestCase):
         }
         text = '<t>hello world</t><n>42</n><j>{"a": 1, "b": 2}</j><x><name=foo><age=10></x><kv>k1: v1\nk2: v2</kv>'
         # Drive byte-by-byte to maximise chunk count.
-        streamer = ResponseParser(spec)
+        streamer = ResponseParser(spec, prefix="")
         events: list[dict] = []
         for ch in text:
             events.extend(streamer.feed(ch))
@@ -1009,18 +1011,18 @@ class ResponseEventStreamTest(unittest.TestCase):
             "<|start|>assistant<|channel|>commentary to=functions.get_current_weather "
             '<|constrain|>json<|message|>{"location": "San Francisco, CA"}<|call|>'
         )
-        expected = parse_response(text, gpt_oss_template)
+        expected = parse_response(text, gpt_oss_template, prefix="")
         # Sanity: the whole-string parse really does recover the tool call.
         self.assertEqual(len(expected["tool_calls"]), 1)
         self.assertEqual(expected["tool_calls"][0]["function"]["name"], "get_current_weather")
-        streamer = ResponseParser(gpt_oss_template)
+        streamer = ResponseParser(gpt_oss_template, prefix="")
         for ch in text:  # one byte at a time -- the worst case for the old heuristic
             streamer.feed(ch)
         message, _ = streamer.finalize()
         self.assertEqual(message, expected)
 
     def test_feed_after_finalize_raises(self):
-        streamer = ResponseParser(smollm_template)
+        streamer = ResponseParser(smollm_template, prefix="")
         streamer.feed("<think>x</think>")
         streamer.finalize()
         with self.assertRaises(RuntimeError):
@@ -1029,7 +1031,7 @@ class ResponseEventStreamTest(unittest.TestCase):
             streamer.finalize()
 
     def test_empty_input_streams_cleanly(self):
-        streamer = ResponseParser(smollm_template)
+        streamer = ResponseParser(smollm_template, prefix="")
         self.assertEqual(streamer.feed(""), [])
         result, final_events = streamer.finalize()
         # Only the default fields should remain; nothing else is required.
@@ -1147,15 +1149,15 @@ class PrefixAndTruncationTest(unittest.TestCase):
         clean = {"role": "assistant", "content": "Hello there!"}
         # The supported guard: pass the prompt as prefix= so history is truncated off the prefix.
         self.assertEqual(parse_response(gen, spec, prefix=prompt), clean)
-        # Pure generation parses cleanly with no prefix.
-        self.assertEqual(parse_response(gen, spec), clean)
+        # Pure generation parses cleanly with the explicit no-prefix opt-out (prefix="").
+        self.assertEqual(parse_response(gen, spec, prefix=""), clean)
         # An anchor inside the response is treated as content, never as a history boundary:
         # gpt-oss re-emits `<|start|>assistant` between channels, and that content survives.
         gpt_oss_gen = (
             "<|channel|>analysis<|message|>thinking<|end|><|start|>assistant<|channel|>final<|message|>answer"
         )
         self.assertEqual(
-            parse_response(gpt_oss_gen, gpt_oss_template),
+            parse_response(gpt_oss_gen, gpt_oss_template, prefix=""),
             {"role": "assistant", "thinking": "thinking", "content": "answer"},
         )
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46980)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46980)
<!-- ci-dashboard-badge:end -->

The new chat response parser requires the prompt tokens to be passed to the `prefix` argument, but if they're not passed it just assumes an empty prefix. In testing I found it was very easy to forget it, and just get silently wrong parsing. This would definitely trip lots of users up, so this modifies `parse_response` so that it yells at you if you forget `prefix`. The other changes are doc/test changes to match. Pipelines already worked correctly and so they're unchanged.

This creates a slightly awkward API right now where `prefix` is unsupported for old response schemas but mandatory for new templates, but that'll all get cleaned up as soon as I can deprecate and drop response schemas.

cc @vasqu for review but if you're overloaded let me know and I'll pass it on to someone else!