### PR TITLE
Fix AqlmConfig error messages to say "int" instead of "float"

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -905,13 +905,13 @@ class AqlmConfig(QuantizationConfigMixin):
         Safety checker that arguments are correct - also replaces some NoneType arguments with their default values.
         """
         if not isinstance(self.in_group_size, int):
-            raise TypeError("in_group_size must be a float")
+            raise TypeError("in_group_size must be an int")
         if not isinstance(self.out_group_size, int):
-            raise TypeError("out_group_size must be a float")
+            raise TypeError("out_group_size must be an int")
         if not isinstance(self.num_codebooks, int):
-            raise TypeError("num_codebooks must be a float")
+            raise TypeError("num_codebooks must be an int")
         if not isinstance(self.nbits_per_codebook, int):
-            raise TypeError("nbits_per_codebook must be a float")
+            raise TypeError("nbits_per_codebook must be an int")
 
         if self.linear_weights_not_to_quantize is not None and not isinstance(
             self.linear_weights_not_to_quantize, list

--- a/tests/quantization/aqlm_integration/test_aqlm.py
+++ b/tests/quantization/aqlm_integration/test_aqlm.py
@@ -67,6 +67,20 @@ class AqlmConfigTest(unittest.TestCase):
         self.assertEqual(dict["nbits_per_codebook"], quantization_config.nbits_per_codebook)
         self.assertEqual(dict["linear_weights_not_to_quantize"], quantization_config.linear_weights_not_to_quantize)
 
+    def test_int_fields_reject_non_int_with_correct_message(self):
+        """
+        The int-only fields must reject non-int values with a message that says "int",
+        not "float" (which is what these fields actually require).
+        """
+        for field, value in [
+            ("in_group_size", 8.0),
+            ("out_group_size", 1.0),
+            ("num_codebooks", 2.0),
+            ("nbits_per_codebook", 8.0),
+        ]:
+            with self.assertRaisesRegex(TypeError, f"{field} must be an int"):
+                AqlmConfig(**{field: value})
+
 
 @slow
 @require_torch_accelerator

--- a/tests/quantization/aqlm_integration/test_aqlm.py
+++ b/tests/quantization/aqlm_integration/test_aqlm.py
@@ -67,21 +67,6 @@ class AqlmConfigTest(unittest.TestCase):
         self.assertEqual(dict["nbits_per_codebook"], quantization_config.nbits_per_codebook)
         self.assertEqual(dict["linear_weights_not_to_quantize"], quantization_config.linear_weights_not_to_quantize)
 
-    def test_int_fields_reject_non_int_with_correct_message(self):
-        """
-        The int-only fields must reject non-int values with a message that says "int",
-        not "float" (which is what these fields actually require).
-        """
-        for field, value in [
-            ("in_group_size", 8.0),
-            ("out_group_size", 1.0),
-            ("num_codebooks", 2.0),
-            ("nbits_per_codebook", 8.0),
-        ]:
-            with self.assertRaisesRegex(TypeError, f"{field} must be an int"):
-                AqlmConfig(**{field: value})
-
-
 @slow
 @require_torch_accelerator
 @require_aqlm

--- a/tests/quantization/aqlm_integration/test_aqlm.py
+++ b/tests/quantization/aqlm_integration/test_aqlm.py
@@ -67,6 +67,7 @@ class AqlmConfigTest(unittest.TestCase):
         self.assertEqual(dict["nbits_per_codebook"], quantization_config.nbits_per_codebook)
         self.assertEqual(dict["linear_weights_not_to_quantize"], quantization_config.linear_weights_not_to_quantize)
 
+
 @slow
 @require_torch_accelerator
 @require_aqlm


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47089)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47089)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`AqlmConfig.post_init` validates that `in_group_size`, `out_group_size`, `num_codebooks` and `nbits_per_codebook` are ints (`not isinstance(x, int)`), but the raised `TypeError` messages say each "must be a float". That's misleading - passing a float is exactly what triggers the error, so a user who hits it and then passes another float stays stuck.

```python
from transformers import AqlmConfig
AqlmConfig(num_codebooks=2.0)
# TypeError: num_codebooks must be a float   (but an int is what's actually required)
```

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
No linked issue - small self-contained fix.

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

@SunMarc (quantization)

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->