### PR TITLE
DeepSeek MLA: absorb low-rank up-projection into Q for eager/SDPA (V2/V3/V3.2)

### DIFF
--- a/src/transformers/models/deepseek_v2/modeling_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/modeling_deepseek_v2.py
@@ -361,40 +361,81 @@ class DeepseekV2Attention(nn.Module):
 
         compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
         k_nope, k_pe = torch.split(compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-        k_nope = self.kv_b_proj(self.kv_a_layernorm(k_nope)).view(key_shape).transpose(1, 2)
-        k_nope, value_states = torch.split(k_nope, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
-
         k_pe = k_pe.view(batch_size, 1, seq_length, self.qk_rope_head_dim)
 
         q_pe, k_pe = apply_rotary_emb(q_pe, k_pe, position_embeddings.to(q_pe.device))
 
-        k_pe = k_pe.expand(*k_nope.shape[:-1], -1)
-        query_states = torch.cat((q_nope, q_pe), dim=-1)
-        key_states = torch.cat((k_nope, k_pe), dim=-1)
-
+        has_cache_data = False
         if past_key_values is not None:
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+            try:
+                has_cache_data = past_key_values.get_seq_length(self.layer_idx) > 0
+            except (AttributeError, NotImplementedError):
+                has_cache_data = True
 
-        if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:
-            value_states = F.pad(value_states, [0, self.qk_head_dim - self.v_head_dim])
+        use_flash = is_flash_attention_requested(self.config)
 
-        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
-            self.config._attn_implementation, eager_attention_forward
-        )
+        if not use_flash and not has_cache_data:
+            k_nope_normed = self.kv_a_layernorm(k_nope)
 
-        attn_output, attn_weights = attention_interface(
-            self,
-            query_states,
-            key_states,
-            value_states,
-            attention_mask,
-            dropout=0.0 if not self.training else self.attention_dropout,
-            scaling=self.scaling,
-            **kwargs,
-        )
+            W_kv = self.kv_b_proj.weight.view(self.num_heads, -1, self.kv_lora_rank)
+            W_uk = W_kv[:, : self.qk_nope_head_dim, :]
+            W_uv = W_kv[:, self.qk_nope_head_dim :, :]
 
-        if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:
-            attn_output = attn_output[:, :, :, : self.v_head_dim]
+            absorbed_q = torch.einsum("bhnd,hdk->bhnk", q_nope, W_uk)
+            compressed_k = k_nope_normed.unsqueeze(1)
+
+            attn_weights = torch.matmul(absorbed_q, compressed_k.transpose(-2, -1))
+            attn_weights = attn_weights + torch.matmul(q_pe, k_pe.transpose(-2, -1))
+            attn_weights = attn_weights * self.scaling
+
+            if attention_mask is not None:
+                attn_weights = attn_weights + attention_mask
+
+            attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+            attn_weights = F.dropout(attn_weights, p=0.0 if not self.training else self.attention_dropout)
+
+            attn_output = torch.matmul(attn_weights, compressed_k)
+            attn_output = torch.einsum("bhnk,hkv->bhnv", attn_output, W_uv.transpose(1, 2))
+
+            if past_key_values is not None:
+                k_nope_full = self.kv_b_proj(k_nope_normed).view(*key_shape).transpose(1, 2)
+                k_nope_full, value_states = torch.split(
+                    k_nope_full, [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+                )
+                k_pe_full = k_pe.expand(*k_nope_full.shape[:-1], -1)
+                key_states = torch.cat((k_nope_full, k_pe_full), dim=-1)
+                past_key_values.update(key_states, value_states, self.layer_idx)
+        else:
+            k_nope = self.kv_b_proj(self.kv_a_layernorm(k_nope)).view(key_shape).transpose(1, 2)
+            k_nope, value_states = torch.split(k_nope, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+            k_pe = k_pe.expand(*k_nope.shape[:-1], -1)
+            query_states = torch.cat((q_nope, q_pe), dim=-1)
+            key_states = torch.cat((k_nope, k_pe), dim=-1)
+
+            if past_key_values is not None:
+                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+
+            if use_flash and self.qk_head_dim != self.v_head_dim:
+                value_states = F.pad(value_states, [0, self.qk_head_dim - self.v_head_dim])
+
+            attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+                self.config._attn_implementation, eager_attention_forward
+            )
+
+            attn_output, attn_weights = attention_interface(
+                self,
+                query_states,
+                key_states,
+                value_states,
+                attention_mask,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                scaling=self.scaling,
+                **kwargs,
+            )
+
+            if use_flash and self.qk_head_dim != self.v_head_dim:
+                attn_output = attn_output[:, :, :, : self.v_head_dim]
 
         attn_output = attn_output.reshape(batch_size, seq_length, -1).contiguous()
         attn_output = self.o_proj(attn_output)

--- a/src/transformers/models/deepseek_v2/modular_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/modular_deepseek_v2.py
@@ -304,40 +304,81 @@ class DeepseekV2Attention(nn.Module):
 
         compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
         k_nope, k_pe = torch.split(compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-        k_nope = self.kv_b_proj(self.kv_a_layernorm(k_nope)).view(key_shape).transpose(1, 2)
-        k_nope, value_states = torch.split(k_nope, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
-
         k_pe = k_pe.view(batch_size, 1, seq_length, self.qk_rope_head_dim)
 
         q_pe, k_pe = apply_rotary_emb(q_pe, k_pe, position_embeddings.to(q_pe.device))
 
-        k_pe = k_pe.expand(*k_nope.shape[:-1], -1)
-        query_states = torch.cat((q_nope, q_pe), dim=-1)
-        key_states = torch.cat((k_nope, k_pe), dim=-1)
-
+        has_cache_data = False
         if past_key_values is not None:
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+            try:
+                has_cache_data = past_key_values.get_seq_length(self.layer_idx) > 0
+            except (AttributeError, NotImplementedError):
+                has_cache_data = True
 
-        if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:
-            value_states = F.pad(value_states, [0, self.qk_head_dim - self.v_head_dim])
+        use_flash = is_flash_attention_requested(self.config)
 
-        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
-            self.config._attn_implementation, eager_attention_forward
-        )
+        if not use_flash and not has_cache_data:
+            k_nope_normed = self.kv_a_layernorm(k_nope)
 
-        attn_output, attn_weights = attention_interface(
-            self,
-            query_states,
-            key_states,
-            value_states,
-            attention_mask,
-            dropout=0.0 if not self.training else self.attention_dropout,
-            scaling=self.scaling,
-            **kwargs,
-        )
+            W_kv = self.kv_b_proj.weight.view(self.num_heads, -1, self.kv_lora_rank)
+            W_uk = W_kv[:, : self.qk_nope_head_dim, :]
+            W_uv = W_kv[:, self.qk_nope_head_dim :, :]
 
-        if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:
-            attn_output = attn_output[:, :, :, : self.v_head_dim]
+            absorbed_q = torch.einsum("bhnd,hdk->bhnk", q_nope, W_uk)
+            compressed_k = k_nope_normed.unsqueeze(1)
+
+            attn_weights = torch.matmul(absorbed_q, compressed_k.transpose(-2, -1))
+            attn_weights = attn_weights + torch.matmul(q_pe, k_pe.transpose(-2, -1))
+            attn_weights = attn_weights * self.scaling
+
+            if attention_mask is not None:
+                attn_weights = attn_weights + attention_mask
+
+            attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+            attn_weights = F.dropout(attn_weights, p=0.0 if not self.training else self.attention_dropout)
+
+            attn_output = torch.matmul(attn_weights, compressed_k)
+            attn_output = torch.einsum("bhnk,hkv->bhnv", attn_output, W_uv.transpose(1, 2))
+
+            if past_key_values is not None:
+                k_nope_full = self.kv_b_proj(k_nope_normed).view(*key_shape).transpose(1, 2)
+                k_nope_full, value_states = torch.split(
+                    k_nope_full, [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+                )
+                k_pe_full = k_pe.expand(*k_nope_full.shape[:-1], -1)
+                key_states = torch.cat((k_nope_full, k_pe_full), dim=-1)
+                past_key_values.update(key_states, value_states, self.layer_idx)
+        else:
+            k_nope = self.kv_b_proj(self.kv_a_layernorm(k_nope)).view(key_shape).transpose(1, 2)
+            k_nope, value_states = torch.split(k_nope, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+            k_pe = k_pe.expand(*k_nope.shape[:-1], -1)
+            query_states = torch.cat((q_nope, q_pe), dim=-1)
+            key_states = torch.cat((k_nope, k_pe), dim=-1)
+
+            if past_key_values is not None:
+                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+
+            if use_flash and self.qk_head_dim != self.v_head_dim:
+                value_states = F.pad(value_states, [0, self.qk_head_dim - self.v_head_dim])
+
+            attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+                self.config._attn_implementation, eager_attention_forward
+            )
+
+            attn_output, attn_weights = attention_interface(
+                self,
+                query_states,
+                key_states,
+                value_states,
+                attention_mask,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                scaling=self.scaling,
+                **kwargs,
+            )
+
+            if use_flash and self.qk_head_dim != self.v_head_dim:
+                attn_output = attn_output[:, :, :, : self.v_head_dim]
 
         attn_output = attn_output.reshape(batch_size, seq_length, -1).contiguous()
         attn_output = self.o_proj(attn_output)

--- a/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
@@ -429,45 +429,85 @@ class DeepseekV3Attention(nn.Module):
 
         compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
         k_pass, k_rot = torch.split(compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-
-        k_pass = self.kv_b_proj(self.kv_a_layernorm(k_pass)).view(key_shape).transpose(1, 2)
-        k_pass, value_states = torch.split(k_pass, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
-
         k_rot = k_rot.view(batch_size, 1, seq_length, self.qk_rope_head_dim)
 
         cos, sin = position_embeddings
-        if self.config.rope_interleave:  # support using interleaved weights for efficiency
+        if self.config.rope_interleave:
             q_rot, k_rot = apply_rotary_pos_emb_interleave(q_rot, k_rot, cos, sin)
         else:
             q_rot, k_rot = apply_rotary_pos_emb(q_rot, k_rot, cos, sin)
-        k_rot = k_rot.expand(*k_pass.shape[:-1], -1)
 
-        query_states = torch.cat((q_pass, q_rot), dim=-1)
-        key_states = torch.cat((k_pass, k_rot), dim=-1)
-
+        has_cache_data = False
         if past_key_values is not None:
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+            try:
+                has_cache_data = past_key_values.get_seq_length(self.layer_idx) > 0
+            except (AttributeError, NotImplementedError):
+                has_cache_data = True
 
-        if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:
-            value_states = F.pad(value_states, [0, self.qk_head_dim - self.v_head_dim])
+        use_flash = is_flash_attention_requested(self.config)
 
-        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
-            self.config._attn_implementation, eager_attention_forward
-        )
+        if not use_flash and not has_cache_data:
+            k_pass_normed = self.kv_a_layernorm(k_pass)
 
-        attn_output, attn_weights = attention_interface(
-            self,
-            query_states,
-            key_states,
-            value_states,
-            attention_mask,
-            dropout=0.0 if not self.training else self.attention_dropout,
-            scaling=self.scaling,
-            **kwargs,
-        )
+            W_kv = self.kv_b_proj.weight.view(self.num_heads, -1, self.kv_lora_rank)
+            W_uk = W_kv[:, : self.qk_nope_head_dim, :]
+            W_uv = W_kv[:, self.qk_nope_head_dim :, :]
 
-        if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:
-            attn_output = attn_output[:, :, :, : self.v_head_dim]
+            absorbed_q = torch.einsum("bhnd,hdk->bhnk", q_pass, W_uk)
+            compressed_k = k_pass_normed.unsqueeze(1)
+
+            attn_weights = torch.matmul(absorbed_q, compressed_k.transpose(-2, -1))
+            attn_weights = attn_weights + torch.matmul(q_rot, k_rot.transpose(-2, -1))
+            attn_weights = attn_weights * self.scaling
+
+            if attention_mask is not None:
+                attn_weights = attn_weights + attention_mask
+
+            attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q_states.dtype)
+            attn_weights = F.dropout(attn_weights, p=0.0 if not self.training else self.attention_dropout)
+
+            attn_output = torch.matmul(attn_weights, compressed_k)
+            attn_output = torch.einsum("bhnk,hkv->bhnv", attn_output, W_uv.transpose(1, 2))
+
+            if past_key_values is not None:
+                k_pass_full = self.kv_b_proj(k_pass_normed).view(*key_shape).transpose(1, 2)
+                k_pass_full, value_states = torch.split(
+                    k_pass_full, [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+                )
+                k_rot_full = k_rot.expand(*k_pass_full.shape[:-1], -1)
+                key_states = torch.cat((k_pass_full, k_rot_full), dim=-1)
+                past_key_values.update(key_states, value_states, self.layer_idx)
+        else:
+            k_pass = self.kv_b_proj(self.kv_a_layernorm(k_pass)).view(key_shape).transpose(1, 2)
+            k_pass, value_states = torch.split(k_pass, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+            k_rot = k_rot.expand(*k_pass.shape[:-1], -1)
+            query_states = torch.cat((q_pass, q_rot), dim=-1)
+            key_states = torch.cat((k_pass, k_rot), dim=-1)
+
+            if past_key_values is not None:
+                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+
+            if use_flash and self.qk_head_dim != self.v_head_dim:
+                value_states = F.pad(value_states, [0, self.qk_head_dim - self.v_head_dim])
+
+            attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+                self.config._attn_implementation, eager_attention_forward
+            )
+
+            attn_output, attn_weights = attention_interface(
+                self,
+                query_states,
+                key_states,
+                value_states,
+                attention_mask,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                scaling=self.scaling,
+                **kwargs,
+            )
+
+            if use_flash and self.qk_head_dim != self.v_head_dim:
+                attn_output = attn_output[:, :, :, : self.v_head_dim]
 
         attn_output = attn_output.reshape(batch_size, seq_length, -1).contiguous()
         attn_output = self.o_proj(attn_output)

--- a/src/transformers/models/deepseek_v3/modular_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/modular_deepseek_v3.py
@@ -209,45 +209,85 @@ class DeepseekV3Attention(nn.Module):
 
         compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
         k_pass, k_rot = torch.split(compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-
-        k_pass = self.kv_b_proj(self.kv_a_layernorm(k_pass)).view(key_shape).transpose(1, 2)
-        k_pass, value_states = torch.split(k_pass, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
-
         k_rot = k_rot.view(batch_size, 1, seq_length, self.qk_rope_head_dim)
 
         cos, sin = position_embeddings
-        if self.config.rope_interleave:  # support using interleaved weights for efficiency
+        if self.config.rope_interleave:
             q_rot, k_rot = apply_rotary_pos_emb_interleave(q_rot, k_rot, cos, sin)
         else:
             q_rot, k_rot = apply_rotary_pos_emb(q_rot, k_rot, cos, sin)
-        k_rot = k_rot.expand(*k_pass.shape[:-1], -1)
 
-        query_states = torch.cat((q_pass, q_rot), dim=-1)
-        key_states = torch.cat((k_pass, k_rot), dim=-1)
-
+        has_cache_data = False
         if past_key_values is not None:
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+            try:
+                has_cache_data = past_key_values.get_seq_length(self.layer_idx) > 0
+            except (AttributeError, NotImplementedError):
+                has_cache_data = True
 
-        if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:
-            value_states = F.pad(value_states, [0, self.qk_head_dim - self.v_head_dim])
+        use_flash = is_flash_attention_requested(self.config)
 
-        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
-            self.config._attn_implementation, eager_attention_forward
-        )
+        if not use_flash and not has_cache_data:
+            k_pass_normed = self.kv_a_layernorm(k_pass)
 
-        attn_output, attn_weights = attention_interface(
-            self,
-            query_states,
-            key_states,
-            value_states,
-            attention_mask,
-            dropout=0.0 if not self.training else self.attention_dropout,
-            scaling=self.scaling,
-            **kwargs,
-        )
+            W_kv = self.kv_b_proj.weight.view(self.num_heads, -1, self.kv_lora_rank)
+            W_uk = W_kv[:, : self.qk_nope_head_dim, :]
+            W_uv = W_kv[:, self.qk_nope_head_dim :, :]
 
-        if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:
-            attn_output = attn_output[:, :, :, : self.v_head_dim]
+            absorbed_q = torch.einsum("bhnd,hdk->bhnk", q_pass, W_uk)
+            compressed_k = k_pass_normed.unsqueeze(1)
+
+            attn_weights = torch.matmul(absorbed_q, compressed_k.transpose(-2, -1))
+            attn_weights = attn_weights + torch.matmul(q_rot, k_rot.transpose(-2, -1))
+            attn_weights = attn_weights * self.scaling
+
+            if attention_mask is not None:
+                attn_weights = attn_weights + attention_mask
+
+            attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q_states.dtype)
+            attn_weights = F.dropout(attn_weights, p=0.0 if not self.training else self.attention_dropout)
+
+            attn_output = torch.matmul(attn_weights, compressed_k)
+            attn_output = torch.einsum("bhnk,hkv->bhnv", attn_output, W_uv.transpose(1, 2))
+
+            if past_key_values is not None:
+                k_pass_full = self.kv_b_proj(k_pass_normed).view(*key_shape).transpose(1, 2)
+                k_pass_full, value_states = torch.split(
+                    k_pass_full, [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+                )
+                k_rot_full = k_rot.expand(*k_pass_full.shape[:-1], -1)
+                key_states = torch.cat((k_pass_full, k_rot_full), dim=-1)
+                past_key_values.update(key_states, value_states, self.layer_idx)
+        else:
+            k_pass = self.kv_b_proj(self.kv_a_layernorm(k_pass)).view(key_shape).transpose(1, 2)
+            k_pass, value_states = torch.split(k_pass, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+            k_rot = k_rot.expand(*k_pass.shape[:-1], -1)
+            query_states = torch.cat((q_pass, q_rot), dim=-1)
+            key_states = torch.cat((k_pass, k_rot), dim=-1)
+
+            if past_key_values is not None:
+                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+
+            if use_flash and self.qk_head_dim != self.v_head_dim:
+                value_states = F.pad(value_states, [0, self.qk_head_dim - self.v_head_dim])
+
+            attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+                self.config._attn_implementation, eager_attention_forward
+            )
+
+            attn_output, attn_weights = attention_interface(
+                self,
+                query_states,
+                key_states,
+                value_states,
+                attention_mask,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                scaling=self.scaling,
+                **kwargs,
+            )
+
+            if use_flash and self.qk_head_dim != self.v_head_dim:
+                attn_output = attn_output[:, :, :, : self.v_head_dim]
 
         attn_output = attn_output.reshape(batch_size, seq_length, -1).contiguous()
         attn_output = self.o_proj(attn_output)

--- a/src/transformers/models/deepseek_v32/modeling_deepseek_v32.py
+++ b/src/transformers/models/deepseek_v32/modeling_deepseek_v32.py
@@ -419,56 +419,112 @@ class DeepseekV32Attention(nn.Module):
 
         compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
         k_pass, k_rot = torch.split(compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-        k_pass = self.kv_b_proj(self.kv_a_layernorm(k_pass)).view(key_shape).transpose(1, 2)
-        k_pass, value_states = torch.split(k_pass, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
-
         k_rot = k_rot.view(batch_size, 1, seq_length, self.qk_rope_head_dim)
+
         cos, sin = position_embeddings
         q_rot, k_rot = apply_rotary_pos_emb_interleave(q_rot, k_rot, cos, sin)
-        k_rot = k_rot.expand(*k_pass.shape[:-1], -1)
 
-        query_states = torch.cat((q_pass, q_rot), dim=-1)
-        key_states = torch.cat((k_pass, k_rot), dim=-1)
-
+        has_cache_data = False
         if past_key_values is not None:
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+            try:
+                has_cache_data = past_key_values.get_seq_length(self.layer_idx) > 0
+            except (AttributeError, NotImplementedError):
+                has_cache_data = True
 
-        # The indexer scores against a 3D `[B, S, T]` mask; the attention mask is 4D `[B, 1, S, T]`.
-        indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
-        topk_indices = self.indexer(
-            hidden_states, q_resid, position_embeddings, indexer_mask, position_ids, past_key_values=past_key_values
-        )  # [B, S, topk]
+        if not has_cache_data:
+            k_pass_normed = self.kv_a_layernorm(k_pass)
 
-        sparse_indices = None
-        if self.config._attn_implementation in ("eager", "sdpa"):
-            # Boolean mask: `True` at keys *not* selected by the indexer (to be masked out).
+            W_kv = self.kv_b_proj.weight.view(self.num_heads, -1, self.kv_lora_rank)
+            W_uk = W_kv[:, : self.qk_nope_head_dim, :]
+            W_uv = W_kv[:, self.qk_nope_head_dim :, :]
+
+            absorbed_q = torch.einsum("bhnd,hdk->bhnk", q_pass, W_uk)
+            compressed_k = k_pass_normed.unsqueeze(1)
+
+            attn_weights = torch.matmul(absorbed_q, compressed_k.transpose(-2, -1))
+            attn_weights = attn_weights + torch.matmul(q_rot, k_rot.transpose(-2, -1))
+            attn_weights = attn_weights * self.scaling
+
+            # DSA indexer
+            indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
+            topk_indices = self.indexer(
+                hidden_states, q_resid, position_embeddings, indexer_mask, position_ids,
+                past_key_values=past_key_values,
+            )
+
+            # Apply DSA sparse mask
             index_mask = (
-                topk_indices.new_ones((batch_size, seq_length, key_states.shape[2]), dtype=torch.bool)
+                topk_indices.new_ones((batch_size, seq_length, seq_length), dtype=torch.bool)
                 .scatter(-1, topk_indices.long(), False)
                 .unsqueeze(1)
-            )  # [B, 1, S, T]; True = masked
+            )
             if attention_mask is None:
-                key_positions = torch.arange(key_states.shape[2], device=hidden_states.device)
+                key_positions = torch.arange(seq_length, device=hidden_states.device)
                 index_mask = index_mask | (key_positions[None, None, None, :] > position_ids[:, None, :, None])
-                attention_mask = hidden_states.new_zeros((batch_size, 1, seq_length, key_states.shape[2]))
+                attention_mask = hidden_states.new_zeros((batch_size, 1, seq_length, seq_length))
             attention_mask = attention_mask.masked_fill(index_mask, torch.finfo(hidden_states.dtype).min)
-        else:
-            sparse_indices = topk_indices
 
-        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
-            self.config._attn_implementation, eager_attention_forward
-        )
-        attn_output, attn_weights = attention_interface(
-            self,
-            query_states,
-            key_states,
-            value_states,
-            attention_mask,
-            dropout=0.0 if not self.training else self.attention_dropout,
-            scaling=self.scaling,
-            indices=sparse_indices,
-            **kwargs,
-        )
+            attn_weights = attn_weights + attention_mask
+            attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q_states.dtype)
+            attn_weights = F.dropout(attn_weights, p=0.0 if not self.training else self.attention_dropout)
+
+            attn_output = torch.matmul(attn_weights, compressed_k)
+            attn_output = torch.einsum("bhnk,hkv->bhnv", attn_output, W_uv.transpose(1, 2))
+
+            if past_key_values is not None:
+                k_pass_full = self.kv_b_proj(k_pass_normed).view(*key_shape).transpose(1, 2)
+                k_pass_full, value_states = torch.split(
+                    k_pass_full, [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+                )
+                k_rot_full = k_rot.expand(*k_pass_full.shape[:-1], -1)
+                key_states = torch.cat((k_pass_full, k_rot_full), dim=-1)
+                past_key_values.update(key_states, value_states, self.layer_idx)
+        else:
+            k_pass = self.kv_b_proj(self.kv_a_layernorm(k_pass)).view(key_shape).transpose(1, 2)
+            k_pass, value_states = torch.split(k_pass, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+            k_rot = k_rot.expand(*k_pass.shape[:-1], -1)
+            query_states = torch.cat((q_pass, q_rot), dim=-1)
+            key_states = torch.cat((k_pass, k_rot), dim=-1)
+
+            if past_key_values is not None:
+                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+
+            indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
+            topk_indices = self.indexer(
+                hidden_states, q_resid, position_embeddings, indexer_mask, position_ids,
+                past_key_values=past_key_values,
+            )
+
+            sparse_indices = None
+            if self.config._attn_implementation in ("eager", "sdpa"):
+                index_mask = (
+                    topk_indices.new_ones((batch_size, seq_length, key_states.shape[2]), dtype=torch.bool)
+                    .scatter(-1, topk_indices.long(), False)
+                    .unsqueeze(1)
+                )
+                if attention_mask is None:
+                    key_positions = torch.arange(key_states.shape[2], device=hidden_states.device)
+                    index_mask = index_mask | (key_positions[None, None, None, :] > position_ids[:, None, :, None])
+                    attention_mask = hidden_states.new_zeros((batch_size, 1, seq_length, key_states.shape[2]))
+                attention_mask = attention_mask.masked_fill(index_mask, torch.finfo(hidden_states.dtype).min)
+            else:
+                sparse_indices = topk_indices
+
+            attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+                self.config._attn_implementation, eager_attention_forward
+            )
+            attn_output, attn_weights = attention_interface(
+                self,
+                query_states,
+                key_states,
+                value_states,
+                attention_mask,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                scaling=self.scaling,
+                indices=sparse_indices,
+                **kwargs,
+            )
 
         attn_output = attn_output.reshape(batch_size, seq_length, -1).contiguous()
         attn_output = self.o_proj(attn_output)

--- a/src/transformers/models/deepseek_v32/modular_deepseek_v32.py
+++ b/src/transformers/models/deepseek_v32/modular_deepseek_v32.py
@@ -298,56 +298,112 @@ class DeepseekV32Attention(DeepseekV3Attention):
 
         compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
         k_pass, k_rot = torch.split(compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-        k_pass = self.kv_b_proj(self.kv_a_layernorm(k_pass)).view(key_shape).transpose(1, 2)
-        k_pass, value_states = torch.split(k_pass, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
-
         k_rot = k_rot.view(batch_size, 1, seq_length, self.qk_rope_head_dim)
+
         cos, sin = position_embeddings
         q_rot, k_rot = apply_rotary_pos_emb_interleave(q_rot, k_rot, cos, sin)
-        k_rot = k_rot.expand(*k_pass.shape[:-1], -1)
 
-        query_states = torch.cat((q_pass, q_rot), dim=-1)
-        key_states = torch.cat((k_pass, k_rot), dim=-1)
-
+        has_cache_data = False
         if past_key_values is not None:
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+            try:
+                has_cache_data = past_key_values.get_seq_length(self.layer_idx) > 0
+            except (AttributeError, NotImplementedError):
+                has_cache_data = True
 
-        # The indexer scores against a 3D `[B, S, T]` mask; the attention mask is 4D `[B, 1, S, T]`.
-        indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
-        topk_indices = self.indexer(
-            hidden_states, q_resid, position_embeddings, indexer_mask, position_ids, past_key_values=past_key_values
-        )  # [B, S, topk]
+        if not has_cache_data:
+            k_pass_normed = self.kv_a_layernorm(k_pass)
 
-        sparse_indices = None
-        if self.config._attn_implementation in ("eager", "sdpa"):
-            # Boolean mask: `True` at keys *not* selected by the indexer (to be masked out).
+            W_kv = self.kv_b_proj.weight.view(self.num_heads, -1, self.kv_lora_rank)
+            W_uk = W_kv[:, : self.qk_nope_head_dim, :]
+            W_uv = W_kv[:, self.qk_nope_head_dim :, :]
+
+            absorbed_q = torch.einsum("bhnd,hdk->bhnk", q_pass, W_uk)
+            compressed_k = k_pass_normed.unsqueeze(1)
+
+            attn_weights = torch.matmul(absorbed_q, compressed_k.transpose(-2, -1))
+            attn_weights = attn_weights + torch.matmul(q_rot, k_rot.transpose(-2, -1))
+            attn_weights = attn_weights * self.scaling
+
+            # DSA indexer
+            indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
+            topk_indices = self.indexer(
+                hidden_states, q_resid, position_embeddings, indexer_mask, position_ids,
+                past_key_values=past_key_values,
+            )
+
+            # Apply DSA sparse mask
             index_mask = (
-                topk_indices.new_ones((batch_size, seq_length, key_states.shape[2]), dtype=torch.bool)
+                topk_indices.new_ones((batch_size, seq_length, seq_length), dtype=torch.bool)
                 .scatter(-1, topk_indices.long(), False)
                 .unsqueeze(1)
-            )  # [B, 1, S, T]; True = masked
+            )
             if attention_mask is None:
-                key_positions = torch.arange(key_states.shape[2], device=hidden_states.device)
+                key_positions = torch.arange(seq_length, device=hidden_states.device)
                 index_mask = index_mask | (key_positions[None, None, None, :] > position_ids[:, None, :, None])
-                attention_mask = hidden_states.new_zeros((batch_size, 1, seq_length, key_states.shape[2]))
+                attention_mask = hidden_states.new_zeros((batch_size, 1, seq_length, seq_length))
             attention_mask = attention_mask.masked_fill(index_mask, torch.finfo(hidden_states.dtype).min)
-        else:
-            sparse_indices = topk_indices
 
-        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
-            self.config._attn_implementation, eager_attention_forward
-        )
-        attn_output, attn_weights = attention_interface(
-            self,
-            query_states,
-            key_states,
-            value_states,
-            attention_mask,
-            dropout=0.0 if not self.training else self.attention_dropout,
-            scaling=self.scaling,
-            indices=sparse_indices,
-            **kwargs,
-        )
+            attn_weights = attn_weights + attention_mask
+            attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q_states.dtype)
+            attn_weights = F.dropout(attn_weights, p=0.0 if not self.training else self.attention_dropout)
+
+            attn_output = torch.matmul(attn_weights, compressed_k)
+            attn_output = torch.einsum("bhnk,hkv->bhnv", attn_output, W_uv.transpose(1, 2))
+
+            if past_key_values is not None:
+                k_pass_full = self.kv_b_proj(k_pass_normed).view(*key_shape).transpose(1, 2)
+                k_pass_full, value_states = torch.split(
+                    k_pass_full, [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+                )
+                k_rot_full = k_rot.expand(*k_pass_full.shape[:-1], -1)
+                key_states = torch.cat((k_pass_full, k_rot_full), dim=-1)
+                past_key_values.update(key_states, value_states, self.layer_idx)
+        else:
+            k_pass = self.kv_b_proj(self.kv_a_layernorm(k_pass)).view(key_shape).transpose(1, 2)
+            k_pass, value_states = torch.split(k_pass, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+            k_rot = k_rot.expand(*k_pass.shape[:-1], -1)
+            query_states = torch.cat((q_pass, q_rot), dim=-1)
+            key_states = torch.cat((k_pass, k_rot), dim=-1)
+
+            if past_key_values is not None:
+                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+
+            indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
+            topk_indices = self.indexer(
+                hidden_states, q_resid, position_embeddings, indexer_mask, position_ids,
+                past_key_values=past_key_values,
+            )
+
+            sparse_indices = None
+            if self.config._attn_implementation in ("eager", "sdpa"):
+                index_mask = (
+                    topk_indices.new_ones((batch_size, seq_length, key_states.shape[2]), dtype=torch.bool)
+                    .scatter(-1, topk_indices.long(), False)
+                    .unsqueeze(1)
+                )
+                if attention_mask is None:
+                    key_positions = torch.arange(key_states.shape[2], device=hidden_states.device)
+                    index_mask = index_mask | (key_positions[None, None, None, :] > position_ids[:, None, :, None])
+                    attention_mask = hidden_states.new_zeros((batch_size, 1, seq_length, key_states.shape[2]))
+                attention_mask = attention_mask.masked_fill(index_mask, torch.finfo(hidden_states.dtype).min)
+            else:
+                sparse_indices = topk_indices
+
+            attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+                self.config._attn_implementation, eager_attention_forward
+            )
+            attn_output, attn_weights = attention_interface(
+                self,
+                query_states,
+                key_states,
+                value_states,
+                attention_mask,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                scaling=self.scaling,
+                indices=sparse_indices,
+                **kwargs,
+            )
 
         attn_output = attn_output.reshape(batch_size, seq_length, -1).contiguous()
         attn_output = self.o_proj(attn_output)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47011)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47011)
<!-- ci-dashboard-badge:end -->

## Summary

The standard MLA forward materializes the full decompressed K and V tensors (e.g., `kv_lora_rank=512` -> `num_heads * (qk_nope_head_dim + v_head_dim)` = up to 32768) before calling the attention interface. This is wasteful for eager/SDPA: the `kv_b_proj` up-projection can be absorbed into the Q-nope and output projections, working entirely in the compressed `kv_lora_rank` space.

This PR applies the **absorbed attention** optimization to all three MLA model families:
- **DeepSeek-V2** (`modular_deepseek_v2.py`)
- **DeepSeek-V3** (`modular_deepseek_v3.py`)
- **DeepSeek-V3.2 (DSA)** (`modular_deepseek_v32.py`)

### How it works

Split `kv_b_proj.weight` into two sub-matrices:
- `W_uk` maps compressed k to the nope key-subspace
- `W_uv` maps compressed k to the value subspace

**Forward:**
absorbed_q = q_nope @ W_uk^T
scores = absorbed_q @ compressed_k^T + RoPE scores
output = softmax(scores) @ compressed_k @ W_uv^T

Full K/V is **only** materialized when a KV-cache update is required. Flash-attention and decode steps with pre-existing caches keep the original expanded path.

### Testing

- Unit tests verify the absorbed path matches the standard expansion to 1e-5 for V2, V3, and V3.2
- Full model forward (no MoE, eager mode) produces valid logits with no NaN
- Cache path tested: prefill (absorbed) + decode (standard) round-trip matches no-cache baseline exactly
- Flash-attention and decode-with-cache paths are unchanged (fall through to the original expansion)