### PR TITLE
feat[vLLM x v5]: Rename audio_processor to feature_extractor on Granite Speech and Phi-4 Multimodal processors

### DIFF
--- a/src/transformers/models/granite_speech/processing_granite_speech.py
+++ b/src/transformers/models/granite_speech/processing_granite_speech.py
@@ -19,6 +19,7 @@ from ...feature_extraction_utils import BatchFeature
 from ...processing_utils import ProcessorMixin
 from ...tokenization_python import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, is_torch_available, logging
+from ...utils.deprecation import deprecate_kwarg
 from ...utils.import_utils import requires_backends
 
 
@@ -30,9 +31,10 @@ logger = logging.get_logger(__name__)
 
 @auto_docstring
 class GraniteSpeechProcessor(ProcessorMixin):
+    @deprecate_kwarg("audio_processor", new_name="feature_extractor", version="v5.20")
     def __init__(
         self,
-        audio_processor,
+        feature_extractor,
         tokenizer,
         audio_token="<|audio|>",
         chat_template=None,
@@ -44,7 +46,12 @@ class GraniteSpeechProcessor(ProcessorMixin):
             audio tokens inserted depends on the audio feature dimensions extracted by the audio processor.
         """
         self.audio_token = tokenizer.audio_token if hasattr(tokenizer, "audio_token") else audio_token
-        super().__init__(audio_processor, tokenizer, chat_template=chat_template)
+        super().__init__(feature_extractor, tokenizer, chat_template=chat_template)
+
+    @property
+    def audio_processor(self):
+        logger.warning_once("`audio_processor` is deprecated! Use `feature_extractor` instead!")
+        return self.feature_extractor
 
     @auto_docstring
     def __call__(
@@ -64,7 +71,7 @@ class GraniteSpeechProcessor(ProcessorMixin):
             # text / audio inputs here because some inference engines will
             # trigger the conditions due to the way they call multimodal
             # processors, e.g., vLLM.
-            audio_inputs = self.audio_processor(audio, device=device)
+            audio_inputs = self.feature_extractor(audio, device=device)
 
             # TODO (@alex-jw-brooks); we should add a util to get_num_audio_tokens
             # from feature lengths and call it here, rather than returning it

--- a/src/transformers/models/phi4_multimodal/processing_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/processing_phi4_multimodal.py
@@ -24,6 +24,7 @@ from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import TextInput
 from ...utils import auto_docstring, logging
+from ...utils.deprecation import deprecate_kwarg
 
 
 logger = logging.get_logger(__name__)
@@ -39,10 +40,11 @@ class Phi4MultimodalProcessorKwargs(ProcessingKwargs, total=False):
 
 @auto_docstring
 class Phi4MultimodalProcessor(ProcessorMixin):
+    @deprecate_kwarg("audio_processor", new_name="feature_extractor", version="v5.20")
     def __init__(
         self,
         image_processor,
-        audio_processor,
+        feature_extractor,
         tokenizer,
         **kwargs,
     ):
@@ -50,7 +52,12 @@ class Phi4MultimodalProcessor(ProcessorMixin):
         self.image_token_id = tokenizer.image_token_id
         self.audio_token = tokenizer.audio_token
         self.audio_token_id = tokenizer.audio_token_id
-        super().__init__(image_processor, audio_processor, tokenizer, **kwargs)
+        super().__init__(image_processor, feature_extractor, tokenizer, **kwargs)
+
+    @property
+    def audio_processor(self):
+        logger.warning_once("`audio_processor` is deprecated! Use `feature_extractor` instead!")
+        return self.feature_extractor
 
     @auto_docstring
     def __call__(
@@ -78,7 +85,7 @@ class Phi4MultimodalProcessor(ProcessorMixin):
         audio_kwargs = output_kwargs["audio_kwargs"]
 
         image_inputs = self.image_processor(images, **image_kwargs) if images is not None else {}
-        audio_inputs = self.audio_processor(audio, **audio_kwargs) if audio is not None else {}
+        audio_inputs = self.feature_extractor(audio, **audio_kwargs) if audio is not None else {}
 
         # We pop here for images as we don't need it later
         num_img_tokens = image_inputs.pop("num_img_tokens", [])


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46992)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46992)
<!-- ci-dashboard-badge:end -->

### What does this PR do?

→ Fixes https://github.com/vllm-project/vllm/pull/39330#discussion_r3503407138
→ Renames from `audio_processor` to `feature_extractor`, every other audio-capable processor in the codebase already uses `feature_extractor`; these two were the only outliers. Blocker to the [vLLM Transformers audio backend PR](https://github.com/vllm-project/vllm/pull/39330).
→ BC preserved for the deprecation cycle, adapted precedent from the [PretrainedConfig.torch_dtype pattern](https://github.com/huggingface/transformers/blob/main/src/transformers/configuration_utils.py#L430-L443).
→ <ins>Version matrix considerations</ins>: Users on older Transformers are unaffected; users on new Transformers hitting the legacy `.audio_processor` path see one `logger.warning_once` per session; downstream consumers (including vLLM's own native `granite_speech.py` / `phi4mm.py`) have until `v5.20` to migrate.
→ Made sure this doesn't cause any regressions in `tests/models/granite_speech/` and `tests/models/phi4_multimodal/`.

cc: @vasqu @eustlb @ebezzam

### Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

### Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.