### PR TITLE
Don't crash the ASR pipeline when an installed torchcodec cannot be imported

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -365,9 +365,19 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 inputs = inputs.cpu().numpy()
 
         if is_torchcodec_available():
-            import torchcodec
+            try:
+                import torchcodec
+            except (ImportError, OSError):
+                # torchcodec wheels are built against a specific torch and FFmpeg, and a mismatched
+                # install fails at import time. It is only needed for AudioDecoder inputs, so a broken
+                # install should not fail inputs that never use it.
+                torchcodec = None
+                logger.warning_once(
+                    "torchcodec is installed but could not be imported. "
+                    "torchcodec.decoders.AudioDecoder inputs will not be supported."
+                )
 
-            if isinstance(inputs, torchcodec.decoders.AudioDecoder):
+            if torchcodec is not None and isinstance(inputs, torchcodec.decoders.AudioDecoder):
                 _audio_samples = inputs.get_all_samples()
 
                 # torchcodec always returns (num_channels, num_samples)

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import unittest
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -1262,6 +1264,37 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         output = speech_recognizer([audio_tiled], batch_size=2)
         self.assertEqual(output, [{"text": ANY(str)}])
         self.assertEqual(output[0]["text"][:6], "ZBT ZC")
+
+    @require_torch
+    def test_torchcodec_import_failure_is_ignored(self):
+        """A torchcodec install that cannot be imported (e.g. built against a mismatched torch or
+        FFmpeg) should not break inputs that never needed torchcodec."""
+        speech_recognizer = pipeline(
+            task="automatic-speech-recognition",
+            model="hf-internal-testing/tiny-random-wav2vec2",
+        )
+        waveform = np.tile(np.arange(1000, dtype=np.float32), 10)
+
+        class RaisingFinder:
+            def find_spec(self, name, path=None, target=None):
+                if name == "torchcodec" or name.startswith("torchcodec."):
+                    raise OSError("Could not load this library: libtorchcodec_core7.so")
+                return None
+
+        finder = RaisingFinder()
+        previously_imported = sys.modules.pop("torchcodec", None)
+        sys.meta_path.insert(0, finder)
+        try:
+            with mock.patch(
+                "transformers.pipelines.automatic_speech_recognition.is_torchcodec_available", return_value=True
+            ):
+                output = speech_recognizer(waveform)
+        finally:
+            sys.meta_path.remove(finder)
+            if previously_imported is not None:
+                sys.modules["torchcodec"] = previously_imported
+
+        self.assertIn("text", output)
 
     @require_torch
     def test_input_parameter_passthrough(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47071)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47071)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47070

`AutomaticSpeechRecognitionPipeline.preprocess` imports torchcodec whenever the package is installed:

```python
if is_torchcodec_available():
    import torchcodec
```

`is_torchcodec_available()` is a package-metadata check, not an importability check. torchcodec wheels are binary-tied to a specific torch/FFmpeg but declare no torch requirement in their metadata, so resolvers routinely produce installed-but-unimportable combinations (e.g. `torch==2.10.0` + `torchcodec==0.14.0`, a pairing pip/uv will create today via `pyannote-audio` → `torchcodec`). The bare import then raises `OSError` and crashes **every** pipeline call — including plain file-path, array, and `{"raw": ...}` inputs that never needed torchcodec, since the file-path branch decodes with `ffmpeg_read`.

This PR wraps the import in `try/except (ImportError, OSError)`: on failure, torchcodec is treated as unavailable with a one-time warning, and only `torchcodec.decoders.AudioDecoder` inputs lose support (they would fail to exist anyway). No behavior change for healthy installs.

Real-world impact example: this failure mode currently breaks 100% of fresh installs of `insanely-fast-whisper` (worked around downstream in Vaibhavs10/insanely-fast-whisper#283).

Includes a regression test that simulates a broken torchcodec via a meta-path finder raising `OSError`, with `is_torchcodec_available` patched to `True`, and asserts the pipeline still transcribes a plain numpy waveform.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a Github issue? → #47070
- [x] Did you write any new necessary tests?

## Who can review?

Pipelines: @Rocketknight1