### PR TITLE
Fix CohereAsr training-loss double-shift (train against labels, not labels[..., 1:])

### DIFF
--- a/src/transformers/models/cohere_asr/modeling_cohere_asr.py
+++ b/src/transformers/models/cohere_asr/modeling_cohere_asr.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
+from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
@@ -637,7 +638,8 @@ class CohereAsrForConditionalGeneration(CohereAsrPreTrainedModel, GenerationMixi
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
+            loss_fct = CrossEntropyLoss()
+            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/cohere_asr/modeling_cohere_asr.py
+++ b/src/transformers/models/cohere_asr/modeling_cohere_asr.py
@@ -22,7 +22,6 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
-from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
@@ -638,8 +637,13 @@ class CohereAsrForConditionalGeneration(CohereAsrPreTrainedModel, GenerationMixi
 
         loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
+            # labels were already right-shifted into decoder_input_ids above (whisper legacy
+            # convention), so logits[i] lines up with labels[i]. Pass them as shift_labels so
+            # ForCausalLMLoss skips its internal shift but keeps num_items_in_batch handling
+            # (proper loss reduction under gradient accumulation).
+            loss = self.loss_function(
+                logits=logits, labels=None, shift_labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/cohere_asr/modular_cohere_asr.py
+++ b/src/transformers/models/cohere_asr/modular_cohere_asr.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
+from torch.nn import CrossEntropyLoss
 
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
 from ...generation import GenerationMixin
@@ -500,7 +501,8 @@ class CohereAsrForConditionalGeneration(MoonshineForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
+            loss_fct = CrossEntropyLoss()
+            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/cohere_asr/modular_cohere_asr.py
+++ b/src/transformers/models/cohere_asr/modular_cohere_asr.py
@@ -16,7 +16,6 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
-from torch.nn import CrossEntropyLoss
 
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
 from ...generation import GenerationMixin
@@ -501,8 +500,13 @@ class CohereAsrForConditionalGeneration(MoonshineForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
+            # labels were already right-shifted into decoder_input_ids above (whisper legacy
+            # convention), so logits[i] lines up with labels[i]. Pass them as shift_labels so
+            # ForCausalLMLoss skips its internal shift but keeps num_items_in_batch handling
+            # (proper loss reduction under gradient accumulation).
+            loss = self.loss_function(
+                logits=logits, labels=None, shift_labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/moonshine/modeling_moonshine.py
+++ b/src/transformers/models/moonshine/modeling_moonshine.py
@@ -24,7 +24,6 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
-from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
@@ -934,8 +933,13 @@ class MoonshineForConditionalGeneration(MoonshinePreTrainedModel, GenerationMixi
 
         loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
+            # labels were already right-shifted into decoder_input_ids above (whisper legacy
+            # convention), so logits[i] lines up with labels[i]. Pass them as shift_labels so
+            # ForCausalLMLoss skips its internal shift but keeps num_items_in_batch handling
+            # (proper loss reduction under gradient accumulation).
+            loss = self.loss_function(
+                logits=logits, labels=None, shift_labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/moonshine/modular_moonshine.py
+++ b/src/transformers/models/moonshine/modular_moonshine.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 from huggingface_hub.dataclasses import strict
-from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
@@ -773,8 +772,13 @@ class MoonshineForConditionalGeneration(MoonshinePreTrainedModel, GenerationMixi
 
         loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
+            # labels were already right-shifted into decoder_input_ids above (whisper legacy
+            # convention), so logits[i] lines up with labels[i]. Pass them as shift_labels so
+            # ForCausalLMLoss skips its internal shift but keeps num_items_in_batch handling
+            # (proper loss reduction under gradient accumulation).
+            loss = self.loss_function(
+                logits=logits, labels=None, shift_labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
@@ -25,7 +25,6 @@ from typing import Optional
 import torch
 import torch.nn as nn
 from torch import Tensor
-from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
@@ -1098,8 +1097,13 @@ class MoonshineStreamingForConditionalGeneration(MoonshineStreamingPreTrainedMod
 
         loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
+            # labels were already right-shifted into decoder_input_ids above (whisper legacy
+            # convention), so logits[i] lines up with labels[i]. Pass them as shift_labels so
+            # ForCausalLMLoss skips its internal shift but keeps num_items_in_batch handling
+            # (proper loss reduction under gradient accumulation).
+            loss = self.loss_function(
+                logits=logits, labels=None, shift_labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/pp_formulanet/modeling_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/modeling_pp_formulanet.py
@@ -1103,8 +1103,16 @@ class PPFormulaNetForConditionalGeneration(PPFormulaNetPreTrainedModel, Generati
 
         loss = None
         if labels is not None:
+            # decoder_input_ids are built by right-shifting input_ids (mbart legacy convention),
+            # so logits[i] already lines up with labels[i]. Pass them as shift_labels so
+            # ForCausalLMLoss skips its internal shift but keeps num_items_in_batch handling
+            # (proper loss reduction under gradient accumulation), as Florence2 does.
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+                logits=logits,
+                labels=None,
+                shift_labels=labels,
+                vocab_size=self.config.text_config.vocab_size,
+                **kwargs,
             )
 
         return Seq2SeqLMOutput(

--- a/src/transformers/models/pp_formulanet/modular_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/modular_pp_formulanet.py
@@ -488,8 +488,16 @@ class PPFormulaNetForConditionalGeneration(Florence2ForConditionalGeneration):
 
         loss = None
         if labels is not None:
+            # decoder_input_ids are built by right-shifting input_ids (mbart legacy convention),
+            # so logits[i] already lines up with labels[i]. Pass them as shift_labels so
+            # ForCausalLMLoss skips its internal shift but keeps num_items_in_batch handling
+            # (proper loss reduction under gradient accumulation), as Florence2 does.
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+                logits=logits,
+                labels=None,
+                shift_labels=labels,
+                vocab_size=self.config.text_config.vocab_size,
+                **kwargs,
             )
 
         return Seq2SeqLMOutput(

--- a/tests/models/cohere_asr/test_modeling_cohere_asr.py
+++ b/tests/models/cohere_asr/test_modeling_cohere_asr.py
@@ -179,8 +179,9 @@ class CohereAsrModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         # contrary to the llama-like approach where labels == input_ids and ForCausalLMLoss
         # shifts internally so logits[i] predicts labels[i+1], here forward already right-shifts labels
         # into decoder_input_ids via shift_tokens_right (which also prepends decoder_start_token_id)
-        # (whisper legacy paradigm). The loss must therefore be a plain CE against the
-        # (unshifted) labels; using self.loss_function/ForCausalLMLoss would shift a second time.
+        # (whisper legacy paradigm). The loss must therefore be a CE against the (unshifted) labels:
+        # forward passes them as shift_labels so ForCausalLMLoss skips its internal shift (which
+        # would shift a second time) while keeping num_items_in_batch handling for grad accumulation.
         from torch.nn import CrossEntropyLoss
 
         config = self.model_tester.get_config()
@@ -207,6 +208,14 @@ class CohereAsrModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
                 out = model(input_features=input_features, labels=lbl, use_cache=False)
             self.assertTrue(torch.allclose(out.loss, aligned_ce(out.logits, lbl)))
             self.assertFalse(torch.allclose(out.loss, double_shift_ce(out.logits, lbl)))
+
+        # with num_items_in_batch (as passed by Trainer under gradient accumulation), the loss
+        # must be summed over tokens and divided by the global count, not mean-reduced per step
+        num_items = (padded != -100).sum()
+        with torch.no_grad():
+            out = model(input_features=input_features, labels=padded, use_cache=False, num_items_in_batch=num_items)
+        summed_ce = CrossEntropyLoss(reduction="sum")(out.logits.reshape(-1, vocab_size), padded.reshape(-1))
+        self.assertTrue(torch.allclose(out.loss, summed_ce / num_items))
 
     def test_reverse_loading_mapping(self):
         # proj_out conversion only applies to ForConditionalGeneration, not the base model

--- a/tests/models/cohere_asr/test_modeling_cohere_asr.py
+++ b/tests/models/cohere_asr/test_modeling_cohere_asr.py
@@ -175,6 +175,35 @@ class CohereAsrModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_config(self):
         self.config_tester.run_common_tests()
 
+    def test_training_loss_no_double_shift(self):
+        # forward shifts labels into decoder_input_ids, so loss must be plain CE against the labels (no second shift)
+        from torch.nn import CrossEntropyLoss
+
+        config = self.model_tester.get_config()
+        config.pad_token_id = self.model_tester.pad_token_id
+        model = CohereAsrForConditionalGeneration(config).to(torch_device).eval()
+        vocab_size = config.vocab_size
+
+        torch.manual_seed(0)
+        bsz, dec_len = 2, 6
+        input_features = floats_tensor([bsz, self.model_tester.seq_length, self.model_tester.num_mel_bins], scale=1.0)
+        labels = torch.randint(3, vocab_size, (bsz, dec_len), device=torch_device)
+        padded = labels.clone()
+        padded[0, -1] = -100
+        padded[1, -2:] = -100
+
+        def aligned_ce(logits, lbl):
+            return CrossEntropyLoss()(logits.reshape(-1, vocab_size), lbl.reshape(-1))
+
+        def double_shift_ce(logits, lbl):
+            return CrossEntropyLoss()(logits[..., :-1, :].reshape(-1, vocab_size), lbl[..., 1:].reshape(-1))
+
+        for lbl in (labels, padded):
+            with torch.no_grad():
+                out = model(input_features=input_features, labels=lbl, use_cache=False)
+            self.assertTrue(torch.allclose(out.loss, aligned_ce(out.logits, lbl)))
+            self.assertFalse(torch.allclose(out.loss, double_shift_ce(out.logits, lbl)))
+
     def test_reverse_loading_mapping(self):
         # proj_out conversion only applies to ForConditionalGeneration, not the base model
         super().test_reverse_loading_mapping(skip_base_model=True)

--- a/tests/models/cohere_asr/test_modeling_cohere_asr.py
+++ b/tests/models/cohere_asr/test_modeling_cohere_asr.py
@@ -176,7 +176,11 @@ class CohereAsrModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         self.config_tester.run_common_tests()
 
     def test_training_loss_no_double_shift(self):
-        # forward shifts labels into decoder_input_ids, so loss must be plain CE against the labels (no second shift)
+        # contrary to the llama-like approach where labels == input_ids and ForCausalLMLoss
+        # shifts internally so logits[i] predicts labels[i+1], here forward already right-shifts labels
+        # into decoder_input_ids via shift_tokens_right (which also prepends decoder_start_token_id)
+        # (whisper legacy paradigm). The loss must therefore be a plain CE against the
+        # (unshifted) labels; using self.loss_function/ForCausalLMLoss would shift a second time.
         from torch.nn import CrossEntropyLoss
 
         config = self.model_tester.get_config()

--- a/tests/models/cohere_asr/test_modeling_cohere_asr.py
+++ b/tests/models/cohere_asr/test_modeling_cohere_asr.py
@@ -210,8 +210,10 @@ class CohereAsrModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
             self.assertFalse(torch.allclose(out.loss, double_shift_ce(out.logits, lbl)))
 
         # with num_items_in_batch (as passed by Trainer under gradient accumulation), the loss
-        # must be summed over tokens and divided by the global count, not mean-reduced per step
-        num_items = (padded != -100).sum()
+        # must be summed over tokens and divided by the global count, not mean-reduced per step.
+        # Use a global count different from this batch's valid-token count (as with 2 accumulation
+        # steps) so the summed path is distinguishable from the mean.
+        num_items = 2 * (padded != -100).sum()
         with torch.no_grad():
             out = model(input_features=input_features, labels=padded, use_cache=False, num_items_in_batch=num_items)
         summed_ce = CrossEntropyLoss(reduction="sum")(out.logits.reshape(-1, vocab_size), padded.reshape(-1))

--- a/tests/models/moonshine/test_modeling_moonshine.py
+++ b/tests/models/moonshine/test_modeling_moonshine.py
@@ -152,7 +152,9 @@ class MoonshineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
         self.config_tester.run_common_tests()
 
     def test_training_loss_no_double_shift(self):
-        # forward shifts labels into decoder_input_ids, so loss must be plain CE against the labels (no second shift)
+        # forward shifts labels into decoder_input_ids, so the loss must be a CE against the
+        # (unshifted) labels: forward passes them as shift_labels so ForCausalLMLoss skips its
+        # internal shift while keeping num_items_in_batch handling for gradient accumulation
         from torch.nn import CrossEntropyLoss
 
         from transformers.models.moonshine.modeling_moonshine import MoonshineEncoderModelOutput
@@ -182,6 +184,16 @@ class MoonshineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
                 out = model(encoder_outputs=encoder_outputs, labels=lbl, use_cache=False)
             self.assertTrue(torch.allclose(out.loss, aligned_ce(out.logits, lbl)))
             self.assertFalse(torch.allclose(out.loss, double_shift_ce(out.logits, lbl)))
+
+        # with num_items_in_batch (as passed by Trainer under gradient accumulation), the loss
+        # must be summed over tokens and divided by the global count, not mean-reduced per step.
+        # Use a global count different from this batch's valid-token count (as with 2 accumulation
+        # steps) so the summed path is distinguishable from the mean.
+        num_items = 2 * (padded != -100).sum()
+        with torch.no_grad():
+            out = model(encoder_outputs=encoder_outputs, labels=padded, use_cache=False, num_items_in_batch=num_items)
+        summed_ce = CrossEntropyLoss(reduction="sum")(out.logits.reshape(-1, vocab_size), padded.reshape(-1))
+        self.assertTrue(torch.allclose(out.loss, summed_ce / num_items))
 
     def test_attention_outputs(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/models/moonshine_streaming/test_modeling_moonshine_streaming.py
+++ b/tests/models/moonshine_streaming/test_modeling_moonshine_streaming.py
@@ -157,7 +157,9 @@ class MoonshineStreamingModelTest(ModelTesterMixin, PipelineTesterMixin, unittes
         self.config_tester.run_common_tests()
 
     def test_training_loss_no_double_shift(self):
-        # forward shifts labels into decoder_input_ids, so loss must be plain CE against the labels (no second shift)
+        # forward shifts labels into decoder_input_ids, so the loss must be a CE against the
+        # (unshifted) labels: forward passes them as shift_labels so ForCausalLMLoss skips its
+        # internal shift while keeping num_items_in_batch handling for gradient accumulation
         from torch.nn import CrossEntropyLoss
 
         from transformers.models.moonshine_streaming.modeling_moonshine_streaming import (
@@ -189,6 +191,16 @@ class MoonshineStreamingModelTest(ModelTesterMixin, PipelineTesterMixin, unittes
                 out = model(encoder_outputs=encoder_outputs, labels=lbl, use_cache=False)
             self.assertTrue(torch.allclose(out.loss, aligned_ce(out.logits, lbl)))
             self.assertFalse(torch.allclose(out.loss, double_shift_ce(out.logits, lbl)))
+
+        # with num_items_in_batch (as passed by Trainer under gradient accumulation), the loss
+        # must be summed over tokens and divided by the global count, not mean-reduced per step.
+        # Use a global count different from this batch's valid-token count (as with 2 accumulation
+        # steps) so the summed path is distinguishable from the mean.
+        num_items = 2 * (padded != -100).sum()
+        with torch.no_grad():
+            out = model(encoder_outputs=encoder_outputs, labels=padded, use_cache=False, num_items_in_batch=num_items)
+        summed_ce = CrossEntropyLoss(reduction="sum")(out.logits.reshape(-1, vocab_size), padded.reshape(-1))
+        self.assertTrue(torch.allclose(out.loss, summed_ce / num_items))
 
     def test_can_init_all_missing_weights(self):
         self.skipTest("MoonshineStreaming uses special parameter initialization that conflicts with this test")

--- a/tests/models/pp_formulanet/test_modeling_pp_formulanet.py
+++ b/tests/models/pp_formulanet/test_modeling_pp_formulanet.py
@@ -131,6 +131,50 @@ class PPFormulaNetModelTest(VLMModelTest, unittest.TestCase):
     test_resize_embeddings = False
     is_encoder_decoder = True
 
+    def test_training_loss_no_double_shift(self):
+        # decoder_input_ids are built by right-shifting input_ids (mbart legacy convention), so
+        # logits[i] lines up with labels[i]. forward passes labels as shift_labels so ForCausalLMLoss
+        # skips its internal shift while keeping num_items_in_batch handling for grad accumulation.
+        from torch.nn import CrossEntropyLoss
+
+        config = self.model_tester.get_config()
+        model = PPFormulaNetForConditionalGeneration(config).to(torch_device).eval()
+        vocab_size = config.text_config.vocab_size
+
+        torch.manual_seed(0)
+        bsz, dec_len = 2, 6
+        pixel_values = floats_tensor(
+            [bsz, self.model_tester.num_channels, self.model_tester.image_size, self.model_tester.image_size]
+        )
+        labels = torch.randint(3, vocab_size, (bsz, dec_len), device=torch_device)
+
+        def aligned_ce(logits, lbl):
+            return CrossEntropyLoss()(logits.reshape(-1, vocab_size), lbl.reshape(-1))
+
+        def double_shift_ce(logits, lbl):
+            return CrossEntropyLoss()(logits[..., :-1, :].reshape(-1, vocab_size), lbl[..., 1:].reshape(-1))
+
+        with torch.no_grad():
+            out = model(pixel_values=pixel_values, input_ids=labels, labels=labels, use_cache=False)
+        self.assertTrue(torch.allclose(out.loss, aligned_ce(out.logits, labels)))
+        self.assertFalse(torch.allclose(out.loss, double_shift_ce(out.logits, labels)))
+
+        # with num_items_in_batch (as passed by Trainer under gradient accumulation), the loss
+        # must be summed over tokens and divided by the global count, not mean-reduced per step.
+        # Use a global count different from this batch's token count (as with 2 accumulation
+        # steps) so the summed path is distinguishable from the mean.
+        num_items = 2 * labels.numel()
+        with torch.no_grad():
+            out = model(
+                pixel_values=pixel_values,
+                input_ids=labels,
+                labels=labels,
+                use_cache=False,
+                num_items_in_batch=torch.tensor(num_items),
+            )
+        summed_ce = CrossEntropyLoss(reduction="sum")(out.logits.reshape(-1, vocab_size), labels.reshape(-1))
+        self.assertTrue(torch.allclose(out.loss, summed_ce / num_items))
+
     def _check_encoder_attention_for_generate(self, attentions, batch_size, config, prompt_length):
         # Ignoring batch size for now as it is dynamically changed during window partitioning
         encoder_config = self.model_tester.vision_config


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47090)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47090)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`CohereAsrForConditionalGeneration.forward` right-shifts `labels` into `decoder_input_ids` via `shift_tokens_right`, then computes the loss with `self.loss_function` (`ForCausalLMLoss`), which shifts the labels a second time internally. The model therefore trains against `labels[..., 1:]` instead of `labels`.

Verified on main (`b70d02fc72`) with a tiny random-init model:

```
model loss:            4.990426
aligned CE (correct):  4.985212
double-shift CE (bug): 4.990426
```

This is the same bug fixed for Moonshine in #46784. CohereAsr inherits from Moonshine but overrides `forward`, so that fix didn't propagate.

The fix keeps `self.loss_function` and passes the (already aligned) labels as `shift_labels`, so `ForCausalLMLoss` skips its internal shift while preserving the `num_items_in_batch` handling needed for correct loss reduction under gradient accumulation — same pattern as Florence2 after #46898. Changed in `modular_cohere_asr.py` and regenerated `modeling_cohere_asr.py` with the modular converter.

Also adds the same regression test as Moonshine's (`test_training_loss_no_double_shift`, with and without `-100` padding), extended with an assertion for the `num_items_in_batch` (summed) reduction path. It fails on current main and passes with this fix; the full `tests/models/cohere_asr` file passes (124 passed, 138 skipped).

Fixes #46894
Closes #46895, closes #46958 (earlier PRs for the same issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the forum? Please add a link to it if that's the case. → #46894
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@eustlb @vasqu
