### PR TITLE
Fix off-by-one in sliding_window_mask_function right window boundary

### DIFF
--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1920,7 +1920,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask

--- a/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
@@ -356,7 +356,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask

--- a/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
@@ -269,7 +269,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47010)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47010)
<!-- ci-dashboard-badge:end -->

Fixes #46305

**Bug:** `sliding_window_mask_function` uses strict less-than (`< right_window_size`) for the right context boundary, so `right_window_size=4` attends to only 3 future frames instead of 4. This is a 25% reduction in effective right-context.

According to the Moonshine v2 paper (arXiv:2602.12241): "a right window of w_right=4 implies an algorithmic lookahead of 4×20 ms = 80 ms". At 50 Hz, 4 frames = 80 ms, but the code gives 3 frames = 60 ms.

**Fix:** Change `< right_window_size` to `<= right_window_size`.

**Files changed:**
- `moonshine_streaming/modular_moonshine_streaming.py` (source)
- `moonshine_streaming/modeling_moonshine_streaming.py` (generated)
- `gemma4/modeling_gemma4.py` (standalone copy of the same function)