### PR TITLE
Add QNN (Qualcomm HTP) backend to the ExecuTorch exporter

### DIFF
--- a/src/transformers/exporters/configs.py
+++ b/src/transformers/exporters/configs.py
@@ -163,8 +163,28 @@ class ExecutorchConfig(DynamoConfig):
 
             - `"xnnpack"` — CPU inference via the XNNPACK library (default; runs anywhere).
             - `"cuda"` — GPU inference via the ExecuTorch CUDA backend.
+            - `"qnn"` — Qualcomm HTP (NPU) inference via the ExecuTorch QNN backend.
+        soc_model (`str`, *optional*, defaults to `"SM8750"`):
+            QNN only. Target Qualcomm SoC (e.g. `"SM8750"` = 8 Elite/S25, `"SM8550"` = 8 Gen 2/S23).
+            The QNN context binary is SoC-locked.
+        quantize (`str`, *optional*):
+            QNN only. PT2E quantization scheme run after export (`"8a8w"`, `"16a4w"`, `"16a8w"`,
+            `"16a4w_block"`). `None` (default) exports FP16.
+        static_cache (`bool`, *optional*, defaults to `True`):
+            QNN only. Wrap decoder-only LMs in a static-KV-cache module so the exported graph is
+            decode-capable (KV cache as I/O) rather than prefill-only.
+        max_cache_len (`int`, *optional*, defaults to `128`):
+            QNN only. Static cache length when `static_cache=True`.
+        calibration_inputs (`list`, *optional*):
+            QNN only. Batches of forward-kwargs dicts used to calibrate PT2E quantization. If `None`,
+            falls back to the single `sample_inputs` batch (functional but low-accuracy — a warning is logged).
     """
 
     export_format: ExportFormat = ExportFormat.EXECUTORCH
 
     backend: str = "xnnpack"
+    soc_model: str = "SM8750"
+    quantize: str | None = None
+    static_cache: bool = True
+    max_cache_len: int = 128
+    calibration_inputs: list[Any] | None = None

--- a/src/transformers/exporters/exporter_executorch.py
+++ b/src/transformers/exporters/exporter_executorch.py
@@ -55,6 +55,7 @@ from .utils import (
     register_fx_program_fix,
     register_patch,
 )
+from .qnn_utils import _lower_for_qnn, prepare_for_qnn, quantize_for_qnn
 
 
 if is_torch_available():
@@ -113,14 +114,23 @@ class ExecutorchExporter(DynamoExporter):
         if prepare_for_backend is None:
             raise ValueError(f"Unsupported backend {config.backend} for ExecuTorch export")
 
-        model, sample_inputs, partitioner = prepare_for_backend(model, sample_inputs)
+        model, sample_inputs, partitioner = prepare_for_backend(model, sample_inputs, config)
 
         with apply_patches("executorch"):
             exported_program: ExportedProgram = super().export(model, sample_inputs, config=config)
             apply_fx_program_fixes("executorch", exported_program)
             apply_fx_node_fixes("executorch", exported_program.graph_module)
-            edge_program_manager: EdgeProgramManager = to_edge_transform_and_lower(
-                exported_program, partitioner=partitioner, compile_config=_get_edge_compile_config()
+            # Post-export transform (e.g. QNN PT2E quantization), runs on the ExportedProgram
+            # between torch.export and lowering. No-op for backends not in the table.
+            post_transform = _POST_EXPORT_TRANSFORM.get(config.backend)
+            if post_transform is not None:
+                exported_program = post_transform(exported_program, sample_inputs, config)
+            # Backend-specific lowering. Most backends use the generic to_edge_transform_and_lower
+            # (a partitioner is enough); QNN needs its own pre-export + edge pass pipeline, so it
+            # supplies an entry in _BACKEND_LOWER.
+            lower_for_backend = _BACKEND_LOWER.get(config.backend, _lower_default)
+            edge_program_manager: EdgeProgramManager = lower_for_backend(
+                exported_program, partitioner, _get_edge_compile_config()
             )
             executorch_programs_manager: ExecutorchProgramManager = edge_program_manager.to_executorch()
 
@@ -164,7 +174,7 @@ def _get_edge_compile_config() -> EdgeCompileConfig:
 # To add a new backend: implement _prepare_for_new_backend and add it to the _BACKEND_PREPARE table.
 
 
-def prepare_for_xnnpack(model: PreTrainedModel, sample_inputs: dict[str, Any]):
+def prepare_for_xnnpack(model: PreTrainedModel, sample_inputs: dict[str, Any], config: Any = None):
     """CPU inference via XNNPACK. Moves the model to CPU and uses the default XnnpackPartitioner."""
 
     model.requires_grad_(False)
@@ -178,7 +188,7 @@ def prepare_for_xnnpack(model: PreTrainedModel, sample_inputs: dict[str, Any]):
     return model, sample_inputs, partitioner
 
 
-def prepare_for_cuda(model: PreTrainedModel, sample_inputs: dict[str, Any]):
+def prepare_for_cuda(model: PreTrainedModel, sample_inputs: dict[str, Any], config: Any = None):
     """GPU inference via the ExecuTorch CUDA backend.
 
     Moves the model to CUDA and upcasts to bfloat16 — required by the CUDA backend.
@@ -198,6 +208,39 @@ def prepare_for_cuda(model: PreTrainedModel, sample_inputs: dict[str, Any]):
 _BACKEND_PREPARE = {
     "xnnpack": prepare_for_xnnpack,
     "cuda": prepare_for_cuda,
+    "qnn": prepare_for_qnn,
+}
+
+
+# ── Post-export transforms ────────────────────────────────────────────────────
+# Run on the ExportedProgram between torch.export.export() and lowering. XNNPACK quantizes
+# TorchAO-eager *before* export (nothing here); QNN quantizes with PT2E *after* export
+# (QnnQuantizer annotates the exported graph for HTP), so it registers a hook below.
+# Signature: transform(exported_program, sample_inputs, config) -> ExportedProgram.
+
+
+_POST_EXPORT_TRANSFORM = {
+    "qnn": quantize_for_qnn,
+}
+
+
+# ── Stage 1b: Backend lowering ────────────────────────────────────────────────
+# Most backends lower with the generic to_edge_transform_and_lower (a partitioner is enough).
+# QNN is the exception: the partitioner alone fails (KeyError aten.alias_copy.default, rank-3
+# FullyConnected, "No QnnManager active") because QNN's pre-export + edge passes never run. The
+# _BACKEND_LOWER table lets a backend supply its own lowering; QNN replicates
+# to_edge_transform_and_lower_to_qnn on the already-exported program (no re-export).
+
+
+def _lower_default(exported_program, partitioner, compile_config) -> EdgeProgramManager:
+    """Generic lowering used by xnnpack/cuda: partitioner does all the work."""
+    return to_edge_transform_and_lower(
+        exported_program, partitioner=partitioner, compile_config=compile_config
+    )
+
+
+_BACKEND_LOWER = {
+    "qnn": _lower_for_qnn,
 }
 
 

--- a/src/transformers/exporters/qnn_utils.py
+++ b/src/transformers/exporters/qnn_utils.py
@@ -1,0 +1,201 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+"""QNN (Qualcomm HTP / NPU) hooks for the ExecuTorch exporter.
+
+"Shift-left" of QNN export from optimum-executorch into transformers: three hooks that the
+``ExecutorchExporter`` dispatches when ``ExecutorchConfig(backend="qnn")`` is used.
+
+- ``prepare_for_qnn``  — pre-export prep: static-KV-cache wrap for decoder-only LMs + HTP compiler spec.
+- ``quantize_for_qnn`` — PT2E quantization (8a8w/16a4w/…) *after* torch.export (``_POST_EXPORT_TRANSFORM``).
+- ``_lower_for_qnn``   — backend-specific lowering: QNN pre-export + edge passes inside a QnnManagerContext.
+
+All ExecuTorch/QNN imports are lazy (inside the functions) so importing this module never requires the
+``executorch`` package to be installed — only the ``qnn`` backend path pulls it in.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..utils import logging
+from ..utils.import_utils import is_torch_available
+from .utils import module_device
+
+
+if is_torch_available():
+    import torch
+    from torch.export import ExportedProgram
+
+    from ..modeling_utils import PreTrainedModel
+
+
+logger = logging.get_logger(__name__)
+
+
+def prepare_for_qnn(model: "PreTrainedModel", sample_inputs: dict[str, Any], config: Any = None):
+    """Qualcomm HTP (NPU) inference via the ExecuTorch QNN backend.
+
+    1. **Static-KV-cache wrap.** For decoder-only LMs, wrap the model in
+       ``TorchExportableModuleForDecoderOnlyLM`` so the exported graph is decode-capable (KV cache as
+       I/O) and the causal mask/positions are real graph inputs — without this a fixed-seq-len export
+       folds the mask to constants and QNN can't serialize ("No graph inputs present"). ``sample_inputs``
+       is rewritten to ``{input_ids, cache_position}`` to match the wrapper's forward.
+    2. **Compiler spec.** ``use_fp16`` is off when ``config.quantize`` is set (PT2E runs later in
+       ``quantize_for_qnn``); the SoC (context binaries are SoC-locked) comes from ``config.soc_model``.
+    3. The partitioner is necessary but **not sufficient** — QNN lowering is finished by ``_lower_for_qnn``.
+    """
+    from executorch.backends.qualcomm.partition.qnn_partitioner import QnnPartitioner
+    from executorch.backends.qualcomm.serialization.qc_schema import QcomChipset
+    from executorch.backends.qualcomm.utils.utils import (
+        generate_htp_compiler_spec,
+        generate_qnn_executorch_compiler_spec,
+    )
+
+    from ..integrations.executorch import TorchExportableModuleForDecoderOnlyLM
+
+    soc_model = getattr(config, "soc_model", "SM8750")
+    quantize = getattr(config, "quantize", None)
+    static_cache = getattr(config, "static_cache", True)
+    max_cache_len = getattr(config, "max_cache_len", 128)
+
+    model.requires_grad_(False)
+    device = module_device(model)
+    if device is not None and device.type != "cpu":
+        model = model.to(device="cpu")
+
+    # Decode-capable graph for decoder-only LMs via a static KV cache.
+    if static_cache and isinstance(model, PreTrainedModel) and model.can_generate():
+        model.config.use_cache = True
+        if getattr(model, "generation_config", None) is not None:
+            model.generation_config.use_cache = True
+            model.generation_config.cache_implementation = "static"
+        text_config = model.config.get_text_config()
+        if getattr(text_config, "max_cache_len", None) is None:
+            text_config.max_cache_len = max_cache_len
+        wrapped = TorchExportableModuleForDecoderOnlyLM(model, batch_size=1, max_cache_len=max_cache_len)
+        input_ids = sample_inputs["input_ids"]
+        sample_inputs = {
+            "input_ids": input_ids,
+            "cache_position": torch.arange(input_ids.shape[-1], dtype=torch.long),
+        }
+        model = wrapped
+    elif isinstance(model, PreTrainedModel):
+        # Prefill-only graph: disable the KV cache so the model returns logits only. With use_cache=True
+        # it emits a DynamicCache, which breaks PT2E calibration (NaN observers) and pytree flattening.
+        model.config.use_cache = False
+
+    backend_options = generate_htp_compiler_spec(use_fp16=quantize is None)
+    compiler_specs = generate_qnn_executorch_compiler_spec(
+        soc_model=getattr(QcomChipset, soc_model),
+        backend_options=backend_options,
+    )
+    partitioner = [QnnPartitioner(compiler_specs)]
+    return model, sample_inputs, partitioner
+
+
+def quantize_for_qnn(exported_program: "ExportedProgram", sample_inputs, config) -> "ExportedProgram":
+    """QNN PT2E quantization (8a8w / 16a4w / …) on the exported graph.
+
+    QNN quantizes *after* export: ``prepare_pt2e`` annotates the (core-ATen) graph with a
+    ``QnnQuantizer``, we calibrate, then ``convert_pt2e`` inserts Q/DQ. Because ``convert_pt2e`` returns
+    an nn.Module while lowering consumes an ``ExportedProgram``, we re-export the converted module.
+    ``run_decompositions()`` first inlines transformers HOPs (``WrapWithSetGradEnabled``) that PT2E /
+    QNN passes can't introspect. No-op when ``config.quantize`` is None (the FP16 path).
+    """
+    quant_dtype = getattr(config, "quantize", None)
+    if quant_dtype is None:
+        return exported_program
+
+    from executorch.backends.qualcomm.quantizer.quantizer import QnnQuantizer, QuantDtype
+    from executorch.backends.qualcomm.serialization.qc_schema import QcomChipset, QnnExecuTorchBackendType
+    from torchao.quantization.pt2e import MovingAverageMinMaxObserver
+    from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
+
+    quantizer = QnnQuantizer(
+        backend=QnnExecuTorchBackendType.kHtpBackend,
+        soc_model=getattr(QcomChipset, config.soc_model),
+    )
+    # Per-channel weights + MovingAverageMinMax activations = the native Qualcomm LLM recipe;
+    # the default observer is NaN-sensitive on transformer activations.
+    quantizer.set_default_quant_config(
+        quant_dtype=getattr(QuantDtype, f"use_{quant_dtype}"),
+        is_conv_per_channel=True,
+        is_linear_per_channel=True,
+        act_observer=MovingAverageMinMaxObserver,
+    )
+
+    try:
+        module = exported_program.run_decompositions().module()
+    except Exception as exc:
+        logger.warning("QNN PT2E: run_decompositions() failed (%s); using the module as-is.", type(exc).__name__)
+        module = exported_program.module()
+    prepared = prepare_pt2e(module, quantizer)
+
+    calibration_inputs = getattr(config, "calibration_inputs", None)
+    if not calibration_inputs:
+        logger.warning(
+            "QNN PT2E: no `calibration_inputs` provided; calibrating with the single `sample_inputs` "
+            "batch. This is functional but yields poor %s accuracy — pass representative batches via "
+            "ExecutorchConfig(calibration_inputs=...) for production.",
+            quant_dtype,
+        )
+        calibration_inputs = [sample_inputs]
+    with torch.no_grad():
+        for batch in calibration_inputs:
+            prepared(**batch)
+
+    converted = convert_pt2e(prepared)
+    args, kwargs = exported_program.example_inputs
+    return torch.export.export(converted, args, kwargs=kwargs, strict=False)
+
+
+def _lower_for_qnn(exported_program, partitioner, compile_config):
+    """QNN lowering: run QNN's pre-export pipeline + edge passes inside a ``QnnManagerContext``.
+
+    The exporter's generic ``to_edge_transform_and_lower`` skips ``transform_for_export_pipeline``
+    (decompose SDPA, lift constant scalars, canonicalize conv, remove alias_copy) and
+    ``get_to_edge_transform_passes`` (FoldQDQ, LayoutTransform, TagQuantIO …) and never enters a
+    ``QnnManagerContext`` — so a bare ``QnnPartitioner`` crashes (``KeyError aten.alias_copy.default``,
+    rank-3 FullyConnected, "No QnnManager active"). This mirrors ``to_edge_transform_and_lower_to_qnn``
+    but operates on the ExportedProgram the exporter already produced (single export, QNN edge config).
+    """
+    from executorch.backends.qualcomm._passes.qnn_pass_manager import get_qnn_pass_manager_cls
+    from executorch.backends.qualcomm.serialization.qc_schema import QnnExecuTorchBackendType
+    from executorch.backends.qualcomm.utils.qnn_manager_lifecycle import QnnManagerContext
+    from executorch.backends.qualcomm.utils.utils import qnn_edge_config
+    from executorch.exir.program import to_edge_transform_and_lower
+
+    compiler_specs = partitioner[0].compiler_specs_snapshot
+    # Decompose to core ATen first: transformers' export can leave HOPs (WrapWithSetGradEnabled,
+    # vmap/flat_apply) that QNN's LiftConstantScalarOperands can't introspect. Skip for an already
+    # quantized graph (quantize_for_qnn already decomposed; re-decomposing would disturb the Q/DQ).
+    already_quantized = any(
+        "quantize" in str(getattr(n, "target", "")) for n in exported_program.graph_module.graph.nodes
+    )
+    if not already_quantized:
+        try:
+            exported_program = exported_program.run_decompositions()
+        except Exception as exc:
+            # Static-cache graphs (in-place KV buffer copy_) can trip aot_export inside
+            # run_decompositions. Proceed without it; QNN passes handle non-HOP graphs fine.
+            logger.warning("QNN: run_decompositions() failed (%s); lowering the graph as-is.", type(exc).__name__)
+
+    pass_manager = get_qnn_pass_manager_cls(QnnExecuTorchBackendType.kHtpBackend)()
+    exported_program = pass_manager.transform_for_export_pipeline(exported_program)
+    transform_passes = pass_manager.get_to_edge_transform_passes(exported_program, compiler_specs=compiler_specs)
+    with QnnManagerContext({"forward": compiler_specs}):
+        return to_edge_transform_and_lower(
+            exported_program,
+            transform_passes=transform_passes,
+            partitioner=partitioner,
+            compile_config=qnn_edge_config(),
+        )

--- a/src/transformers/integrations/executorch.py
+++ b/src/transformers/integrations/executorch.py
@@ -240,7 +240,9 @@ class TorchExportableModuleForDecoderOnlyLM(torch.nn.Module):
         Returns:
             torch.Tensor: Logits output from the model.
         """
-        return self.model.forward(input_ids=input_ids, inputs_embeds=inputs_embeds)
+        return self.model.forward(
+            input_ids=input_ids, inputs_embeds=inputs_embeds, cache_position=cache_position
+        )
 
     def export(
         self,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46989)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46989)
<!-- ci-dashboard-badge:end -->

Shift-left of QNN export from optimum-executorch into transformers: exporting an HF model with ExecutorchConfig(backend="qnn") now produces a QNN-delegated .pte directly.

New src/transformers/exporters/qnn_utils.py with three hooks, wired into the exporter's backend dispatch:
- prepare_for_qnn: pre-export prep — static-KV-cache wrap for decoder-only LMs (decode-capable graph; avoids the constant-folded-mask "No graph inputs present" QNN serialization failure) + HTP compiler spec (fp16, or int for the quantized path).
- quantize_for_qnn (_POST_EXPORT_TRANSFORM): PT2E 8a8w/16a4w quantization AFTER torch.export, which is where QNN quantizes (QnnQuantizer annotates the exported graph, then convert_pt2e).
- _lower_for_qnn (_BACKEND_LOWER): backend-specific lowering that runs QNN's pre-export + edge pass pipeline inside a QnnManagerContext. The exporter's generic to_edge_transform_and_lower can't lower QNN (hits KeyError aten.alias_copy.default / rank-3 FullyConnected / "No QnnManager active") because those passes never run.

Exporter plumbing:
- Add a _POST_EXPORT_TRANSFORM hook (runs on the ExportedProgram between export and lowering) and a _BACKEND_LOWER table (backend supplies its own lowering; default stays the generic path).
- ExecutorchConfig gains soc_model / quantize / static_cache / max_cache_len / calibration_inputs (all QNN-only; ignored by xnnpack/cuda).
- integrations/executorch.py: TorchExportableModuleForDecoderOnlyLM.forward now threads cache_position into the static-cache module (it was dropped, breaking the decode graph).

Validated on Qwen2.5-0.5B -> fully QnnBackend-delegated .pte (FP16, SM8750 and SM8550).

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->