### PR TITLE
Fix mllama cross-attention leak for fully masked-out text rows

### DIFF
--- a/src/transformers/models/mllama/modeling_mllama.py
+++ b/src/transformers/models/mllama/modeling_mllama.py
@@ -691,6 +691,8 @@ class MllamaCrossAttentionDecoderLayer(GradientCheckpointingLayer):
             past_key_values=past_key_values,
             **kwargs,
         )
+        if full_text_row_masked_out_mask is not None:
+            hidden_states = full_text_row_masked_out_mask[:, 0] * hidden_states  # type: ignore
         hidden_states = residual + self.cross_attn_attn_gate.tanh() * hidden_states
 
         residual = hidden_states

--- a/tests/models/mllama/test_modeling_mllama.py
+++ b/tests/models/mllama/test_modeling_mllama.py
@@ -726,3 +726,60 @@ class MllamaForConditionalGenerationIntegrationTest(unittest.TestCase):
             expected_output,
             f"Decoded output: {decoded_output}\nExpected output: {expected_output}",
         )
+
+
+@require_torch
+class MllamaCrossAttentionMaskTest(unittest.TestCase):
+    def test_full_text_row_masked_out_mask_blocks_cross_attention_residual(self):
+        """
+        Regression test for #39379. A text row that is fully masked out of cross-attention (e.g. a
+        token that precedes its image) must not receive any image information. `full_text_row_masked_out_mask`
+        was only applied to the MLP output, so the cross-attention result still leaked into the row
+        through the residual connection. Such a row must come out of the decoder layer unchanged.
+        """
+        from transformers.models.mllama.modeling_mllama import MllamaCrossAttentionDecoderLayer
+
+        config = MllamaTextConfig(
+            vocab_size=99,
+            hidden_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            intermediate_size=37,
+            hidden_act="gelu",
+            max_position_embeddings=512,
+            rope_parameters={"rope_type": "default"},
+        )
+        config._attn_implementation = "eager"
+
+        torch.manual_seed(0)
+        layer = MllamaCrossAttentionDecoderLayer(config, layer_idx=0).eval()
+        # The cross-attention and MLP contributions are tanh-gated and the gates are zero-initialized,
+        # so open them to make the residual contributions non-trivial for this test.
+        with torch.no_grad():
+            layer.cross_attn_attn_gate.fill_(1.0)
+            layer.cross_attn_mlp_gate.fill_(1.0)
+
+        batch_size, seq_len, image_len = 1, 4, 6
+        hidden_states = torch.randn(batch_size, seq_len, config.hidden_size)
+        cross_attention_states = torch.randn(batch_size, image_len, config.hidden_size)
+
+        # Row 0 is masked out of cross-attention (it precedes the image); the other rows attend normally.
+        full_text_row_masked_out_mask = torch.ones(batch_size, 1, seq_len, 1)
+        full_text_row_masked_out_mask[:, :, 0, :] = 0.0
+
+        output = layer(
+            hidden_states=hidden_states,
+            cross_attention_states=cross_attention_states,
+            cross_attention_mask=None,
+            attention_mask=None,
+            full_text_row_masked_out_mask=full_text_row_masked_out_mask,
+            past_key_values=None,
+            use_cache=False,
+            position_embeddings=None,
+        )
+
+        # The fully masked-out row must be untouched by cross-attention...
+        torch.testing.assert_close(output[:, 0], hidden_states[:, 0])
+        # ...while a row that does attend to the image is modified.
+        self.assertFalse(torch.allclose(output[:, 1], hidden_states[:, 1]))


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47103)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47103)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #39379. In `MllamaCrossAttentionDecoderLayer.forward`, `full_text_row_masked_out_mask` was applied only to the MLP output, but not to the cross-attention output before its residual add. As a result, text rows that are fully masked out of cross-attention (tokens that precede their `<|image|>`) still received image information through the residual connection.

This matches the reference implementation, which applies the mask both after the attention and after the MLP. The added lines mirror the existing post-MLP masking:

```python
if full_text_row_masked_out_mask is not None:
    hidden_states = full_text_row_masked_out_mask[:, 0] * hidden_states  # type: ignore
hidden_states = residual + self.cross_attn_attn_gate.tanh() * hidden_states
```

As noted in the issue, the discrepancy only appears when the image is **not** the first token, which is why the existing tests (built around image-first prompts) didn't catch it.

## Tests

Adds `MllamaCrossAttentionMaskTest` (CPU-only): it drives a single `MllamaCrossAttentionDecoderLayer` with a fully masked-out text row and asserts that row is left unchanged by the layer (no cross-attention leakage), while a row that does attend to the image is modified. The gates are tanh-gated and zero-initialized, so the test opens them to make the residual contributions non-trivial. It fails on `main` (100% of the masked row's elements change) and passes with the fix.

```
pytest tests/models/mllama/test_modeling_mllama.py::MllamaCrossAttentionMaskTest
```

## Who can review?

@zucchini-nlp (thanks for the go-ahead on the issue) @ArthurZucker