### PR TITLE
Fix image_transforms.pad rejecting NumPy-int padding and float constant_values

### DIFF
--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -721,10 +721,13 @@ def pad(
             values = ((values, values), (values, values))
         elif isinstance(values, tuple) and len(values) == 1:
             values = ((values[0], values[0]), (values[0], values[0]))
-        elif isinstance(values, tuple) and len(values) == 2 and isinstance(values[0], int):
-            values = (values, values)
         elif isinstance(values, tuple) and len(values) == 2 and isinstance(values[0], tuple):
             pass
+        elif isinstance(values, tuple) and len(values) == 2:
+            # (before, after) pair of scalars applied to both axes. Accept any
+            # scalar here (e.g. Python/NumPy ints for `padding`, floats for
+            # `constant_values`), not just Python `int`.
+            values = (values, values)
         else:
             raise ValueError(f"Unsupported format: {values}")
 

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -431,6 +431,19 @@ class ImageTransformsTester(unittest.TestCase):
         # fmt: on
         self.assertTrue(np.allclose(expected_image, pad(image, 1)))
 
+        # `padding` given as a (before, after) pair must accept NumPy integers,
+        # not only Python `int` (padding amounts are commonly computed from array shapes).
+        self.assertTrue(np.allclose(pad(image, (2, 1)), pad(image, (np.int64(2), np.int64(1)))))
+
+        # `constant_values` given as a (before, after) pair of floats must be accepted,
+        # matching its documented `Iterable[float]` type.
+        self.assertTrue(
+            np.allclose(
+                pad(image, 1, constant_values=(0.5, 1.0)),
+                pad(image, 1, constant_values=((0.5, 1.0), (0.5, 1.0))),
+            )
+        )
+
         # Test the left and right of each axis is padded (pad_left, pad_right)
         # fmt: off
         expected_image = np.array(


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47119)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47119)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`image_transforms.pad()` builds its `np.pad` arguments via `_expand_for_data_format`, which only accepted a `(before, after)` pair when its first element was a Python `int`. So two valid, documented inputs crash:

```python
import numpy as np
from transformers.image_transforms import pad

# padding amounts derived from an image's .shape are NumPy ints:
pad(image, (np.int64(1), np.int64(2)))        # ValueError: Unsupported format
# constant_values is documented as `float | Iterable[float]`:
pad(image, 1, constant_values=(0.5, 1.0))     # ValueError: Unsupported format
```

`(1, 2)` (Python ints) works, but the equivalent NumPy ints don't and NumPy ints are exactly what you get when padding is computed from array shapes.

The fix distinguishes the nested `((before_h, after_h), (before_w, after_w))` form (first element is a tuple → passed through) from a scalar `(before, after)` pair (applied to both axes), instead of gating on Python `int`. Added regression assertions to `test_pad`.

No linked issue - small self-contained bug fix.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

@yonigozlan (vision / image processing)

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->