### PR TITLE
Fix MoonshineStreaming right-window off-by-one in sliding_window_mask_function

### DIFF
--- a/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
@@ -356,7 +356,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask

--- a/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
@@ -269,7 +269,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47028)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47028)
<!-- ci-dashboard-badge:end -->

Fixes #46305

## Problem

`sliding_window_mask_function` uses a strict less-than for the right (future) context:

```python
right_mask = (dist < 0) & (-dist < right_window_size)
```

With `right_window_size=4`, a query attends to only **3** future frames, but the Moonshine v2 paper (arXiv:2602.12241) defines the right window as:

> "a right window of w_right=4 implies an algorithmic lookahead of 4×20 ms = 80 ms"

At 50 Hz, 80 ms = **4** future frames. Repro from the issue:

```python
fn = sliding_window_mask_function((16, 4))
[kv for kv in range(11, 20) if fn(0, 0, 10, kv)]
# current: [11, 12, 13]        (3 frames, 60 ms)
# paper:   [11, 12, 13, 14]    (4 frames, 80 ms)
```

## Fix

Use `<=` so `right_window_size` future frames are attended, matching the paper's definition of `w_right`. Applied to both `modular_moonshine_streaming.py` and the generated `modeling_moonshine_streaming.py` (identical one-token change, so the two stay in sync).

## Note for @eustlb

This aligns the mask with the paper's stated `w_right` semantics. If the released weights were instead trained/exported with the strict (`< `, 3-frame) mask, please advise — in that case the inference mask should match training and the *docs/param semantics* would be what needs clarifying rather than the mask. The change itself is verifiable by inspection against the issue's pure-function repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)