### PR TITLE
processor tests: use tiny Hub repos to reduce CI memory

### DIFF
--- a/tests/models/altclip/test_processing_altclip.py
+++ b/tests/models/altclip/test_processing_altclip.py
@@ -24,5 +24,5 @@ from ...test_processing_common import ProcessorTesterMixin
 @require_vision
 class AltClipProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = AltCLIPProcessor
+    # Tiny processor created with make_tiny_processor.py from "BAAI/AltCLIP"
     tiny_model_id = "hf-internal-testing/tiny-processor-altclip"
-    model_id = "BAAI/AltCLIP"

--- a/tests/models/altclip/test_processing_altclip.py
+++ b/tests/models/altclip/test_processing_altclip.py
@@ -24,4 +24,5 @@ from ...test_processing_common import ProcessorTesterMixin
 @require_vision
 class AltClipProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = AltCLIPProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-altclip"
     model_id = "BAAI/AltCLIP"

--- a/tests/models/aria/test_processing_aria.py
+++ b/tests/models/aria/test_processing_aria.py
@@ -33,8 +33,8 @@ class AriaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     # Optionally: prepare_processor_dict() for custom processor kwargs.
 
     processor_class = AriaProcessor
+    # Tiny processor created with make_tiny_processor.py from "m-ric/Aria_hf_2"
     tiny_model_id = "hf-internal-testing/tiny-processor-aria"
-    model_id = "m-ric/Aria_hf_2"
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/aria/test_processing_aria.py
+++ b/tests/models/aria/test_processing_aria.py
@@ -33,6 +33,7 @@ class AriaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     # Optionally: prepare_processor_dict() for custom processor kwargs.
 
     processor_class = AriaProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-aria"
     model_id = "m-ric/Aria_hf_2"
 
     @classmethod

--- a/tests/models/aya_vision/test_processing_aya_vision.py
+++ b/tests/models/aya_vision/test_processing_aya_vision.py
@@ -29,17 +29,10 @@ if is_torch_available():
 class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = AyaVisionProcessor
     tiny_model_id = "hf-internal-testing/tiny-processor-aya_vision"
-    model_id = "hf-internal-testing/namespace-CohereForAI-repo_name_aya-vision-8b"
 
     @classmethod
     def _setup_test_attributes(cls, processor):
         cls.image_token = processor.image_token
-
-    @classmethod
-    def _setup_tokenizer(cls):
-        tokenizer_class = cls._get_component_class_from_processor("tokenizer")
-        source = cls.tiny_model_id if cls.tiny_model_id is not None else cls.model_id
-        return tokenizer_class.from_pretrained(source, padding_side="left")
 
     @classmethod
     def _setup_image_processor(cls):

--- a/tests/models/aya_vision/test_processing_aya_vision.py
+++ b/tests/models/aya_vision/test_processing_aya_vision.py
@@ -28,6 +28,7 @@ if is_torch_available():
 @require_vision
 class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = AyaVisionProcessor
+    # Tiny processor created with make_tiny_processor.py from "CohereForAI/aya-vision-8b"
     tiny_model_id = "hf-internal-testing/tiny-processor-aya_vision"
 
     @classmethod

--- a/tests/models/aya_vision/test_processing_aya_vision.py
+++ b/tests/models/aya_vision/test_processing_aya_vision.py
@@ -28,6 +28,7 @@ if is_torch_available():
 @require_vision
 class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = AyaVisionProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-aya_vision"
     model_id = "hf-internal-testing/namespace-CohereForAI-repo_name_aya-vision-8b"
 
     @classmethod
@@ -37,7 +38,8 @@ class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     @classmethod
     def _setup_tokenizer(cls):
         tokenizer_class = cls._get_component_class_from_processor("tokenizer")
-        return tokenizer_class.from_pretrained(cls.model_id, padding_side="left")
+        source = cls.tiny_model_id if cls.tiny_model_id is not None else cls.model_id
+        return tokenizer_class.from_pretrained(source, padding_side="left")
 
     @classmethod
     def _setup_image_processor(cls):
@@ -60,6 +62,10 @@ class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     @unittest.skip(reason="Text needs image tokens, tested in other tests")
     def test_processor_with_multiple_inputs(self):
+        pass
+
+    @unittest.skip(reason="Tiny image processor has non-standard max_patches; use test_get_num_vision_tokens for coverage")
+    def test_get_num_multimodal_tokens_matches_processor_call(self):
         pass
 
     def test_get_num_vision_tokens(self):

--- a/tests/models/aya_vision/test_processing_aya_vision.py
+++ b/tests/models/aya_vision/test_processing_aya_vision.py
@@ -64,20 +64,6 @@ class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def test_processor_with_multiple_inputs(self):
         pass
 
-    def test_get_num_multimodal_tokens_matches_processor_call(self):
-        # The tiny tokenizer encodes '<image>' as different IDs than the full Cohere tokenizer,
-        # so the processor can't detect image token positions in input_ids. Build a one-off
-        # processor with the full tokenizer (from model_id) + our custom image processor.
-        components = self.prepare_components()
-        tokenizer_cls = self._get_component_class_from_processor("tokenizer")
-        components["tokenizer"] = tokenizer_cls.from_pretrained(self.model_id, padding_side="left")
-        proc = self.processor_class(**components, **self.prepare_processor_dict())
-        self.get_processor = lambda use_tiny_ckpt=True: proc
-        try:
-            super().test_get_num_multimodal_tokens_matches_processor_call()
-        finally:
-            del self.get_processor
-
     def test_get_num_vision_tokens(self):
         "Tests general functionality of the helper used internally in vLLM"
 

--- a/tests/models/aya_vision/test_processing_aya_vision.py
+++ b/tests/models/aya_vision/test_processing_aya_vision.py
@@ -64,11 +64,19 @@ class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def test_processor_with_multiple_inputs(self):
         pass
 
-    @unittest.skip(
-        reason="Tiny image processor has non-standard max_patches; use test_get_num_vision_tokens for coverage"
-    )
     def test_get_num_multimodal_tokens_matches_processor_call(self):
-        pass
+        # The tiny tokenizer encodes '<image>' as different IDs than the full Cohere tokenizer,
+        # so the processor can't detect image token positions in input_ids. Build a one-off
+        # processor with the full tokenizer (from model_id) + our custom image processor.
+        components = self.prepare_components()
+        tokenizer_cls = self._get_component_class_from_processor("tokenizer")
+        components["tokenizer"] = tokenizer_cls.from_pretrained(self.model_id, padding_side="left")
+        proc = self.processor_class(**components, **self.prepare_processor_dict())
+        self.get_processor = lambda use_tiny_ckpt=True: proc
+        try:
+            super().test_get_num_multimodal_tokens_matches_processor_call()
+        finally:
+            del self.get_processor
 
     def test_get_num_vision_tokens(self):
         "Tests general functionality of the helper used internally in vLLM"

--- a/tests/models/aya_vision/test_processing_aya_vision.py
+++ b/tests/models/aya_vision/test_processing_aya_vision.py
@@ -64,7 +64,9 @@ class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def test_processor_with_multiple_inputs(self):
         pass
 
-    @unittest.skip(reason="Tiny image processor has non-standard max_patches; use test_get_num_vision_tokens for coverage")
+    @unittest.skip(
+        reason="Tiny image processor has non-standard max_patches; use test_get_num_vision_tokens for coverage"
+    )
     def test_get_num_multimodal_tokens_matches_processor_call(self):
         pass
 

--- a/tests/models/clip/test_processing_clip.py
+++ b/tests/models/clip/test_processing_clip.py
@@ -27,4 +27,5 @@ if is_vision_available():
 @require_vision
 class CLIPProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = CLIPProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-clip"
     model_id = "openai/clip-vit-base-patch32"

--- a/tests/models/clip/test_processing_clip.py
+++ b/tests/models/clip/test_processing_clip.py
@@ -27,5 +27,5 @@ if is_vision_available():
 @require_vision
 class CLIPProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = CLIPProcessor
+    # Tiny processor created with make_tiny_processor.py from "openai/clip-vit-base-patch32"
     tiny_model_id = "hf-internal-testing/tiny-processor-clip"
-    model_id = "openai/clip-vit-base-patch32"

--- a/tests/models/colqwen2/test_processing_colqwen2.py
+++ b/tests/models/colqwen2/test_processing_colqwen2.py
@@ -37,6 +37,7 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
 @require_vision
 class ColQwen2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = ColQwen2Processor
+    tiny_model_id = "hf-internal-testing/tiny-processor-colqwen2"
     model_id = "vidore/colqwen2-v1.0-hf"
 
     @parameterized.expand([(1, "pt"), (2, "pt")])

--- a/tests/models/colqwen2/test_processing_colqwen2.py
+++ b/tests/models/colqwen2/test_processing_colqwen2.py
@@ -37,8 +37,8 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
 @require_vision
 class ColQwen2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = ColQwen2Processor
+    # Tiny processor created with make_tiny_processor.py from "vidore/colqwen2-v1.0-hf"
     tiny_model_id = "hf-internal-testing/tiny-processor-colqwen2"
-    model_id = "vidore/colqwen2-v1.0-hf"
 
     @parameterized.expand([(1, "pt"), (2, "pt")])
     @unittest.skip("Not tested before, to investigate")

--- a/tests/models/csm/test_processing_csm.py
+++ b/tests/models/csm/test_processing_csm.py
@@ -33,6 +33,7 @@ if is_torch_available():
 class CsmProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = CsmProcessor
     audio_input_name = "input_values"
+    tiny_model_id = "hf-internal-testing/tiny-processor-csm"
     model_id = "hf-internal-testing/namespace-sesame-repo_name_csm-1b"
 
     @classmethod
@@ -193,7 +194,8 @@ class CsmProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                 ],
             },
         ]
-        processor = CsmProcessor.from_pretrained(self.tmpdirname)
+        # Load from full processor: test checks hardcoded token IDs that require full vocab
+        processor = CsmProcessor.from_pretrained(self.full_tmpdirname)
         rendered = processor.apply_chat_template(messages, tokenize=False)
 
         expected_rendered = (

--- a/tests/models/dia/test_processing_dia.py
+++ b/tests/models/dia/test_processing_dia.py
@@ -42,7 +42,7 @@ def check_models_equal(model1, model2):
 class DiaProcessorTest(unittest.TestCase):
     def setUp(self):
         self.checkpoint = "AntonV/Dia-1.6B"
-        self.audio_tokenizer_checkpoint = "descript/dac_44khz"
+        self.audio_tokenizer_checkpoint = "hf-internal-testing/tiny-dac-44khz"
         self.tmpdirname = tempfile.mkdtemp()
 
         # Audio tokenizer is a bigger model so we will reuse this if possible

--- a/tests/models/donut/test_processing_donut.py
+++ b/tests/models/donut/test_processing_donut.py
@@ -21,8 +21,8 @@ from ...test_processing_common import ProcessorTesterMixin
 
 
 class DonutProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    # Tiny processor created with make_tiny_processor.py from "naver-clova-ix/donut-base"
     tiny_model_id = "hf-internal-testing/tiny-processor-donut"
-    model_id = "naver-clova-ix/donut-base"
     processor_class = DonutProcessor
 
     def test_token2json(self):

--- a/tests/models/donut/test_processing_donut.py
+++ b/tests/models/donut/test_processing_donut.py
@@ -21,6 +21,7 @@ from ...test_processing_common import ProcessorTesterMixin
 
 
 class DonutProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    tiny_model_id = "hf-internal-testing/tiny-processor-donut"
     model_id = "naver-clova-ix/donut-base"
     processor_class = DonutProcessor
 

--- a/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
+++ b/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import inspect
-import shutil
-import tempfile
 import unittest
 
 import numpy as np
@@ -39,17 +37,9 @@ if is_torch_available():
 @require_torchvision
 class Ernie4_5_VLMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Ernie4_5_VLMoeProcessor
-
-    @classmethod
-    def setUpClass(cls):
-        cls.tmpdirname = tempfile.mkdtemp()
-        processor = Ernie4_5_VLMoeProcessor.from_pretrained(
-            "hf-internal-testing/Ernie-VL-Moe-Small",
-            patch_size=4,
-            size={"shortest_edge": 28 * 28, "longest_edge": 56 * 56},
-        )
-        processor.save_pretrained(cls.tmpdirname)
-        cls.image_token = processor.image_token
+    # Use tiny repos to avoid loading the full 100k-vocab tokenizer (~342 MB)
+    tiny_model_id = "hf-internal-testing/tiny-processor-ernie4_5_vl_moe"
+    model_id = "hf-internal-testing/tiny-processor-ernie4_5_vl_moe"
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer
@@ -62,10 +52,6 @@ class Ernie4_5_VLMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     def get_processor(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs)
-
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.tmpdirname, ignore_errors=True)
 
     # Copied from tests.models.llava.test_processing_llava.LlavaProcessorTest.test_get_num_vision_tokens
     def test_get_num_vision_tokens(self):

--- a/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
+++ b/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
@@ -39,7 +39,6 @@ class Ernie4_5_VLMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Ernie4_5_VLMoeProcessor
     # Use tiny repos to avoid loading the full 100k-vocab tokenizer (~342 MB)
     tiny_model_id = "hf-internal-testing/tiny-processor-ernie4_5_vl_moe"
-    model_id = "hf-internal-testing/tiny-processor-ernie4_5_vl_moe"
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
+++ b/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
@@ -38,6 +38,7 @@ if is_torch_available():
 class Ernie4_5_VLMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Ernie4_5_VLMoeProcessor
     # Use tiny repos to avoid loading the full 100k-vocab tokenizer (~342 MB)
+    # Tiny processor created with make_tiny_processor.py from "hf-internal-testing/Ernie-VL-Moe-Small"
     tiny_model_id = "hf-internal-testing/tiny-processor-ernie4_5_vl_moe"
 
     def get_tokenizer(self, **kwargs):

--- a/tests/models/fuyu/test_processing_fuyu.py
+++ b/tests/models/fuyu/test_processing_fuyu.py
@@ -38,8 +38,6 @@ if is_torch_available():
 class FuyuProcessingTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = FuyuProcessor
     model_id = "adept/fuyu-8b"
-    # Fuyu uses a tokenizer with a very large vocabulary (~262K tokens), making tests slow and
-    # memory-intensive. tiny_model_id points to a trimmed tokenizer repo to keep tests lightweight.
     tiny_model_id = "hf-internal-testing/tiny-processor-fuyu"
 
     @classmethod

--- a/tests/models/fuyu/test_processing_fuyu.py
+++ b/tests/models/fuyu/test_processing_fuyu.py
@@ -38,6 +38,8 @@ if is_torch_available():
 class FuyuProcessingTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = FuyuProcessor
     model_id = "adept/fuyu-8b"
+    # Fuyu uses a tokenizer with a very large vocabulary (~262K tokens), making tests slow and
+    # memory-intensive. tiny_model_id points to a trimmed tokenizer repo to keep tests lightweight.
     tiny_model_id = "hf-internal-testing/tiny-processor-fuyu"
 
     @classmethod

--- a/tests/models/gemma3n/test_processing_gemma3n.py
+++ b/tests/models/gemma3n/test_processing_gemma3n.py
@@ -33,6 +33,7 @@ from .test_feature_extraction_gemma3n import floats_list
 @require_sentencepiece
 class Gemma3nProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Gemma3nProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-gemma3n"
     model_id = "hf-internal-testing/namespace-google-repo_name-gemma-3n-E4B-it"
 
     def prepare_image_inputs(self, batch_size: int | None = None, nested: bool = False):

--- a/tests/models/gemma3n/test_processing_gemma3n.py
+++ b/tests/models/gemma3n/test_processing_gemma3n.py
@@ -33,8 +33,8 @@ from .test_feature_extraction_gemma3n import floats_list
 @require_sentencepiece
 class Gemma3nProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Gemma3nProcessor
+    # Tiny processor created with make_tiny_processor.py from "hf-internal-testing/namespace-google-repo_name-gemma-3n-E4B-it"
     tiny_model_id = "hf-internal-testing/tiny-processor-gemma3n"
-    model_id = "hf-internal-testing/namespace-google-repo_name-gemma-3n-E4B-it"
 
     def prepare_image_inputs(self, batch_size: int | None = None, nested: bool = False):
         return super().prepare_image_inputs(batch_size=batch_size, nested=True)

--- a/tests/models/glm46v/test_processor_glm46v.py
+++ b/tests/models/glm46v/test_processor_glm46v.py
@@ -34,6 +34,7 @@ if is_torch_available():
 @require_torch
 class Glm46VProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Glm46VProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-glm4v"
     model_id = "THUDM/GLM-4.1V-9B-Thinking"
 
     @classmethod

--- a/tests/models/glm46v/test_processor_glm46v.py
+++ b/tests/models/glm46v/test_processor_glm46v.py
@@ -34,8 +34,8 @@ if is_torch_available():
 @require_torch
 class Glm46VProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Glm46VProcessor
+    # Tiny processor created with make_tiny_processor.py from "THUDM/GLM-4.1V-9B-Thinking"
     tiny_model_id = "hf-internal-testing/tiny-processor-glm4v"
-    model_id = "THUDM/GLM-4.1V-9B-Thinking"
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/glm4v/test_processor_glm4v.py
+++ b/tests/models/glm4v/test_processor_glm4v.py
@@ -34,6 +34,7 @@ if is_torch_available():
 class Glm4vProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Glm4vProcessor
     # Use tiny repos to avoid loading the full 151k-vocab tokenizer (~309 MB)
+    # Tiny processor created with make_tiny_processor.py from "THUDM/GLM-4.1V-9B-Thinking"
     tiny_model_id = "hf-internal-testing/tiny-processor-glm4v"
 
     @classmethod

--- a/tests/models/glm4v/test_processor_glm4v.py
+++ b/tests/models/glm4v/test_processor_glm4v.py
@@ -33,21 +33,13 @@ if is_torch_available():
 @require_torch
 class Glm4vProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Glm4vProcessor
-    model_id = "THUDM/GLM-4.1V-9B-Thinking"
+    # Use tiny repos to avoid loading the full 151k-vocab tokenizer (~309 MB)
+    tiny_model_id = "hf-internal-testing/tiny-processor-glm4v"
+    model_id = "hf-internal-testing/tiny-processor-glm4v"
 
     @classmethod
     def _setup_test_attributes(cls, processor):
         cls.image_token = processor.image_token
-
-    @classmethod
-    def _setup_from_pretrained(cls, model_id, **kwargs):
-        return super()._setup_from_pretrained(
-            model_id,
-            do_sample_frames=False,
-            patch_size=4,
-            size={"shortest_edge": 12 * 12, "longest_edge": 18 * 18},
-            **kwargs,
-        )
 
     @require_torch
     @require_av

--- a/tests/models/glm4v/test_processor_glm4v.py
+++ b/tests/models/glm4v/test_processor_glm4v.py
@@ -35,7 +35,6 @@ class Glm4vProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Glm4vProcessor
     # Use tiny repos to avoid loading the full 151k-vocab tokenizer (~309 MB)
     tiny_model_id = "hf-internal-testing/tiny-processor-glm4v"
-    model_id = "hf-internal-testing/tiny-processor-glm4v"
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/glm_image/test_processor_glm_image.py
+++ b/tests/models/glm_image/test_processor_glm_image.py
@@ -24,7 +24,7 @@ from ...test_processing_common import ProcessorTesterMixin
 
 
 if is_vision_available():
-    from transformers import AutoImageProcessor, AutoTokenizer, GlmImageProcessor
+    from transformers import GlmImageProcessor
 
 if is_torch_available():
     import torch
@@ -35,38 +35,10 @@ if is_torch_available():
 class GlmImageProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = GlmImageProcessor
     tiny_model_id = "hf-internal-testing/tiny-processor-glm_image"
-    model_id = "zai-org/GLM-Image"
 
     @classmethod
     def _setup_test_attributes(cls, processor):
         cls.image_token = processor.image_token
-
-    @classmethod
-    def _setup_from_pretrained(cls, model_id, **kwargs):
-        # Tiny model has files at root level; full model uses processor/ subfolder
-        if cls.tiny_model_id and model_id == cls.tiny_model_id:
-            return super()._setup_from_pretrained(model_id, **kwargs)
-        return super()._setup_from_pretrained(model_id, subfolder="processor", **kwargs)
-
-    @classmethod
-    def _setup_image_processor(cls):
-        # Provide a tiny image-processor config so placeholder expansion stays small
-        source = cls.tiny_model_id if cls.full_tmpdirname is None else cls.model_id
-        subfolder_kwargs = {} if cls.full_tmpdirname is None else {"subfolder": "processor"}
-        return AutoImageProcessor.from_pretrained(
-            source,
-            do_resize=True,
-            patch_size=4,
-            min_pixels=12 * 12,
-            max_pixels=18 * 18,
-            **subfolder_kwargs,
-        )
-
-    @classmethod
-    def _setup_tokenizer(cls):
-        source = cls.tiny_model_id if cls.full_tmpdirname is None else cls.model_id
-        subfolder_kwargs = {} if cls.full_tmpdirname is None else {"subfolder": "processor"}
-        return AutoTokenizer.from_pretrained(source, **subfolder_kwargs)
 
     def prepare_image_inputs(self, batch_size: int | None = None, nested: bool = False):
         """Override to create images with valid aspect ratio (< 4) for GLM-Image."""

--- a/tests/models/glm_image/test_processor_glm_image.py
+++ b/tests/models/glm_image/test_processor_glm_image.py
@@ -34,6 +34,7 @@ if is_torch_available():
 @require_torch
 class GlmImageProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = GlmImageProcessor
+    # Tiny processor created with make_tiny_processor.py from "zai-org/GLM-Image"
     tiny_model_id = "hf-internal-testing/tiny-processor-glm_image"
 
     @classmethod

--- a/tests/models/glm_image/test_processor_glm_image.py
+++ b/tests/models/glm_image/test_processor_glm_image.py
@@ -34,6 +34,7 @@ if is_torch_available():
 @require_torch
 class GlmImageProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = GlmImageProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-glm_image"
     model_id = "zai-org/GLM-Image"
 
     @classmethod
@@ -42,28 +43,30 @@ class GlmImageProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     @classmethod
     def _setup_from_pretrained(cls, model_id, **kwargs):
-        return super()._setup_from_pretrained(
-            model_id,
-            subfolder="processor",
-            **kwargs,
-        )
+        # Tiny model has files at root level; full model uses processor/ subfolder
+        if cls.tiny_model_id and model_id == cls.tiny_model_id:
+            return super()._setup_from_pretrained(model_id, **kwargs)
+        return super()._setup_from_pretrained(model_id, subfolder="processor", **kwargs)
 
     @classmethod
     def _setup_image_processor(cls):
         # Provide a tiny image-processor config so placeholder expansion stays small
+        source = cls.tiny_model_id if cls.full_tmpdirname is None else cls.model_id
+        subfolder_kwargs = {} if cls.full_tmpdirname is None else {"subfolder": "processor"}
         return AutoImageProcessor.from_pretrained(
-            cls.model_id,
-            subfolder="processor",
+            source,
             do_resize=True,
             patch_size=4,
             min_pixels=12 * 12,
             max_pixels=18 * 18,
+            **subfolder_kwargs,
         )
 
     @classmethod
     def _setup_tokenizer(cls):
-        # Ensure tokenizer is loaded from the correct subfolder when using custom components
-        return AutoTokenizer.from_pretrained(cls.model_id, subfolder="processor")
+        source = cls.tiny_model_id if cls.full_tmpdirname is None else cls.model_id
+        subfolder_kwargs = {} if cls.full_tmpdirname is None else {"subfolder": "processor"}
+        return AutoTokenizer.from_pretrained(source, **subfolder_kwargs)
 
     def prepare_image_inputs(self, batch_size: int | None = None, nested: bool = False):
         """Override to create images with valid aspect ratio (< 4) for GLM-Image."""

--- a/tests/models/grounding_dino/test_processing_grounding_dino.py
+++ b/tests/models/grounding_dino/test_processing_grounding_dino.py
@@ -32,6 +32,7 @@ if is_torch_available():
 @require_torch
 @require_vision
 class GroundingDinoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    tiny_model_id = "hf-internal-testing/tiny-processor-grounding_dino"
     model_id = "IDEA-Research/grounding-dino-base"
     processor_class = GroundingDinoProcessor
     batch_size = 7

--- a/tests/models/grounding_dino/test_processing_grounding_dino.py
+++ b/tests/models/grounding_dino/test_processing_grounding_dino.py
@@ -32,8 +32,8 @@ if is_torch_available():
 @require_torch
 @require_vision
 class GroundingDinoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    # Tiny processor created with make_tiny_processor.py from "IDEA-Research/grounding-dino-base"
     tiny_model_id = "hf-internal-testing/tiny-processor-grounding_dino"
-    model_id = "IDEA-Research/grounding-dino-base"
     processor_class = GroundingDinoProcessor
     batch_size = 7
     num_queries = 5

--- a/tests/models/idefics2/test_processing_idefics2.py
+++ b/tests/models/idefics2/test_processing_idefics2.py
@@ -62,10 +62,13 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def prepare_processor_dict():
         return {"image_seq_len": 2}
 
-    @unittest.skip("Batch padding order depends on tokenization lengths which differ with tiny tokenizer")
     def test_process_interleaved_images_prompts_no_image_splitting(self):
-        processor = self.get_processor()
+        processor = self.get_processor(use_tiny_ckpt=False)
         tokenizer = processor.tokenizer
+        bos_token_id = tokenizer.convert_tokens_to_ids(tokenizer.bos_token)
+        image_token_id = tokenizer.convert_tokens_to_ids(processor.image_token)
+        fake_image_token_id = tokenizer.convert_tokens_to_ids(processor.fake_image_token)
+        image_seq_len = processor.image_seq_len
 
         processor.image_processor.do_image_splitting = False
 
@@ -83,7 +86,7 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         # fmt: off
         tokenized_sentence = tokenizer(text_str, add_special_tokens=False)
-        expected_input_ids = [[self.bos_token_id] + [self.fake_image_token_id] + [self.image_token_id] * self.image_seq_len + [self.fake_image_token_id] + tokenized_sentence["input_ids"]]
+        expected_input_ids = [[bos_token_id] + [fake_image_token_id] + [image_token_id] * image_seq_len + [fake_image_token_id] + tokenized_sentence["input_ids"]]
         self.assertEqual(inputs["input_ids"], expected_input_ids)
         self.assertEqual(inputs["attention_mask"], [[1] * len(expected_input_ids[0])])
         self.assertEqual(inputs["pixel_values"].shape, (1, 1, 3, 653, 980))
@@ -106,8 +109,8 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # fmt: off
         tokenized_sentence_1 = tokenizer(text_str_1, add_special_tokens=False)
         tokenized_sentence_2 = tokenizer(text_str_2, add_special_tokens=False)
-        expected_input_ids_1 = [self.bos_token_id] + [self.fake_image_token_id] + [self.image_token_id] * self.image_seq_len + [self.fake_image_token_id] + tokenized_sentence_1["input_ids"]
-        expected_input_ids_2 = [self.bos_token_id] + tokenized_sentence_2["input_ids"] + [self.fake_image_token_id] + [self.image_token_id] * self.image_seq_len + [self.fake_image_token_id] + [self.image_token_id] * self.image_seq_len + [self.fake_image_token_id]
+        expected_input_ids_1 = [bos_token_id] + [fake_image_token_id] + [image_token_id] * image_seq_len + [fake_image_token_id] + tokenized_sentence_1["input_ids"]
+        expected_input_ids_2 = [bos_token_id] + tokenized_sentence_2["input_ids"] + [fake_image_token_id] + [image_token_id] * image_seq_len + [fake_image_token_id] + [image_token_id] * image_seq_len + [fake_image_token_id]
         # Pad the first input to match the second input
         pad_len = len(expected_input_ids_2) - len(expected_input_ids_1)
         padded_expected_input_ids_1 = [0] * pad_len + expected_input_ids_1

--- a/tests/models/idefics2/test_processing_idefics2.py
+++ b/tests/models/idefics2/test_processing_idefics2.py
@@ -32,6 +32,7 @@ if is_vision_available():
 @require_vision
 class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Idefics2Processor
+    tiny_model_id = "hf-internal-testing/tiny-processor-idefics2"
     model_id = "HuggingFaceM4/idefics2-8b"
 
     @classmethod
@@ -61,6 +62,7 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def prepare_processor_dict():
         return {"image_seq_len": 2}
 
+    @unittest.skip("Batch padding order depends on tokenization lengths which differ with tiny tokenizer")
     def test_process_interleaved_images_prompts_no_image_splitting(self):
         processor = self.get_processor()
         tokenizer = processor.tokenizer

--- a/tests/models/idefics3/test_processing_idefics3.py
+++ b/tests/models/idefics3/test_processing_idefics3.py
@@ -27,6 +27,7 @@ from ...test_processing_common import ProcessorTesterMixin, url_to_local_path
 @require_vision
 class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Idefics3Processor
+    # Tiny processor created with make_tiny_processor.py from "HuggingFaceM4/Idefics3-8B-Llama3"
     tiny_model_id = "hf-internal-testing/tiny-processor-idefics3"
     # Default 76 is too small: idefics3 with the tiny tokenizer expands <image> to ~78 tokens, then with
     # surrounding text tokens we exceed 76, truncation cuts through image tokens, and _check_special_mm_tokens

--- a/tests/models/idefics3/test_processing_idefics3.py
+++ b/tests/models/idefics3/test_processing_idefics3.py
@@ -28,8 +28,10 @@ from ...test_processing_common import ProcessorTesterMixin, url_to_local_path
 class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Idefics3Processor
     tiny_model_id = "hf-internal-testing/tiny-processor-idefics3"
-    model_id = "HuggingFaceM4/Idefics3-8B-Llama3"
-    image_unstructured_max_length = 100  # tiny tokenizer produces more tokens than default 76
+    # Default 76 is too small: idefics3 with the tiny tokenizer expands <image> to ~78 tokens, then with
+    # surrounding text tokens we exceed 76, truncation cuts through image tokens, and _check_special_mm_tokens
+    # raises a mismatch error.
+    image_unstructured_max_length = 100
 
     def get_processor(self):
         processor = self.processor_class.from_pretrained(self.tmpdirname)

--- a/tests/models/idefics3/test_processing_idefics3.py
+++ b/tests/models/idefics3/test_processing_idefics3.py
@@ -27,7 +27,9 @@ from ...test_processing_common import ProcessorTesterMixin, url_to_local_path
 @require_vision
 class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Idefics3Processor
+    tiny_model_id = "hf-internal-testing/tiny-processor-idefics3"
     model_id = "HuggingFaceM4/Idefics3-8B-Llama3"
+    image_unstructured_max_length = 100  # tiny tokenizer produces more tokens than default 76
 
     def get_processor(self):
         processor = self.processor_class.from_pretrained(self.tmpdirname)

--- a/tests/models/internvl/test_processing_internvl.py
+++ b/tests/models/internvl/test_processing_internvl.py
@@ -33,7 +33,7 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = InternVLProcessor
     videos_input_name = "pixel_values"
     tiny_model_id = "hf-internal-testing/tiny-processor-internvl"
-    model_id = "OpenGVLab/InternVL3-1B-hf"
+    model_id = "hf-internal-testing/tiny-processor-internvl"
 
     @classmethod
     def _setup_image_processor(cls):

--- a/tests/models/internvl/test_processing_internvl.py
+++ b/tests/models/internvl/test_processing_internvl.py
@@ -32,6 +32,7 @@ if is_torch_available():
 class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = InternVLProcessor
     videos_input_name = "pixel_values"
+    # Tiny processor created with make_tiny_processor.py from "OpenGVLab/InternVL3-1B-hf"
     tiny_model_id = "hf-internal-testing/tiny-processor-internvl"
 
     @classmethod

--- a/tests/models/internvl/test_processing_internvl.py
+++ b/tests/models/internvl/test_processing_internvl.py
@@ -33,7 +33,6 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = InternVLProcessor
     videos_input_name = "pixel_values"
     tiny_model_id = "hf-internal-testing/tiny-processor-internvl"
-    model_id = "hf-internal-testing/tiny-processor-internvl"
 
     @classmethod
     def _setup_image_processor(cls):

--- a/tests/models/internvl/test_processing_internvl.py
+++ b/tests/models/internvl/test_processing_internvl.py
@@ -32,6 +32,8 @@ if is_torch_available():
 class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = InternVLProcessor
     videos_input_name = "pixel_values"
+    tiny_model_id = "hf-internal-testing/tiny-processor-internvl"
+    model_id = "OpenGVLab/InternVL3-1B-hf"
 
     @classmethod
     def _setup_image_processor(cls):
@@ -61,16 +63,6 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             image_std=[0.229, 0.224, 0.225],
             do_convert_rgb=True,
         )
-
-    @classmethod
-    def _setup_tokenizer(cls):
-        tokenizer_class = cls._get_component_class_from_processor("tokenizer")
-        return tokenizer_class.from_pretrained("OpenGVLab/InternVL3-1B-hf", padding_side="left")
-
-    @classmethod
-    def _setup_test_attributes(cls, processor):
-        cls.image_token = processor.image_token
-        cls.video_token = processor.video_token
 
     @unittest.skip("InternVL requires text")
     def test_video_processor_defaults(self):
@@ -382,6 +374,7 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         inputs = processor(
             text=texts[:batch_size],
             return_tensors="pt",
+            padding=True,
             videos=videos[:batch_size],
             videos_kwargs={"size": (448, 448)},
         )

--- a/tests/models/janus/test_processing_janus.py
+++ b/tests/models/janus/test_processing_janus.py
@@ -24,6 +24,7 @@ from ...test_processing_common import ProcessorTesterMixin, url_to_local_path
 
 class JanusProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = JanusProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-janus"
     model_id = "deepseek-community/Janus-Pro-1B"
 
     @classmethod

--- a/tests/models/janus/test_processing_janus.py
+++ b/tests/models/janus/test_processing_janus.py
@@ -24,8 +24,8 @@ from ...test_processing_common import ProcessorTesterMixin, url_to_local_path
 
 class JanusProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = JanusProcessor
+    # Tiny processor created with make_tiny_processor.py from "deepseek-community/Janus-Pro-1B"
     tiny_model_id = "hf-internal-testing/tiny-processor-janus"
-    model_id = "deepseek-community/Janus-Pro-1B"
 
     @classmethod
     def _setup_from_pretrained(cls, model_id, **kwargs):

--- a/tests/models/kosmos2_5/test_processor_kosmos2_5.py
+++ b/tests/models/kosmos2_5/test_processor_kosmos2_5.py
@@ -44,6 +44,7 @@ if is_vision_available():
 class Kosmos2_5ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Kosmos2_5Processor
     images_input_name = "flattened_patches"
+    tiny_model_id = "hf-internal-testing/tiny-processor-kosmos2_5"
     model_id = "microsoft/kosmos-2.5"
 
     @unittest.skip("Kosmos2_5Processor removes 'rows' and 'cols' from the output")
@@ -52,7 +53,7 @@ class Kosmos2_5ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     def test_image_procesor_load_save_reload(self):
         # make sure load from Hub repo. -> save -> reload locally work
-        image_processor = Kosmos2_5ImageProcessor.from_pretrained("microsoft/kosmos-2.5")
+        image_processor = Kosmos2_5ImageProcessor.from_pretrained(self.full_tmpdirname)
         with TemporaryDirectory() as tmp_dir:
             image_processor.save_pretrained(tmp_dir)
             reloaded_image_processor = Kosmos2_5ImageProcessor.from_pretrained(tmp_dir)
@@ -60,10 +61,9 @@ class Kosmos2_5ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             assert image_processor.to_json_string() == reloaded_image_processor.to_json_string()
 
     def test_can_load_various_tokenizers(self):
-        for checkpoint in ["microsoft/kosmos-2.5"]:
-            processor = AutoProcessor.from_pretrained(checkpoint)
-            tokenizer = AutoTokenizer.from_pretrained(checkpoint)
-            self.assertEqual(processor.tokenizer.__class__, tokenizer.__class__)
+        processor = AutoProcessor.from_pretrained(self.full_tmpdirname)
+        tokenizer = AutoTokenizer.from_pretrained(self.full_tmpdirname)
+        self.assertEqual(processor.tokenizer.__class__, tokenizer.__class__)
 
     @require_torch
     def test_model_input_names(self):

--- a/tests/models/kosmos2_5/test_processor_kosmos2_5.py
+++ b/tests/models/kosmos2_5/test_processor_kosmos2_5.py
@@ -45,7 +45,6 @@ class Kosmos2_5ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Kosmos2_5Processor
     images_input_name = "flattened_patches"
     tiny_model_id = "hf-internal-testing/tiny-processor-kosmos2_5"
-    model_id = "microsoft/kosmos-2.5"
 
     @unittest.skip("Kosmos2_5Processor removes 'rows' and 'cols' from the output")
     def test_image_processor_defaults(self):
@@ -53,7 +52,7 @@ class Kosmos2_5ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     def test_image_procesor_load_save_reload(self):
         # make sure load from Hub repo. -> save -> reload locally work
-        image_processor = Kosmos2_5ImageProcessor.from_pretrained(self.full_tmpdirname)
+        image_processor = Kosmos2_5ImageProcessor.from_pretrained(self.tmpdirname)
         with TemporaryDirectory() as tmp_dir:
             image_processor.save_pretrained(tmp_dir)
             reloaded_image_processor = Kosmos2_5ImageProcessor.from_pretrained(tmp_dir)
@@ -61,8 +60,8 @@ class Kosmos2_5ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             assert image_processor.to_json_string() == reloaded_image_processor.to_json_string()
 
     def test_can_load_various_tokenizers(self):
-        processor = AutoProcessor.from_pretrained(self.full_tmpdirname)
-        tokenizer = AutoTokenizer.from_pretrained(self.full_tmpdirname)
+        processor = AutoProcessor.from_pretrained(self.tmpdirname)
+        tokenizer = AutoTokenizer.from_pretrained(self.tmpdirname)
         self.assertEqual(processor.tokenizer.__class__, tokenizer.__class__)
 
     @require_torch

--- a/tests/models/kosmos2_5/test_processor_kosmos2_5.py
+++ b/tests/models/kosmos2_5/test_processor_kosmos2_5.py
@@ -44,6 +44,7 @@ if is_vision_available():
 class Kosmos2_5ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Kosmos2_5Processor
     images_input_name = "flattened_patches"
+    # Tiny processor created with make_tiny_processor.py from "microsoft/kosmos-2.5"
     tiny_model_id = "hf-internal-testing/tiny-processor-kosmos2_5"
 
     @unittest.skip("Kosmos2_5Processor removes 'rows' and 'cols' from the output")

--- a/tests/models/lighton_ocr/test_processor_lighton_ocr.py
+++ b/tests/models/lighton_ocr/test_processor_lighton_ocr.py
@@ -37,8 +37,8 @@ class LightOnOcrProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     """Test suite for LightOnOcr processor."""
 
     processor_class = LightOnOcrProcessor
+    # Tiny processor created with make_tiny_processor.py from "lightonai/LightOnOCR-1B-1025"
     tiny_model_id = "hf-internal-testing/tiny-processor-lighton_ocr"
-    model_id = "lightonai/LightOnOCR-1B-1025"
 
     def setUp(self):
         """Set up test fixtures."""

--- a/tests/models/lighton_ocr/test_processor_lighton_ocr.py
+++ b/tests/models/lighton_ocr/test_processor_lighton_ocr.py
@@ -37,6 +37,7 @@ class LightOnOcrProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     """Test suite for LightOnOcr processor."""
 
     processor_class = LightOnOcrProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-lighton_ocr"
     model_id = "lightonai/LightOnOCR-1B-1025"
 
     def setUp(self):

--- a/tests/models/llava/test_processing_llava.py
+++ b/tests/models/llava/test_processing_llava.py
@@ -23,6 +23,7 @@ from ...test_processing_common import ProcessorTesterMixin
 @require_vision
 class LlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaProcessor
+    # Tiny processor created with make_tiny_processor.py from "llava-hf/llava-1.5-7b-hf"
     tiny_model_id = "hf-internal-testing/tiny-processor-llava"
 
     @classmethod

--- a/tests/models/llava/test_processing_llava.py
+++ b/tests/models/llava/test_processing_llava.py
@@ -24,7 +24,6 @@ from ...test_processing_common import ProcessorTesterMixin
 class LlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaProcessor
     tiny_model_id = "hf-internal-testing/tiny-processor-llava"
-    model_id = "hf-internal-testing/tiny-processor-llava"
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/llava/test_processing_llava.py
+++ b/tests/models/llava/test_processing_llava.py
@@ -23,22 +23,8 @@ from ...test_processing_common import ProcessorTesterMixin
 @require_vision
 class LlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaProcessor
-
-    @classmethod
-    def _setup_image_processor(cls):
-        image_processor_class = cls._get_component_class_from_processor("image_processor")
-        return image_processor_class()
-
-    @classmethod
-    def _setup_tokenizer(cls):
-        tokenizer_class = cls._get_component_class_from_processor("tokenizer")
-        tokenizer = tokenizer_class.from_pretrained("huggyllama/llama-7b")
-        tokenizer.add_special_tokens({"additional_special_tokens": ["<image>"]})
-        if not tokenizer.pad_token:
-            tokenizer.pad_token = "[PAD]"
-            if tokenizer.pad_token_id is None:
-                tokenizer.pad_token_id = 0
-        return tokenizer
+    tiny_model_id = "hf-internal-testing/tiny-processor-llava"
+    model_id = "llava-hf/llava-1.5-7b-hf"
 
     @classmethod
     def _setup_test_attributes(cls, processor):
@@ -49,7 +35,8 @@ class LlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         return {
             "chat_template": "{% for message in messages %}{% if message['role'] != 'system' %}{{ message['role'].upper() + ': '}}{% endif %}{# Render all images first #}{% for content in message['content'] | selectattr('type', 'equalto', 'image') %}{{ '<image>\n' }}{% endfor %}{# Render all text next #}{% if message['role'] != 'assistant' %}{% for content in message['content'] | selectattr('type', 'equalto', 'text') %}{{ content['text'] + ' '}}{% endfor %}{% else %}{% for content in message['content'] | selectattr('type', 'equalto', 'text') %}{% generation %}{{ content['text'] + ' '}}{% endgeneration %}{% endfor %}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ 'ASSISTANT:' }}{% endif %}",
             "patch_size": 128,
-            "vision_feature_select_strategy": "default"
+            "vision_feature_select_strategy": "default",
+            "num_additional_image_tokens": 1  # must match processor_config.json from the Hub repo
         }  # fmt: skip
 
     def test_get_num_vision_tokens(self):

--- a/tests/models/llava/test_processing_llava.py
+++ b/tests/models/llava/test_processing_llava.py
@@ -63,7 +63,11 @@ class LlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertTrue(processor_loaded.chat_template == processor_dict.get("chat_template", None))
 
     def test_can_load_various_tokenizers(self):
-        for checkpoint in ["Intel/llava-gemma-2b", "llava-hf/llava-1.5-7b-hf"]:
+        # Use tiny repos to avoid loading full 256k-vocab Gemma and 32k-vocab LLaMA tokenizers
+        for checkpoint in [
+            "hf-internal-testing/tiny-processor-llava-gemma",
+            "hf-internal-testing/tiny-processor-llava",
+        ]:
             processor = LlavaProcessor.from_pretrained(checkpoint)
             tokenizer = AutoTokenizer.from_pretrained(checkpoint)
             self.assertEqual(processor.tokenizer.__class__, tokenizer.__class__)
@@ -71,7 +75,7 @@ class LlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def test_special_mm_token_truncation(self):
         """Tests that special vision tokens do not get truncated when `truncation=True` is set."""
 
-        processor = LlavaProcessor.from_pretrained("llava-hf/llava-1.5-7b-hf")
+        processor = LlavaProcessor.from_pretrained("hf-internal-testing/tiny-processor-llava")
 
         input_str = self.prepare_text_inputs(batch_size=2, modalities="image")
         image_input = self.prepare_image_inputs(batch_size=2)

--- a/tests/models/llava/test_processing_llava.py
+++ b/tests/models/llava/test_processing_llava.py
@@ -24,7 +24,7 @@ from ...test_processing_common import ProcessorTesterMixin
 class LlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaProcessor
     tiny_model_id = "hf-internal-testing/tiny-processor-llava"
-    model_id = "llava-hf/llava-1.5-7b-hf"
+    model_id = "hf-internal-testing/tiny-processor-llava"
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/llava_next_video/test_processing_llava_next_video.py
+++ b/tests/models/llava_next_video/test_processing_llava_next_video.py
@@ -33,7 +33,6 @@ if is_vision_available():
 class LlavaNextVideoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaNextVideoProcessor
     tiny_model_id = "hf-internal-testing/tiny-processor-llava_next_video"
-    model_id = "hf-internal-testing/tiny-processor-llava_next_video"
 
     @classmethod
     def prepare_processor_dict(cls):

--- a/tests/models/llava_next_video/test_processing_llava_next_video.py
+++ b/tests/models/llava_next_video/test_processing_llava_next_video.py
@@ -32,6 +32,7 @@ if is_vision_available():
 @require_vision
 class LlavaNextVideoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaNextVideoProcessor
+    # Tiny processor created with make_tiny_processor.py from "llava-hf/LLaVA-NeXT-Video-7B-hf"
     tiny_model_id = "hf-internal-testing/tiny-processor-llava_next_video"
 
     @classmethod

--- a/tests/models/llava_next_video/test_processing_llava_next_video.py
+++ b/tests/models/llava_next_video/test_processing_llava_next_video.py
@@ -33,7 +33,7 @@ if is_vision_available():
 class LlavaNextVideoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaNextVideoProcessor
     tiny_model_id = "hf-internal-testing/tiny-processor-llava_next_video"
-    model_id = "llava-hf/LLaVA-NeXT-Video-7B-hf"
+    model_id = "hf-internal-testing/tiny-processor-llava_next_video"
 
     @classmethod
     def prepare_processor_dict(cls):

--- a/tests/models/llava_next_video/test_processing_llava_next_video.py
+++ b/tests/models/llava_next_video/test_processing_llava_next_video.py
@@ -32,18 +32,8 @@ if is_vision_available():
 @require_vision
 class LlavaNextVideoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaNextVideoProcessor
-
-    @classmethod
-    def _setup_tokenizer(cls):
-        tokenizer_class = cls._get_component_class_from_processor("tokenizer")
-        tokenizer = tokenizer_class.from_pretrained("llava-hf/LLaVA-NeXT-Video-7B-hf")
-        tokenizer.add_special_tokens({"additional_special_tokens": ["<image>", "<video>"]})
-        return tokenizer
-
-    @classmethod
-    def _setup_test_attributes(cls, processor):
-        cls.image_token = processor.image_token
-        cls.video_token = processor.video_token
+    tiny_model_id = "hf-internal-testing/tiny-processor-llava_next_video"
+    model_id = "llava-hf/LLaVA-NeXT-Video-7B-hf"
 
     @classmethod
     def prepare_processor_dict(cls):

--- a/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
@@ -36,6 +36,7 @@ if is_torch_available():
 class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = MiniCPMV4_6Processor
     # Use tiny repos to avoid loading the full 248k-vocab tokenizer (~308 MB)
+    # Tiny processor created with make_tiny_processor.py from "openbmb/MiniCPM-V-4_6"
     tiny_model_id = "hf-internal-testing/tiny-processor-minicpmv4_6"
 
     video_text_kwargs_max_length = 600

--- a/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
@@ -41,7 +41,9 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     video_text_kwargs_max_length = 600
     video_text_kwargs_override_max_length = 550
     video_unstructured_max_length = 600
-    image_unstructured_max_length = 100  # MiniCPM expands image to ~70 tokens
+    # Default 76 is too small: MiniCPM expands <image> to ~70 tokens, then with surrounding text tokens
+    # we exceed 76, truncation cuts through image tokens, and _check_special_mm_tokens raises a mismatch error.
+    image_unstructured_max_length = 100
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
@@ -37,7 +37,6 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = MiniCPMV4_6Processor
     # Use tiny repos to avoid loading the full 248k-vocab tokenizer (~308 MB)
     tiny_model_id = "hf-internal-testing/tiny-processor-minicpmv4_6"
-    model_id = "hf-internal-testing/tiny-processor-minicpmv4_6"
 
     video_text_kwargs_max_length = 600
     video_text_kwargs_override_max_length = 550

--- a/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
@@ -35,11 +35,14 @@ if is_torch_available():
 @require_torchvision
 class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = MiniCPMV4_6Processor
-    model_id = "openbmb/MiniCPM-V-4_6"
+    # Use tiny repos to avoid loading the full 248k-vocab tokenizer (~308 MB)
+    tiny_model_id = "hf-internal-testing/tiny-processor-minicpmv4_6"
+    model_id = "hf-internal-testing/tiny-processor-minicpmv4_6"
 
     video_text_kwargs_max_length = 600
     video_text_kwargs_override_max_length = 550
     video_unstructured_max_length = 600
+    image_unstructured_max_length = 100  # MiniCPM expands image to ~70 tokens
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/mistral3/test_processing_mistral3.py
+++ b/tests/models/mistral3/test_processing_mistral3.py
@@ -32,6 +32,7 @@ class Mistral3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     """This tests Pixtral processor with the new `spatial_merge_size` argument in Mistral3."""
 
     processor_class = PixtralProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-mistral3"
     model_id = "hf-internal-testing/Mistral-Small-3.1-24B-Instruct-2503-only-processor"
 
     @classmethod
@@ -54,7 +55,7 @@ class Mistral3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         }  # fmt: skip
 
     def test_image_token_filling(self):
-        processor = self.processor_class.from_pretrained(self.tmpdirname)
+        processor = self.processor_class.from_pretrained(self.full_tmpdirname)
         # Important to check with non square image
         image = torch.randint(0, 2, (3, 500, 316))
         expected_image_tokens = 4
@@ -82,7 +83,7 @@ class Mistral3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertEqual(expected_image_tokens, image_tokens)
 
     def test_processor_with_single_image(self):
-        processor = self.processor_class.from_pretrained(self.tmpdirname)
+        processor = self.processor_class.from_pretrained(self.full_tmpdirname)
         prompt_string = "USER: [IMG]\nWhat's the content of the image? ASSISTANT:"
 
         # Make small for checking image token expansion
@@ -146,7 +147,7 @@ class Mistral3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # fmt: on
 
     def test_processor_with_multiple_images_single_list(self):
-        processor = self.processor_class.from_pretrained(self.tmpdirname)
+        processor = self.processor_class.from_pretrained(self.full_tmpdirname)
         prompt_string = "USER: [IMG][IMG]\nWhat's the difference between these two images? ASSISTANT:"
 
         # Make small for checking image token expansion
@@ -199,7 +200,7 @@ class Mistral3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # fmt: on
 
     def test_processor_with_multiple_images_multiple_lists(self):
-        processor = self.processor_class.from_pretrained(self.tmpdirname)
+        processor = self.processor_class.from_pretrained(self.full_tmpdirname)
         prompt_string = [
             "USER: [IMG][IMG]\nWhat's the difference between these two images? ASSISTANT:",
             "USER: [IMG]\nWhat's the content of the image? ASSISTANT:",
@@ -260,7 +261,7 @@ class Mistral3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     def test_processor_returns_full_length_batches(self):
         # to avoid https://github.com/huggingface/transformers/issues/34204
-        processor = self.processor_class.from_pretrained(self.tmpdirname)
+        processor = self.processor_class.from_pretrained(self.full_tmpdirname)
         prompt_string = [
             "USER: [IMG]\nWhat's the content of the image? ASSISTANT:",
         ] * 5
@@ -279,7 +280,7 @@ class Mistral3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def test_special_mm_token_truncation(self):
         """Tests that special vision tokens do not get truncated when `truncation=True` is set."""
 
-        processor = self.get_processor()
+        processor = self.processor_class.from_pretrained(self.full_tmpdirname)
 
         input_str = self.prepare_text_inputs(batch_size=2, modalities="image")
         image_input = self.prepare_image_inputs(batch_size=2)

--- a/tests/models/mistral3/test_processing_mistral3.py
+++ b/tests/models/mistral3/test_processing_mistral3.py
@@ -261,7 +261,7 @@ class Mistral3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     def test_processor_returns_full_length_batches(self):
         # to avoid https://github.com/huggingface/transformers/issues/34204
-        processor = self.processor_class.from_pretrained(self.full_tmpdirname)
+        processor = self.processor_class.from_pretrained(self.tmpdirname)
         prompt_string = [
             "USER: [IMG]\nWhat's the content of the image? ASSISTANT:",
         ] * 5

--- a/tests/models/mllama/test_processing_mllama.py
+++ b/tests/models/mllama/test_processing_mllama.py
@@ -32,6 +32,7 @@ if is_vision_available():
 @require_vision
 class MllamaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = MllamaProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-mllama"
     model_id = "hf-internal-testing/mllama-11b"
 
     @classmethod
@@ -99,7 +100,7 @@ class MllamaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                 ],
             },
         ]
-        processor = MllamaProcessor.from_pretrained(self.tmpdirname)
+        processor = self.get_processor(use_tiny_ckpt=False)
         rendered = processor.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
 
         expected_rendered = (
@@ -228,7 +229,10 @@ class MllamaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertEqual(rendered_list, rendered_str)
 
     def test_process_interleaved_images_prompts_image_splitting(self):
-        processor = MllamaProcessor.from_pretrained(self.tmpdirname)
+        processor = self.get_processor(use_tiny_ckpt=False)
+        image_token_id = processor.image_token_id
+        bos_token_id = processor.tokenizer.bos_token_id
+        pad_token_id = processor.tokenizer.pad_token_id
         # Test that a single image is processed correctly
         inputs = processor(images=self.image2, size={"width": 224, "height": 224})
         self.assertEqual(inputs["pixel_values"].shape, (1, 1, 4, 3, 224, 224))
@@ -236,7 +240,7 @@ class MllamaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # Test that text is processed correctly
         text = "<|begin_of_text|>This is a test sentence.<|end_of_text|>"
         inputs = processor(text=text)
-        expected_ids = [128000, 2028, 374, 264, 1296, 11914, 13, 128001]
+        expected_ids = [bos_token_id, 2028, 374, 264, 1296, 11914, 13, 128001]  # 128001 = <|end_of_text|>
         self.assertEqual(inputs["input_ids"][0], expected_ids)
         self.assertEqual(inputs["attention_mask"][0], [1] * len(expected_ids))
         self.assertEqual(inputs.get("cross_attention_mask"), None)
@@ -250,7 +254,7 @@ class MllamaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             images=self.image1,
             size={"width": 128, "height": 128},
         )
-        expected_ids = [self.image_token_id, self.bos_token_id] + [2028, 374, 264, 1296, 11914, 13]
+        expected_ids = [image_token_id, bos_token_id] + [2028, 374, 264, 1296, 11914, 13]
 
         self.assertEqual(inputs["pixel_values"].shape, (1, 1, 4, 3, 128, 128))
         self.assertEqual(inputs["input_ids"][0], expected_ids)
@@ -268,8 +272,8 @@ class MllamaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         ]
         # fmt: off
         expected_ids = [
-            [self.image_token_id, self.bos_token_id, 2028, 374, 264, 1296, 11914, 13],
-            [self.bos_token_id, 2028, 374, 264, 1296, 11914, 13, self.image_token_id, self.image_token_id, 2028, 374, 264, 1296, 11914, 13],
+            [image_token_id, bos_token_id, 2028, 374, 264, 1296, 11914, 13],
+            [bos_token_id, 2028, 374, 264, 1296, 11914, 13, image_token_id, image_token_id, 2028, 374, 264, 1296, 11914, 13],
         ]
         # fmt: on
         images = [[self.image1], [self.image1, self.image2]]
@@ -282,7 +286,7 @@ class MllamaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             pad_ids = [id for id, m in zip(input_ids_i, attention_mask_i) if m == 0]
             input_ids = [id for id, m in zip(input_ids_i, attention_mask_i) if m == 1]
             self.assertEqual(input_ids, expected_ids_i)
-            self.assertEqual(pad_ids, [self.pad_token_id] * len(pad_ids))
+            self.assertEqual(pad_ids, [pad_token_id] * len(pad_ids))
 
         cross_attention_mask = inputs["cross_attention_mask"]
         self.assertEqual(cross_attention_mask.shape, (2, 15, 2, 4))

--- a/tests/models/mllama/test_processing_mllama.py
+++ b/tests/models/mllama/test_processing_mllama.py
@@ -230,6 +230,8 @@ class MllamaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     def test_process_interleaved_images_prompts_image_splitting(self):
         processor = self.get_processor(use_tiny_ckpt=False)
+        # Read token IDs from the full processor rather than self.* attributes, which are set from the
+        # tiny processor in _setup_test_attributes and would have different IDs.
         image_token_id = processor.image_token_id
         bos_token_id = processor.tokenizer.bos_token_id
         pad_token_id = processor.tokenizer.pad_token_id

--- a/tests/models/owlv2/test_processing_owlv2.py
+++ b/tests/models/owlv2/test_processing_owlv2.py
@@ -9,4 +9,5 @@ from ...test_processing_common import ProcessorTesterMixin
 @require_scipy
 class Owlv2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Owlv2Processor
+    tiny_model_id = "hf-internal-testing/tiny-processor-owlv2"
     model_id = "google/owlv2-base-patch16-ensemble"

--- a/tests/models/owlv2/test_processing_owlv2.py
+++ b/tests/models/owlv2/test_processing_owlv2.py
@@ -9,5 +9,5 @@ from ...test_processing_common import ProcessorTesterMixin
 @require_scipy
 class Owlv2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Owlv2Processor
+    # Tiny processor created with make_tiny_processor.py from "google/owlv2-base-patch16-ensemble"
     tiny_model_id = "hf-internal-testing/tiny-processor-owlv2"
-    model_id = "google/owlv2-base-patch16-ensemble"

--- a/tests/models/parakeet/test_processing_parakeet.py
+++ b/tests/models/parakeet/test_processing_parakeet.py
@@ -25,5 +25,5 @@ from ...test_processing_common import ProcessorTesterMixin
 class ParakeetProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = ParakeetProcessor
     text_input_name = "labels"
+    # Tiny processor created with make_tiny_processor.py from "nvidia/parakeet-ctc-1.1b"
     tiny_model_id = "hf-internal-testing/tiny-processor-parakeet"
-    model_id = "nvidia/parakeet-ctc-1.1b"

--- a/tests/models/parakeet/test_processing_parakeet.py
+++ b/tests/models/parakeet/test_processing_parakeet.py
@@ -25,4 +25,5 @@ from ...test_processing_common import ProcessorTesterMixin
 class ParakeetProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = ParakeetProcessor
     text_input_name = "labels"
+    tiny_model_id = "hf-internal-testing/tiny-processor-parakeet"
     model_id = "nvidia/parakeet-ctc-1.1b"

--- a/tests/models/pixtral/test_processing_pixtral.py
+++ b/tests/models/pixtral/test_processing_pixtral.py
@@ -31,7 +31,7 @@ if is_vision_available():
 class PixtralProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = PixtralProcessor
     tiny_model_id = "hf-internal-testing/tiny-processor-pixtral"
-    model_id = "mistral-labs/pixtral-12b"
+    model_id = "mistral-community/pixtral-12b"
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/pixtral/test_processing_pixtral.py
+++ b/tests/models/pixtral/test_processing_pixtral.py
@@ -30,7 +30,8 @@ if is_vision_available():
 @require_vision
 class PixtralProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = PixtralProcessor
-    model_id = "mistral-community/pixtral-12b"
+    tiny_model_id = "hf-internal-testing/tiny-processor-pixtral"
+    model_id = "mistral-labs/pixtral-12b"
 
     @classmethod
     def _setup_test_attributes(cls, processor):
@@ -78,7 +79,7 @@ class PixtralProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertIsNotNone(processor.tokenizer)
 
     def test_processor_with_single_image(self):
-        processor = self.processor_class.from_pretrained(self.tmpdirname)
+        processor = self.processor_class.from_pretrained(self.full_tmpdirname)
         prompt_string = "USER: [IMG]\nWhat's the content of the image? ASSISTANT:"
 
         # Make small for checking image token expansion
@@ -142,7 +143,7 @@ class PixtralProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # fmt: on
 
     def test_processor_with_multiple_images_single_list(self):
-        processor = self.processor_class.from_pretrained(self.tmpdirname)
+        processor = self.processor_class.from_pretrained(self.full_tmpdirname)
         prompt_string = "USER: [IMG][IMG]\nWhat's the difference between these two images? ASSISTANT:"
 
         # Make small for checking image token expansion
@@ -195,7 +196,7 @@ class PixtralProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # fmt: on
 
     def test_processor_with_multiple_images_multiple_lists(self):
-        processor = self.processor_class.from_pretrained(self.tmpdirname)
+        processor = self.processor_class.from_pretrained(self.full_tmpdirname)
         prompt_string = [
             "USER: [IMG][IMG]\nWhat's the difference between these two images? ASSISTANT:",
             "USER: [IMG]\nWhat's the content of the image? ASSISTANT:",

--- a/tests/models/qianfan_ocr/test_processing_qianfan_ocr.py
+++ b/tests/models/qianfan_ocr/test_processing_qianfan_ocr.py
@@ -33,8 +33,8 @@ if is_torch_available():
 @require_vision
 class QianfanOCRProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = QianfanOCRProcessor
+    # Tiny processor created with make_tiny_processor.py from "bairongz/QianfanOCR"
     tiny_model_id = "hf-internal-testing/tiny-processor-qianfan_ocr"
-    model_id = "bairongz/QianfanOCR"
     # QianfanOCR has no video support; images and pixel values share the same tensor key
     videos_input_name = "pixel_values"
 

--- a/tests/models/qianfan_ocr/test_processing_qianfan_ocr.py
+++ b/tests/models/qianfan_ocr/test_processing_qianfan_ocr.py
@@ -33,6 +33,7 @@ if is_torch_available():
 @require_vision
 class QianfanOCRProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = QianfanOCRProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-qianfan_ocr"
     model_id = "bairongz/QianfanOCR"
     # QianfanOCR has no video support; images and pixel values share the same tensor key
     videos_input_name = "pixel_values"

--- a/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
+++ b/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
@@ -44,8 +44,8 @@ if is_torch_available():
 @require_torchvision
 class Qwen2_5OmniProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen2_5OmniProcessor
+    # Tiny processor created with make_tiny_processor.py from "Qwen/Qwen2.5-Omni-7B"
     tiny_model_id = "hf-internal-testing/tiny-processor-qwen2_5_omni"
-    model_id = "Qwen/Qwen2.5-Omni-7B"
 
     video_unstructured_max_length = 690
     video_text_kwargs_max_length = 690

--- a/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
+++ b/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
@@ -55,14 +55,14 @@ class Qwen2_5OmniProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def _setup_image_processor(cls):
         image_processor_class = cls._get_component_class_from_processor("image_processor")
         return image_processor_class.from_pretrained(
-            cls.model_id, size={"shortest_edge": 28 * 28, "longest_edge": 56 * 56}
+            cls.tiny_model_id, size={"shortest_edge": 28 * 28, "longest_edge": 56 * 56}
         )
 
     @classmethod
     def _setup_video_processor(cls):
         video_processor_class = cls._get_component_class_from_processor("video_processor")
         return video_processor_class.from_pretrained(
-            cls.model_id, size={"shortest_edge": 12 * 12, "longest_edge": 28 * 28}
+            cls.tiny_model_id, size={"shortest_edge": 12 * 12, "longest_edge": 28 * 28}
         )
 
     def prepare_audio_inputs(self, batch_size: int = 3):

--- a/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
+++ b/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
@@ -44,6 +44,7 @@ if is_torch_available():
 @require_torchvision
 class Qwen2_5OmniProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen2_5OmniProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-qwen2_5_omni"
     model_id = "Qwen/Qwen2.5-Omni-7B"
 
     video_unstructured_max_length = 690

--- a/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
@@ -35,8 +35,8 @@ if is_torch_available():
 @require_torchvision
 class Qwen2_5_VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen2_5_VLProcessor
+    # Tiny processor created with make_tiny_processor.py from "Qwen/Qwen2-VL-7B-Instruct"
     tiny_model_id = "hf-internal-testing/tiny-processor-qwen2_5_vl"
-    model_id = "Qwen/Qwen2-VL-7B-Instruct"
 
     @classmethod
     def _setup_from_pretrained(cls, model_id, **kwargs):

--- a/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
@@ -35,6 +35,7 @@ if is_torch_available():
 @require_torchvision
 class Qwen2_5_VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen2_5_VLProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-qwen2_5_vl"
     model_id = "Qwen/Qwen2-VL-7B-Instruct"
 
     @classmethod

--- a/tests/models/qwen2_audio/test_processing_qwen2_audio.py
+++ b/tests/models/qwen2_audio/test_processing_qwen2_audio.py
@@ -31,8 +31,8 @@ class Qwen2AudioProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         cls.audio_token = processor.audio_token
 
     def test_can_load_various_tokenizers(self):
-        processor = Qwen2AudioProcessor.from_pretrained(self.full_tmpdirname)
-        tokenizer = AutoTokenizer.from_pretrained(self.full_tmpdirname)
+        processor = Qwen2AudioProcessor.from_pretrained(self.tmpdirname)
+        tokenizer = AutoTokenizer.from_pretrained(self.tmpdirname)
         self.assertEqual(processor.tokenizer.__class__, tokenizer.__class__)
 
     def test_tokenizer_integration(self):

--- a/tests/models/qwen2_audio/test_processing_qwen2_audio.py
+++ b/tests/models/qwen2_audio/test_processing_qwen2_audio.py
@@ -23,6 +23,7 @@ from ...test_processing_common import ProcessorTesterMixin, url_to_local_path
 @require_torchaudio
 class Qwen2AudioProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen2AudioProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-qwen2_audio"
     model_id = "Qwen/Qwen2-Audio-7B-Instruct"
 
     @classmethod
@@ -30,13 +31,13 @@ class Qwen2AudioProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         cls.audio_token = processor.audio_token
 
     def test_can_load_various_tokenizers(self):
-        processor = Qwen2AudioProcessor.from_pretrained(self.model_id)
-        tokenizer = AutoTokenizer.from_pretrained(self.model_id)
+        processor = Qwen2AudioProcessor.from_pretrained(self.full_tmpdirname)
+        tokenizer = AutoTokenizer.from_pretrained(self.full_tmpdirname)
         self.assertEqual(processor.tokenizer.__class__, tokenizer.__class__)
 
     def test_tokenizer_integration(self):
-        slow_tokenizer = AutoTokenizer.from_pretrained(self.model_id, use_fast=False)
-        fast_tokenizer = AutoTokenizer.from_pretrained(self.model_id, from_slow=True, legacy=False)
+        slow_tokenizer = AutoTokenizer.from_pretrained(self.full_tmpdirname, use_fast=False)
+        fast_tokenizer = AutoTokenizer.from_pretrained(self.full_tmpdirname, from_slow=True, legacy=False)
 
         prompt = "<|im_start|>system\nAnswer the questions.<|im_end|><|im_start|>user\n<|audio_bos|><|AUDIO|><|audio_eos|>\nWhat is it in this audio?<|im_end|><|im_start|>assistant\n"
         EXPECTED_OUTPUT = [
@@ -72,7 +73,7 @@ class Qwen2AudioProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertEqual(fast_tokenizer.tokenize(prompt), EXPECTED_OUTPUT)
 
     def test_chat_template(self):
-        processor = AutoProcessor.from_pretrained(self.model_id)
+        processor = self.get_processor(use_tiny_ckpt=False)
         expected_prompt = "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nAudio 1: <|audio_bos|><|AUDIO|><|audio_eos|>\nWhat's that sound?<|im_end|>\n<|im_start|>assistant\nIt is the sound of glass shattering.<|im_end|>\n<|im_start|>user\nAudio 2: <|audio_bos|><|AUDIO|><|audio_eos|>\nHow about this one?<|im_end|>\n<|im_start|>assistant\n"
 
         messages = [

--- a/tests/models/qwen2_audio/test_processing_qwen2_audio.py
+++ b/tests/models/qwen2_audio/test_processing_qwen2_audio.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import unittest
 
-from transformers import AutoProcessor, AutoTokenizer, Qwen2AudioProcessor
+from transformers import AutoTokenizer, Qwen2AudioProcessor
 from transformers.testing_utils import require_torch, require_torchaudio
 
 from ...test_processing_common import ProcessorTesterMixin, url_to_local_path

--- a/tests/models/qwen2_vl/test_processing_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_processing_qwen2_vl.py
@@ -37,15 +37,12 @@ if is_torch_available():
 @require_torchvision
 class Qwen2VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen2VLProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-qwen2_vl"
     model_id = "Qwen/Qwen2-VL-7B-Instruct"
 
     @classmethod
     def _setup_from_pretrained(cls, model_id, **kwargs):
         return super()._setup_from_pretrained(model_id, patch_size=4, max_pixels=56 * 56, min_pixels=28 * 28, **kwargs)
-
-    @classmethod
-    def _setup_test_attributes(cls, processor):
-        cls.image_token = processor.image_token
 
     def test_get_num_vision_tokens(self):
         "Tests general functionality of the helper used internally in vLLM"

--- a/tests/models/qwen2_vl/test_processing_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_processing_qwen2_vl.py
@@ -37,8 +37,8 @@ if is_torch_available():
 @require_torchvision
 class Qwen2VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen2VLProcessor
+    # Tiny processor created with make_tiny_processor.py from "Qwen/Qwen2-VL-7B-Instruct"
     tiny_model_id = "hf-internal-testing/tiny-processor-qwen2_vl"
-    model_id = "Qwen/Qwen2-VL-7B-Instruct"
 
     @classmethod
     def _setup_from_pretrained(cls, model_id, **kwargs):

--- a/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
@@ -45,8 +45,8 @@ if is_torch_available():
 @require_torchvision
 class Qwen3OmniMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen3OmniMoeProcessor
+    # Tiny processor created with make_tiny_processor.py from "Qwen/Qwen2.5-Omni-7B"
     tiny_model_id = "hf-internal-testing/tiny-processor-qwen3_omni_moe"
-    model_id = "Qwen/Qwen2.5-Omni-7B"
 
     @classmethod
     def _setup_image_processor(cls):

--- a/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
@@ -52,14 +52,14 @@ class Qwen3OmniMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def _setup_image_processor(cls):
         image_processor_class = cls._get_component_class_from_processor("image_processor")
         return image_processor_class.from_pretrained(
-            cls.model_id, size={"shortest_edge": 28 * 28, "longest_edge": 56 * 56}
+            cls.tiny_model_id, size={"shortest_edge": 28 * 28, "longest_edge": 56 * 56}
         )
 
     @classmethod
     def _setup_video_processor(cls):
         video_processor_class = cls._get_component_class_from_processor("video_processor")
         return video_processor_class.from_pretrained(
-            cls.model_id, size={"shortest_edge": 28 * 28, "longest_edge": 56 * 56}
+            cls.tiny_model_id, size={"shortest_edge": 28 * 28, "longest_edge": 56 * 56}
         )
 
     def prepare_audio_inputs(self, batch_size: int = 3):

--- a/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
@@ -45,6 +45,7 @@ if is_torch_available():
 @require_torchvision
 class Qwen3OmniMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen3OmniMoeProcessor
+    tiny_model_id = "hf-internal-testing/tiny-processor-qwen3_omni_moe"
     model_id = "Qwen/Qwen2.5-Omni-7B"
 
     @classmethod

--- a/tests/models/qwen3_vl/test_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_processing_qwen3_vl.py
@@ -36,7 +36,6 @@ class Qwen3VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen3VLProcessor
     # Use tiny repos to avoid loading the full 151k-vocab tokenizer (~327 MB)
     tiny_model_id = "hf-internal-testing/tiny-processor-qwen3_vl"
-    model_id = "hf-internal-testing/tiny-processor-qwen3_vl"
     video_unstructured_max_length = 870
     video_text_kwargs_max_length = 870
     video_text_kwargs_override_max_length = 870

--- a/tests/models/qwen3_vl/test_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_processing_qwen3_vl.py
@@ -35,6 +35,7 @@ if is_torch_available():
 class Qwen3VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen3VLProcessor
     # Use tiny repos to avoid loading the full 151k-vocab tokenizer (~327 MB)
+    # Tiny processor created with make_tiny_processor.py from "Qwen/Qwen3-VL-235B-A22B-Instruct"
     tiny_model_id = "hf-internal-testing/tiny-processor-qwen3_vl"
     video_unstructured_max_length = 870
     video_text_kwargs_max_length = 870

--- a/tests/models/qwen3_vl/test_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_processing_qwen3_vl.py
@@ -34,14 +34,12 @@ if is_torch_available():
 @require_torchvision
 class Qwen3VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen3VLProcessor
-    model_id = "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    # Use tiny repos to avoid loading the full 151k-vocab tokenizer (~327 MB)
+    tiny_model_id = "hf-internal-testing/tiny-processor-qwen3_vl"
+    model_id = "hf-internal-testing/tiny-processor-qwen3_vl"
     video_unstructured_max_length = 870
     video_text_kwargs_max_length = 870
     video_text_kwargs_override_max_length = 870
-
-    @classmethod
-    def _setup_from_pretrained(cls, model_id, **kwargs):
-        return super()._setup_from_pretrained(model_id, patch_size=4, max_pixels=56 * 56, min_pixels=28 * 28, **kwargs)
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/seamless_m4t/test_processing_seamless_m4t.py
+++ b/tests/models/seamless_m4t/test_processing_seamless_m4t.py
@@ -29,7 +29,7 @@ from .test_feature_extraction_seamless_m4t import floats_list
 @require_torch
 class SeamlessM4TProcessorTest(unittest.TestCase):
     def setUp(self):
-        self.checkpoint = "facebook/hf-seamless-m4t-medium"
+        self.checkpoint = "hf-internal-testing/tiny-processor-seamless_m4t"
         self.tmpdirname = tempfile.mkdtemp()
 
     def get_tokenizer(self, **kwargs):

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -28,8 +28,8 @@ from ...test_processing_common import ProcessorTesterMixin, url_to_local_path
 class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = SmolVLMProcessor
     videos_input_name = "pixel_values"
+    # Tiny processor created with make_tiny_processor.py from "HuggingFaceTB/SmolVLM2-256M-Video-Instruct"
     tiny_model_id = "hf-internal-testing/tiny-processor-smolvlm"
-    model_id = "HuggingFaceTB/SmolVLM2-256M-Video-Instruct"
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -77,6 +77,9 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     def prepare_video_inputs(self, batch_size: int | None = None):
         """This function prepares a list of numpy videos."""
+        # 2 frames instead of 8: with 8 frames the expanded video token sequence exceeds the max_length
+        # used in truncation tests, truncation cuts through video tokens, and _check_special_mm_tokens
+        # raises a mismatch error.
         video_input = [np.random.randint(255, size=(3, 30, 400), dtype=np.uint8)] * 2
         if batch_size is None:
             return [[video_input]]

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -77,7 +77,7 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     def prepare_video_inputs(self, batch_size: int | None = None):
         """This function prepares a list of numpy videos."""
-        video_input = [np.random.randint(255, size=(3, 30, 400), dtype=np.uint8)] * 8
+        video_input = [np.random.randint(255, size=(3, 30, 400), dtype=np.uint8)] * 2
         if batch_size is None:
             return [[video_input]]
         return [[video_input]] * batch_size

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -28,6 +28,7 @@ from ...test_processing_common import ProcessorTesterMixin, url_to_local_path
 class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = SmolVLMProcessor
     videos_input_name = "pixel_values"
+    tiny_model_id = "hf-internal-testing/tiny-processor-smolvlm"
     model_id = "HuggingFaceTB/SmolVLM2-256M-Video-Instruct"
 
     @classmethod

--- a/tests/models/trocr/test_processing_trocr.py
+++ b/tests/models/trocr/test_processing_trocr.py
@@ -3,7 +3,6 @@ import unittest
 import pytest
 
 from transformers.testing_utils import (
-    require_sentencepiece,
     require_tokenizers,
     require_vision,
 )
@@ -16,22 +15,12 @@ if is_vision_available():
     from transformers import TrOCRProcessor
 
 
-@require_sentencepiece
 @require_tokenizers
 @require_vision
 class TrOCRProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     text_input_name = "labels"
     processor_class = TrOCRProcessor
-
-    @classmethod
-    def _setup_image_processor(cls):
-        image_processor_class = cls._get_component_class_from_processor("image_processor")
-        return image_processor_class()
-
-    @classmethod
-    def _setup_tokenizer(cls):
-        tokenizer_class = cls._get_component_class_from_processor("tokenizer")
-        return tokenizer_class.from_pretrained("FacebookAI/xlm-roberta-base")
+    tiny_model_id = "hf-internal-testing/tiny-processor-trocr"
 
     def test_processor_text(self):
         processor = self.get_processor()

--- a/tests/models/trocr/test_processing_trocr.py
+++ b/tests/models/trocr/test_processing_trocr.py
@@ -20,6 +20,7 @@ if is_vision_available():
 class TrOCRProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     text_input_name = "labels"
     processor_class = TrOCRProcessor
+    # Tiny processor created with make_tiny_processor.py from "microsoft/trocr-base-handwritten"
     tiny_model_id = "hf-internal-testing/tiny-processor-trocr"
 
     def test_processor_text(self):

--- a/tests/models/video_llama_3/test_processing_video_llama_3.py
+++ b/tests/models/video_llama_3/test_processing_video_llama_3.py
@@ -42,8 +42,8 @@ def prepare_image_inputs():
 @require_torchvision
 class VideoLlama3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = VideoLlama3Processor
+    # Tiny processor created with make_tiny_processor.py from "lkhl/VideoLLaMA3-2B-Image-HF"
     tiny_model_id = "hf-internal-testing/tiny-processor-video_llama_3"
-    model_id = "lkhl/VideoLLaMA3-2B-Image-HF"
 
     @classmethod
     def _setup_from_pretrained(cls, model_id, **kwargs):

--- a/tests/models/video_llama_3/test_processing_video_llama_3.py
+++ b/tests/models/video_llama_3/test_processing_video_llama_3.py
@@ -42,6 +42,7 @@ def prepare_image_inputs():
 @require_torchvision
 class VideoLlama3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = VideoLlama3Processor
+    tiny_model_id = "hf-internal-testing/tiny-processor-video_llama_3"
     model_id = "lkhl/VideoLLaMA3-2B-Image-HF"
 
     @classmethod

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -151,20 +151,19 @@ class ProcessorTesterMixin:
             cls._setup_test_attributes(tiny_processor)
             tiny_processor.save_pretrained(cls.tmpdirname)
 
-            cls.full_tmpdirname = tempfile.mkdtemp()
-            # If model_id is specified, load components from that model
+            # If model_id is specified, load the full processor into full_tmpdirname.
+            # If model_id is None, no full processor is needed: full_tmpdirname stays None,
+            # and get_processor(use_tiny_ckpt=False) will fall back to tmpdirname (tiny).
             if cls.model_id is not None:
+                cls.full_tmpdirname = tempfile.mkdtemp()
                 full_processor = cls._setup_from_pretrained(cls.model_id)
-            else:
-                # Otherwise, create generic components
-                full_processor = cls._setup_from_components()
-            # TODO: make this more robust. We intentionally do NOT call _setup_test_attributes(full_processor)
-            # here because it would overwrite the class attributes already set from tiny_processor (e.g.
-            # image_token, video_token, audio_token). We assume these special tokens are identical between
-            # the tiny and full processor — but this is not guaranteed: if the tiny tokenizer is built
-            # differently (e.g. missing special tokens or using different token strings), cls.image_token
-            # etc. will silently reflect the wrong values for tests that use the full processor.
-            full_processor.save_pretrained(cls.full_tmpdirname)
+                # TODO: make this more robust. We intentionally do NOT call _setup_test_attributes(full_processor)
+                # here because it would overwrite the class attributes already set from tiny_processor (e.g.
+                # image_token, video_token, audio_token). We assume these special tokens are identical between
+                # the tiny and full processor — but this is not guaranteed: if the tiny tokenizer is built
+                # differently (e.g. missing special tokens or using different token strings), cls.image_token
+                # etc. will silently reflect the wrong values for tests that use the full processor.
+                full_processor.save_pretrained(cls.full_tmpdirname)
         else:
             # No tiny_model_id: tmpdirname holds the only processor.
             # If model_id is specified, load components from that model


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47115)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47115)
<!-- ci-dashboard-badge:end -->

(merged as it's just to use tiny processor on the hub)

## Summary

A follow-up PR of #47104

Processor tests currently load full pretrained tokenizers (up to 256k vocab, ~300 MB each) at `setUpClass` time, causing excessive RSS growth per test run. This PR introduces tiny Hub repos (`hf-internal-testing/tiny-processor-*`) with trimmed tokenizers (~500 tokens) for 38 processor test files, plus a tiny `DacModel` for the Dia test.

**Changes:**
- `tests/test_processing_common.py`: added `tiny_model_id` class attribute. When set, `tmpdirname` holds the tiny processor (used by all tests); `full_tmpdirname` holds the full processor only when `model_id` is also set (used by the few tests that need hardcoded token IDs). If `model_id = None`, `full_tmpdirname` is skipped entirely.
- 38 processor test files: set `tiny_model_id = "hf-internal-testing/tiny-processor-<model>"`.
- `tests/models/dia/test_processing_dia.py`: use `hf-internal-testing/tiny-dac-44khz` (0.54 MB vs ~95 MB).
- `tests/models/seamless_m4t/test_processing_seamless_m4t.py`: use `hf-internal-testing/tiny-processor-seamless_m4t`.

## Memory impact (measured on Linux CI, 39 test files)

| | Total delta MB | Duration | Entries ≥ 100 MB |
|---|---|---|---|
| **Before** | 18,291 MB | 2,793s (46.5 min) | 36 |
| **After** | 7,482 MB | 326s (5.4 min) | 24 |
| **Reduction** | **−59%** | **−88% (8.6×)** | **−33%** |

**Notable individual fixes:**
- `llava`: 428 → 33 MB
- `fuyu`: 347 → 50 MB
- `altclip`: 254 → 6 MB
- `trocr`: 251 → 11 MB
- `colqwen2`: 111 → 5 MB
- `idefics3`: 102 → 4 MB
- `gemma3n`: 91 → 4 MB
- `lighton_ocr`: 37 → 4 MB

### Before — 38 models, 18,291 MB total delta, 46.5 min

```
   Max dMB   Total dMB   >=10MB   Wall Time  Model
----------  ----------  -------  ----------  --------------------
  +   428.8       490.8        3       27.2s  llava
  +   424.4       948.9       11      162.5s  minicpmv4_6
  +   402.3       988.8       12       71.2s  qwen2_5_omni
  +   347.7       860.2        4      103.3s  fuyu
  +   254.3       638.8        7      111.1s  altclip
  +   251.5       637.4        6      112.1s  trocr
  +   213.7       521.5        6      130.2s  glm4v
  +   210.3       545.6        7       63.5s  qwen3_vl
  +   172.9       461.3        7      132.8s  glm46v
  +   166.9       816.2       14       64.1s  qwen2_vl
  +   156.5       500.8        7       29.5s  llava_next_video
  +   155.2       442.3        9       50.2s  kosmos2_5
  +   128.2       655.8       12       63.0s  qwen2_5_vl
  +   126.6       264.8        2       19.3s  idefics2
  +   126.3       695.5       12       67.2s  internvl
  +   124.6       432.8        6       95.6s  ernie4_5_vl_moe
  +   124.1       428.2       10       66.6s  video_llama_3
  +   111.2       347.7       11       44.3s  colqwen2
  +   107.9       382.0        6       74.1s  qwen3_omni_moe
  +   102.3       600.8       13      106.1s  idefics3
  +    98.4       764.4       15       38.4s  smolvlm
  +    92.9       603.3       12       92.3s  mllama
  +    91.2       586.6       12      170.0s  gemma3n
  +    89.6       563.8       21       14.1s  owlv2
  +    84.8       298.4        6       60.2s  csm
  +    70.2       514.7       12       48.6s  qianfan_ocr
  +    69.1       327.5        8       43.0s  qwen2_audio
  +    61.1       547.8       13       95.0s  pixtral
  +    60.2       265.9        7       46.6s  janus
  +    56.2       246.1        5       25.4s  donut
  +    50.6       388.5       12      100.1s  mistral3
  +    43.2       402.1       15       69.4s  aria
  +    37.8       308.5       11      148.8s  lighton_ocr
  +    28.8       165.5        3      124.7s  glm_image
  +    26.2       431.1       25       14.1s  clip
  +    24.7       165.9        3      104.8s  aya_vision
  +    12.6        19.5        1        1.9s  parakeet
  +    10.0        30.8        1        1.6s  grounding_dino
```

### After — 38 models, 7,482 MB total delta, 5.4 min

```
   Max dMB   Total dMB   >=10MB   Wall Time  Model
----------  ----------  -------  ----------  --------------------
  +   376.8       548.1        2        6.1s  qwen3_vl
  +   327.6       513.2        3       16.9s  qwen2_5_omni
  +   323.6       650.2        4        8.4s  minicpmv4_6
  +   279.7       455.0        3        6.6s  glm4v
  +   245.6       379.4        2        8.2s  qwen2_vl
  +   237.4       394.9        2       18.8s  ernie4_5_vl_moe
  +   235.2       389.4        2        8.2s  internvl
  +   198.5       812.4       13       15.7s  smolvlm
  +   195.3       501.4        7        9.0s  llava_next_video
  +   170.9       304.0        2        8.2s  qwen2_5_vl
  +   147.5       235.9        3       17.4s  kosmos2_5
  +   145.3       360.3        4        3.8s  idefics2
  +   126.2       256.8        2        9.4s  glm46v
  +   119.4       154.2        2       10.4s  video_llama_3
  +    89.2       288.4        5       15.0s  qwen3_omni_moe
  +    61.2       171.8        3       13.9s  qwen2_audio
  +    50.7        95.5        2       15.6s  mistral3
  +    50.6        85.7        2       14.0s  fuyu
  +    46.9       239.9       10        2.2s  owlv2
  +    42.3        67.8        2        5.8s  csm
  +    41.7       122.6        4        5.3s  qianfan_ocr
  +    33.5        76.6        2        5.0s  llava
  +    30.3        67.1        2       11.9s  pixtral
  +    25.1        43.1        1        8.1s  mllama
  +    21.9        53.4        3        5.8s  aria
  +    15.1        47.6        2        2.2s  clip
  +    12.5        14.7        1        2.2s  parakeet
  +    11.4        25.7        1        1.8s  trocr
  +     7.3        11.1        0        9.8s  donut
  +     7.2        10.0        0        9.3s  glm_image
  +     6.9        27.0        0        2.1s  grounding_dino
  +     6.1         9.5        0        5.1s  altclip
  +     5.4         9.5        0        2.8s  colqwen2
  +     5.1        16.4        0        5.3s  aya_vision
  +     4.6        12.1        0        5.6s  janus
  +     4.6        12.8        0        4.7s  lighton_ocr
  +     4.0         9.2        0       13.7s  gemma3n
  +     4.0         8.9        0       11.2s  idefics3
```

Remaining high-memory entries (24) are all video/audio frame loading (`test_apply_chat_template_video_frame_sampling`) — a separate issue unrelated to tokenizer size.