### PR TITLE
Fix case where `_LazyAutoMapping.register` is passed a `str` key

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -662,7 +662,7 @@ class _LazyAutoMapping(OrderedDict[type[PreTrainedConfig], _LazyAutoMappingValue
         model_type = self._reverse_config_mapping[item.__name__]
         return model_type in self._model_mapping
 
-    def register(self, key: type[PreTrainedConfig], value: _LazyAutoMappingValue, exist_ok=False) -> None:
+    def register(self, key: type[PreTrainedConfig] | str, value: _LazyAutoMappingValue, exist_ok=False) -> None:
         """
         Register a new model in this mapping.
         """
@@ -677,7 +677,7 @@ class _LazyAutoMapping(OrderedDict[type[PreTrainedConfig], _LazyAutoMappingValue
         # Transformers model/processor/... corresponding to the config)
         # This is because remote/native is indistinguisable from the config class only in such cases, as they both use the same class - then
         # `from_pretrained`/`from_config` are responsible to grab the correct class depending on whether `trust_remote_code` is True/False
-        if key.__module__.startswith("transformers."):
+        if getattr(key, "__module__", "").startswith("transformers."):
             return
 
         # Register the new mapping (this will always take precedence in __getattr__ and __contains__ compared to base mapping)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47148)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47148)
<!-- ci-dashboard-badge:end -->

Downstream users of the auto classes register classes using `str` keys (i.e. model type). https://github.com/huggingface/transformers/pull/46876 added an early exit that causes all downstream usage like this to fail with `AttributeError: 'str' object has no attribute '__module__'`.

This PR adds a `getattr` so that downstream usage of `_LazyAutoMapping.register` is not broken.