### PR TITLE
Fix serve tool parsing for legacy response schemas

### DIFF
--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -216,7 +216,8 @@ def parse_tool_calls(processor, generated_ids, schema: dict) -> list[dict] | Non
 
     Returns a list of ``{"name": str, "arguments": str}`` dicts, or ``None`` if none found.
     """
-    parsed = processor.parse_response(generated_ids, schema, prefix="")
+    parse_kwargs = {"prefix": ""} if isinstance(schema, dict) and ("version" in schema or "fields" in schema) else {}
+    parsed = processor.parse_response(generated_ids, schema, **parse_kwargs)
     # The new response_template path returns a dict like {"tool_calls": [...]}; unwrap.
     if isinstance(parsed, dict) and "tool_calls" in parsed:
         parsed = parsed["tool_calls"]
@@ -225,7 +226,7 @@ def parse_tool_calls(processor, generated_ids, schema: dict) -> list[dict] | Non
     if not isinstance(parsed, list):
         parsed = [parsed]
     tool_calls = [_normalize_tool_call(tool_call) for tool_call in parsed]
-    return tool_calls if tool_calls else None
+    return tool_calls or None
 
 
 # Default start/end tokens + schema. The opening token is optional so prefilled

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -1826,6 +1826,17 @@ class TestToolCallUnit(unittest.TestCase):
         calls = parse_tool_calls(processor, text, schema)
         self.assertEqual(len(calls), 2)
 
+    def test_parse_tool_calls_with_legacy_schema_does_not_pass_prefix(self):
+        def parse_legacy(response, schema):
+            return [{"name": "get_weather", "arguments": {"city": "Paris"}}]
+
+        processor = MagicMock()
+        processor.parse_response.side_effect = parse_legacy
+        schema = next(v["schema"] for k, v in _TOOL_CALL_FALLBACKS.items() if "qwen3_5" in k)
+        calls = parse_tool_calls(processor, "unused", schema)
+
+        self.assertEqual(calls, [{"name": "get_weather", "arguments": '{"city": "Paris"}'}])
+
 
 class TestCBWorkerDeadServerIntegration(unittest.TestCase):
     """End-to-end FastAPI behavior when the CB worker has died.


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47033)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47033)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

#46980 made new-style response templates require `prefix=`, but legacy `response_schema` rejects `prefix`. `parse_tool_calls` currently passes `prefix=""` unconditionally, so the serving tool-call path crashes for legacy schemas and the Qwen3.5 fallback schema before parsing any tool call.

This only passes `prefix=""` for new-style schemas (`version` or `fields`) and keeps legacy schemas on the no-prefix path. The existing new-style fallback remains covered, and this adds a regression guard for the legacy fallback.

<details><summary>Repro and output</summary>

```python
from transformers.cli.serving.utils import _TOOL_CALL_FALLBACKS, parse_tool_calls
from transformers.tokenization_utils_base import PreTrainedTokenizerBase


class Processor:
    parse_response = PreTrainedTokenizerBase.parse_response


processor = Processor()
schema = next(v["schema"] for k, v in _TOOL_CALL_FALLBACKS.items() if "qwen3_5" in k)
text = "<function=get_weather><parameter=city>Paris</parameter></function>"

print("schema keys", sorted(schema.keys()))
print("text", text)
print(parse_tool_calls(processor, text, schema))
```

Before this PR:

```text
schema keys ['items', 'type', 'x-regex-iterator']
text <function=get_weather><parameter=city>Paris</parameter></function>
ValueError: `prefix=` is only supported with new-style `response_template` specs, not legacy `response_schema`.
```

After this PR:

```text
schema keys ['items', 'type', 'x-regex-iterator']
text <function=get_weather><parameter=city>Paris</parameter></function>
[{'name': 'get_weather', 'arguments': '{"city": "Paris"}'}]
```

</details>

<details><summary>Tests</summary>

```text
python -m pytest -q tests/cli/test_serve.py::TestToolCallUnit::test_parse_tool_calls_from_text tests/cli/test_serve.py::TestToolCallUnit::test_parse_multiple_tool_calls_from_text tests/cli/test_serve.py::TestToolCallUnit::test_parse_tool_calls_with_legacy_schema_does_not_pass_prefix

tests/cli/test_serve.py::TestToolCallUnit::test_parse_tool_calls_from_text PASSED [ 33%]
tests/cli/test_serve.py::TestToolCallUnit::test_parse_multiple_tool_calls_from_text PASSED [ 66%]
tests/cli/test_serve.py::TestToolCallUnit::test_parse_tool_calls_with_legacy_schema_does_not_pass_prefix PASSED [100%]

============================== 3 passed in 0.31s ===============================

python -m ruff check src/transformers/cli/serving/utils.py tests/cli/test_serve.py
All checks passed!

git diff --check
```

</details>

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@Rocketknight1 @SunMarc