### PR TITLE
Add max_groups input to nightly Serge triage caller (single-task test mode)

### DIFF
--- a/.github/workflows/nightly-integration-failure-triage-caller.yml
+++ b/.github/workflows/nightly-integration-failure-triage-caller.yml
@@ -16,6 +16,10 @@ on:
         description: "Compute the report but do not dispatch to Serge"
         type: boolean
         default: false
+      max_groups:
+        description: "Cap failure groups dispatched to Serge (set to 1 for a single-task test run; empty = normal)"
+        type: string
+        default: ""
 
 # Permissions are granted here and bound the reusable workflow's job token.
 permissions:
@@ -39,4 +43,5 @@ jobs:
     uses: huggingface/transformers-ci/.github/workflows/integration-failure-triage.yml@main # main
     with:
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      max_groups: ${{ github.event_name == 'workflow_dispatch' && inputs.max_groups || '' }}
     secrets: inherit


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47012)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47012)
<!-- ci-dashboard-badge:end -->

## What

Adds a `max_groups` `workflow_dispatch` input to the nightly integration-failure
triage caller and passes it to the reusable transformers-ci workflow.

- Empty (default) / scheduled runs → unchanged behavior.
- Manual run with `max_groups=1` → dispatches a **single** Serge fix task (one
  PR), for testing the Serge normalize pipeline end-to-end without opening
  ~10-20 PRs.

## Dependency

Requires **huggingface/transformers-ci#7** (which adds the `max_groups` input to
the reusable workflow) to be merged first — the caller passes the input to
`integration-failure-triage.yml@main`.

## Notes

Workflow-only change to the Serge triage pipeline (no codebase changes).
AI-assisted (Claude Code); human-owned pipeline, to be reviewed/merged by the maintainer.