### PR TITLE
 Fix legacy list-based special_tokens handling in _set_model_specific_special_tokens

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1409,7 +1409,52 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         """
         return self.convert_tokens_to_ids(self.all_special_tokens)
 
-    def _set_model_specific_special_tokens(self, special_tokens: dict[str, str | AddedToken]):
+    def _set_model_specific_special_tokens(self, special_tokens):
+        """
+        Adds model-specific special tokens.
+
+        Supports both:
+        - New format:
+                {
+                    "image_token": "<image>",
+                    "audio_token": "<audio>"
+                }
+
+        - Legacy format:
+                ["<s>NOTUSED", "</s>NOTUSED", "<unk>NOTUSED"]
+        """
+
+        # ------------------------------
+        # Backward compatibility
+        # ------------------------------
+        if isinstance(special_tokens, list):
+            special_tokens = {
+                f"extra_special_token_{i}": token
+                for i, token in enumerate(special_tokens)
+            }
+
+        if not isinstance(special_tokens, dict):
+            raise TypeError(
+                f"`special_tokens` must be a dict or list, "
+                f"but got {type(special_tokens).__name__}."
+            )
+
+        # Register new token names
+        self.SPECIAL_TOKENS_ATTRIBUTES.extend(
+            key
+            for key in special_tokens.keys()
+            if key not in self.SPECIAL_TOKENS_ATTRIBUTES
+        )
+
+        # Store tokens
+        for key, value in special_tokens.items():
+            if isinstance(value, (str, AddedToken)):
+                self._special_tokens_map[key] = value
+            else:
+                raise TypeError(
+                    f"Special token '{key}' must be a str or AddedToken, "
+                    f"got {type(value).__name__}."
+                )
         """
         Adds new model-specific special tokens (e.g., for multimodal models).
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1410,29 +1410,14 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         return self.convert_tokens_to_ids(self.all_special_tokens)
 
     def _set_model_specific_special_tokens(self, special_tokens):
-        """
-        Adds model-specific special tokens.
-
-        Supports legacy tokenizer configs where `special_tokens`
-        may be provided as a list.
-        """
-
-        if isinstance(special_tokens, list):
-            special_tokens = {
-                f"extra_special_token_{i}": token
-                for i, token in enumerate(special_tokens)
-            }
-
         if not isinstance(special_tokens, dict):
             raise TypeError(
-                "`special_tokens` must be a dictionary or a list, "
-                f"got {type(special_tokens).__name__}."
+                "`special_tokens` must be a dictionary mapping attribute names "
+                f"to token values, got {type(special_tokens).__name__}."
             )
 
         self.SPECIAL_TOKENS_ATTRIBUTES.extend(
-            key
-            for key in special_tokens
-            if key not in self.SPECIAL_TOKENS_ATTRIBUTES
+            key for key in special_tokens if key not in self.SPECIAL_TOKENS_ATTRIBUTES
         )
 
         for key, value in special_tokens.items():

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1413,20 +1413,10 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         """
         Adds model-specific special tokens.
 
-        Supports both:
-        - New format:
-                {
-                    "image_token": "<image>",
-                    "audio_token": "<audio>"
-                }
-
-        - Legacy format:
-                ["<s>NOTUSED", "</s>NOTUSED", "<unk>NOTUSED"]
+        Supports legacy tokenizer configs where `special_tokens`
+        may be provided as a list.
         """
 
-        # ------------------------------
-        # Backward compatibility
-        # ------------------------------
         if isinstance(special_tokens, list):
             special_tokens = {
                 f"extra_special_token_{i}": token
@@ -1435,41 +1425,24 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
         if not isinstance(special_tokens, dict):
             raise TypeError(
-                f"`special_tokens` must be a dict or list, "
-                f"but got {type(special_tokens).__name__}."
+                "`special_tokens` must be a dictionary or a list, "
+                f"got {type(special_tokens).__name__}."
             )
 
-        # Register new token names
         self.SPECIAL_TOKENS_ATTRIBUTES.extend(
             key
-            for key in special_tokens.keys()
+            for key in special_tokens
             if key not in self.SPECIAL_TOKENS_ATTRIBUTES
         )
 
-        # Store tokens
         for key, value in special_tokens.items():
-            if isinstance(value, (str, AddedToken)):
-                self._special_tokens_map[key] = value
-            else:
+            if not isinstance(value, (str, AddedToken)):
                 raise TypeError(
                     f"Special token '{key}' must be a str or AddedToken, "
                     f"got {type(value).__name__}."
                 )
-        """
-        Adds new model-specific special tokens (e.g., for multimodal models).
 
-        These tokens are added to the named special tokens map and will be saved in tokenizer config.
-        For example: if the model tokenizer is multimodal, we can support special image or audio tokens.
-
-        Args:
-            special_tokens: Dictionary of {token_name: token_value}
-        """
-        self.SPECIAL_TOKENS_ATTRIBUTES = self.SPECIAL_TOKENS_ATTRIBUTES + list(special_tokens.keys())
-        for key, value in special_tokens.items():
-            if isinstance(value, (str, AddedToken)):
-                self._special_tokens_map[key] = value
-            else:
-                raise TypeError(f"Special token {key} has to be either str or AddedToken but got: {type(value)}")
+            self._special_tokens_map[key] = value
 
     @property
     def added_tokens_decoder(self) -> dict[int, AddedToken]:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47132)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47132)
<!-- ci-dashboard-badge:end -->

## Summary

This PR adds backward compatibility for legacy tokenizer configurations where
`special_tokens` is stored as a list instead of a dictionary.

## Problem

`_set_model_specific_special_tokens()` assumes that `special_tokens` is always a
dictionary and immediately calls:

```python
special_tokens.keys()