### PR TITLE
Fix get_json_schema crash on non-string docstring choices

### DIFF
--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -371,7 +371,7 @@ def get_json_schema(func: Callable) -> dict:
         desc = param_descriptions[arg]
         enum_choices = re.search(r"\(choices:\s*(.*?)\)\s*$", desc, flags=re.IGNORECASE)
         if enum_choices:
-            schema["enum"] = [c.strip() for c in json.loads(enum_choices.group(1))]
+            schema["enum"] = [c.strip() if isinstance(c, str) else c for c in json.loads(enum_choices.group(1))]
             desc = enum_choices.string[: enum_choices.start()].strip()
         schema["description"] = desc
 

--- a/tests/utils/test_chat_template_utils.py
+++ b/tests/utils/test_chat_template_utils.py
@@ -384,6 +384,41 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
 
         self.assertEqual(schema["function"], expected_schema)
 
+    def test_enum_extraction_non_string_choices(self):
+        def fn(rating: int, enabled: bool):
+            """
+            Test function
+
+            Args:
+                rating: The rating to give (choices: [1, 2, 3])
+                enabled: Whether it is enabled (choices: [true, false])
+            """
+            return -40.0
+
+        # Non-string choices (numbers, booleans) must be preserved as-is, not stripped as strings
+        schema = get_json_schema(fn)
+        expected_schema = {
+            "name": "fn",
+            "description": "Test function",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "rating": {
+                        "type": "integer",
+                        "enum": [1, 2, 3],
+                        "description": "The rating to give",
+                    },
+                    "enabled": {
+                        "type": "boolean",
+                        "enum": [True, False],
+                        "description": "Whether it is enabled",
+                    },
+                },
+                "required": ["rating", "enabled"],
+            },
+        }
+        self.assertEqual(schema["function"], expected_schema)
+
     def test_literal(self):
         def fn(
             temperature_format: Literal["celsius", "fahrenheit"],


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47072)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47072)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`get_json_schema` parses a docstring's `(choices: ...)` block with `json.loads`, so it accepts any JSON values, but it then calls `.strip()` on every element. This raises `AttributeError: 'int' object has no attribute 'strip'` for non-string choices such as `(choices: [1, 2, 3])` or `(choices: [true, false])`:

```python
def rate(score: int):
    """Rate it.

    Args:
        score: The score to give (choices: [1, 2, 3])
    """

get_json_schema(rate)  # AttributeError: 'int' object has no attribute 'strip'
```
The equivalent `Literal[1, 2, 3]` type hint already produces a valid non-string enum (covered by `test_literal`), so this makes the docstring `(choices: ...)` path consistent: strip only string choices and leave other JSON values (ints, bools, ...) as-is. Added a regression test (`test_enum_extraction_non_string_choices`) covering int and bool choices.

No prior issue; this is a small, self-contained bug fix.

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. (No prior issue; small bug fix.)
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)? (No docs change needed.)
- [X] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)? (Added `test_enum_extraction_non_string_choices`.)


## Who can review?

@Rocketknight1 (chat templates / tool-use JSON schema)