### PR TITLE
Fix: accept scalar audio formats in Voxtral transcription requests

### DIFF
--- a/src/transformers/models/voxtral/processing_voxtral.py
+++ b/src/transformers/models/voxtral/processing_voxtral.py
@@ -329,10 +329,20 @@ class VoxtralProcessor(ProcessorMixin):
             ]
         else:
             audio = make_list_of_audio(audio)
+            if format is None:
+                raise ValueError("`format` must be provided when passing audio arrays to VoxtralProcessor.")
+
+            if isinstance(format, str):
+                format = [format] * len(audio)
+
             if len(audio) != len(format):
                 raise ValueError(
                     f"When passed as a list of audio, the length ({len(audio)}) must match the number of format ({len(format)})"
                 )
+
+            if not is_soundfile_available():
+                raise ImportError("Please install `soundfile` to encode audio arrays with VoxtralProcessor.")
+
             audio_buffers = []
             for array, f in zip(audio, format):
                 # Create new BytesIO object and write audio data to it

--- a/tests/models/voxtral/test_modeling_voxtral.py
+++ b/tests/models/voxtral/test_modeling_voxtral.py
@@ -15,6 +15,8 @@
 
 import unittest
 
+import numpy as np
+
 from transformers import (
     AutoProcessor,
     LlamaConfig,
@@ -27,10 +29,12 @@ from transformers import (
 from transformers.testing_utils import (
     Expectations,
     cleanup,
+    require_mistral_common,
     require_torch,
     slow,
     torch_device,
 )
+from transformers.utils import is_soundfile_available
 
 from ...alm_tester import ALMModelTest, ALMModelTester
 
@@ -379,6 +383,20 @@ class VoxtralForConditionalGenerationIntegrationTest(unittest.TestCase):
             'Describe briefly what you can hear.The audio begins with the speaker delivering a farewell address in Chicago, reflecting on his eight years as president and expressing gratitude to the American people. The audio then transitions to a weather report, stating that it was 35 degrees in Barcelona the previous day, but the temperature would drop to minus 20 degrees the following day.Ok, now compare this new audio with the previous one.The new audio is a humorous conversation between two friends, one of whom has a tattoo. The speaker is excited to see the tattoo and asks what it says. The other friend repeatedly says "sweet" in response, leading to a playful exchange. The speaker then realizes the joke and says "your tattoo says dude, your tattoo says sweet, got it?" The previous audio was a political speech by a president, reflecting on his time in office and expressing gratitude to the American people. The new audio is a casual, light-hearted conversation with no political context.'
         ]
         self.assertEqual(decoded_outputs, EXPECTED_OUTPUT)
+
+    @slow
+    @require_mistral_common
+    @unittest.skipUnless(is_soundfile_available(), "test requires soundfile")
+    def test_transcription_request_accepts_single_format_for_array_audio(self):
+        processor = AutoProcessor.from_pretrained(self.checkpoint_name)
+        audio = np.zeros(16000, dtype=np.float32)
+
+        inputs = processor.apply_transcription_request(
+            audio=audio, model_id=self.checkpoint_name, sampling_rate=16000, format="wav"
+        )
+
+        self.assertIn("input_features", inputs)
+        self.assertEqual(inputs["input_features"].shape[0], 1)
 
     @slow
     def test_transcribe_mode_audio_input(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47045)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47045)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`VoxtralProcessor.apply_transcription_request()` documents `format` as either a string or a list. The array-audio path did not normalize a scalar string, so `format="wav"` was treated as three per-sample formats and a single local audio array failed before the transcription request was encoded.

This broadcasts a scalar `format` to the audio batch length, keeps the existing length check for per-sample format lists, and raises a clear optional-dependency error before encoding array audio without `soundfile`.

<details><summary>Repro and output</summary>

```python
import numpy as np
from transformers import AutoProcessor


model_id = "mistralai/Voxtral-Mini-3B-2507"
processor = AutoProcessor.from_pretrained(model_id)
audio = np.zeros(16000, dtype=np.float32)

for fmt in ["wav", ["wav"]]:
    print("CASE", fmt)
    try:
        out = processor.apply_transcription_request(
            audio=audio,
            model_id=model_id,
            format=fmt,
            sampling_rate=16000,
        )
        print("OK", sorted(out.keys()), out["input_features"].shape, out["input_ids"].shape)
    except Exception as exc:
        print("ERR", type(exc).__name__, str(exc))
```

Before this PR:

```text
CASE wav
ERR ValueError When passed as a list of audio, the length (1) must match the number of format (3)
CASE ['wav']
OK ['attention_mask', 'input_features', 'input_ids'] torch.Size([1, 128, 3000]) torch.Size([1, 380])
```

After this PR:

```text
CASE wav
OK ['attention_mask', 'input_features', 'input_ids'] torch.Size([1, 128, 3000]) torch.Size([1, 380])
CASE ['wav']
OK ['attention_mask', 'input_features', 'input_ids'] torch.Size([1, 128, 3000]) torch.Size([1, 380])
```

</details>

<details><summary>Tests</summary>

```text
RUN_SLOW=1 python -m pytest -q -s tests/models/voxtral/test_modeling_voxtral.py::VoxtralForConditionalGenerationIntegrationTest::test_transcription_request_accepts_single_format_for_array_audio

tests/models/voxtral/test_modeling_voxtral.py::VoxtralForConditionalGenerationIntegrationTest::test_transcription_request_accepts_single_format_for_array_audio PASSED

======================= 1 passed, 11 warnings in 26.85s ========================

python -m ruff check src/transformers/models/voxtral/processing_voxtral.py tests/models/voxtral/test_modeling_voxtral.py
All checks passed!

git diff --check
```

</details>

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

cc @zucchini-nlp @Rocketknight1