### PR TITLE
[docs] fix curly quotes rendering to straight quotes

### DIFF
--- a/docs/source/en/attention_interface.md
+++ b/docs/source/en/attention_interface.md
@@ -19,16 +19,17 @@ All attention implementations perform the same computation. Every token is compa
 
 The [`AttentionInterface`] provides optimized attention implementations. It decouples the attention implementation from the model implementation to simplify experimentation with different functions. Add new backends easily with this consistent interface.
 
-| attention backend | description |
-|---|---|
-| `"flash_attention_3"` | improves FlashAttention-2 by also overlapping operations and fusing forward and backward passes more tightly |
-| `"flash_attention_2"` | tiles computations into smaller blocks and uses fast on-chip memory |
-| `"flex_attention"` | framework for specifying custom attention patterns (sparse, block-local, sliding window) without writing low-level kernels by hand |
-| `"sdpa"` | built-in PyTorch implementation of [scaled dot product attention](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) |
-| <code>"paged&#124;flash_attention_3"</code> | Paged version of FlashAttention-3 |
-| <code>"paged&#124;flash_attention_2"</code> | Paged version of FlashAttention-2 |
-| <code>"paged&#124;sdpa"</code> | Paged version of SDPA |
-| <code>"paged&#124;eager"</code> | Paged version of eager |
+<table>
+<tr><th>Attention backend</th><th>Description</th></tr>
+<tr><td><code>"flash_attention_3"</code></td><td>improves FlashAttention-2 by also overlapping operations and fusing forward and backward passes more tightly</td></tr>
+<tr><td><code>"flash_attention_2"</code></td><td>tiles computations into smaller blocks and uses fast on-chip memory</td></tr>
+<tr><td><code>"flex_attention"</code></td><td>framework for specifying custom attention patterns (sparse, block-local, sliding window) without writing low-level kernels by hand</td></tr>
+<tr><td><code>"sdpa"</code></td><td>built-in PyTorch implementation of <a href="https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html">scaled dot product attention</a></td></tr>
+<tr><td><code>"paged&#124;flash_attention_3"</code></td><td>Paged version of FlashAttention-3</td></tr>
+<tr><td><code>"paged&#124;flash_attention_2"</code></td><td>Paged version of FlashAttention-2</td></tr>
+<tr><td><code>"paged&#124;sdpa"</code></td><td>Paged version of SDPA</td></tr>
+<tr><td><code>"paged&#124;eager"</code></td><td>Paged version of eager</td></tr>
+</table>
 
 ## Set an attention backend
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47135)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47135)
<!-- ci-dashboard-badge:end -->

# What does this PR do?
Minor docs polish for [Attention backend docs](https://huggingface.co/docs/transformers/v5.13.0/en/attention_interface), where some options involving the `|` pipe symbol are rendered with curly quotes: `“paged|flash_attention_3”` instead of regular quote `"paged|flash_attention_3"`. It may have been cause of the `<code>` tags and how the docs-builder renders quotes inside HTML tags. Quoting the straight quote outside the code block fixes the issue in the locally built docs. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Tagging @stevhliu since this is concerning docs.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->