### PR TITLE
Forward direct generation kwargs in multimodal generation pipelines

### DIFF
--- a/src/transformers/pipelines/any_to_any.py
+++ b/src/transformers/pipelines/any_to_any.py
@@ -44,6 +44,8 @@ if is_vision_available():
 
 logger = logging.get_logger(__name__)
 
+_GENERATION_CONFIG_KWARGS = set(GenerationConfig().to_dict())
+
 
 class ReturnType(enum.Enum):
     TENSORS = 0
@@ -168,7 +170,12 @@ class AnyToAnyPipeline(Pipeline):
         postprocess_params = {}
 
         # Preprocess params
-        preprocess_params.update(kwargs)
+        direct_generate_kwargs = {}
+        for key, value in kwargs.items():
+            if key in _GENERATION_CONFIG_KWARGS:
+                direct_generate_kwargs[key] = value
+            else:
+                preprocess_params[key] = value
         if timeout is not None:
             preprocess_params["timeout"] = timeout
         if continue_final_message is not None:
@@ -177,7 +184,16 @@ class AnyToAnyPipeline(Pipeline):
             preprocess_params["processor_kwargs"] = processor_kwargs
 
         # Forward kwargs
-        forward_kwargs["generate_kwargs"] = generate_kwargs or {}
+        forward_kwargs["generate_kwargs"] = dict(generate_kwargs) if generate_kwargs is not None else {}
+        if direct_generate_kwargs:
+            duplicate_kwargs = set(forward_kwargs["generate_kwargs"]).intersection(direct_generate_kwargs)
+            if duplicate_kwargs:
+                duplicate_kwargs = ", ".join(sorted(duplicate_kwargs))
+                raise ValueError(
+                    f"The following generation kwargs are defined twice: {duplicate_kwargs}. "
+                    "Please use either direct keyword arguments or `generate_kwargs`, not both."
+                )
+            forward_kwargs["generate_kwargs"].update(direct_generate_kwargs)
         if generation_mode is not None and generation_mode != "text":
             forward_kwargs["generate_kwargs"]["generation_mode"] = generation_mode
         # Qwen-Omni models need to know the origin of audio, to align mm position ids

--- a/src/transformers/pipelines/any_to_any.py
+++ b/src/transformers/pipelines/any_to_any.py
@@ -21,7 +21,15 @@ import numpy as np
 from ..audio_utils import AudioInput
 from ..generation import GenerationConfig
 from ..image_utils import ImageInput
-from ..processing_utils import ProcessingKwargs, Unpack
+from ..processing_utils import (
+    AudioKwargs,
+    ImagesKwargs,
+    ProcessingKwargs,
+    ProcessorChatTemplateKwargs,
+    TextKwargs,
+    Unpack,
+    VideosKwargs,
+)
 from ..utils import (
     add_end_docstrings,
     is_torch_available,
@@ -44,7 +52,16 @@ if is_vision_available():
 
 logger = logging.get_logger(__name__)
 
-_GENERATION_CONFIG_KWARGS = set(GenerationConfig().to_dict())
+_PREPROCESS_KWARGS = (
+    set(TextKwargs.__annotations__)
+    | set(ImagesKwargs.__annotations__)
+    | set(VideosKwargs.__annotations__)
+    | set(AudioKwargs.__annotations__)
+    | set(ProcessorChatTemplateKwargs.__annotations__)
+    | {"audio_kwargs", "common_kwargs", "images_kwargs", "processor_kwargs", "text_kwargs", "videos_kwargs"}
+)
+# `max_length` is both a processing and generation kwarg, matching TextGenerationPipeline.
+_PREPROCESS_KWARGS.discard("max_length")
 
 
 class ReturnType(enum.Enum):
@@ -170,12 +187,12 @@ class AnyToAnyPipeline(Pipeline):
         postprocess_params = {}
 
         # Preprocess params
-        direct_generate_kwargs = {}
-        for key, value in kwargs.items():
-            if key in _GENERATION_CONFIG_KWARGS:
-                direct_generate_kwargs[key] = value
-            else:
-                preprocess_params[key] = value
+        direct_generate_kwargs = dict(kwargs)
+        for key in list(direct_generate_kwargs):
+            if key in _PREPROCESS_KWARGS:
+                preprocess_params[key] = direct_generate_kwargs.pop(key)
+        if "max_length" in direct_generate_kwargs:
+            preprocess_params["max_length"] = direct_generate_kwargs["max_length"]
         if timeout is not None:
             preprocess_params["timeout"] = timeout
         if continue_final_message is not None:
@@ -197,7 +214,10 @@ class AnyToAnyPipeline(Pipeline):
         if generation_mode is not None and generation_mode != "text":
             forward_kwargs["generate_kwargs"]["generation_mode"] = generation_mode
         # Qwen-Omni models need to know the origin of audio, to align mm position ids
-        if kwargs.get("load_audio_from_video") and re.search(r"qwen\domni", self.model.__class__.__name__.lower()):
+        if preprocess_params.get("load_audio_from_video") and re.search(
+            r"qwen\domni",
+            self.model.__class__.__name__.lower(),
+        ):
             forward_kwargs["generate_kwargs"]["use_audio_in_video"] = True
         if stop_sequence is not None:
             if isinstance(stop_sequence, str):

--- a/src/transformers/pipelines/image_text_to_text.py
+++ b/src/transformers/pipelines/image_text_to_text.py
@@ -16,7 +16,7 @@ import enum
 from typing import Any, Union, overload
 
 from ..generation import GenerationConfig
-from ..processing_utils import ProcessingKwargs, Unpack
+from ..processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorChatTemplateKwargs, TextKwargs, Unpack
 from ..utils import (
     add_end_docstrings,
     is_torch_available,
@@ -41,7 +41,14 @@ if is_torch_available():
 logger = logging.get_logger(__name__)
 
 IMAGE_TOKEN = "<image>"
-_GENERATION_CONFIG_KWARGS = set(GenerationConfig().to_dict())
+_PREPROCESS_KWARGS = (
+    set(TextKwargs.__annotations__)
+    | set(ImagesKwargs.__annotations__)
+    | set(ProcessorChatTemplateKwargs.__annotations__)
+    | {"common_kwargs", "images_kwargs", "processor_kwargs", "text_kwargs"}
+)
+# `max_length` is both a processing and generation kwarg, matching TextGenerationPipeline.
+_PREPROCESS_KWARGS.discard("max_length")
 
 
 class ReturnType(enum.Enum):
@@ -149,12 +156,12 @@ class ImageTextToTextPipeline(Pipeline):
         postprocess_params = {}
 
         # Preprocess params
-        direct_generate_kwargs = {}
-        for key, value in kwargs.items():
-            if key in _GENERATION_CONFIG_KWARGS:
-                direct_generate_kwargs[key] = value
-            else:
-                preprocess_params[key] = value
+        direct_generate_kwargs = dict(kwargs)
+        for key in list(direct_generate_kwargs):
+            if key in _PREPROCESS_KWARGS:
+                preprocess_params[key] = direct_generate_kwargs.pop(key)
+        if "max_length" in direct_generate_kwargs:
+            preprocess_params["max_length"] = direct_generate_kwargs["max_length"]
         if timeout is not None:
             preprocess_params["timeout"] = timeout
         if continue_final_message is not None:

--- a/src/transformers/pipelines/image_text_to_text.py
+++ b/src/transformers/pipelines/image_text_to_text.py
@@ -41,6 +41,7 @@ if is_torch_available():
 logger = logging.get_logger(__name__)
 
 IMAGE_TOKEN = "<image>"
+_GENERATION_CONFIG_KWARGS = set(GenerationConfig().to_dict())
 
 
 class ReturnType(enum.Enum):
@@ -148,7 +149,12 @@ class ImageTextToTextPipeline(Pipeline):
         postprocess_params = {}
 
         # Preprocess params
-        preprocess_params.update(kwargs)
+        direct_generate_kwargs = {}
+        for key, value in kwargs.items():
+            if key in _GENERATION_CONFIG_KWARGS:
+                direct_generate_kwargs[key] = value
+            else:
+                preprocess_params[key] = value
         if timeout is not None:
             preprocess_params["timeout"] = timeout
         if continue_final_message is not None:
@@ -157,6 +163,16 @@ class ImageTextToTextPipeline(Pipeline):
             preprocess_params["processor_kwargs"] = processor_kwargs
 
         # Forward kwargs
+        if direct_generate_kwargs:
+            generate_kwargs = dict(generate_kwargs) if generate_kwargs is not None else {}
+            duplicate_kwargs = set(generate_kwargs).intersection(direct_generate_kwargs)
+            if duplicate_kwargs:
+                duplicate_kwargs = ", ".join(sorted(duplicate_kwargs))
+                raise ValueError(
+                    f"The following generation kwargs are defined twice: {duplicate_kwargs}. "
+                    "Please use either direct keyword arguments or `generate_kwargs`, not both."
+                )
+            generate_kwargs.update(direct_generate_kwargs)
         if generate_kwargs is not None:
             forward_kwargs["generate_kwargs"] = generate_kwargs
         if stop_sequence is not None:

--- a/tests/pipelines/test_pipelines_any_to_any.py
+++ b/tests/pipelines/test_pipelines_any_to_any.py
@@ -48,11 +48,12 @@ class AnyToAnyPipelineSanitizeParametersTests(unittest.TestCase):
             temperature=0.7,
             top_p=0.8,
             padding=True,
+            max_length=12,
         )
 
-        self.assertEqual({"padding": True}, preprocess_params)
+        self.assertEqual({"padding": True, "max_length": 12}, preprocess_params)
         self.assertEqual(
-            {"do_sample": True, "temperature": 0.7, "top_p": 0.8},
+            {"do_sample": True, "temperature": 0.7, "top_p": 0.8, "max_length": 12},
             forward_params["generate_kwargs"],
         )
 

--- a/tests/pipelines/test_pipelines_any_to_any.py
+++ b/tests/pipelines/test_pipelines_any_to_any.py
@@ -39,6 +39,24 @@ if is_vision_available():
     import PIL
 
 
+class AnyToAnyPipelineSanitizeParametersTests(unittest.TestCase):
+    def test_direct_generation_kwargs_are_forwarded(self):
+        pipe = object.__new__(AnyToAnyPipeline)
+
+        preprocess_params, forward_params, _ = pipe._sanitize_parameters(
+            do_sample=True,
+            temperature=0.7,
+            top_p=0.8,
+            padding=True,
+        )
+
+        self.assertEqual({"padding": True}, preprocess_params)
+        self.assertEqual(
+            {"do_sample": True, "temperature": 0.7, "top_p": 0.8},
+            forward_params["generate_kwargs"],
+        )
+
+
 @is_pipeline_test
 @require_vision
 @require_librosa

--- a/tests/pipelines/test_pipelines_image_text_to_text.py
+++ b/tests/pipelines/test_pipelines_image_text_to_text.py
@@ -245,11 +245,12 @@ class ImageTextToTextPipelineTests(unittest.TestCase):
             temperature=0.7,
             top_p=0.8,
             padding=True,
+            max_length=12,
         )
 
-        self.assertEqual({"padding": True}, preprocess_params)
+        self.assertEqual({"padding": True, "max_length": 12}, preprocess_params)
         self.assertEqual(
-            {"do_sample": True, "temperature": 0.7, "top_p": 0.8},
+            {"do_sample": True, "temperature": 0.7, "top_p": 0.8, "max_length": 12},
             forward_params["generate_kwargs"],
         )
 

--- a/tests/pipelines/test_pipelines_image_text_to_text.py
+++ b/tests/pipelines/test_pipelines_image_text_to_text.py
@@ -237,6 +237,22 @@ class ImageTextToTextPipelineTests(unittest.TestCase):
         outputs_batched = pipe([image, image], text=[prompt, prompt], batch_size=2, max_new_tokens=10)
         self.assertEqual(outputs, outputs_batched)
 
+    def test_direct_generation_kwargs_are_forwarded(self):
+        pipe = object.__new__(ImageTextToTextPipeline)
+
+        preprocess_params, forward_params, _ = pipe._sanitize_parameters(
+            do_sample=True,
+            temperature=0.7,
+            top_p=0.8,
+            padding=True,
+        )
+
+        self.assertEqual({"padding": True}, preprocess_params)
+        self.assertEqual(
+            {"do_sample": True, "temperature": 0.7, "top_p": 0.8},
+            forward_params["generate_kwargs"],
+        )
+
     @slow
     @require_torch
     def test_model_pt_chat_template_with_response_parsing(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47051)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47051)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`ImageTextToTextPipeline` and `AnyToAnyPipeline` currently special-case `max_new_tokens`, but other direct generation kwargs such as `do_sample`, `temperature`, and `top_p` stay in the preprocessing kwargs. Processors then warn that these are not valid processor arguments and ignore them, so the model never receives the generation settings the user passed.

<details>
<summary>E2E Repro</summary>

```python
from PIL import Image

from transformers import AutoModelForImageTextToText, AutoProcessor, pipeline


model_id = "Xenova/tiny-random-LlavaForConditionalGeneration"
processor = AutoProcessor.from_pretrained(model_id)
model = AutoModelForImageTextToText.from_pretrained(model_id)
orig_generate = model.generate


def logged_generate(*args, **kwargs):
    print(
        "GENERATE_KWARGS",
        {k: kwargs.get(k) for k in ("do_sample", "temperature", "top_p", "max_new_tokens") if k in kwargs},
    )
    return orig_generate(*args, **kwargs)


model.generate = logged_generate
pipe = pipeline("image-text-to-text", model=model, processor=processor)
img = Image.new("RGB", (8, 8), "white")
out = pipe(
    images=img,
    text="<image> Describe.",
    return_full_text=False,
    max_new_tokens=2,
    do_sample=True,
    temperature=0.7,
    top_p=0.8,
)
print("OUT", out)
```

Before:

```text
[transformers] Keyword argument `do_sample` is not a valid argument for this processor and will be ignored.
[transformers] Keyword argument `temperature` is not a valid argument for this processor and will be ignored.
[transformers] Keyword argument `top_p` is not a valid argument for this processor and will be ignored.
GENERATE_KWARGS {'max_new_tokens': 2}
```

After:

```text
GENERATE_KWARGS {'do_sample': True, 'temperature': 0.7, 'top_p': 0.8, 'max_new_tokens': 2}
```

</details>

This PR moves direct kwargs whose names are part of `GenerationConfig` into `generate_kwargs` for both multimodal generation pipelines. Processor kwargs such as `padding` still stay in preprocessing, and duplicate generation kwargs now raise a clear error instead of having implicit precedence.

Tests:

```text
tests/pipelines/test_pipelines_image_text_to_text.py::ImageTextToTextPipelineTests::test_direct_generation_kwargs_are_forwarded PASSED [ 50%]
tests/pipelines/test_pipelines_image_text_to_text.py::ImageTextToTextPipelineTests::test_direct_generation_kwargs_are_forwarded [PASSED] 0.00s

tests/pipelines/test_pipelines_any_to_any.py::AnyToAnyPipelineSanitizeParametersTests::test_direct_generation_kwargs_are_forwarded PASSED [100%]
tests/pipelines/test_pipelines_any_to_any.py::AnyToAnyPipelineSanitizeParametersTests::test_direct_generation_kwargs_are_forwarded [PASSED] 0.00s

============================== 2 passed in 0.81s ===============================
```

`git diff --check` and `ruff check` pass for the touched files.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

cc @zucchini-nlp @Rocketknight1