### PR TITLE
revert #47121

### DIFF
--- a/src/transformers/models/dac/modeling_dac.py
+++ b/src/transformers/models/dac/modeling_dac.py
@@ -479,7 +479,6 @@ class DacPreTrainedModel(PreTrainedAudioTokenizerBase):
 
     @torch.no_grad()
     def _init_weights(self, module):
-        super()._init_weights(module)
         if isinstance(module, nn.Conv1d):
             init.trunc_normal_(module.weight, std=0.02)
             init.constant_(module.bias, 0)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47144)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47144)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This reverts commit c2e101442d3e85cf7c8d006dffe8b3eeaa5e7a47, introduced in  #47121.

Indeed, not only did it not fix the mentioned DAC slow test, but introduced a new failure.