### PR TITLE
Fix dtype-sensitive vision position ids for Idefics/SmolVLM

### DIFF
--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -134,9 +134,6 @@ class Idefics2VisionEmbeddings(nn.Module):
         embeddings = patch_embeds.flatten(2).transpose(1, 2)
 
         max_nb_patches_h, max_nb_patches_w = max_im_h // self.patch_size, max_im_w // self.patch_size
-        boundaries = torch.arange(
-            1 / self.num_patches_per_side, 1.0, 1 / self.num_patches_per_side, device=pixel_values.device
-        )
         position_ids = torch.full(
             size=(batch_size, max_nb_patches_h * max_nb_patches_w), fill_value=0, device=pixel_values.device
         )
@@ -144,25 +141,17 @@ class Idefics2VisionEmbeddings(nn.Module):
         nb_patches_h = patch_attention_mask[:, :, 0].sum(dim=1)  # (batch_size,)
         nb_patches_w = patch_attention_mask[:, 0, :].sum(dim=1)  # (batch_size,)
 
-        step_h = 1.0 / nb_patches_h  # (batch_size,)
-        step_w = 1.0 / nb_patches_w  # (batch_size,)
-
         max_patches_h = patch_attention_mask.size(1)
         max_patches_w = patch_attention_mask.size(2)
-        h_indices = torch.arange(max_patches_h, device=position_ids.device, dtype=torch.float32)
-        w_indices = torch.arange(max_patches_w, device=position_ids.device, dtype=torch.float32)
+        h_indices = torch.arange(max_patches_h, device=position_ids.device)
+        w_indices = torch.arange(max_patches_w, device=position_ids.device)
 
-        fractional_coords_h = h_indices[None, :] * step_h[:, None]
-        fractional_coords_w = w_indices[None, :] * step_w[:, None]
-
-        fractional_coords_h = torch.clamp(fractional_coords_h, max=(1.0 - 1e-6))
-        fractional_coords_w = torch.clamp(fractional_coords_w, max=(1.0 - 1e-6))
-
-        fractional_coords_h = fractional_coords_h.to(pixel_values.dtype)
-        fractional_coords_w = fractional_coords_w.to(pixel_values.dtype)
-
-        bucket_coords_h = torch.bucketize(fractional_coords_h, boundaries, right=True)
-        bucket_coords_w = torch.bucketize(fractional_coords_w, boundaries, right=True)
+        bucket_coords_h = (h_indices[None, :] * self.num_patches_per_side // nb_patches_h[:, None]).clamp(
+            max=self.num_patches_per_side - 1
+        )
+        bucket_coords_w = (w_indices[None, :] * self.num_patches_per_side // nb_patches_w[:, None]).clamp(
+            max=self.num_patches_per_side - 1
+        )
 
         pos_ids = bucket_coords_h[:, :, None] * self.num_patches_per_side + bucket_coords_w[:, None, :]
         pos_ids = pos_ids.reshape(batch_size, -1)

--- a/src/transformers/models/idefics3/modeling_idefics3.py
+++ b/src/transformers/models/idefics3/modeling_idefics3.py
@@ -132,9 +132,6 @@ class Idefics3VisionEmbeddings(nn.Module):
         embeddings = patch_embeds.flatten(2).transpose(1, 2)
 
         max_nb_patches_h, max_nb_patches_w = max_im_h // self.patch_size, max_im_w // self.patch_size
-        boundaries = torch.arange(
-            1 / self.num_patches_per_side, 1.0, 1 / self.num_patches_per_side, device=pixel_values.device
-        )
         position_ids = torch.full(
             size=(batch_size, max_nb_patches_h * max_nb_patches_w), fill_value=0, device=pixel_values.device
         )
@@ -142,25 +139,17 @@ class Idefics3VisionEmbeddings(nn.Module):
         nb_patches_h = patch_attention_mask[:, :, 0].sum(dim=1)  # (batch_size,)
         nb_patches_w = patch_attention_mask[:, 0, :].sum(dim=1)  # (batch_size,)
 
-        step_h = 1.0 / nb_patches_h  # (batch_size,)
-        step_w = 1.0 / nb_patches_w  # (batch_size,)
-
         max_patches_h = patch_attention_mask.size(1)
         max_patches_w = patch_attention_mask.size(2)
-        h_indices = torch.arange(max_patches_h, device=position_ids.device, dtype=torch.float32)
-        w_indices = torch.arange(max_patches_w, device=position_ids.device, dtype=torch.float32)
+        h_indices = torch.arange(max_patches_h, device=position_ids.device)
+        w_indices = torch.arange(max_patches_w, device=position_ids.device)
 
-        fractional_coords_h = h_indices[None, :] * step_h[:, None]
-        fractional_coords_w = w_indices[None, :] * step_w[:, None]
-
-        fractional_coords_h = torch.clamp(fractional_coords_h, max=(1.0 - 1e-6))
-        fractional_coords_w = torch.clamp(fractional_coords_w, max=(1.0 - 1e-6))
-
-        fractional_coords_h = fractional_coords_h.to(pixel_values.dtype)
-        fractional_coords_w = fractional_coords_w.to(pixel_values.dtype)
-
-        bucket_coords_h = torch.bucketize(fractional_coords_h, boundaries, right=True)
-        bucket_coords_w = torch.bucketize(fractional_coords_w, boundaries, right=True)
+        bucket_coords_h = (h_indices[None, :] * self.num_patches_per_side // nb_patches_h[:, None]).clamp(
+            max=self.num_patches_per_side - 1
+        )
+        bucket_coords_w = (w_indices[None, :] * self.num_patches_per_side // nb_patches_w[:, None]).clamp(
+            max=self.num_patches_per_side - 1
+        )
 
         pos_ids = bucket_coords_h[:, :, None] * self.num_patches_per_side + bucket_coords_w[:, None, :]
         pos_ids = pos_ids.reshape(batch_size, -1)

--- a/src/transformers/models/smolvlm/modeling_smolvlm.py
+++ b/src/transformers/models/smolvlm/modeling_smolvlm.py
@@ -93,9 +93,6 @@ class SmolVLMVisionEmbeddings(nn.Module):
         embeddings = patch_embeds.flatten(2).transpose(1, 2)
 
         max_nb_patches_h, max_nb_patches_w = max_im_h // self.patch_size, max_im_w // self.patch_size
-        boundaries = torch.arange(
-            1 / self.num_patches_per_side, 1.0, 1 / self.num_patches_per_side, device=pixel_values.device
-        )
         position_ids = torch.full(
             size=(batch_size, max_nb_patches_h * max_nb_patches_w), fill_value=0, device=pixel_values.device
         )
@@ -103,25 +100,17 @@ class SmolVLMVisionEmbeddings(nn.Module):
         nb_patches_h = patch_attention_mask[:, :, 0].sum(dim=1)  # (batch_size,)
         nb_patches_w = patch_attention_mask[:, 0, :].sum(dim=1)  # (batch_size,)
 
-        step_h = 1.0 / nb_patches_h  # (batch_size,)
-        step_w = 1.0 / nb_patches_w  # (batch_size,)
-
         max_patches_h = patch_attention_mask.size(1)
         max_patches_w = patch_attention_mask.size(2)
-        h_indices = torch.arange(max_patches_h, device=position_ids.device, dtype=torch.float32)
-        w_indices = torch.arange(max_patches_w, device=position_ids.device, dtype=torch.float32)
+        h_indices = torch.arange(max_patches_h, device=position_ids.device)
+        w_indices = torch.arange(max_patches_w, device=position_ids.device)
 
-        fractional_coords_h = h_indices[None, :] * step_h[:, None]
-        fractional_coords_w = w_indices[None, :] * step_w[:, None]
-
-        fractional_coords_h = torch.clamp(fractional_coords_h, max=(1.0 - 1e-6))
-        fractional_coords_w = torch.clamp(fractional_coords_w, max=(1.0 - 1e-6))
-
-        fractional_coords_h = fractional_coords_h.to(pixel_values.dtype)
-        fractional_coords_w = fractional_coords_w.to(pixel_values.dtype)
-
-        bucket_coords_h = torch.bucketize(fractional_coords_h, boundaries, right=True)
-        bucket_coords_w = torch.bucketize(fractional_coords_w, boundaries, right=True)
+        bucket_coords_h = (h_indices[None, :] * self.num_patches_per_side // nb_patches_h[:, None]).clamp(
+            max=self.num_patches_per_side - 1
+        )
+        bucket_coords_w = (w_indices[None, :] * self.num_patches_per_side // nb_patches_w[:, None]).clamp(
+            max=self.num_patches_per_side - 1
+        )
 
         pos_ids = bucket_coords_h[:, :, None] * self.num_patches_per_side + bucket_coords_w[:, None, :]
         pos_ids = pos_ids.reshape(batch_size, -1)

--- a/tests/models/smolvlm/test_modeling_smolvlm.py
+++ b/tests/models/smolvlm/test_modeling_smolvlm.py
@@ -50,6 +50,7 @@ if is_torch_available():
         SmolVLMForConditionalGeneration,
         SmolVLMModel,
     )
+    from transformers.models.smolvlm.modeling_smolvlm import SmolVLMVisionEmbeddings
 
 if is_vision_available():
     from PIL import Image
@@ -192,6 +193,53 @@ class SmolVLMModelTest(ModelTesterMixin, unittest.TestCase):
     @unittest.skip(reason="Compile not yet supported in SmolVLM models")
     def test_sdpa_can_dispatch_on_flash(self):
         pass
+
+    def test_vision_position_ids_are_dtype_invariant(self):
+        config = self.model_tester.get_config().vision_config
+        embeddings = SmolVLMVisionEmbeddings(config).to(torch_device)
+        embeddings.eval()
+
+        def patch_embedding(pixel_values):
+            return torch.zeros(
+                pixel_values.shape[0],
+                config.hidden_size,
+                pixel_values.shape[2] // config.patch_size,
+                pixel_values.shape[3] // config.patch_size,
+                device=pixel_values.device,
+            )
+
+        embeddings.patch_embedding.forward = patch_embedding
+        expected_position_ids = torch.arange(embeddings.num_positions, device=torch_device).unsqueeze(0)
+        patch_attention_mask = torch.ones(
+            1,
+            config.image_size // config.patch_size,
+            config.image_size // config.patch_size,
+            dtype=torch.bool,
+            device=torch_device,
+        )
+
+        for dtype in (torch.float32, torch.float16):
+            captured_position_ids = []
+
+            def capture_position_ids(module, inputs):
+                captured_position_ids.append(inputs[0].detach())
+
+            hook = embeddings.position_embedding.register_forward_pre_hook(capture_position_ids)
+            try:
+                pixel_values = torch.zeros(
+                    1,
+                    getattr(config, "num_channels", 3),
+                    config.image_size,
+                    config.image_size,
+                    dtype=dtype,
+                    device=torch_device,
+                )
+                embeddings(pixel_values=pixel_values, patch_attention_mask=patch_attention_mask)
+            finally:
+                hook.remove()
+
+            self.assertEqual(len(captured_position_ids), 1)
+            self.assertTrue(torch.equal(captured_position_ids[0], expected_position_ids))
 
     # We need to override as we need to prepare such that the image token is the last token
     def test_resize_tokens_embeddings(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47133)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47133)
<!-- ci-dashboard-badge:end -->

## What changed

  This updates the vision position id computation used by Idefics2, Idefics3, and SmolVLM to use integer arithmetic instead of floating point bucketization.

  ## Why

  The previous implementation computed fractional coordinates, cast them to `pixel_values.dtype`, and then used `torch.bucketize`. This made the generated position ids dtype-
  sensitive.

  For a full 32x32 patch grid, `float32` could map the last row/column to bucket 30 because of the `1 - 1e-6` clamp, producing max position id 990. In `float16`/`bfloat16`, the
  factor rounds to 1.0, producing the expected max position id 1023.

  The new integer mapping preserves the intended bucket assignment while making it independent of pixel dtype.

  ## Tests

  - `python -m py_compile src/transformers/models/idefics2/modeling_idefics2.py src/transformers/models/idefics3/modeling_idefics3.py src/transformers/models/smolvlm/
  modeling_smolvlm.py tests/models/smolvlm/test_modeling_smolvlm.py`
  - `git diff --check`
  - Added `test_vision_position_ids_are_dtype_invariant`