### PR TITLE
docs: fix LED config max_decoder_position_embeddings default (16384 -> 1024)

### DIFF
--- a/src/transformers/models/led/configuration_led.py
+++ b/src/transformers/models/led/configuration_led.py
@@ -25,7 +25,7 @@ class LEDConfig(PreTrainedConfig):
     r"""
     max_encoder_position_embeddings (`int`, *optional*, defaults to 16384):
         The maximum sequence length that the encoder might ever be used with.
-    max_decoder_position_embeddings (`int`, *optional*, defaults to 16384):
+    max_decoder_position_embeddings (`int`, *optional*, defaults to 1024):
         The maximum sequence length that the decoder might ever be used with.
     attention_window (`int` or `list[int]`, *optional*, defaults to 512):
         Size of an attention window around each token. If an `int`, use the same size for all layers. To specify a


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47106)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47106)
<!-- ci-dashboard-badge:end -->

The `max_decoder_position_embeddings` docstring documents `defaults to 16384`, but the actual default in `__init__` is `1024`. The `16384` value belongs to `max_encoder_position_embeddings`, matching the canonical LED architecture (e.g. allenai/led-base-16384: encoder 16384 / decoder 1024). This is a docstring-only fix to align the documented default with the code.