### PR TITLE
we want to run the CI in the release branches

### DIFF
--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - ci-*
+      - v*-release
 
 concurrency:
   # Group by PR number, commit SHA (main) to avoid cross-branch cancellation, or branch ref for cancellation within each branch


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47125)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47125)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

We missed the release branches in the new WF

The CircleCI to AWS migration swapped an implicit "run on every branch" model for an explicit allowlist (main, ci-*) and we did not add release branches.