### PR TITLE
Cleanup pipelines, stop materializing generators

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -76,6 +76,13 @@ def no_collate_fn(items):
     return items[0]
 
 
+def _reform_generator(first_item, remaining):
+    # Sticks an item back onto the start of a generator. Used when we pop the first item
+    # to infer data formats.
+    yield first_item
+    yield from remaining
+
+
 def _pad(items, key, padding_value, padding_side):
     batch_size = len(items)
     if isinstance(items[0][key], torch.Tensor):
@@ -1205,17 +1212,33 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         if args:
             logger.warning(f"Ignoring args : {args}")
 
-        # Detect if inputs are a chat-style input(s) and cast as `Chat` or list of `Chat`
-        container_types = (list, tuple, types.GeneratorType)
-        if is_torch_available():
-            container_types = (*container_types, KeyDataset)
-        if isinstance(inputs, container_types):
-            if isinstance(inputs, types.GeneratorType):
-                inputs = list(inputs)
-            if is_valid_message(inputs[0]):
-                inputs = Chat(inputs)
-            elif isinstance(inputs[0], (list, tuple)) and all(chat and is_valid_message(chat[0]) for chat in inputs):
-                inputs = [Chat(chat) for chat in inputs]
+        # Detect if inputs are a chat-style input(s) and cast as `Chat` or list of `Chat`.
+        # We peek at the first output of generators to decide the data format, which means we
+        # then have to stick it back on afterward using _reform_generator()
+        if isinstance(inputs, types.GeneratorType):
+            try:
+                first = next(inputs)
+            except StopIteration:
+                inputs = []
+            else:
+                if is_valid_message(first):
+                    inputs = Chat([first, *inputs])
+                elif isinstance(first, (list, tuple)) and first and is_valid_message(first[0]):
+                    # Keep this a generator expression, not a list, so it doesn't materialize everything
+                    inputs = (Chat(chat) for chat in _reform_generator(first, inputs))
+                else:
+                    inputs = _reform_generator(first, inputs)
+        else:
+            container_types = (list, tuple)
+            if is_torch_available():
+                container_types = (*container_types, KeyDataset)
+            if isinstance(inputs, container_types):
+                if is_valid_message(inputs[0]):
+                    inputs = Chat(inputs)
+                elif isinstance(inputs[0], (list, tuple)) and all(
+                    chat and is_valid_message(chat[0]) for chat in inputs
+                ):
+                    inputs = [Chat(chat) for chat in inputs]
 
         if num_workers is None:
             if self._num_workers is None:
@@ -1246,24 +1269,18 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         is_generator = isinstance(inputs, types.GeneratorType)
         is_list = isinstance(inputs, list)
 
-        is_iterable = is_dataset or is_generator or is_list
-        can_use_iterator = is_dataset or is_generator or is_list
-
         if is_list:
-            if can_use_iterator:
-                final_iterator = self.get_iterator(
-                    inputs, num_workers, batch_size, preprocess_params, forward_params, postprocess_params
-                )
-                outputs = list(final_iterator)
-                return outputs
-            else:
-                return self.run_multi(inputs, preprocess_params, forward_params, postprocess_params)
-        elif can_use_iterator:
+            # A list input is eagerly consumed and returns a list of outputs.
+            final_iterator = self.get_iterator(
+                inputs, num_workers, batch_size, preprocess_params, forward_params, postprocess_params
+            )
+            return list(final_iterator)
+        elif is_dataset or is_generator:
+            # Datasets and generators stream lazily: return an iterator consumed on demand so the input is
+            # never fully materialized.
             return self.get_iterator(
                 inputs, num_workers, batch_size, preprocess_params, forward_params, postprocess_params
             )
-        elif is_iterable:
-            return self.iterate(inputs, preprocess_params, forward_params, postprocess_params)
         elif isinstance(self, ChunkPipeline):
             return next(
                 iter(
@@ -1275,20 +1292,11 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         else:
             return self.run_single(inputs, preprocess_params, forward_params, postprocess_params)
 
-    def run_multi(self, inputs, preprocess_params, forward_params, postprocess_params):
-        return [self.run_single(item, preprocess_params, forward_params, postprocess_params) for item in inputs]
-
     def run_single(self, inputs, preprocess_params, forward_params, postprocess_params):
         model_inputs = self.preprocess(inputs, **preprocess_params)
         model_outputs = self.forward(model_inputs, **forward_params)
         outputs = self.postprocess(model_outputs, **postprocess_params)
         return outputs
-
-    def iterate(self, inputs, preprocess_params, forward_params, postprocess_params):
-        # This function should become `get_iterator` again, this is a temporary
-        # easy solution.
-        for input_ in inputs:
-            yield self.run_single(input_, preprocess_params, forward_params, postprocess_params)
 
 
 Pipeline.push_to_hub = copy_func(Pipeline.push_to_hub)

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import itertools
 import logging
 import os
 import sys
@@ -180,6 +181,91 @@ class CommonPipelineTest(unittest.TestCase):
             self.assertEqual(nested_simplify(out), {"label": "LABEL_0", "score": 0.504})
             results.append(out)
         self.assertEqual(len(results), 10)
+
+    @require_torch
+    def test_generator_input_not_materialized(self):
+        # Regression test for #47116: passing a generator must stream lazily rather than be pulled into a
+        # list up front, which OOMs on large/streaming inputs.
+        produced = 0
+
+        def data(n: int):
+            nonlocal produced
+            for _ in range(n):
+                produced += 1
+                yield "This is a test"
+
+        pipe = pipeline(model="hf-internal-testing/tiny-random-distilbert")
+
+        outputs = pipe(data(1000))
+        # A generator input returns a lazy iterator, not a fully materialized list of outputs.
+        self.assertNotIsInstance(outputs, list)
+        # Detecting chat-style inputs only peeks at the first item, so at most one element is consumed up
+        # front (the old code did `list(inputs)`, draining all 1000 here).
+        self.assertLessEqual(produced, 1)
+        # Pulling only the first few outputs must not drain the whole generator.
+        first = list(itertools.islice(outputs, 3))
+        self.assertEqual(len(first), 3)
+        self.assertLess(produced, 1000)
+
+    @require_torch
+    def test_chat_input_as_generator(self):
+        # A single chat can be passed as a generator of messages; it is a bounded conversation that gets
+        # detected and wrapped as a `Chat` (one input), matching the list-of-messages behavior. Downstream
+        # tokenization does not understand `Chat` for text-classification, so we short-circuit `run_single`
+        # and only assert on what it receives.
+        from unittest import mock
+
+        from transformers.utils.chat_template_utils import Chat
+
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"},
+        ]
+
+        class _Stop(Exception):
+            pass
+
+        captured = {}
+
+        def spy(self, inputs, *args, **kwargs):
+            captured["inputs"] = inputs
+            raise _Stop
+
+        pipe = pipeline(model="hf-internal-testing/tiny-random-distilbert")
+        with mock.patch.object(Pipeline, "run_single", spy), self.assertRaises(_Stop):
+            pipe(m for m in messages)
+
+        self.assertIsInstance(captured["inputs"], Chat)
+        self.assertEqual(captured["inputs"].messages, messages)
+
+    @require_torch
+    def test_chats_as_generator_wrapped_lazily(self):
+        # A generator of chats (each a list of messages) is wrapped as `Chat` per item and streamed lazily,
+        # rather than being materialized to a list of `Chat` up front like the list-of-chats case.
+        from unittest import mock
+
+        from transformers.utils.chat_template_utils import Chat
+
+        chats = [
+            [{"role": "user", "content": "Hello!"}],
+            [{"role": "user", "content": "Goodbye!"}],
+        ]
+
+        captured = {}
+
+        def fake_get_iterator(self, inputs, *args, **kwargs):
+            captured["inputs"] = inputs
+            return iter([])
+
+        pipe = pipeline(model="hf-internal-testing/tiny-random-distilbert")
+        with mock.patch.object(Pipeline, "get_iterator", fake_get_iterator):
+            list(pipe(c for c in chats))
+
+        # `get_iterator` receives a still-unconsumed generator; draining it here yields one `Chat` per item.
+        streamed = list(captured["inputs"])
+        self.assertEqual(len(streamed), 2)
+        self.assertTrue(all(isinstance(chat, Chat) for chat in streamed))
+        self.assertEqual(streamed[0].messages, chats[0])
 
     @require_torch
     def test_unbatch_attentions_hidden_states(self):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import datasets
 from huggingface_hub import delete_repo, snapshot_download
@@ -55,6 +56,7 @@ from transformers.testing_utils import (
 )
 from transformers.utils import direct_transformers_import, is_torch_available
 from transformers.utils import logging as transformers_logging
+from transformers.utils.chat_template_utils import Chat
 
 
 sys.path.append(str(Path(__file__).parent.parent.parent / "utils"))
@@ -213,10 +215,6 @@ class CommonPipelineTest(unittest.TestCase):
         # detected and wrapped as a `Chat` (one input), matching the list-of-messages behavior. Downstream
         # tokenization does not understand `Chat` for text-classification, so we short-circuit `run_single`
         # and only assert on what it receives.
-        from unittest import mock
-
-        from transformers.utils.chat_template_utils import Chat
-
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Hello!"},
@@ -242,10 +240,6 @@ class CommonPipelineTest(unittest.TestCase):
     def test_chats_as_generator_wrapped_lazily(self):
         # A generator of chats (each a list of messages) is wrapped as `Chat` per item and streamed lazily,
         # rather than being materialized to a list of `Chat` up front like the list-of-chats case.
-        from unittest import mock
-
-        from transformers.utils.chat_template_utils import Chat
-
         chats = [
             [{"role": "user", "content": "Hello!"}],
             [{"role": "user", "content": "Goodbye!"}],


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47142)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47142)
<!-- ci-dashboard-badge:end -->

This does some cleanups to pipelines, and how we handle complex inputs and generators. In particular, it avoids the situation where large generators were totally materialized, which caused OOMs in some cases.

Fixes #47116