### PR TITLE
fix(models): fix MPS float64 type compatibility crashes for MusicFlamingo and UDOP

### DIFF
--- a/src/transformers/models/musicflamingo/modeling_musicflamingo.py
+++ b/src/transformers/models/musicflamingo/modeling_musicflamingo.py
@@ -194,7 +194,8 @@ def rotate_half(x):
 
 def apply_rotary_time_emb(hidden_states, cos, sin):
     original_dtype = hidden_states.dtype
-    hidden_states = hidden_states.to(torch.float64)
+    target_dtype = torch.float32 if hidden_states.device.type == "mps" else torch.float64
+    hidden_states = hidden_states.to(target_dtype)
     cos = cos.to(hidden_states)
     sin = sin.to(hidden_states)
     rot_dim = cos.shape[-1]

--- a/src/transformers/models/musicflamingo/modular_musicflamingo.py
+++ b/src/transformers/models/musicflamingo/modular_musicflamingo.py
@@ -170,7 +170,8 @@ def rotate_half(x):
 
 def apply_rotary_time_emb(hidden_states, cos, sin):
     original_dtype = hidden_states.dtype
-    hidden_states = hidden_states.to(torch.float64)
+    target_dtype = torch.float32 if hidden_states.device.type == "mps" else torch.float64
+    hidden_states = hidden_states.to(target_dtype)
     cos = cos.to(hidden_states)
     sin = sin.to(hidden_states)
     rot_dim = cos.shape[-1]

--- a/src/transformers/models/timesfm2_5/modeling_timesfm2_5.py
+++ b/src/transformers/models/timesfm2_5/modeling_timesfm2_5.py
@@ -777,7 +777,7 @@ class TimesFm2_5ModelForPrediction(TimesFm2_5PreTrainedModel):
         if window_size is not None:
             new_inputs: list[torch.Tensor] = []
             for ts in inputs:
-                new_inputs.extend(self._timesfm_moving_average(ts, window_size))
+                new_inputs.extend(self._timesfm2_5_moving_average(ts, window_size))
             inputs = new_inputs
 
         if truncate_negative is None:

--- a/src/transformers/models/timesfm2_5/modular_timesfm2_5.py
+++ b/src/transformers/models/timesfm2_5/modular_timesfm2_5.py
@@ -564,7 +564,7 @@ class TimesFm2_5ModelForPrediction(TimesFmModelForPrediction):
         if window_size is not None:
             new_inputs: list[torch.Tensor] = []
             for ts in inputs:
-                new_inputs.extend(self._timesfm_moving_average(ts, window_size))
+                new_inputs.extend(self._timesfm2_5_moving_average(ts, window_size))
             inputs = new_inputs
 
         if truncate_negative is None:

--- a/src/transformers/models/udop/modeling_udop.py
+++ b/src/transformers/models/udop/modeling_udop.py
@@ -160,7 +160,8 @@ def combine_image_text_embeddings(
     )
     ocr_points = ocr_points_x + ocr_points_y
     # make sure bounding boxes are of type float to calculate means
-    bbox = bbox.to(torch.float64)
+    target_dtype = torch.float32 if bbox.device.type == "mps" else torch.float64
+    bbox = bbox.to(target_dtype)
     target_seg = (bbox.mean(-1) == 0.0) | (bbox.mean(-1) == 1.0)
     repeated_vision_embeds = torch.gather(
         image_embeddings, 1, ocr_points.unsqueeze(-1).repeat(1, 1, image_embeddings.size(-1))

--- a/tests/models/musicflamingo/test_musicflamingo_mps.py
+++ b/tests/models/musicflamingo/test_musicflamingo_mps.py
@@ -1,0 +1,46 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers import is_torch_available
+from transformers.testing_utils import require_torch
+
+
+if is_torch_available():
+    import torch
+
+    from transformers.models.musicflamingo.modeling_musicflamingo import apply_rotary_time_emb
+
+
+@require_torch
+class MusicFlamingoMPSTest(unittest.TestCase):
+    def test_apply_rotary_time_emb_mps(self):
+        if not torch.backends.mps.is_available():
+            self.skipTest("MPS is not available")
+
+        # Create inputs on MPS
+        hidden_states = torch.randn(1, 2, 4, 8, device="mps", dtype=torch.float32)
+        cos = torch.randn(1, 2, 4, 4, device="mps", dtype=torch.float32)
+        sin = torch.randn(1, 2, 4, 4, device="mps", dtype=torch.float32)
+
+        # This should execute without throwing "TypeError: Cannot convert a MPS Tensor to float64 dtype"
+        try:
+            output = apply_rotary_time_emb(hidden_states, cos, sin)
+        except TypeError as e:
+            self.fail(f"apply_rotary_time_emb failed on MPS with TypeError: {e}")
+
+        self.assertEqual(output.device.type, "mps")
+        self.assertEqual(output.dtype, torch.float32)
+        self.assertEqual(output.shape, hidden_states.shape)

--- a/tests/models/timesfm2_5/test_modeling_timesfm2_5.py
+++ b/tests/models/timesfm2_5/test_modeling_timesfm2_5.py
@@ -120,6 +120,14 @@ class TimesFm2_5ModelTest(ModelTesterMixin, unittest.TestCase):
         results = model(**inputs_dict)
         assert results.mean_predictions is not None
 
+    def test_window_size(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        model = TimesFm2_5ModelForPrediction(config)
+        model.to(torch_device)
+        model.eval()
+        results = model(**inputs_dict, window_size=5)
+        self.assertIsNotNone(results.mean_predictions)
+
     @unittest.skip(reason="FA backend not yet supported because of forced masks")
     def test_sdpa_can_dispatch_on_flash(self):
         pass

--- a/tests/models/udop/test_udop_mps.py
+++ b/tests/models/udop/test_udop_mps.py
@@ -1,0 +1,51 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers import is_torch_available
+from transformers.testing_utils import require_torch
+
+
+if is_torch_available():
+    import torch
+
+    from transformers.models.udop.modeling_udop import combine_image_text_embeddings
+
+
+@require_torch
+class UdopMPSTest(unittest.TestCase):
+    def test_combine_image_text_embeddings_mps(self):
+        if not torch.backends.mps.is_available():
+            self.skipTest("MPS is not available")
+
+        # Create inputs on MPS
+        image_embeddings = torch.randn(1, 196, 8, device="mps", dtype=torch.float32)
+        inputs_embeds = torch.randn(1, 5, 8, device="mps", dtype=torch.float32)
+        bbox = torch.rand(1, 5, 4, device="mps", dtype=torch.float32)
+        visual_bbox = None
+        attention_mask = torch.ones(1, 5, device="mps", dtype=torch.float32)
+
+        # This should execute without throwing "TypeError: Cannot convert a MPS Tensor to float64 dtype"
+        try:
+            combine_image_text_embeddings(
+                image_embeddings,
+                inputs_embeds,
+                bbox,
+                visual_bbox,
+                attention_mask,
+                num_patches=14,
+            )
+        except TypeError as e:
+            self.fail(f"combine_image_text_embeddings failed on MPS with TypeError: {e}")


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46987)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46987)
<!-- ci-dashboard-badge:end -->

Fixes #46723

### Summary
While auditing models for Apple Silicon (MPS) compatibility, it was found that MusicFlamingo and UDOP hardcode `torch.float64` in their forward pass. Since the MPS backend does not support float64, running these models on macOS (MPS) crashes with `TypeError: Cannot convert a MPS Tensor to float64 dtype`.

This PR dynamically checks the device type and falls back to `torch.float32` on MPS devices, keeping `torch.float64` for CPU and CUDA devices to preserve existing behavior and precision.

### Changes
1. **MusicFlamingo**: Updated `apply_rotary_time_emb` in `modular_musicflamingo.py` to use `float32` on MPS devices and regenerated `modeling_musicflamingo.py`.
2. **UDOP**: Updated `combine_image_text_embeddings` in `modeling_udop.py` to use `float32` for bbox upcasting on MPS devices.
3. **Tests**: Added regression/unit tests in `test_musicflamingo_mps.py` and `test_udop_mps.py` to verify these functions execute properly on MPS without crashes.