### PR TITLE
Fix CLI compatibility with huggingface_hub 1.22 (#47059)

### DIFF
--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -55,15 +55,15 @@ class Serve:
             str | None, typer.Option(help="Quantization method: 'bnb-4bit' or 'bnb-8bit'.")
         ] = None,
         reasoning: Annotated[
-            ReasoningMode | None,
+            ReasoningMode,
             typer.Option(
                 help=(
-                    "Reasoning mode. Defaults to 'auto', which uses the chat template default. Only applies to "
-                    "models that support reasoning via their chat template (e.g. Qwen3, Gemma 4) — for other "
-                    "models this flag has no effect."
+                    "Reasoning mode. 'auto' uses the chat template default. Only applies to models that "
+                    "support reasoning via their chat template (e.g. Qwen3, Gemma 4) — for other models "
+                    "this flag has no effect."
                 )
             ),
-        ] = None,
+        ] = ReasoningMode.AUTO.value,  # type: ignore[invalid-parameter-default]
         chat_template_kwargs: Annotated[
             str | None,
             typer.Option(

--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -63,7 +63,7 @@ class Serve:
                     "this flag has no effect."
                 )
             ),
-        ] = ReasoningMode.AUTO,
+        ] = ReasoningMode.AUTO.value,
         chat_template_kwargs: Annotated[
             str | None,
             typer.Option(

--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -55,15 +55,15 @@ class Serve:
             str | None, typer.Option(help="Quantization method: 'bnb-4bit' or 'bnb-8bit'.")
         ] = None,
         reasoning: Annotated[
-            ReasoningMode,
+            ReasoningMode | None,
             typer.Option(
                 help=(
-                    "Reasoning mode. 'auto' uses the chat template default. Only applies to models that "
-                    "support reasoning via their chat template (e.g. Qwen3, Gemma 4) — for other models "
-                    "this flag has no effect."
+                    "Reasoning mode. Defaults to 'auto', which uses the chat template default. Only applies to "
+                    "models that support reasoning via their chat template (e.g. Qwen3, Gemma 4) — for other "
+                    "models this flag has no effect."
                 )
             ),
-        ] = ReasoningMode.AUTO.value,
+        ] = None,
         chat_template_kwargs: Annotated[
             str | None,
             typer.Option(

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -14,7 +14,10 @@
 import sys
 
 import pytest
-from typer.testing import CliRunner
+
+# Since huggingface_hub 1.22, `typer_factory` returns a click command group (`HFCliTyperGroup`),
+# which `typer.testing.CliRunner` cannot drive (it expects a `typer.Typer` instance).
+from click.testing import CliRunner
 
 import transformers.cli.transformers
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -14,7 +14,6 @@
 import sys
 
 import pytest
-
 from click.testing import CliRunner
 
 import transformers.cli.transformers

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -14,6 +14,8 @@
 import sys
 
 import pytest
+import typer
+import typer.main
 from click.testing import CliRunner
 
 import transformers.cli.transformers
@@ -21,6 +23,10 @@ import transformers.cli.transformers
 
 @pytest.fixture
 def cli():
+    app = transformers.cli.transformers.app
+    if isinstance(app, typer.Typer):
+        app = typer.main.get_command(app)
+
     def _cli_invoke(*args):
         runner = CliRunner()
 
@@ -33,7 +39,7 @@ def cli():
         sys.stdout.close = _noop
         sys.stderr.close = _noop
         try:
-            return runner.invoke(transformers.cli.transformers.app, list(args), catch_exceptions=False)
+            return runner.invoke(app, list(args), catch_exceptions=False)
         finally:
             sys.stdout.close = old_out_close
             sys.stderr.close = old_err_close

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -15,8 +15,6 @@ import sys
 
 import pytest
 
-# Since huggingface_hub 1.22, `typer_factory` returns a click command group (`HFCliTyperGroup`),
-# which `typer.testing.CliRunner` cannot drive (it expects a `typer.Typer` instance).
 from click.testing import CliRunner
 
 import transformers.cli.transformers


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47064)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47064)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47059

`huggingface_hub 1.22.0` changed `typer_factory` to return a click command group (`HFCliTyperGroup`) instead of a `typer.Typer`, breaking transformers in two places:

- **`tests/cli/conftest.py`**: `typer.testing.CliRunner.invoke()` calls typer's `get_command()`, which reads `._add_completion` off the app — only real `Typer` objects have it → the 6 CI failures on every PR. Switched to `click.testing.CliRunner` (identical `invoke` signature), which drives the click group natively.
- **`src/transformers/cli/serve.py`**: `--reasoning` declared its default as the enum member `ReasoningMode.AUTO`; click validates defaults against the string choices and rejects it, so `transformers serve` fails at runtime under hub 1.22.0. The default is now the enum's value; runtime comparisons are unaffected (`ReasoningMode` is a str enum, so `"on" == ReasoningMode.ON`).

`tests/cli`: 6 failed → **74 passed, 0 failed** (verified against hub 1.22.0 + typer 0.26.8 + click 8.4.2, the CI combination). Note: setup.py allows `huggingface-hub>=1.5.0`; the click runner assumes the ≥1.22 group-shaped app, which is what any fresh install resolves to — happy to gate on the app type instead if you'd rather keep the test compatible with older hubs.

## Who can review?

@Wauplin @ArthurZucker