### PR TITLE
Add eval_epochs to TrainingArguments to support evaluating every N epochs

### DIFF
--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -612,7 +612,10 @@ class DefaultFlowCallback(TrainerCallback):
 
         # Evaluate
         if args.eval_strategy == IntervalStrategy.EPOCH and args.eval_delay <= state.epoch:
-            control.should_evaluate = True
+            is_eval_epoch = round(state.epoch) % args.eval_epochs == 0
+            is_last_epoch = round(state.epoch) >= state.num_train_epochs
+            if is_eval_epoch or is_last_epoch:
+                control.should_evaluate = True
 
         # Save
         if args.save_strategy == SaveStrategy.EPOCH:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -420,6 +420,10 @@ class TrainingArguments:
             Number of update steps between two evaluations if `eval_strategy="steps"`. Will default to the same
             value as `logging_steps` if not set. Should be an integer or a float in range `[0,1)`. If smaller than 1,
             will be interpreted as ratio of total training steps.
+        eval_epochs (`int`, *optional*, defaults to 1):
+            Number of epochs between two evaluations if `eval_strategy="epoch"`. Has no effect for any other
+            `eval_strategy`. Useful when evaluation is expensive and running it after every single epoch would slow
+            training down. For example, `eval_epochs=5` only evaluates at the end of epochs 5, 10, 15, and so on.
         eval_delay (`float`, *optional*):
             Number of epochs or steps to wait for before the first evaluation can be performed, depending on the
             eval_strategy.
@@ -1071,6 +1075,14 @@ class TrainingArguments:
             )
         },
     )
+    eval_epochs: int = field(
+        default=1,
+        metadata={
+            "help": (
+                "Number of epochs between evaluations if `eval_strategy='epoch'`. Ignored for any other eval_strategy."
+            )
+        },
+    )
     eval_delay: float = field(
         default=0,
         metadata={
@@ -1521,6 +1533,14 @@ class TrainingArguments:
                     f"evaluation strategy {self.eval_strategy} requires either non-zero --eval_steps or"
                     " --logging_steps"
                 )
+
+        if self.eval_epochs is not None and self.eval_epochs < 1:
+            raise ValueError(f"eval_epochs must be a positive integer, got {self.eval_epochs}")
+        if self.eval_strategy != IntervalStrategy.EPOCH and self.eval_epochs != 1:
+            logger.warning(
+                f"eval_epochs={self.eval_epochs} was set but eval_strategy is '{self.eval_strategy.value}', so"
+                " eval_epochs has no effect. Set eval_strategy='epoch' to use it."
+            )
 
         if (
             self.load_best_model_at_end

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -1341,3 +1341,73 @@ class NotebookProgressCallbackTest(unittest.TestCase):
         self.assertIn("eval_loss", metrics1)
         self.assertIn("eval_loss", metrics2)
         self.assertIn("eval_loss", metrics3)
+
+
+class DefaultFlowCallbackEvalEpochsTest(unittest.TestCase):
+    """Tests for the eval_epochs argument used by DefaultFlowCallback.on_epoch_end."""
+
+    def _run_epochs(self, num_train_epochs, eval_epochs, eval_delay=0):
+        args = TrainingArguments(
+            output_dir=tempfile.mkdtemp(),
+            eval_strategy="epoch",
+            eval_epochs=eval_epochs,
+            eval_delay=eval_delay,
+        )
+        state = TrainerState()
+        state.num_train_epochs = num_train_epochs
+        callback = DefaultFlowCallback()
+
+        evaluated_epochs = []
+        for epoch in range(1, num_train_epochs + 1):
+            state.epoch = float(epoch)
+            control = TrainerControl()
+            callback.on_epoch_end(args, state, control)
+            if control.should_evaluate:
+                evaluated_epochs.append(epoch)
+        return evaluated_epochs
+
+    def test_default_eval_epochs_evaluates_every_epoch(self):
+        """eval_epochs defaults to 1, so evaluation should fire after every epoch."""
+        evaluated_epochs = self._run_epochs(num_train_epochs=4, eval_epochs=1)
+
+        self.assertEqual(evaluated_epochs, [1, 2, 3, 4])
+
+    def test_eval_epochs_skips_intermediate_epochs(self):
+        """With eval_epochs=3, only epochs 3, 6, 9 should trigger evaluation."""
+        evaluated_epochs = self._run_epochs(num_train_epochs=9, eval_epochs=3)
+
+        self.assertEqual(evaluated_epochs, [3, 6, 9])
+
+    def test_eval_epochs_always_evaluates_final_epoch(self):
+        """The last epoch should always be evaluated, even if it isn't a multiple of eval_epochs."""
+        evaluated_epochs = self._run_epochs(num_train_epochs=10, eval_epochs=3)
+
+        self.assertEqual(evaluated_epochs, [3, 6, 9, 10])
+
+    def test_eval_epochs_respects_eval_delay(self):
+        """No evaluation should happen before eval_delay, even on a multiple of eval_epochs."""
+        evaluated_epochs = self._run_epochs(num_train_epochs=6, eval_epochs=2, eval_delay=3)
+
+        self.assertEqual(evaluated_epochs, [4, 6])
+
+    def test_eval_epochs_zero_or_negative_raises(self):
+        """eval_epochs must be a positive integer."""
+        with self.assertRaises(ValueError):
+            TrainingArguments(output_dir=tempfile.mkdtemp(), eval_strategy="epoch", eval_epochs=0)
+
+    def test_eval_epochs_ignored_when_strategy_is_not_epoch(self):
+        """eval_epochs should have no effect when eval_strategy is 'steps' or 'no'."""
+        args = TrainingArguments(
+            output_dir=tempfile.mkdtemp(),
+            eval_strategy="steps",
+            eval_steps=10,
+            eval_epochs=5,
+        )
+        state = TrainerState()
+        state.num_train_epochs = 3
+        state.epoch = 1.0
+        control = TrainerControl()
+
+        DefaultFlowCallback().on_epoch_end(args, state, control)
+
+        self.assertFalse(control.should_evaluate)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47084)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47084)
<!-- ci-dashboard-badge:end -->

Fixes #45308

`eval_strategy` currently only supports `"steps"` and `"epoch"`, with no way to evaluate every N epochs. This is a problem when evaluation is expensive (large eval sets, generation-based metrics) and training runs for many epochs.

This PR adds a new `eval_epochs` argument (default `1`, so existing behavior is unchanged) to `TrainingArguments`, and uses it in `DefaultFlowCallback.on_epoch_end` to only trigger evaluation on epochs that are multiples of `eval_epochs`.

Two details worth calling out for review:
- The final training epoch always triggers evaluation, even if it isn't a multiple of `eval_epochs`, so users always get metrics for their last checkpoint.
- Setting `eval_epochs` while `eval_strategy` isn't `"epoch"` doesn't raise, but logs a warning, since it's a silent no-op otherwise and I'd rather not break scripts that set it defensively.

**Testing:** added `DefaultFlowCallbackEvalEpochsTest` in `tests/trainer/test_trainer_callback.py` covering default behavior, skipping intermediate epochs, forced final-epoch evaluation, interaction with `eval_delay`, the `eval_epochs < 1` validation error, and no-op behavior under `eval_strategy="steps"`. Full `tests/trainer/test_trainer_callback.py` suite passes (57 passed, 3 skipped). `ruff check` and `ruff format --check` are clean on all changed files.