### PR TITLE
only in the original repo

### DIFF
--- a/.github/workflows/nightly-integration-failure-triage-caller.yml
+++ b/.github/workflows/nightly-integration-failure-triage-caller.yml
@@ -35,6 +35,7 @@ permissions:
 # we will pin once the feature is stable.
 jobs:
   triage:
+    if: github.repository == 'huggingface/transformers'
     uses: huggingface/transformers-ci/.github/workflows/integration-failure-triage.yml@main # main
     with:
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46982)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46982)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Don't run this workflow in forks