### PR TITLE
[docs] MoE decode switching

### DIFF
--- a/docs/source/en/experts_interface.md
+++ b/docs/source/en/experts_interface.md
@@ -31,8 +31,11 @@ The [`ExpertsInterface`] provides optimized experts backends. It decouples the e
 
 The `"batched_mm"` and `"grouped_mm"` backends also run FP8 and FP4 (`int8`-packed) quantized experts through the Triton finegrained-fp8 kernel, reading either `float32` or UE8M0 scales. They act as the fallback for quantized checkpoints when the `"deepgemm"` backend is unavailable.
 
-> [!NOTE]
-> When using `experts_implementation="grouped_mm"` on GPU, the model automatically switches to `"batched_mm"` during the decode stage of generation (after prefill). This is because `batched_mm` is significantly faster on lower token count during autoregressive decoding on GPU. On CPU, `grouped_mm` remains active throughout generation as it is more efficient for all input sizes.
+## Decode-stage switching
+
+On GPU, a model loaded with `experts_implementation="grouped_mm"` automatically switches to `"batched_mm"` for the decode stage of generation, which is significantly faster on lower token counts. The original backend is restored once generation finishes. On CPU, `grouped_mm` stays active throughout generation because it's more efficient at every input size.
+
+The switch reaches MoE layers in the top-level model and in any sub-config backbone, such as the `text_config` of a vision-language model. Only `grouped_mm` entries switch to `batched_mm`. Experts running any other backend keep it.
 
 ## Set an experts backend
 
@@ -52,6 +55,13 @@ Switch between experts backends at runtime without reloading the model using [`~
 
 ```py
 model.set_experts_implementation("eager")
+```
+
+Read the backend that's currently running with [`~PreTrainedModel.get_experts_implementation`]. It returns a `dict` with one entry for the model, and one entry per sub-config.
+
+```py
+model.get_experts_implementation()
+# {"": "grouped_mm", "text_config": "grouped_mm", "vision_config": "eager"}
 ```
 
 ## Backbone-specific experts backend


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47149)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47149)
<!-- ci-dashboard-badge:end -->

Adds docs for #47107

- Adds some docs to clarify that when you switch from `grouped_mm` to `batched_mm`, it also applies to any sub-config backbone and not just the top-level model.
- Adds brief mention of `get_experts_implementation` which naturally complements `set_experts_implementation`