### PR TITLE
Add GGUF support for Cohere2 (Command R7B / Command A)

### DIFF
--- a/src/transformers/integrations/ggml.py
+++ b/src/transformers/integrations/ggml.py
@@ -337,6 +337,22 @@ GGUF_CONFIG_MAPPING = {
         "vocab_size": "vocab_size",
         "expert_gating_func": "scoring_func",
     },
+    "cohere2": {
+        "context_length": "max_position_embeddings",
+        "block_count": "num_hidden_layers",
+        "feed_forward_length": "intermediate_size",
+        "embedding_length": "hidden_size",
+        # NOTE: Cohere2 derives head_dim as hidden_size // num_attention_heads
+        "rope.dimension_count": None,
+        "rope.freq_base": "rope_theta",
+        "attention.head_count": "num_attention_heads",
+        "attention.head_count_kv": "num_key_value_heads",
+        # NOTE: Cohere2 uses LayerNorm, not RMSNorm
+        "attention.layer_norm_epsilon": "layer_norm_eps",
+        "attention.sliding_window": "sliding_window",
+        "logit_scale": "logit_scale",
+        "vocab_size": "vocab_size",
+    },
 }
 
 GGUF_TOKENIZER_MAPPING = {
@@ -674,6 +690,45 @@ class GGUFGPTConverter(GPT2Converter):
         return tokenizer
 
 
+class GGUFCohere2Converter(GPT2Converter):
+    def __init__(self, tokenizer_dict):
+        self.original_tokenizer = GGUFTokenizerSkeleton(tokenizer_dict)
+        self.additional_kwargs = {}
+
+    def converted(self) -> Tokenizer:
+        proto = self.original_tokenizer
+        vocab = {word: i for i, word in enumerate(proto.tokens)}
+        merges = proto.merges
+        tokenizer = super().converted(vocab, merges)
+
+        # Register control tokens (token_type == 3, e.g. <|START_OF_TURN_TOKEN|>) so they are never split by BPE
+        if hasattr(proto, "token_type"):
+            special_tokens_idx = np.where(np.array(proto.token_type) == 3)[0]
+            tokenizer.add_special_tokens(
+                [AddedToken(proto.tokens[idx], normalized=False, special=True) for idx in special_tokens_idx]
+            )
+
+        # Cohere2 prepends a BOS token (`tokenizer.ggml.add_bos_token=True` in GGUF) and appends no EOS
+        bos_token = proto.tokens[proto.bos_token_id]
+        tokenizer.post_processor = processors.TemplateProcessing(
+            single=f"{bos_token}:0 $A:0",
+            pair=f"{bos_token}:0 $A:0 $B:1",
+            special_tokens=[(bos_token, proto.bos_token_id)],
+        )
+
+        self.additional_kwargs["unk_token"] = (
+            proto.tokens[proto.unk_token_id] if proto.unk_token_id is not None else None
+        )
+        self.additional_kwargs["bos_token"] = bos_token
+        self.additional_kwargs["eos_token"] = (
+            proto.tokens[proto.eos_token_id] if getattr(proto, "eos_token_id", None) is not None else None
+        )
+        self.additional_kwargs["pad_token"] = (
+            proto.tokens[proto.pad_token_id] if getattr(proto, "pad_token_id", None) is not None else None
+        )
+        return tokenizer
+
+
 class GGUFT5Converter(T5Converter):
     def __init__(self, tokenizer_dict):
         # set dummy data to avoid unnecessary merges calculation
@@ -824,6 +879,7 @@ GGUF_TO_FAST_CONVERTERS = {
     "deci": GGUFLlamaConverter,
     "decilm": GGUFLlamaConverter,
     "minimax_m2": GGUFQwen2Converter,
+    "cohere2": GGUFCohere2Converter,
 }
 
 

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -353,6 +353,8 @@ class GgufModelTests(unittest.TestCase):
     q4_k_m_lfm2_model_id = "LFM2-1.2B-Q4_K_M.gguf"
     gpt_oss_model_id = "unsloth/gpt-oss-20b-GGUF"
     gpt_oss_gguf_file = "gpt-oss-20b-Q5_K_M.gguf"
+    cohere2_model_id = "bartowski/c4ai-command-r7b-12-2024-GGUF"
+    q2_k_cohere2_model_id = "c4ai-command-r7b-12-2024-Q2_K.gguf"
 
     example_text = "Hello"
 
@@ -1145,3 +1147,30 @@ class GgufModelTests(unittest.TestCase):
 
         EXPECTED_TEXT = "Hello Atari 2600! es un videoj"
         self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
+
+    def test_cohere2_q2_k(self):
+        tokenizer = AutoTokenizer.from_pretrained(self.cohere2_model_id, gguf_file=self.q2_k_cohere2_model_id)
+        model = AutoModelForCausalLM.from_pretrained(
+            self.cohere2_model_id,
+            gguf_file=self.q2_k_cohere2_model_id,
+            device_map="auto",
+            dtype=torch.float16,
+        )
+
+        text = tokenizer(self.example_text, return_tensors="pt").to(torch_device)
+        out = model.generate(**text, max_new_tokens=10)
+
+        EXPECTED_TEXT = "Hello, I am looking for someone to create a logo"
+        self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
+
+    def test_cohere2_q2_k_tokenizer(self):
+        # Cohere2 prepends a BOS token and registers control tokens (e.g. turn delimiters) as special tokens
+        tokenizer = AutoTokenizer.from_pretrained(self.cohere2_model_id, gguf_file=self.q2_k_cohere2_model_id)
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tokenizer.save_pretrained(tmpdirname)
+            tokenizer = AutoTokenizer.from_pretrained(tmpdirname)
+            special_sentence = "<|START_OF_TURN_TOKEN|><|USER_TOKEN|>Hello<|END_OF_TURN_TOKEN|>"
+            input_ids = tokenizer.encode(special_sentence, return_tensors="pt")[0].tolist()
+            self.assertEqual(input_ids, [5, 255000, 255006, 28339, 255001])
+            predicted_text = tokenizer.decode(input_ids)
+            self.assertEqual(predicted_text, "<BOS_TOKEN>" + special_sentence)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47052)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47052)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Adds GGUF loading support for the **Cohere2** architecture (Command R7B / Command A), as suggested in #33260.

- `c4ai-command-r7b-12-2024` and `c4ai-command-a-03-2025` both use the llama.cpp `cohere2` architecture, so this enables both.

## Changes

- **`GGUF_CONFIG_MAPPING`**: new `cohere2` entry. Cohere2 uses LayerNorm (not RMSNorm), so `attention.layer_norm_epsilon → layer_norm_eps`; also maps `logit_scale` and `attention.sliding_window`. `rope.dimension_count` is ignored since `Cohere2Config` derives `head_dim = hidden_size // num_attention_heads`.
- **`GGUFCohere2Converter`**: builds on `GPT2Converter` (Cohere GGUFs use byte-level BPE, `tokenizer.ggml.model = "gpt2"`), and additionally:
  - registers control tokens (`token_type == 3`, e.g. `<|START_OF_TURN_TOKEN|>`) as special tokens so they are never split by BPE,
  - prepends BOS via a `TemplateProcessing` post-processor (`tokenizer.ggml.add_bos_token = true` in Cohere GGUFs — Cohere2 generation degenerates without BOS).
- Tensor mapping needs no custom `TensorProcessor` — the model is dense and gguf-py's `MODEL_ARCH.COHERE2` name map covers all tensors.
- Tests: generation test + tokenizer round-trip test in `tests/quantization/ggml/test_ggml.py`.

## Testing done

Verified locally with `bartowski/c4ai-command-r7b-12-2024-GGUF` (Q2_K):

- **Config**: all fields match the original `Cohere2Config` (hidden 4096, 32 layers, 32/8 heads, logit_scale 0.25, sliding_window 4096, rope_theta 50000, layer_types pattern).
- **Weights**: all 258 GGUF tensors map to HF parameters, zero unmapped in either direction (lm_head correctly tied).
- **Tokenizer parity**: token-by-token identical with the original tokenizer on a 19-case battery (unicode, digits, contractions, whitespace, control tokens, chat template, with/without special tokens).
- **Generation** (greedy, Q2_K, fp16): coherent output; chat-template prompt "What is the capital of France?" → "Paris."
- `RUN_SLOW=1 pytest tests/quantization/ggml/test_ggml.py -k cohere2` passes locally (CPU).

Note: `EXPECTED_TEXT` in `test_cohere2_q2_k` was produced on CPU (fp16) — happy to update if the CI GPU runners produce a different completion.

Fixes item "c4ai-command-a" in #33260.

## Who can review?

@SunMarc @Isotr0py

🤖 Generated with [Claude Code](https://claude.com/claude-code)