### PR TITLE
TST Skip PEFT tests if PEFT version is too low

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -782,9 +782,9 @@ def require_peft_greater_or_equal(version: str):
     """
 
     def decorator(test_case):
-        return unittest.skipUnless(
-            is_peft_greater_or_equal(version), f"test requires PEFT version >= {version}"
-        )(test_case)
+        return unittest.skipUnless(is_peft_greater_or_equal(version), f"test requires PEFT version >= {version}")(
+            test_case
+        )
 
     return decorator
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -128,6 +128,7 @@ from .utils import (
     is_optimum_quanto_available,
     is_pandas_available,
     is_peft_available,
+    is_peft_greater_or_equal,
     is_phonemizer_available,
     is_pretty_midi_available,
     is_psutil_available,
@@ -771,6 +772,21 @@ def require_peft(test_case):
 
     """
     return unittest.skipUnless(is_peft_available(), "test requires PEFT")(test_case)
+
+
+def require_peft_greater_or_equal(version: str):
+    """
+    Decorator marking a test that requires PEFT version >= `version`.
+
+    These tests are skipped when PEFT version is less than `version`.
+    """
+
+    def decorator(test_case):
+        return unittest.skipUnless(
+            is_peft_greater_or_equal(version), f"test requires PEFT version >= {version}"
+        )(test_case)
+
+    return decorator
 
 
 def require_torchvision(test_case):

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -182,6 +182,7 @@ from .import_utils import (
     is_optimum_quanto_available,
     is_pandas_available,
     is_peft_available,
+    is_peft_greater_or_equal,
     is_phonemizer_available,
     is_pretty_midi_available,
     is_protobuf_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -884,6 +884,18 @@ def is_peft_available() -> bool:
 
 
 @lru_cache
+def is_peft_greater_or_equal(library_version: str, accept_dev: bool = False) -> bool:
+    is_available, peft_version = _is_package_available("peft", return_version=True)
+    if not is_available:
+        return False
+
+    if accept_dev:
+        return version.parse(version.parse(peft_version).base_version) >= version.parse(library_version)
+    else:
+        return version.parse(peft_version) >= version.parse(library_version)
+
+
+@lru_cache
 def is_bs4_available() -> bool:
     return _is_package_available("bs4")[0]
 

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gc
+import importlib.metadata
 import json
 import os
 import re
@@ -22,6 +23,7 @@ from unittest.mock import patch
 
 from datasets import Dataset, DatasetDict
 from huggingface_hub import hf_hub_download
+from packaging import version
 from torch import nn
 
 from transformers import (
@@ -215,6 +217,9 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
         Regression test: after save_pretrained + from_pretrained roundtrip, the reloaded model's LoRA
         weights must match the pre-save values. Covers both the encoder and decoder paths.
         """
+        if version.parse(importlib.metadata.version("peft")) < version.parse("0.20.0"):
+            self.skipTest("For this test to pass, PEFT 0.20 is required.")
+
         from peft import LoraConfig
 
         cases = [
@@ -1050,6 +1055,9 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                 assert not torch.allclose(output_base, output_peft, atol=atol, rtol=rtol)
 
     def test_mixtral_lora_conversion(self):
+        if version.parse(importlib.metadata.version("peft")) < version.parse("0.20.0"):
+            self.skipTest("For this test to pass, PEFT 0.20 is required.")
+
         inputs = torch.arange(10).view(1, -1).to(torch_device)
         model_name = "hf-internal-testing/Mixtral-tiny"
         adapter_name = "peft-internal-testing/mixtral-pre-v5-lora"

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gc
-import importlib.metadata
 import json
 import os
 import re
@@ -23,7 +22,6 @@ from unittest.mock import patch
 
 from datasets import Dataset, DatasetDict
 from huggingface_hub import hf_hub_download
-from packaging import version
 from torch import nn
 
 from transformers import (
@@ -42,6 +40,7 @@ from transformers.testing_utils import (
     CaptureLogger,
     require_bitsandbytes,
     require_peft,
+    require_peft_greater_or_equal,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -212,14 +211,12 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                     model_from_pretrained = transformers_class.from_pretrained(tmpdirname).to(torch_device)
                     self.assertTrue(self._check_lora_correctly_converted(model_from_pretrained))
 
+    @require_peft_greater_or_equal("0.20.0")
     def test_peft_save_reload_preserves_adapter_weights(self):
         """
         Regression test: after save_pretrained + from_pretrained roundtrip, the reloaded model's LoRA
         weights must match the pre-save values. Covers both the encoder and decoder paths.
         """
-        if version.parse(importlib.metadata.version("peft")) < version.parse("0.20.0"):
-            self.skipTest("For this test to pass, PEFT 0.20 is required.")
-
         from peft import LoraConfig
 
         cases = [
@@ -1054,10 +1051,8 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                 # should be different
                 assert not torch.allclose(output_base, output_peft, atol=atol, rtol=rtol)
 
+    @require_peft_greater_or_equal("0.20.0")
     def test_mixtral_lora_conversion(self):
-        if version.parse(importlib.metadata.version("peft")) < version.parse("0.20.0"):
-            self.skipTest("For this test to pass, PEFT 0.20 is required.")
-
         inputs = torch.arange(10).view(1, -1).to(torch_device)
         model_name = "hf-internal-testing/Mixtral-tiny"
         adapter_name = "peft-internal-testing/mixtral-pre-v5-lora"


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47027)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47027)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Two PEFT tests fail with the current PEFT release v0.19 but the failure is already fixed on main. Therefore, skip those tests unless v0.20+ is found, which is the next PEFT release.

Fixes https://github.com/huggingface/transformers/actions/runs/28604971769/job/84823334564?pr=46960#step:17:575

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.