### PR TITLE
Fix dtype casting for quantized Gemma4 vision/audio embedders

### DIFF
--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -373,7 +373,9 @@ class Gemma4AudioSubSampleConvProjectionLayer(nn.Module):
             mask = mask.to(device=hidden_states.device)
             hidden_states = hidden_states * mask[:, None, :, None]
 
-        hidden_states = self.conv(hidden_states.to(self.conv.weight.dtype))
+        if (target_dtype := self.conv.weight.dtype).is_floating_point:
+            hidden_states = hidden_states.to(target_dtype)
+        hidden_states = self.conv(hidden_states)
         hidden_states = self.act(self.norm(hidden_states.permute(0, 2, 3, 1)).permute(0, 3, 1, 2).contiguous())
 
         if mask is not None:
@@ -614,7 +616,9 @@ class Gemma4VisionPatchEmbedder(nn.Module):
     ) -> torch.Tensor:
         # Gemma4 applies no normalization and instead scales in model code
         pixel_values = 2 * (pixel_values - 0.5)
-        hidden_states = self.input_proj(pixel_values.to(self.input_proj.weight.dtype))
+        if (target_dtype := self.input_proj.weight.dtype).is_floating_point:
+            pixel_values = pixel_values.to(target_dtype)
+        hidden_states = self.input_proj(pixel_values)
         position_embeddings = self._position_embeddings(pixel_position_ids, padding_positions)
         return hidden_states + position_embeddings
 

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -402,7 +402,9 @@ class Gemma4AudioSubSampleConvProjectionLayer(nn.Module):
             mask = mask.to(device=hidden_states.device)
             hidden_states = hidden_states * mask[:, None, :, None]
 
-        hidden_states = self.conv(hidden_states.to(self.conv.weight.dtype))
+        if (target_dtype := self.conv.weight.dtype).is_floating_point:
+            hidden_states = hidden_states.to(target_dtype)
+        hidden_states = self.conv(hidden_states)
         hidden_states = self.act(self.norm(hidden_states.permute(0, 2, 3, 1)).permute(0, 3, 1, 2).contiguous())
 
         if mask is not None:
@@ -643,7 +645,9 @@ class Gemma4VisionPatchEmbedder(nn.Module):
     ) -> torch.Tensor:
         # Gemma4 applies no normalization and instead scales in model code
         pixel_values = 2 * (pixel_values - 0.5)
-        hidden_states = self.input_proj(pixel_values.to(self.input_proj.weight.dtype))
+        if (target_dtype := self.input_proj.weight.dtype).is_floating_point:
+            pixel_values = pixel_values.to(target_dtype)
+        hidden_states = self.input_proj(pixel_values)
         position_embeddings = self._position_embeddings(pixel_position_ids, padding_positions)
         return hidden_states + position_embeddings
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47008)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47008)
<!-- ci-dashboard-badge:end -->

Fixes #46932

Applies the same fix from PR #46904 (gemma4_unified) to the non-unified Gemma4 module. The existing code casts inputs to `layer.weight.dtype`, which returns `torch.uint8` for quantized `Linear4bit` layers, corrupting inputs. This fix uses `weight.dtype` only when it is a floating-point type.

**Changes:**
- `Gemma4VisionPatchEmbedder.forward()`: guard dtype cast with `is_floating_point` check
- `Gemma4AudioSubSampleConvProjectionLayer.forward()`: same guard