### PR TITLE
Fix GLM video frame padding for temporal patches

### DIFF
--- a/src/transformers/models/glm46v/video_processing_glm46v.py
+++ b/src/transformers/models/glm46v/video_processing_glm46v.py
@@ -231,9 +231,10 @@ class Glm46VVideoProcessor(BaseVideoProcessor):
             patches = stacked_videos
 
             # Check that videos have `num_frames` divisible by `temporal_patch_size`
-            if patches.shape[1] % temporal_patch_size != 0:
-                repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
-                patches = torch.cat([patches, repeats], dim=1)
+            T = patches.shape[1]
+            if pad := -T % temporal_patch_size:
+                repeats = patches[:, -1:].expand(-1, pad, -1, -1, -1)
+                patches = torch.cat((patches, repeats), dim=1)
             batch_size, grid_t, channel = patches.shape[:3]
             grid_t = grid_t // temporal_patch_size
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size

--- a/src/transformers/models/glm4v/video_processing_glm4v.py
+++ b/src/transformers/models/glm4v/video_processing_glm4v.py
@@ -204,9 +204,10 @@ class Glm4vVideoProcessor(BaseVideoProcessor):
             patches = stacked_videos
 
             # Check that videos have `num_frames` divisible by `temporal_patch_size`
-            if patches.shape[1] % temporal_patch_size != 0:
-                repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
-                patches = torch.cat([patches, repeats], dim=1)
+            T = patches.shape[1]
+            if pad := -T % temporal_patch_size:
+                repeats = patches[:, -1:].expand(-1, pad, -1, -1, -1)
+                patches = torch.cat((patches, repeats), dim=1)
             batch_size, grid_t, channel = patches.shape[:3]
             grid_t = grid_t // temporal_patch_size
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size

--- a/src/transformers/models/glmga/modular_glmga.py
+++ b/src/transformers/models/glmga/modular_glmga.py
@@ -441,9 +441,10 @@ class GlmgaVideoProcessor(Glm46VVideoProcessor):
             patches = stacked_videos
 
             # Check that videos have `num_frames` divisible by `temporal_patch_size`
-            if patches.shape[1] % temporal_patch_size != 0:
-                repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
-                patches = torch.cat([patches, repeats], dim=1)
+            T = patches.shape[1]
+            if pad := -T % temporal_patch_size:
+                repeats = patches[:, -1:].expand(-1, pad, -1, -1, -1)
+                patches = torch.cat((patches, repeats), dim=1)
             batch_size, grid_t, channel = patches.shape[:3]
             grid_t = grid_t // temporal_patch_size
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size

--- a/src/transformers/models/glmga/video_processing_glmga.py
+++ b/src/transformers/models/glmga/video_processing_glmga.py
@@ -227,9 +227,10 @@ class GlmgaVideoProcessor(BaseVideoProcessor):
             patches = stacked_videos
 
             # Check that videos have `num_frames` divisible by `temporal_patch_size`
-            if patches.shape[1] % temporal_patch_size != 0:
-                repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
-                patches = torch.cat([patches, repeats], dim=1)
+            T = patches.shape[1]
+            if pad := -T % temporal_patch_size:
+                repeats = patches[:, -1:].expand(-1, pad, -1, -1, -1)
+                patches = torch.cat((patches, repeats), dim=1)
             batch_size, grid_t, channel = patches.shape[:3]
             grid_t = grid_t // temporal_patch_size
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size

--- a/src/transformers/models/video_llama_3/modular_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/modular_video_llama_3.py
@@ -1366,9 +1366,10 @@ class VideoLlama3VideoProcessor(Qwen2VLVideoProcessor):
             patches = stacked_videos
 
             # Check that videos have `num_frames` divisible by `temporal_patch_size`
-            if patches.shape[1] % temporal_patch_size != 0:
-                repeats = patches[:, -1:].repeat(1, self.temporal_patch_size - 1, 1, 1, 1)
-                patches = torch.cat([patches, repeats], dim=1)
+            T = patches.shape[1]
+            if pad := -T % temporal_patch_size:
+                repeats = patches[:, -1:].expand(-1, pad, -1, -1, -1)
+                patches = torch.cat((patches, repeats), dim=1)
 
             batch_size, grid_t, channel = patches.shape[:3]
             grid_t = grid_t // temporal_patch_size

--- a/src/transformers/models/video_llama_3/video_processing_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/video_processing_video_llama_3.py
@@ -250,9 +250,10 @@ class VideoLlama3VideoProcessor(BaseVideoProcessor):
             patches = stacked_videos
 
             # Check that videos have `num_frames` divisible by `temporal_patch_size`
-            if patches.shape[1] % temporal_patch_size != 0:
-                repeats = patches[:, -1:].repeat(1, self.temporal_patch_size - 1, 1, 1, 1)
-                patches = torch.cat([patches, repeats], dim=1)
+            T = patches.shape[1]
+            if pad := -T % temporal_patch_size:
+                repeats = patches[:, -1:].expand(-1, pad, -1, -1, -1)
+                patches = torch.cat((patches, repeats), dim=1)
 
             batch_size, grid_t, channel = patches.shape[:3]
             grid_t = grid_t // temporal_patch_size


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47141)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47141)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This PR fixes video frame padding in the GLM-family video processors.

The affected processors currently repeat `temporal_patch_size - 1` frames
whenever the number of video frames is not divisible by `temporal_patch_size`.
That only works for the default `temporal_patch_size = 2`; for larger temporal
patch sizes it can still leave the padded frame count indivisible.

For example, with `num_frames = 18` and `temporal_patch_size = 4`, the current
logic pads to `21` frames, which is still not divisible by `4`. The new logic
matches the Qwen2-VL/Qwen3-VL video processors and pads to the next valid
multiple instead:


https://github.com/huggingface/transformers/blob/v5.13.0/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py#L230-L232
```python
T = patches.shape[1]
if pad := -T % temporal_patch_size:
    repeats = patches[:, -1:].expand(-1, pad, -1, -1, -1)
    patches = torch.cat((patches, repeats), dim=1)
```

This keeps the default GLM configurations unchanged while making the padding
logic correct for non-default temporal patch sizes.

Affected processors:

- `Glm4vVideoProcessor`
- `Glm46VVideoProcessor`
- `GlmgaVideoProcessor`
- `VideoLlama3VideoProcessor`

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.


- vision models: @yonigozlan @molbap
- multimodal models: @zucchini-nlp