### PR TITLE
[sdpa] Allow prefill to use FA kernel with StaticCache

### DIFF
--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -62,6 +62,9 @@ def sdpa_attention_forward(
         else:
             sdpa_kwargs = {"enable_gqa": True}
 
+    q_length = query.shape[2]
+    kv_length = key.shape[2]
+
     # Instead of relying on the value set in the module directly, we use the is_causal passed in kwargs if it is presented
     is_causal = is_causal if is_causal is not None else getattr(module, "is_causal", True)
 
@@ -75,7 +78,7 @@ def sdpa_attention_forward(
     #   full graph options. Otherwise, dynamic shapes are prevented from compiling.
     # - It is important to check first for the shape, otherwise compile will fail with
     #   `argument 'is_causal' must be bool, not SymBool`.
-    is_causal = query.shape[2] > 1 and attention_mask is None and is_causal
+    is_causal = q_length > 1 and attention_mask is None and is_causal
 
     # Shapes (e.g. query.shape[2]) are tensors during jit tracing, resulting in `is_causal` being a tensor.
     # We convert it to a bool for the SDPA kernel that only accepts bools.
@@ -89,6 +92,16 @@ def sdpa_attention_forward(
         if attention_mask is not None and attention_mask.dtype != torch.bool:
             # Convert to boolean type, making sdpa to force call FlashAttentionScore to improve performance.
             attention_mask = torch.logical_not(attention_mask.bool()).to(query.device)
+
+    # This scenario can only happen during prefill with an empty StaticCache. Technically, since sdpa's `is_causal` mask alignment
+    # is upper-left, `is_causal=True` is enough to correctly compute the attention. However, sdpa will only dispatch to
+    # flash kernel if and only if q_length == kv_length, therefore it is more efficient to slice here and remove the masked tokens
+    # rather than to use the other available kernels for such a case.
+    # Note that we never compile prefill, and even if the user is doing it on its own, prefill and decode are 2 separate graphs
+    # anyway, so altering the shapes is fine here
+    if is_causal and attention_mask is None and q_length > 1 and kv_length > q_length:
+        key = key[:, :, :q_length, :]
+        value = value[:, :, :q_length, :]
 
     attn_output = torch.nn.functional.scaled_dot_product_attention(
         query,

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -935,13 +935,9 @@ def create_causal_mask(
     # are properly index-based as required by our implementation).
     use_vmap = False
 
-    # Do not allow skip if we are compiling (this is to match BC)
-    # TODO: cyril -> probably revisit and remove this, but a lot of tests rely on it
-    if _is_torch_xpu_available:
-        # Do not allow skip if we are compiling for decoding, but for prefill, we still allow skip to optimization the perf of 1st token generation
-        allow_is_causal_skip = not (getattr(past_key_values, "is_compileable", False) and q_length == 1)
-    else:
-        allow_is_causal_skip = not getattr(past_key_values, "is_compileable", False)
+    # Do not allow skip if we are compiling and decoding (but for prefill, we still allow skip to optimize the perfs since
+    # prefill is not compiled)
+    allow_is_causal_skip = not (getattr(past_key_values, "is_compileable", False) and q_length == 1)
 
     # Allow slight deviations from causal mask
     # Note that it is very important to apply this before any other deviations of the mask (such as packed sequence mask,
@@ -1164,9 +1160,9 @@ def create_sliding_window_causal_mask(
     # users passing custom mask functions (as we cannot guarantee that they
     # are properly index-based as required by our implementation).
     use_vmap = False
-    # Do not allow skip if we are compiling (this is to match BC)
-    # TODO: cyril -> probably revisit and remove this, but a lot of tests rely on it
-    allow_is_causal_skip = not getattr(past_key_values, "is_compileable", False)
+    # Do not allow skip if we are compiling and decoding (but for prefill, we still allow skip to optimize the perfs since
+    # prefill is not compiled)
+    allow_is_causal_skip = not (getattr(past_key_values, "is_compileable", False) and q_length == 1)
 
     # Allow slight deviations from causal mask
     # Note that it is very important to apply this before any other deviations of the mask (such as packed sequence mask,
@@ -1379,9 +1375,9 @@ def create_chunked_causal_mask(
     # users passing custom mask functions (as we cannot guarantee that they
     # are properly index-based as required by our implementation).
     use_vmap = False
-    # Do not allow skip if we are compiling (this is to match BC)
-    # TODO: cyril -> probably revisit and remove this, but a lot of tests rely on it
-    allow_is_causal_skip = not getattr(past_key_values, "is_compileable", False)
+    # Do not allow skip if we are compiling and decoding (but for prefill, we still allow skip to optimize the perfs since
+    # prefill is not compiled)
+    allow_is_causal_skip = not (getattr(past_key_values, "is_compileable", False) and q_length == 1)
 
     # Allow slight deviations from causal mask
     # Note that it is very important to apply this before any other deviations of the mask (such as packed sequence mask,

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -227,44 +227,6 @@ def maybe_pad_block_sequence_ids(
     return block_sequence_ids
 
 
-def _can_skip_causal_mask_xpu(
-    padding_mask: torch.Tensor | None,
-    q_length: int,
-    kv_length: int,
-    q_offset: int,
-    kv_offset: int,
-    local_attention_size: int | None,
-) -> bool:
-    """
-    XPU-specific logic for determining if we can skip causal mask creation.
-
-    For XPU devices, we have special handling:
-    - Single query tokens (query_length == 1) use the same logic as CUDA
-    - Multi-query tokens can skip if padding_mask is provided and correctly structured
-      The mask must have all True values in the query window and all False after
-    """
-
-    if is_tracing(padding_mask):
-        return False
-
-    # Check local attention constraint (same as CUDA)
-    if local_attention_size is not None and kv_length >= local_attention_size:
-        return False
-
-    if padding_mask is None:
-        # Without padding mask, can skip if single query token or full causal attention
-        return q_length == 1 or kv_length == q_length
-
-    # XPU allows skipping under additional conditions when padding_mask is provided
-    if q_length == 1:
-        # Single query token: skip only if no padding tokens present
-        return padding_mask.all()
-
-    # XPU-specific: check if query window is all True and rest is all False.
-    # This allows XPU to optimize the 1st token in static cache when the cache is empty.
-    return q_offset == 0 and padding_mask[:, :q_length].all() and not padding_mask[:, q_length:].any()
-
-
 def _ignore_causal_mask_sdpa(
     padding_mask: torch.Tensor | None,
     q_length: int,
@@ -284,13 +246,6 @@ def _ignore_causal_mask_sdpa(
     if padding_mask is not None and padding_mask.shape[-1] > kv_length:
         mask_indices = torch.arange(kv_length, device=padding_mask.device) + kv_offset
         padding_mask = padding_mask[:, mask_indices]
-
-    if _is_torch_xpu_available:
-        # XPU devices have special handling for mask skipping:
-        # - Single query tokens use the same logic as CUDA
-        # - Multi-query tokens can skip if padding_mask is provided and correctly structured
-        #   (all True in query window, all False after)
-        return _can_skip_causal_mask_xpu(padding_mask, q_length, kv_length, q_offset, kv_offset, local_attention_size)
 
     # When using `torch.export` or `torch.onnx.dynamo_export`, we must pass an example input, and `is_causal` behavior is
     # hard-coded to the forward. If a user exports a model with query_length > 1, the exported model will hard-code `is_causal=True`

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -227,6 +227,11 @@ def maybe_pad_block_sequence_ids(
     return block_sequence_ids
 
 
+def fast_all(tensor: torch.BoolTensor) -> torch.BoolTensor:
+    """Similar to `tensor.all()`, but uses an implementation with `tensor.sum()`, which is actually much faster."""
+    return tensor.sum() == tensor.numel()
+
+
 def _ignore_causal_mask_sdpa(
     padding_mask: torch.Tensor | None,
     q_length: int,
@@ -260,13 +265,13 @@ def _ignore_causal_mask_sdpa(
     # If `q_length == 1`, we then use `is_causal=False` in sdpa integration to mimic lower-right alignment. If `kv_length == q_length`,
     # we use `is_causal=True` as upper-left alignment (torch's default) is the same as lower-right in this case. If we have padding,
     # we need to add padding to the mask, so cannot be skipped
-    if (q_length == 1 or kv_length == q_length) and (padding_mask is None or padding_mask.all()):
+    if (q_length == 1 or kv_length == q_length) and (padding_mask is None or fast_all(padding_mask)):
         return True
     # Additional case to optimize prefill: if the cache is empty (`q_offset == 0`), we can use `is_causal=True` even
     # with a padding_mask, if the padding_mask only contains padding related to "future k/v tokens" of the static k/v states
     # returned by StaticCaches. This works thanks to the upper-left alignment of sdpa's `is_causal` mask
     if q_offset == 0 and (
-        padding_mask is None or (padding_mask[:, :q_length].all() and not padding_mask[:, q_length:].any())
+        padding_mask is None or (fast_all(padding_mask[:, :q_length]) and fast_all(~padding_mask[:, q_length:]))
     ):
         return True
 

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -265,7 +265,9 @@ def _ignore_causal_mask_sdpa(
     # Additional case to optimize prefill: if the cache is empty (`q_offset == 0`), we can use `is_causal=True` even
     # with a padding_mask, if the padding_mask only contains padding related to "future k/v tokens" of the static k/v states
     # returned by StaticCaches. This works thanks to the upper-left alignment of sdpa's `is_causal` mask
-    if q_offset == 0 and padding_mask[:, :q_length].all() and not padding_mask[:, q_length:].any():
+    if q_offset == 0 and (
+        padding_mask is None or (padding_mask[:, :q_length].all() and not padding_mask[:, q_length:].any())
+    ):
         return True
 
     return False

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -282,8 +282,7 @@ def _ignore_causal_mask_sdpa(
     passed).
     """
     if padding_mask is not None and padding_mask.shape[-1] > kv_length:
-        mask_indices = torch.arange(kv_length, device=padding_mask.device)
-        mask_indices += kv_offset
+        mask_indices = torch.arange(kv_length, device=padding_mask.device) + kv_offset
         padding_mask = padding_mask[:, mask_indices]
 
     if _is_torch_xpu_available:
@@ -292,19 +291,26 @@ def _ignore_causal_mask_sdpa(
         # - Multi-query tokens can skip if padding_mask is provided and correctly structured
         #   (all True in query window, all False after)
         return _can_skip_causal_mask_xpu(padding_mask, q_length, kv_length, q_offset, kv_offset, local_attention_size)
+
     # When using `torch.export` or `torch.onnx.dynamo_export`, we must pass an example input, and `is_causal` behavior is
     # hard-coded to the forward. If a user exports a model with query_length > 1, the exported model will hard-code `is_causal=True`
     # which is in general wrong (see https://github.com/pytorch/pytorch/issues/108108). Thus, we only set
     # `ignore_causal_mask = True` if we are not tracing
-    if (
-        not is_tracing(padding_mask)
-        # only cases when lower and upper diags are the same, see https://github.com/pytorch/pytorch/issues/108108
-        and (q_length == 1 or kv_length == q_length)
-        # in this case we need to add special patterns to the mask so cannot be skipped otherwise
-        and (local_attention_size is None or kv_length < local_attention_size)
-        # In this case, we need to add padding to the mask, so cannot be skipped otherwise
-        and (padding_mask is None or padding_mask.all())
-    ):
+    if is_tracing(padding_mask):
+        return False
+    # In this case, we need to add special patterns to the mask no matter what, so we cannot use any of the later skip conditions
+    if local_attention_size is not None and kv_length >= local_attention_size:
+        return False
+
+    # If `q_length == 1`, we then use `is_causal=False` in sdpa integration to mimic lower-right alignment. If `kv_length == q_length`,
+    # we use `is_causal=True` as upper-left alignment (torch's default) is the same as lower-right in this case. If we have padding,
+    # we need to add padding to the mask, so cannot be skipped
+    if (q_length == 1 or kv_length == q_length) and (padding_mask is None or padding_mask.all()):
+        return True
+    # Additional case to optimize prefill: if the cache is empty (`q_offset == 0`), we can use `is_causal=True` even
+    # with a padding_mask, if the padding_mask only contains padding related to "future k/v tokens" of the static k/v states
+    # returned by StaticCaches. This works thanks to the upper-left alignment of sdpa's `is_causal` mask
+    if q_offset == 0 and padding_mask[:, :q_length].all() and not padding_mask[:, q_length:].any():
         return True
 
     return False


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47094)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47094)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

As per the title. In general, we have no reason to constrain the prefill to have a mask with sdpa, as most usual situations will not need it. It's more efficient to let it dispatch to the FA kernel if we can. 

It also has the following benefits:
- much faster, with quadratic benefits as the prefill size increases (e.g. 10% faster for input size `(1, 512)` and max cache len `2048`, and a huge 260% faster for input size `(1, 8k)` and max cache length `16k`)
- aligns `_ignore_causal_mask_sdpa` to be the same for cuda and xpu, saving redundant code
- improve the previous xpu version, so that a model that returns `None` early via the `create_mask_for_generate` call will STILL return None quickly after reentering the mask creation function in the model (see issue https://github.com/huggingface/transformers/issues/46962 and PR https://github.com/huggingface/transformers/pull/47019), which should avoid headaches in the future

With a llama 8B with `32` layers, i.e. `32` attention calls during the prefill, an input size of `(1, 512)`, and a max cache length of `2048`, I measured the prefill (excluding cache lazy init) to take an average of `0.029` s with this PR, compared to `0.032` s on main -> 10% faster for small sizes.
For bigger sizes, the benefits are much greater: for size `(1, 8192)` and max cache length `16384`, prefill took `0.735` s on main vs `0.280` s on this PR -> 260% faster

Script used for benchmarking:
<details>

<summary>benchmark.py</summary>

```python
import torch
from transformers import AutoModelForCausalLM, StaticCache, GenerationConfig
import time

model_id = "meta-llama/Llama-3.1-8B-Instruct"
device = 0
prefill_size = 8192
max_len = 16384

model = AutoModelForCausalLM.from_pretrained(model_id, device_map=device)

ids = torch.randint(100, 200, (1, prefill_size), device=device)
generation_config = GenerationConfig()
model_kwargs = {
    "past_key_values": StaticCache(config=model.config, max_cache_len=max_len),
    "position_ids": torch.arange(prefill_size, device=device)[None, :],
    "attention_mask": torch.ones_like(ids)
}

# Lazy init the cache to avoid measuring cache allocation
with torch.no_grad():
    out = model._prefill(
        ids,
        generation_config=generation_config,
        model_kwargs=model_kwargs,
    )

N = 100
times = []
for _ in range(N):
    with torch.no_grad():
        # Reset cache to empty
        model_kwargs["past_key_values"].reset()
        t0 = time.time()
        out = model._prefill(
            ids,
            generation_config=generation_config,
            model_kwargs=model_kwargs,
        )
        dt = time.time() - t0
        times.append(dt)

print(f"Took {torch.mean(torch.tensor(times)):.3f} s in average")
```

</details>

cc @vasqu, @kaixuanliu for viz as well 