### PR TITLE
[Fix] Make DeepGEMM triton fallback more robust

### DIFF
--- a/src/transformers/integrations/deepgemm.py
+++ b/src/transformers/integrations/deepgemm.py
@@ -74,7 +74,7 @@ class DeepGEMM:
 
 
 @functools.cache
-def _try_loading_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
+def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
     """Load DeepGEMM once or returns an error message if env or any required symbol is missing. This is wrapped in a
     function that will raise an `ImportError` with the error message. The reason we raise in the wrapper rather than
     here is that @functools.cache will only cache a return value, not an exception.
@@ -183,23 +183,22 @@ def _try_loading_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str
     )
 
 
-def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM:
-    deepgemm_or_error = _try_loading_deepgemm_kernel(requires_sm100=requires_sm100)
-    if isinstance(deepgemm_or_error, str):
-        raise ImportError(deepgemm_or_error)
-    return deepgemm_or_error
-
-
 @torch._dynamo.allow_in_graph
 def _populate_deepgemm_kernel(requires_sm100: bool = False) -> None:
-    _ = _load_deepgemm_kernel(requires_sm100=requires_sm100)
+    deepgemm_or_error_msg = _load_deepgemm_kernel(requires_sm100=requires_sm100)
+    if isinstance(deepgemm_or_error_msg, str):
+        raise ImportError(deepgemm_or_error_msg)
     return None
 
 
 def load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM:
     if is_torchdynamo_compiling():
         _populate_deepgemm_kernel(requires_sm100=requires_sm100)
-    return _load_deepgemm_kernel(requires_sm100=requires_sm100)
+
+    deepgemm_or_error = _load_deepgemm_kernel(requires_sm100=requires_sm100)
+    if isinstance(deepgemm_or_error, str):
+        raise ImportError(deepgemm_or_error)
+    return deepgemm_or_error
 
 
 # ── Scale-factor helpers ───────────────────────────────────────────────────────

--- a/src/transformers/integrations/deepgemm.py
+++ b/src/transformers/integrations/deepgemm.py
@@ -18,7 +18,7 @@ Provides:
 - `deepgemm_bf16_experts_forward`: BF16 M-grouped experts forward.
 - `deepgemm_fp8_fp4_linear`: end-to-end FP8/FP4 linear (BF16 in, BF16 out).
 - `deepgemm_fp8_fp4_experts_forward`: FP8 (or FP4 on SM100+) M-grouped experts forward.
-- `deepgemm_fp8_fp4_megamoe_experts_forward`: FP8×FP4 Mega MoE forward (SM100+).
+- `deepgemm_fp8_fp4_megamoe_experts_forward`: FP8xFP4 Mega MoE forward (SM100+).
 
 Requirements: CUDA, Hopper (SM90+), CUDA runtime ≥ 12.3, kernels-community/deep-gemm
 ≥ 2.5 (Mega MoE symbols required). Mega MoE additionally needs SM100+ at call time.
@@ -74,21 +74,23 @@ class DeepGEMM:
 
 
 @functools.cache
-def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM:
-    """Load DeepGEMM once; raise `ImportError` if env or any required symbol is missing.
+def _try_loading_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
+    """Load DeepGEMM once or returns an error message if env or any required symbol is missing. This is wrapped in a
+    function that will raise an `ImportError` with the error message. The reason we raise in the wrapper rather than
+    here is that @functools.cache will only cache a return value, not an exception.
 
-    `requires_sm100` raises a Blackwell-specific error for callers (FP4 / Mega MoE)
-    that won't work on Hopper, instead of the generic SM90+ message.
+    `requires_sm100` raises a Blackwell-specific error for callers (FP4 / Mega MoE) that won't work on Hopper, instead
+    of the generic SM90+ message.
     """
     if not is_torchdynamo_compiling():
         if not is_kernels_available():
-            raise ImportError(
-                "DeepGEMM kernel requires the `kernels` package. "
-                f"Please install a compatible version ({KERNELS_MIN_VERSION} <= version < {KERNELS_MAX_VERSION}), "
-                f"e.g. `pip install kernels=={KERNELS_MIN_VERSION}`"
+            return (
+                "DeepGEMM kernel requires the `kernels` package. Please install a compatible version ("
+                f"{KERNELS_MIN_VERSION} <= version < {KERNELS_MAX_VERSION}), e.g. `pip install kernels=="
+                f"{KERNELS_MIN_VERSION}`"
             )
         if not torch.cuda.is_available():
-            raise ImportError("DeepGEMM kernel requires CUDA, but CUDA is not available.")
+            return "DeepGEMM kernel requires CUDA, but CUDA is not available."
 
         major, minor = torch.cuda.get_device_capability()
         # DeepGEMM ships kernels only for SM90 (Hopper) and SM100 (Blackwell); anything
@@ -96,22 +98,20 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM:
         allowed = (10,) if requires_sm100 else (9, 10)
         if major not in allowed:
             arch = "Blackwell (SM100)" if requires_sm100 else "Hopper (SM90) or Blackwell (SM100)"
-            raise ImportError(f"DeepGEMM requires {arch}; current device is SM{major}{minor}.")
+            return f"DeepGEMM requires {arch}; current device is SM{major}{minor}."
 
         # Per the DeepGEMM README: SM90 needs CUDA 12.3+, SM100 needs CUDA 12.9+.
         cuda_major, cuda_minor = get_cuda_runtime_version()
         min_cuda = (12, 9) if major == 10 else (12, 3)
         if (cuda_major, cuda_minor) < min_cuda:
-            raise ImportError(
+            return (
                 f"DeepGEMM on SM{major}{minor} requires CUDA runtime ≥ {min_cuda[0]}.{min_cuda[1]}, "
                 f"found {cuda_major}.{cuda_minor}."
             )
 
     kernel = lazy_load_kernel("deep-gemm")
     if kernel is None:
-        raise ImportError(
-            "Failed to load `kernels-community/deep-gemm` — check that a build matches the current torch/CUDA."
-        )
+        return "Failed to load `kernels-community/deep-gemm` — check that a build matches the current torch/CUDA."
 
     fp8_fp4_matmul = getattr(kernel, "fp8_fp4_gemm_nt", None)
     grouped_fp8_fp4_matmul_nt = getattr(kernel, "m_grouped_fp8_fp4_gemm_nt_contiguous", None)
@@ -143,11 +143,17 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM:
         if attr is None
     ]
     if missing:
-        raise ImportError(
+        return (
             f"DeepGEMM kernel is missing required symbols: {', '.join(missing)}. "
             f"Please install a compatible version ({KERNELS_MIN_VERSION} <= version < {KERNELS_MAX_VERSION}), "
             f"e.g. `pip install kernels=={KERNELS_MIN_VERSION}`"
         )
+
+    try:
+        m_alignment = int(get_mk_alignment())
+    except Exception as e:
+        return f"Failure when calling `get_mk_alignment`: {type(e).__name__}: {e}"
+
     return DeepGEMM(
         fp8_fp4_matmul=fp8_fp4_matmul,
         grouped_fp8_fp4_matmul_nt=grouped_fp8_fp4_matmul_nt,
@@ -159,8 +165,15 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM:
         transform_weights_for_mega_moe=transform_weights_for_mega_moe,
         get_symm_buffer_for_mega_moe=get_symm_buffer_for_mega_moe,
         fp8_fp4_mega_moe=fp8_fp4_mega_moe,
-        m_alignment=int(get_mk_alignment()),
+        m_alignment=m_alignment,
     )
+
+
+def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM:
+    deepgemm_or_error = _try_loading_deepgemm_kernel(requires_sm100=requires_sm100)
+    if isinstance(deepgemm_or_error, str):
+        raise ImportError(deepgemm_or_error)
+    return deepgemm_or_error
 
 
 @torch._dynamo.allow_in_graph

--- a/src/transformers/integrations/deepgemm.py
+++ b/src/transformers/integrations/deepgemm.py
@@ -154,6 +154,20 @@ def _try_loading_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str
     except Exception as e:
         return f"Failure when calling `get_mk_alignment`: {type(e).__name__}: {e}"
 
+    # Everything up to this point checks that the kernels can be compiled, but never run an actual compilation. This is
+    # done here to can catch a broken CUDA toolchain or version mismatch. A small call but better to fall back early on
+    # Triton rather than failing hard mid-forward.
+    if not is_torchdynamo_compiling():
+        try:
+            sf = torch.zeros(128, 1, dtype=torch.float32, device="cuda")
+            transform_sf_into_required_layout(sf, 128, 128, recipe=(1, 128))
+        except Exception as e:
+            return (
+                f"DeepGEMM failed to JIT-compile a probe kernel, which usually means a broken or version-mismatched "
+                "CUDA toolchain. Check that `CUDA_HOME` points to a complete and version-consistent CUDA toolkit. You "
+                f"can re-run with `DG_JIT_DEBUG=1` for the compiler output. Original error: {type(e).__name__}: {e}"
+            )
+
     return DeepGEMM(
         fp8_fp4_matmul=fp8_fp4_matmul,
         grouped_fp8_fp4_matmul_nt=grouped_fp8_fp4_matmul_nt,

--- a/src/transformers/integrations/deepgemm.py
+++ b/src/transformers/integrations/deepgemm.py
@@ -27,6 +27,10 @@ Requirements: CUDA, Hopper (SM90+), CUDA runtime ≥ 12.3, kernels-community/dee
 from __future__ import annotations
 
 import functools
+import json
+import os
+import re
+import shutil
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -36,7 +40,6 @@ from ..utils import logging
 from ..utils.import_utils import (
     KERNELS_MAX_VERSION,
     KERNELS_MIN_VERSION,
-    get_cuda_runtime_version,
     is_kernels_available,
     is_torchdynamo_compiling,
     resolve_internal_import,
@@ -74,6 +77,72 @@ class DeepGEMM:
 
 
 @functools.cache
+def _get_cuda_home() -> str | None:
+    """Resolve the CUDA toolkit root the way DeepGEMM's JIT does:
+    ``CUDA_HOME`` → ``CUDA_PATH`` → dir of ``which nvcc`` → ``/usr/local/cuda`` (``None`` if none found).
+
+    Mirrors DeepGEMM's own ``_find_cuda_home`` so we agree on the path it will actually use, rather than
+    reusing ``torch.utils.cpp_extension.CUDA_HOME`` whose resolution inits a CUDA context (fork-unsafe).
+    """
+    cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
+    if cuda_home:
+        return cuda_home
+    nvcc = shutil.which("nvcc")
+    if nvcc:
+        return os.path.dirname(os.path.dirname(nvcc))
+    if os.path.isdir("/usr/local/cuda"):
+        return "/usr/local/cuda"
+    return None
+
+
+@functools.cache
+def _get_nvcc_version() -> tuple[int, int] | None:
+    """Version of the CUDA toolkit nvcc will use, as ``(major, minor)``, read off disk without a
+    subprocess from (in order) ``{CUDA_HOME}/version.json``, ``version.txt``, or the ``CUDA_VERSION``
+    define in ``include/cuda.h``. ``None`` if unreadable. This is the compiler that builds the kernels,
+    unlike ``torch.version.cuda`` (torch's bundled runtime, which never drives a JIT compile).
+    """
+    cuda_home = _get_cuda_home()
+    if cuda_home is None:
+        return None
+
+    version_json = os.path.join(cuda_home, "version.json")
+    if os.path.isfile(version_json):
+        try:
+            with open(version_json) as f:
+                components = json.load(f)
+            version = components.get("cuda_nvcc", components.get("cuda", {})).get("version", "")
+            major, minor = version.split(".")[:2]
+            return int(major), int(minor)
+        except (OSError, ValueError, AttributeError):
+            pass
+
+    version_txt = os.path.join(cuda_home, "version.txt")
+    if os.path.isfile(version_txt):
+        try:
+            with open(version_txt) as f:
+                match = re.search(r"CUDA Version (\d+)\.(\d+)", f.read())
+            if match:
+                return int(match.group(1)), int(match.group(2))
+        except (OSError, ValueError):  # ValueError covers UnicodeDecodeError on a non-text file
+            pass
+
+    # `cuda.h` ships with every toolkit (incl. distro packages that have no version file).
+    cuda_h = os.path.join(cuda_home, "include", "cuda.h")
+    if os.path.isfile(cuda_h):
+        try:
+            with open(cuda_h) as f:
+                match = re.search(r"#define CUDA_VERSION (\d+)", f.read())
+            if match:
+                cuda_version = int(match.group(1))
+                return cuda_version // 1000, (cuda_version % 1000) // 10
+        except (OSError, ValueError):  # ValueError covers UnicodeDecodeError on a non-text file
+            pass
+
+    return None
+
+
+@functools.cache
 def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
     """Load DeepGEMM once or returns an error message if env or any required symbol is missing. This is wrapped in a
     function that will raise an `ImportError` with the error message. The reason we raise in the wrapper rather than
@@ -100,13 +169,38 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
             arch = "Blackwell (SM100)" if requires_sm100 else "Hopper (SM90) or Blackwell (SM100)"
             return f"DeepGEMM requires {arch}; current device is SM{major}{minor}."
 
+        # DeepGEMM JIT-compiles kernels with the system nvcc, so a resolvable CUDA toolkit is required.
         # Per the DeepGEMM README: SM90 needs CUDA 12.3+, SM100 needs CUDA 12.9+.
-        cuda_major, cuda_minor = get_cuda_runtime_version()
         min_cuda = (12, 9) if major == 10 else (12, 3)
-        if (cuda_major, cuda_minor) < min_cuda:
+        cuda_home = _get_cuda_home()
+        if cuda_home is None:
             return (
-                f"DeepGEMM on SM{major}{minor} requires CUDA runtime ≥ {min_cuda[0]}.{min_cuda[1]}, "
-                f"found {cuda_major}.{cuda_minor}."
+                f"DeepGEMM's JIT needs a CUDA toolkit ≥ {min_cuda[0]}.{min_cuda[1]}, but none was found. "
+                "Set `CUDA_HOME` to a CUDA toolkit."
+            )
+
+        # The Kernel Hub `deep-gemm` build always uses nvcc and ignores `DG_JIT_USE_NVRTC` (there is no
+        # NVRTC fallback), so `CUDA_HOME` must hold an nvcc of the required version.
+        if not os.path.isfile(os.path.join(cuda_home, "bin", "nvcc")):
+            return (
+                f"DeepGEMM's JIT compiles with nvcc, but none was found in `{cuda_home}/bin`. Point "
+                f"`CUDA_HOME` at a full CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit (not a runtime-only install)."
+            )
+
+        # Treat an unreadable version as unsupported: `cuda.h` (with `CUDA_VERSION`) ships with every real
+        # toolkit, so `None` here means an incomplete install we can't vouch for — fail early to Triton.
+        nvcc_version = _get_nvcc_version()
+        if nvcc_version is None:
+            return (
+                f"DeepGEMM found nvcc in `{cuda_home}/bin` but could not read its CUDA version "
+                f"(no parseable `version.json`, `version.txt`, or `include/cuda.h`). Point `CUDA_HOME` at a "
+                f"complete CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit."
+            )
+        if nvcc_version < min_cuda:
+            return (
+                f"DeepGEMM on SM{major}{minor} needs a CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit, but nvcc "
+                f"{nvcc_version[0]}.{nvcc_version[1]} in `{cuda_home}` is too old. Point `CUDA_HOME` at a "
+                f"CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit."
             )
 
     kernel = lazy_load_kernel("deep-gemm")
@@ -149,25 +243,6 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
             f"e.g. `pip install kernels=={KERNELS_MIN_VERSION}`"
         )
 
-    try:
-        m_alignment = int(get_mk_alignment())
-    except Exception as e:
-        return f"Failure when calling `get_mk_alignment`: {type(e).__name__}: {e}"
-
-    # Everything up to this point checks that the kernels can be compiled, but never run an actual compilation. This is
-    # done here to can catch a broken CUDA toolchain or version mismatch. A small call but better to fall back early on
-    # Triton rather than failing hard mid-forward.
-    if not is_torchdynamo_compiling():
-        try:
-            sf = torch.zeros(128, 1, dtype=torch.float32, device="cuda")
-            transform_sf_into_required_layout(sf, 128, 128, recipe=(1, 128))
-        except Exception as e:
-            return (
-                f"DeepGEMM failed to JIT-compile a probe kernel, which usually means a broken or version-mismatched "
-                "CUDA toolchain. Check that `CUDA_HOME` points to a complete and version-consistent CUDA toolkit. You "
-                f"can re-run with `DG_JIT_DEBUG=1` for the compiler output. Original error: {type(e).__name__}: {e}"
-            )
-
     return DeepGEMM(
         fp8_fp4_matmul=fp8_fp4_matmul,
         grouped_fp8_fp4_matmul_nt=grouped_fp8_fp4_matmul_nt,
@@ -179,22 +254,27 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
         transform_weights_for_mega_moe=transform_weights_for_mega_moe,
         get_symm_buffer_for_mega_moe=get_symm_buffer_for_mega_moe,
         fp8_fp4_mega_moe=fp8_fp4_mega_moe,
-        m_alignment=m_alignment,
+        m_alignment=get_mk_alignment(),
     )
 
 
 @torch._dynamo.allow_in_graph
 def _populate_deepgemm_kernel(requires_sm100: bool = False) -> None:
-    deepgemm_or_error_msg = _load_deepgemm_kernel(requires_sm100=requires_sm100)
-    if isinstance(deepgemm_or_error_msg, str):
-        raise ImportError(deepgemm_or_error_msg)
-    return None
+    """Warm the `_load_deepgemm_kernel` cache from an opaque graph node, so Dynamo never traces the loader.
+
+    Under `torch.compile`, Dynamo ignores `@functools.cache` and traces into `_load_deepgemm_kernel`,
+    whose cold path (hub download + dynamic import via `lazy_load_kernel`) is untraceable and errors under
+    `fullgraph`. `@allow_in_graph` turns the call into an opaque fx node instead — but an fx node's return
+    must be proxyable, and the `DeepGEMM` bundle of Python callables isn't (`Unsupported: torch.* op
+    returned non-Tensor`), so we can't just decorate the real loader. Hence two loaders: this one is
+    opaque, returns `None`, and only warms the cache; the real `_load_deepgemm_kernel` right after is then
+    a plain cache lookup.
+    """
+    _load_deepgemm_kernel(requires_sm100=requires_sm100)
 
 
 def load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM:
-    if is_torchdynamo_compiling():
-        _populate_deepgemm_kernel(requires_sm100=requires_sm100)
-
+    _populate_deepgemm_kernel(requires_sm100=requires_sm100)
     deepgemm_or_error = _load_deepgemm_kernel(requires_sm100=requires_sm100)
     if isinstance(deepgemm_or_error, str):
         raise ImportError(deepgemm_or_error)

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -269,7 +269,10 @@ def fp8_linear(
         except ImportError as e:
             # Forward the original reason so the user knows whether DeepGEMM is unavailable
             # (env/build issue) or refused this specific input (e.g. multi-device on SM100).
-            logger.warning_once(f"DeepGEMM unavailable for this call, falling back to Triton. Reason: {e}")
+            logger.warning_once(
+                f"DeepGEMM unavailable for this call, falling back to Triton. Reason: {e}. "
+                "Set `TRANSFORMERS_DISABLE_DEEPGEMM_LINEAR=1` to skip DeepGEMM for FP8 linear entirely."
+            )
 
     return finegrained_fp8_linear(input, weight, weight_scale_inv, block_size, bias, activation_scale, output_dtype)
 

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -270,7 +270,7 @@ def fp8_linear(
             # Forward the original reason so the user knows whether DeepGEMM is unavailable
             # (env/build issue) or refused this specific input (e.g. multi-device on SM100).
             logger.warning_once(
-                f"DeepGEMM unavailable for this call, falling back to Triton. Reason: {e}. "
+                f"DeepGEMM unavailable for this call, falling back to Triton. Reason: {e} "
                 "Set `TRANSFORMERS_DISABLE_DEEPGEMM_LINEAR=1` to skip DeepGEMM for FP8 linear entirely."
             )
 

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -226,13 +226,21 @@ def is_cuda_platform() -> bool:
 
 @lru_cache
 def get_cuda_runtime_version() -> tuple[int, int]:
-    """Return the CUDA runtime version as (major, minor).
+    """Deprecated. Return the CUDA runtime version as (major, minor).
+
+    Deprecated in favor of ``torch.version.cuda`` for the CUDA runtime version.
 
     Prefers a direct query of ``cudaRuntimeGetVersion`` via ``libcudart.so``. If that's
     not on the system loader path (common with pip-installed torch that bundles its own
     CUDA runtime), falls back to ``torch.version.cuda`` — which equals the bundled
     runtime's version for pip wheels. Returns ``(0, 0)`` for CPU-only torch.
     """
+    warnings.warn(
+        "`get_cuda_runtime_version` is deprecated and will be removed in v5.16. "
+        "Use `torch.version.cuda` for the CUDA runtime version.",
+        FutureWarning,
+        stacklevel=2,
+    )
     import ctypes
 
     try:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -46,6 +46,7 @@ from transformers import (
 from transformers.conversion_mapping import get_model_conversion_mapping
 from transformers.core_model_loading import PrefixChange, WeightRenaming, process_target_pattern
 from transformers.integrations import HfDeepSpeedConfig
+from transformers.integrations.deepgemm import _get_nvcc_version
 from transformers.integrations.deepspeed import (
     is_deepspeed_available,
     is_deepspeed_zero3_enabled,
@@ -119,7 +120,6 @@ from transformers.utils import (
     is_torch_bf16_available_on_device,
     is_torch_fp16_available_on_device,
 )
-from transformers.utils.import_utils import get_cuda_runtime_version
 from transformers.utils.output_capturing import CompileableContextVar, OutputRecorder
 
 from .exporters.test_export import ExportTesterMixin
@@ -610,14 +610,15 @@ def _test_eager_matches_batched_and_grouped_inference(self, name, dtype):
             mocks["sonicmoe"] = Mock(wraps=sonicmoe_experts_forward)
             implementations.append("sonicmoe")
 
+        nvcc_version = _get_nvcc_version() or (0, 0)
+        device_major = torch.cuda.get_device_capability()[0] if torch.cuda.is_available() else 0
+        # DeepGEMM ships kernels only for Hopper (SM90, needs nvcc 12.3+) and Blackwell (SM100, needs 12.9+).
         if (
             dtype == torch.bfloat16
             and is_kernels_available()
-            and torch.cuda.is_available()
-            and torch.cuda.get_device_capability() >= (9, 0)
-            and get_cuda_runtime_version() >= (12, 3)
+            and ((device_major == 9 and nvcc_version >= (12, 3)) or (device_major == 10 and nvcc_version >= (12, 9)))
         ):
-            # DeepGEMM BF16 grouped forward requires Hopper+, CUDA runtime 12.3+, and bf16 hidden states
+            # DeepGEMM BF16 grouped forward requires Hopper+, a new-enough nvcc toolkit, and bf16 hidden states
             mocks["deepgemm"] = Mock(wraps=deepgemm_bf16_experts_forward)
             implementations.append("deepgemm")
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47126)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47126)
<!-- ci-dashboard-badge:end -->

This PR makes the triton fallback to DeepGEMM more robust:
- in case `CUDA_HOME` is not set, the current behavior is to fail with an `AssertionError` which is not caught by the `try` block because it specializes on `ImportError`. To avoid this, we call `get_mk_alignment()` before creating the `DeepGemm` object in a `try` block and pass the missing `CUDA_HOME` error as an `ImportError` -> triton fallback works
- in case `CUDA_HOME` is set but does not match the CUDA toolkit, the JIT compilation will fail but this is not caught at loading time, hence the problem manifests at Runtime and we hard-error instead of falling back to triton. To avoid this, we run a tiny JIT compiled kernel at load time (`transform_sf_into_required_layout`) and fallback to triton if the JIT compilation fails. 

Also, I think the `functools.cache` decorator never worked as intended because it does not catch error raised in the function, so any fail during `_load_deepgemm_kernel` was bound to happen all over again. To avoid this, instead of raising the expected `ImportError` in the cached function, we wrap it into a function that will raise by itself. 

Result: on a machine with no `CUDA_HOME` or a mismatching `CUDA_HOME`, we fall back to triton instead of erroring out. I have not tested on a machine with DeepGEMM but it should not change the behavior or a succesful load. Perhaps @IlyasMoutawwakil can confirm please? Thx!