### PR TITLE
Fix AltCLIP text embedding resize test

### DIFF
--- a/src/transformers/models/altclip/modeling_altclip.py
+++ b/src/transformers/models/altclip/modeling_altclip.py
@@ -839,7 +839,7 @@ class AltRobertaModel(AltCLIPPreTrainedModel):
 class AltCLIPTextModel(AltCLIPPreTrainedModel):
     config: AltCLIPTextConfig
     input_modalities = ("text",)
-    _input_embed_layer = "word_embedding"
+    _input_embed_layer = "word_embeddings"
     base_model_prefix = "roberta"
 
     def __init__(self, config):

--- a/src/transformers/models/altclip/modular_altclip.py
+++ b/src/transformers/models/altclip/modular_altclip.py
@@ -387,7 +387,7 @@ class AltRobertaModel(AltCLIPPreTrainedModel):
 class AltCLIPTextModel(AltCLIPPreTrainedModel):
     config: AltCLIPTextConfig
     input_modalities = ("text",)
-    _input_embed_layer = "word_embedding"
+    _input_embed_layer = "word_embeddings"
     base_model_prefix = "roberta"
 
     def __init__(self, config):

--- a/tests/models/altclip/test_modeling_altclip.py
+++ b/tests/models/altclip/test_modeling_altclip.py
@@ -293,9 +293,6 @@ class AltCLIPTextModelTest(ModelTesterMixin, unittest.TestCase):
     # AltCLIPTextModel has large embeddings relative to model size, so we need higher split percentages
     model_split_percents = [0.5, 0.8, 0.9]
 
-    def test_resize_tokens_embeddings(self):
-        super().test_resize_tokens_embeddings()
-
     def setUp(self):
         self.model_tester = AltCLIPTextModelTester(self)
         self.config_tester = ConfigTester(self, config_class=AltCLIPTextConfig, hidden_size=32)

--- a/tests/models/altclip/test_modeling_altclip.py
+++ b/tests/models/altclip/test_modeling_altclip.py
@@ -293,8 +293,6 @@ class AltCLIPTextModelTest(ModelTesterMixin, unittest.TestCase):
     # AltCLIPTextModel has large embeddings relative to model size, so we need higher split percentages
     model_split_percents = [0.5, 0.8, 0.9]
 
-    # TODO (@SunMarc): Fix me
-    @unittest.skip(reason="It's broken.")
     def test_resize_tokens_embeddings(self):
         super().test_resize_tokens_embeddings()
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47079)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47079)
<!-- ci-dashboard-badge:end -->

**Title**  
Fix AltCLIP text embedding resize test

**Description**  
This PR re-enables the AltCLIP text model resize-token-embeddings test and fixes the `_input_embed_layer` name on `AltCLIPTextModel` to match the actual nested `word_embeddings` module.

The resize path now correctly points tooling and common model utilities at the text embeddings, and the previously skipped common resize test is restored.

Verification:
- Ran a local reproduction of the common resize-token-embeddings flow.
- Ran `py_compile` on the touched AltCLIP files.
- Could not run targeted pytest locally because `parameterized` is missing in the environment.


@zucchini-nlp @ArthurZucker