### PR TITLE
Update workflow callers to use `transformers-ci`

### DIFF
--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -19,5 +19,5 @@ permissions:
 jobs:
   pr-ci:
     # DON'T use commit sha here before the CI migration is finished
-    uses: huggingface/transformers-test-ci/.github/workflows/pr-ci_dynamic_caller_example.yml@main # main
+    uses: huggingface/transformers-ci/.github/workflows/pr-ci_dynamic_caller_example.yml@main # main
 

--- a/.github/workflows/pr-ci-security-gate.yml
+++ b/.github/workflows/pr-ci-security-gate.yml
@@ -14,5 +14,5 @@ jobs:
     # Members/collaborators/owners trigger PR CI directly — gate only needed for forks
     if: "!contains(fromJSON('[\"MEMBER\",\"OWNER\",\"COLLABORATOR\"]'), github.event.pull_request.author_association)"
     # Intentionally not passing `secrets: inherit` to avoid leaking secrets in runs triggered from forked repos
-    uses: huggingface/transformers-test-ci/.github/workflows/pr-ci-security-gate.yml@main
+    uses: huggingface/transformers-ci/.github/workflows/pr-ci-security-gate.yml@main
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47040)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47040)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

[See https://github.com/huggingface/transformers-test-ci/pull/3](https://github.com/huggingface/transformers-ci/pull/11)

As discussed offline, this transformers-ci would be our lovely home for CI.