### PR TITLE
[cache] Simplify cache dispatch based on layer_types

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1491,7 +1491,7 @@ def get_layer_types_and_kwargs(config: PreTrainedConfig) -> tuple[list[str], dic
 
     # Prepare additional kwargs that may be needed to __init__ the cache layers
     layer_kwargs = {}
-    if "sliding_attention" in layer_types:
+    if "sliding_attention" in layer_types or "hybrid_sliding" in layer_types:
         layer_kwargs["sliding_window"] = config.sliding_window
     if "chunked_attention" in layer_types:
         layer_kwargs["sliding_window"] = config.attention_chunk_size

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -23,44 +23,24 @@ _is_torch_greater_or_equal_than_2_7 = is_torch_greater_or_equal("2.7", accept_de
 logger = logging.get_logger(__name__)
 
 
-# Registry mapping ``config.layer_types[i]`` -> the dynamic cache layer class to build for
-# that layer. ``DynamicCache.__init__`` consults this mapping when a ``config`` is provided
-# so models with custom layer types (e.g. DeepSeek-V4's CSA / HCA) can register their own
-# cache-layer subclass and stop needing a model-specific ``Cache`` subclass.
-#
-# A cache layer subclass with a class attribute ``layer_type = "..."`` auto-registers via
-# ``CacheLayerMixin.__init_subclass__``. Each registered class must accept a
-# ``PreTrainedConfig`` (the decoder text config) as the only positional argument.
-LAYER_TYPE_CACHE_MAPPING: dict[str, type] = {}
-
-# Parallel registry for the *static* implementation of a custom layer type, consulted by
-# ``StaticCache``. A ``StaticLayer`` subclass with a ``layer_type`` registers here instead of in
-# ``LAYER_TYPE_CACHE_MAPPING`` (constructed with ``max_cache_len=...``), so a single ``layer_type``
-# can have both a dynamic and a static cache layer (e.g. M3's sparse-attention indexer cache).
-LAYER_TYPE_STATIC_CACHE_MAPPING: dict[str, type] = {}
-
-
 class CacheLayerMixin(ABC):
     """Base, abstract class for a single layer's cache."""
 
     is_compileable = False
     supports_early_init = True
-    # Subclasses can set ``layer_type`` to auto-register themselves in
-    # ``LAYER_TYPE_CACHE_MAPPING`` at import time (used by ``DynamicCache`` to dispatch
-    # per-layer cache classes from ``config.layer_types``).
-    layer_type: str | None = None
+    # Subclasses can set `layer_type` to auto-register themselves in the mappings, if the class definition lives in a modeling
+    # file instead of this file. This allows to update the mapping only when the modeling file is imported, which simplify imports
+    _layer_type: str | None = None
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        layer_type = cls.__dict__.get("layer_type", None)
-        if layer_type is not None:
-            static_base = globals().get("StaticLayer")
-            if static_base is not None and issubclass(cls, static_base):
-                LAYER_TYPE_STATIC_CACHE_MAPPING[layer_type] = cls
+        if cls._layer_type is not None:
+            if issubclass(cls, StaticLayer):
+                STATIC_LAYER_TYPE_MAPPING[cls._layer_type] = cls
             else:
-                LAYER_TYPE_CACHE_MAPPING[layer_type] = cls
+                DYNAMIC_LAYER_TYPE_MAPPING[cls._layer_type] = cls
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.keys: torch.Tensor | None = None
         self.values: torch.Tensor | None = None
         self.is_initialized = False
@@ -136,9 +116,6 @@ class DynamicLayer(CacheLayerMixin):
     """
 
     is_sliding = False
-
-    def __init__(self, config: PreTrainedConfig | None = None):
-        super().__init__()
 
     def lazy_initialization(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
         self.dtype, self.device = key_states.dtype, key_states.device
@@ -218,14 +195,8 @@ class DynamicSlidingWindowLayer(DynamicLayer):
 
     is_sliding = True
 
-    def __init__(self, config: PreTrainedConfig | None = None, sliding_window: int | None = None):
+    def __init__(self, sliding_window: int, **kwargs):
         super().__init__()
-        # Accept either a config (registry-style construction via LAYER_TYPE_CACHE_MAPPING)
-        # or a raw ``sliding_window`` int (legacy callers).
-        if sliding_window is None:
-            if config is None:
-                raise ValueError("Either `config` or `sliding_window` must be provided.")
-            sliding_window = getattr(config, "sliding_window", None) or getattr(config, "attention_chunk_size", None)
         self.sliding_window = sliding_window
         self.cumulative_length = 0
         self._sliding_window_tensor = torch.tensor(self.sliding_window, dtype=torch.long)
@@ -306,11 +277,8 @@ class DynamicIndexedLayer(DynamicLayer):
     The indexer key cache stores a tensor of shape `[batch_size, seq_len, index_head_dim]` (3D, single-head).
     """
 
-    # Auto-registers in ``LAYER_TYPE_CACHE_MAPPING`` so ``DynamicCache`` dispatches DSA layers here.
-    layer_type = "deepseek_sparse_attention"
-
-    def __init__(self, config: PreTrainedConfig | None = None):
-        super().__init__(config)
+    def __init__(self, **kwargs):
+        super().__init__()
         self.indexer_keys: torch.Tensor | None = None
         self.is_indexer_initialized: bool = False
 
@@ -386,7 +354,7 @@ class StaticLayer(CacheLayerMixin):
     is_compileable = True
     is_sliding = False
 
-    def __init__(self, max_cache_len: int):
+    def __init__(self, max_cache_len: int, **kwargs):
         super().__init__()
         self.max_cache_len = max_cache_len
         # Very important that it's a tensor here, to avoid recompiling when we update it and use it to create positions
@@ -494,7 +462,7 @@ class StaticSlidingWindowLayer(StaticLayer):
 
     is_sliding = True
 
-    def __init__(self, max_cache_len: int, sliding_window: int):
+    def __init__(self, max_cache_len: int, sliding_window: int, **kwargs):
         effective_max_cache_len = min(sliding_window, max_cache_len)
         super().__init__(max_cache_len=effective_max_cache_len)
         # Here, to avoid data-dependent control flows, we also need to use a python int to keep track of the cumulative length
@@ -616,7 +584,7 @@ class StaticIndexedLayer(StaticLayer):
     The indexer key cache stores a tensor of shape `[batch_size, max_cache_len, index_head_dim]` (3D, single-head).
     """
 
-    def __init__(self, max_cache_len: int):
+    def __init__(self, max_cache_len: int, **kwargs):
         super().__init__(max_cache_len=max_cache_len)
         self.indexer_keys: torch.Tensor | None = None
         self.is_indexer_initialized: bool = False
@@ -869,7 +837,7 @@ class LinearAttentionCacheLayerMixin(ABC):
     # Linear attention layers track their own conv/recurrent states; they don't use the key/value early-init path.
     supports_early_init = False
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.conv_states: torch.Tensor | None = None
         self.recurrent_states: torch.Tensor | None = None
         self.is_conv_states_initialized = False
@@ -930,9 +898,6 @@ class LinearAttentionCacheLayerMixin(ABC):
 
 
 class LinearAttentionLayer(LinearAttentionCacheLayerMixin):
-    def __init__(self, config: PreTrainedConfig | None = None):
-        super().__init__()
-
     def lazy_initialization(
         self, conv_states: torch.Tensor | None = None, recurrent_states: torch.Tensor | None = None
     ) -> None:
@@ -1012,7 +977,7 @@ class LinearAttentionAndFullAttentionLayer(LinearAttentionLayer, DynamicLayer):
     # The dynamic Attention part makes it non-compileable
     is_compileable = False
 
-    def __init__(self, config: PreTrainedConfig | None = None):
+    def __init__(self, **kwargs):
         DynamicLayer.__init__(self)
         LinearAttentionLayer.__init__(self)
 
@@ -1047,8 +1012,8 @@ class LinearAttentionAndSlidingWindowAttentionLayer(LinearAttentionLayer, Dynami
     # The dynamic sliding attention part makes it non-compileable
     is_compileable = False
 
-    def __init__(self, config: PreTrainedConfig | None = None):
-        DynamicSlidingWindowLayer.__init__(self, config)
+    def __init__(self, sliding_window: int, **kwargs):
+        DynamicSlidingWindowLayer.__init__(self, sliding_window=sliding_window)
         LinearAttentionLayer.__init__(self)
 
     def lazy_initialization(self, *args, **kwargs) -> None:
@@ -1070,27 +1035,36 @@ class LinearAttentionAndSlidingWindowAttentionLayer(LinearAttentionLayer, Dynami
         DynamicSlidingWindowLayer.reorder_cache(self, beam_idx)
 
 
-# Pre-register the standard layer types (some classes are shared between multiple types,
-# e.g. ``DynamicSlidingWindowLayer`` covers both ``"sliding_attention"`` and
-# ``"chunked_attention"`` — those need an explicit map entry rather than the
-# auto-registration via ``CacheLayerMixin.__init_subclass__``).
-LAYER_TYPE_CACHE_MAPPING.update(
-    {
-        "full_attention": DynamicLayer,
-        # From a cache point of view, sliding and chunked are the same in how they should behave;
-        # only the mask differs.
-        "sliding_attention": DynamicSlidingWindowLayer,
-        "chunked_attention": DynamicSlidingWindowLayer,
-        # Linear-attention-shaped placeholders (no per-token KV; recurrent state only).
-        # "conv" reuses the same cache shape as linear attention but stores a conv state buffer rather than recurrent SSM state.
-        "conv": LinearAttentionLayer,
-        "moe": LinearAttentionLayer,
-        "linear_attention": LinearAttentionLayer,
-        # Hybrid layers carry both a linear-attention state and a dynamic-attention state.
-        "hybrid": LinearAttentionAndFullAttentionLayer,
-        "hybrid_sliding": LinearAttentionAndSlidingWindowAttentionLayer,
-    }
-)
+# Mappings from layer_type to layer cache class
+DYNAMIC_LAYER_TYPE_MAPPING = {
+    "full_attention": DynamicLayer,
+    # From a cache point of view, sliding and chunked are the same in how they should behave, only the mask differs
+    "sliding_attention": DynamicSlidingWindowLayer,
+    "chunked_attention": DynamicSlidingWindowLayer,
+    # Linear-attention-shaped placeholders (no per-token KV; recurrent state only).
+    # "conv" reuses the same cache shape as linear attention but stores a conv state buffer rather than recurrent SSM state
+    "conv": LinearAttentionLayer,
+    "moe": LinearAttentionLayer,
+    "linear_attention": LinearAttentionLayer,
+    # Hybrid layers carry both a linear-attention state and a dynamic-attention state.
+    "hybrid": LinearAttentionAndFullAttentionLayer,
+    "hybrid_sliding": LinearAttentionAndSlidingWindowAttentionLayer,
+    # More exotic implementations
+    "deepseek_sparse_attention": DynamicIndexedLayer,
+}
+# Same but for StaticCache
+STATIC_LAYER_TYPE_MAPPING = {
+    "full_attention": StaticLayer,
+    # From a cache point of view, sliding and chunked are the same in how they should behave, only the mask differs
+    "sliding_attention": StaticSlidingWindowLayer,
+    "chunked_attention": StaticSlidingWindowLayer,
+    # LinearAttention layers are considered both static and dynamic (they are static, but are used as-is for any cache type)
+    "conv": LinearAttentionLayer,
+    "moe": LinearAttentionLayer,
+    "linear_attention": LinearAttentionLayer,
+    # More exotic implementations
+    "deepseek_sparse_attention": StaticIndexedLayer,
+}
 
 
 class Cache:
@@ -1546,28 +1520,28 @@ class DynamicCache(Cache):
         offloading: bool = False,
         offload_only_non_sliding: bool = False,
     ):
-        layers = []
         # If a config is passed, use it to infer the layer types and initialize accordingly
-        if config is not None:
-            decoder_config = config.get_text_config(decoder=True)
-            sliding_window = getattr(decoder_config, "sliding_window", None) or getattr(
-                decoder_config, "attention_chunk_size", None
-            )
-            layer_types = getattr(decoder_config, "layer_types", None)
-            if layer_types is None:
-                layer_types = []
-                for _ in range(decoder_config.num_hidden_layers):
-                    if sliding_window is not None:
-                        layer_types.append("sliding_attention")
-                    else:
-                        layer_types.append("full_attention")
+        decoder_config = config.get_text_config(decoder=True)
+        layer_types = getattr(decoder_config, "layer_types", None)
+        # The config is usually not used, but pass it for convenience with exotic layer cache implementations
+        layer_kwargs = {"config": decoder_config}
+        # If `layer_types` is not explicitly provided, infer if the model is fully sliding
+        if layer_types is None:
+            if getattr(decoder_config, "sliding_window", None) is not None:
+                layer_types = ["sliding_attention" for _ in range(decoder_config.num_hidden_layers)]
+                layer_kwargs["sliding_window"] = decoder_config.sliding_window
+            elif getattr(decoder_config, "attention_chunk_size", None) is not None:
+                layer_types = ["chunked_attention" for _ in range(decoder_config.num_hidden_layers)]
+                layer_kwargs["sliding_window"] = decoder_config.attention_chunk_size
+            else:
+                layer_types = ["full_attention" for _ in range(decoder_config.num_hidden_layers)]
+
             # Some models have shared layers thus no cache is needed for them (e.g. Gemma3n)
             if hasattr(decoder_config, "num_kv_shared_layers"):
                 layer_types = layer_types[: -decoder_config.num_kv_shared_layers]
 
-            for layer_type in layer_types:
-                cache_cls = LAYER_TYPE_CACHE_MAPPING.get(layer_type, DynamicLayer)
-                layers.append(cache_cls(decoder_config))
+        # Dispatch the layer types
+        layers = [DYNAMIC_LAYER_TYPE_MAPPING[layer_type](**layer_kwargs) for layer_type in layer_types]
 
         # In this case, use the passed data to already fill in the Cache
         if ddp_cache_data is not None:
@@ -1653,12 +1627,16 @@ class StaticCache(Cache):
     ):
         config = config.get_text_config(decoder=True)
         layer_types = getattr(config, "layer_types", None)
+        # The config is usually not used, but pass it for convenience with exotic layer cache implementations
+        layer_kwargs = {"max_cache_len": max_cache_len, "config": config}
         # If `layer_types` is not explicitly provided, infer if the model is fully sliding
         if layer_types is None:
             if getattr(config, "sliding_window", None) is not None:
                 layer_types = ["sliding_attention" for _ in range(config.num_hidden_layers)]
+                layer_kwargs["sliding_window"] = config.sliding_window
             elif getattr(config, "attention_chunk_size", None) is not None:
                 layer_types = ["chunked_attention" for _ in range(config.num_hidden_layers)]
+                layer_kwargs["sliding_window"] = config.attention_chunk_size
             else:
                 layer_types = ["full_attention" for _ in range(config.num_hidden_layers)]
         # Some models have shared layers thus no cache is needed for them (e.g. Gemma3n)
@@ -1666,33 +1644,8 @@ class StaticCache(Cache):
         if num_kv_shared_layers > 0:
             layer_types = layer_types[:-num_kv_shared_layers]
 
-        sliding_layer_types = {
-            name
-            for name, cls in LAYER_TYPE_CACHE_MAPPING.items()
-            if isinstance(cls, type) and issubclass(cls, DynamicSlidingWindowLayer) and name != "chunked_attention"
-        }
-        layers = []
-        for layer_type in layer_types:
-            if layer_type == "chunked_attention":
-                # From a cache point of view, both sliding and chunked are the same in how they should behave and how many
-                # states they should return - only the mask changes to make them different at the end!
-                layer = StaticSlidingWindowLayer(
-                    max_cache_len=max_cache_len, sliding_window=config.attention_chunk_size
-                )
-            elif layer_type in sliding_layer_types:
-                layer = StaticSlidingWindowLayer(max_cache_len=max_cache_len, sliding_window=config.sliding_window)
-            # Recurrent-state-only layers — linear-attention, conv, MoE — share the same static cache class.
-            elif layer_type in ("linear_attention", "conv", "moe"):
-                layer = LinearAttentionLayer()
-            # Custom layer types (e.g. M3's sparse-attention indexer cache) that registered a static variant.
-            elif layer_type in LAYER_TYPE_STATIC_CACHE_MAPPING:
-                layer = LAYER_TYPE_STATIC_CACHE_MAPPING[layer_type](max_cache_len=max_cache_len)
-            elif layer_type == "deepseek_sparse_attention":
-                # Static / compile-friendly indexed layer (preallocated indexer key cache).
-                layer = StaticIndexedLayer(max_cache_len=max_cache_len)
-            else:
-                layer = StaticLayer(max_cache_len=max_cache_len)
-            layers.append(layer)
+        # Dispatch the layer types
+        layers = [STATIC_LAYER_TYPE_MAPPING[layer_type](**layer_kwargs) for layer_type in layer_types]
 
         super().__init__(layers=layers, offloading=offloading, offload_only_non_sliding=offload_only_non_sliding)
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1470,6 +1470,35 @@ class Cache:
         return self.batch_size
 
 
+def get_layer_types_and_kwargs(config: PreTrainedConfig) -> tuple[list[str], dict]:
+    """
+    From a `config`, extract the layer types if not present already, as well as the kwargs needed to initialize
+    the corresponding layer caches.
+    """
+    layer_kwargs = {}
+    layer_types = getattr(config, "layer_types", None)
+    # If `layer_types` is not explicitly provided, infer it from config fields
+    if layer_types is None:
+        if getattr(config, "sliding_window", None) is not None:
+            layer_types = ["sliding_attention" for _ in range(config.num_hidden_layers)]
+            layer_kwargs["sliding_window"] = config.sliding_window
+        elif getattr(config, "attention_chunk_size", None) is not None:
+            layer_types = ["chunked_attention" for _ in range(config.num_hidden_layers)]
+            layer_kwargs["sliding_window"] = config.attention_chunk_size
+        else:
+            layer_types = ["full_attention" for _ in range(config.num_hidden_layers)]
+
+    # Some models have shared layers thus no cache is needed for them (e.g. Gemma3n)
+    if hasattr(config, "num_kv_shared_layers"):
+        layer_types = layer_types[: -config.num_kv_shared_layers]
+
+    # In this case,
+    if "heavily_compressed_attention" in layer_types or "compressed_sparse_attention" in layer_types:
+        layer_kwargs["config"] = config
+
+    return layer_types, layer_kwargs
+
+
 class DynamicCache(Cache):
     """
     A cache that grows dynamically as more tokens are generated. This is the default for generative models.
@@ -1520,28 +1549,13 @@ class DynamicCache(Cache):
         offloading: bool = False,
         offload_only_non_sliding: bool = False,
     ):
+        layers = []
         # If a config is passed, use it to infer the layer types and initialize accordingly
-        decoder_config = config.get_text_config(decoder=True)
-        layer_types = getattr(decoder_config, "layer_types", None)
-        # The config is usually not used, but pass it for convenience with exotic layer cache implementations
-        layer_kwargs = {"config": decoder_config}
-        # If `layer_types` is not explicitly provided, infer if the model is fully sliding
-        if layer_types is None:
-            if getattr(decoder_config, "sliding_window", None) is not None:
-                layer_types = ["sliding_attention" for _ in range(decoder_config.num_hidden_layers)]
-                layer_kwargs["sliding_window"] = decoder_config.sliding_window
-            elif getattr(decoder_config, "attention_chunk_size", None) is not None:
-                layer_types = ["chunked_attention" for _ in range(decoder_config.num_hidden_layers)]
-                layer_kwargs["sliding_window"] = decoder_config.attention_chunk_size
-            else:
-                layer_types = ["full_attention" for _ in range(decoder_config.num_hidden_layers)]
-
-            # Some models have shared layers thus no cache is needed for them (e.g. Gemma3n)
-            if hasattr(decoder_config, "num_kv_shared_layers"):
-                layer_types = layer_types[: -decoder_config.num_kv_shared_layers]
-
-        # Dispatch the layer types
-        layers = [DYNAMIC_LAYER_TYPE_MAPPING[layer_type](**layer_kwargs) for layer_type in layer_types]
+        if config is not None:
+            decoder_config = config.get_text_config(decoder=True)
+            layer_types, layer_kwargs = get_layer_types_and_kwargs(decoder_config)
+            # Dispatch the layer types
+            layers = [DYNAMIC_LAYER_TYPE_MAPPING[layer_type](**layer_kwargs) for layer_type in layer_types]
 
         # In this case, use the passed data to already fill in the Cache
         if ddp_cache_data is not None:
@@ -1625,28 +1639,10 @@ class StaticCache(Cache):
         offload_only_non_sliding: bool = True,
         **kwargs,
     ):
-        config = config.get_text_config(decoder=True)
-        layer_types = getattr(config, "layer_types", None)
-        # The config is usually not used, but pass it for convenience with exotic layer cache implementations
-        layer_kwargs = {"max_cache_len": max_cache_len, "config": config}
-        # If `layer_types` is not explicitly provided, infer if the model is fully sliding
-        if layer_types is None:
-            if getattr(config, "sliding_window", None) is not None:
-                layer_types = ["sliding_attention" for _ in range(config.num_hidden_layers)]
-                layer_kwargs["sliding_window"] = config.sliding_window
-            elif getattr(config, "attention_chunk_size", None) is not None:
-                layer_types = ["chunked_attention" for _ in range(config.num_hidden_layers)]
-                layer_kwargs["sliding_window"] = config.attention_chunk_size
-            else:
-                layer_types = ["full_attention" for _ in range(config.num_hidden_layers)]
-        # Some models have shared layers thus no cache is needed for them (e.g. Gemma3n)
-        num_kv_shared_layers = getattr(config, "num_kv_shared_layers", 0)
-        if num_kv_shared_layers > 0:
-            layer_types = layer_types[:-num_kv_shared_layers]
-
+        layer_types, layer_kwargs = get_layer_types_and_kwargs(config.get_text_config(decoder=True))
+        layer_kwargs["max_cache_len"] = max_cache_len
         # Dispatch the layer types
         layers = [STATIC_LAYER_TYPE_MAPPING[layer_type](**layer_kwargs) for layer_type in layer_types]
-
         super().__init__(layers=layers, offloading=offloading, offload_only_non_sliding=offload_only_non_sliding)
 
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1492,7 +1492,7 @@ def get_layer_types_and_kwargs(config: PreTrainedConfig) -> tuple[list[str], dic
     if hasattr(config, "num_kv_shared_layers"):
         layer_types = layer_types[: -config.num_kv_shared_layers]
 
-    # In this case,
+    # In this case, we need to pass the config as well to properly __init__ the layer classes
     if "heavily_compressed_attention" in layer_types or "compressed_sparse_attention" in layer_types:
         layer_kwargs["config"] = config
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1475,16 +1475,13 @@ def get_layer_types_and_kwargs(config: PreTrainedConfig) -> tuple[list[str], dic
     From a `config`, extract the layer types if not present already, as well as the kwargs needed to initialize
     the corresponding layer caches.
     """
-    layer_kwargs = {}
     layer_types = getattr(config, "layer_types", None)
     # If `layer_types` is not explicitly provided, infer it from config fields
     if layer_types is None:
         if getattr(config, "sliding_window", None) is not None:
             layer_types = ["sliding_attention" for _ in range(config.num_hidden_layers)]
-            layer_kwargs["sliding_window"] = config.sliding_window
         elif getattr(config, "attention_chunk_size", None) is not None:
             layer_types = ["chunked_attention" for _ in range(config.num_hidden_layers)]
-            layer_kwargs["sliding_window"] = config.attention_chunk_size
         else:
             layer_types = ["full_attention" for _ in range(config.num_hidden_layers)]
 
@@ -1492,6 +1489,12 @@ def get_layer_types_and_kwargs(config: PreTrainedConfig) -> tuple[list[str], dic
     if hasattr(config, "num_kv_shared_layers"):
         layer_types = layer_types[: -config.num_kv_shared_layers]
 
+    # Prepare additional kwargs that may be needed to __init__ the cache layers
+    layer_kwargs = {}
+    if "sliding_attention" in layer_types:
+        layer_kwargs["sliding_window"] = config.sliding_window
+    if "chunked_attention" in layer_types:
+        layer_kwargs["sliding_window"] = config.attention_chunk_size
     # In this case, we need to pass the config as well to properly __init__ the layer classes
     if "heavily_compressed_attention" in layer_types or "compressed_sparse_attention" in layer_types:
         layer_kwargs["config"] = config

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -28,7 +28,7 @@ class CacheLayerMixin(ABC):
 
     is_compileable = False
     supports_early_init = True
-    # Subclasses can set `layer_type` to auto-register themselves in the mappings, if the class definition lives in a modeling
+    # Subclasses can set `_layer_type` to auto-register themselves in the mappings, if the class definition lives in a modeling
     # file instead of this file. This allows to update the mapping only when the modeling file is imported, which simplifies imports
     _layer_type: str | None = None
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -29,7 +29,7 @@ class CacheLayerMixin(ABC):
     is_compileable = False
     supports_early_init = True
     # Subclasses can set `layer_type` to auto-register themselves in the mappings, if the class definition lives in a modeling
-    # file instead of this file. This allows to update the mapping only when the modeling file is imported, which simplify imports
+    # file instead of this file. This allows to update the mapping only when the modeling file is imported, which simplifies imports
     _layer_type: str | None = None
 
     def __init_subclass__(cls, **kwargs):

--- a/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
+++ b/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
@@ -191,10 +191,10 @@ class DeepseekV4HCACache(DynamicSlidingWindowLayer):
         `position_ids` so prefill -> decode -> prefill stays consistent.
     """
 
-    layer_type = "heavily_compressed_attention"
+    _layer_type = "heavily_compressed_attention"
 
-    def __init__(self, config: "DeepseekV4Config"):
-        super().__init__(config)
+    def __init__(self, config: "DeepseekV4Config", **kwargs):
+        super().__init__(sliding_window=config.sliding_window)
         self.compress_rate = config.compress_rates["heavily_compressed_attention"]
         self.buffer_kv: dict[str, torch.Tensor | None] = {"compressor": None}
         self.buffer_gate: dict[str, torch.Tensor | None] = {"compressor": None}
@@ -271,9 +271,9 @@ class DeepseekV4CSACache(DeepseekV4HCACache):
     again. That's what `overlap_kv[name]` / `overlap_gate[name]` persist.
     """
 
-    layer_type = "compressed_sparse_attention"
+    _layer_type = "compressed_sparse_attention"
 
-    def __init__(self, config: "DeepseekV4Config"):
+    def __init__(self, config: "DeepseekV4Config", **kwargs):
         super().__init__(config)
         self.compress_rate = config.compress_rates["compressed_sparse_attention"]
         self.buffer_kv["indexer"] = None

--- a/src/transformers/models/deepseek_v4/modular_deepseek_v4.py
+++ b/src/transformers/models/deepseek_v4/modular_deepseek_v4.py
@@ -154,10 +154,10 @@ class DeepseekV4HCACache(DynamicSlidingWindowLayer):
         `position_ids` so prefill -> decode -> prefill stays consistent.
     """
 
-    layer_type = "heavily_compressed_attention"
+    _layer_type = "heavily_compressed_attention"
 
-    def __init__(self, config: "DeepseekV4Config"):
-        super().__init__(config)
+    def __init__(self, config: "DeepseekV4Config", **kwargs):
+        super().__init__(sliding_window=config.sliding_window)
         self.compress_rate = config.compress_rates["heavily_compressed_attention"]
         self.buffer_kv: dict[str, torch.Tensor | None] = {"compressor": None}
         self.buffer_gate: dict[str, torch.Tensor | None] = {"compressor": None}
@@ -234,9 +234,9 @@ class DeepseekV4CSACache(DeepseekV4HCACache):
     again. That's what `overlap_kv[name]` / `overlap_gate[name]` persist.
     """
 
-    layer_type = "compressed_sparse_attention"
+    _layer_type = "compressed_sparse_attention"
 
-    def __init__(self, config: "DeepseekV4Config"):
+    def __init__(self, config: "DeepseekV4Config", **kwargs):
         super().__init__(config)
         self.compress_rate = config.compress_rates["compressed_sparse_attention"]
         self.buffer_kv["indexer"] = None

--- a/src/transformers/models/minimax_m3_vl/modeling_minimax_m3_vl.py
+++ b/src/transformers/models/minimax_m3_vl/modeling_minimax_m3_vl.py
@@ -29,7 +29,6 @@ import torch.nn.functional as F
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, DynamicLayer, StaticLayer
-from ...configuration_utils import PreTrainedConfig
 from ...generation import GenerationMixin
 from ...integrations import use_experts_implementation
 from ...masking_utils import create_causal_mask
@@ -53,10 +52,10 @@ from .configuration_minimax_m3_vl import MiniMaxM3VLConfig, MiniMaxM3VLTextConfi
 
 
 class MiniMaxM3VLSparseCacheLayer(DynamicLayer):
-    layer_type = "minimax_m3_sparse"
+    _layer_type = "minimax_m3_sparse"
 
-    def __init__(self, config: PreTrainedConfig | None = None):
-        super().__init__(config)
+    def __init__(self, **kwargs):
+        super().__init__()
         self.idx_keys: torch.Tensor | None = None
 
     def update_index(self, idx_k: torch.Tensor) -> torch.Tensor:
@@ -88,9 +87,9 @@ class MiniMaxM3VLSparseCacheLayer(DynamicLayer):
 
 
 class MiniMaxM3VLSparseStaticCacheLayer(StaticLayer):
-    layer_type = "minimax_m3_sparse"
+    _layer_type = "minimax_m3_sparse"
 
-    def __init__(self, max_cache_len: int):
+    def __init__(self, max_cache_len: int, **kwargs):
         super().__init__(max_cache_len)
         self.idx_keys: torch.Tensor | None = None
         # Tensor (not int) so it can be marked as a static address for cudagraphs, like `cumulative_length`.

--- a/src/transformers/models/minimax_m3_vl/modular_minimax_m3_vl.py
+++ b/src/transformers/models/minimax_m3_vl/modular_minimax_m3_vl.py
@@ -230,10 +230,10 @@ class MiniMaxM3VLConfig(PreTrainedConfig):
 
 
 class MiniMaxM3VLSparseCacheLayer(DynamicLayer):
-    layer_type = "minimax_m3_sparse"
+    _layer_type = "minimax_m3_sparse"
 
-    def __init__(self, config: PreTrainedConfig | None = None):
-        super().__init__(config)
+    def __init__(self, **kwargs):
+        super().__init__()
         self.idx_keys: torch.Tensor | None = None
 
     def update_index(self, idx_k: torch.Tensor) -> torch.Tensor:
@@ -265,9 +265,9 @@ class MiniMaxM3VLSparseCacheLayer(DynamicLayer):
 
 
 class MiniMaxM3VLSparseStaticCacheLayer(StaticLayer):
-    layer_type = "minimax_m3_sparse"
+    _layer_type = "minimax_m3_sparse"
 
-    def __init__(self, max_cache_len: int):
+    def __init__(self, max_cache_len: int, **kwargs):
         super().__init__(max_cache_len)
         self.idx_keys: torch.Tensor | None = None
         # Tensor (not int) so it can be marked as a static address for cudagraphs, like `cumulative_length`.


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47118)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47118)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

As per the title. This create a mapping for sliding layers as well, because we are currently in a place where we have a mapping but it's not used to dispatch static layers. Also makes the mappings more explicit by only using `__init_subclass__` if the cache layer lives in another modeling file.