### PR TITLE
Restore dynamic_full full-layer cache guard for assisted/contrastive decoding

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -75,6 +75,8 @@ if is_torch_available():
         BartForConditionalGeneration,
         BartTokenizer,
         DataCollatorWithFlattening,
+        Gemma2Config,
+        Gemma2ForCausalLM,
         GPT2LMHeadModel,
         GPT2Tokenizer,
         ImageGPTForCausalImageModeling,
@@ -3791,6 +3793,37 @@ class GenerationIntegrationTests(unittest.TestCase):
             max_new_tokens=7,
         )
         self.assertTrue(out.shape[-1] <= (input_length + 7))
+
+    def test_assisted_generation_sliding_window_model(self):
+        # Regression test for https://github.com/huggingface/transformers/issues/46629: assisted/prompt-lookup decoding
+        # force `dynamic_full`, which crops the cache. Sliding-window models must then build full (croppable) layers,
+        # not `DynamicSlidingWindowLayer`s, which raise in `crop()` once generation runs past the window.
+        config = Gemma2Config(
+            vocab_size=64,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            sliding_window=4,
+            max_position_embeddings=128,
+        )
+        self.assertIn("sliding_attention", config.layer_types)
+        model = Gemma2ForCausalLM(config).to(torch_device).eval()
+
+        # Prompt exceeds the sliding window and we generate past it; repeated n-grams let prompt-lookup find candidates.
+        input_ids = torch.tensor([[1, 2, 3, 4, 5, 6, 1, 2, 3, 4]], device=torch_device)
+        input_length = input_ids.shape[-1]
+
+        # Assisted decoding.
+        assistant = Gemma2ForCausalLM(config).to(torch_device).eval()
+        out = model.generate(input_ids, assistant_model=assistant, max_new_tokens=15, do_sample=False)
+        self.assertGreater(out.shape[-1], input_length)
+
+        # Prompt-lookup decoding (also assisted generation).
+        out = model.generate(input_ids, prompt_lookup_num_tokens=2, max_new_tokens=15, do_sample=False)
+        self.assertGreater(out.shape[-1], input_length)
 
     def test_model_kwarg_assisted_decoding_decoder_only(self):
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47153)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47153)
<!-- ci-dashboard-badge:end -->

> **Edit (2026-07-17):** Reduced to the regression test only. Since I opened this, #47347 (Inkling) reworked `_prepare_cache_for_generation` to always pass the config and then swap sliding layers for full ones, which already fixes #46629 on `main` and makes the guard below redundant. The guard was also breaking Inkling's `test_generate_with_mtp` in the merge queue (it withholds the config for Inkling's `hybrid`/`hybrid_sliding` layers, so `has_previous_state` raises); see comment below. This PR now adds only `test_assisted_generation_sliding_window_model`, which passes on current `main` and fails on the pre-#47347 code. Original description preserved below.


Fixes #46629

`_prepare_cache_for_generation` used to withhold the model config from `DynamicCache` when `cache_implementation="dynamic_full"`, the mode forced by assisted / prompt-lookup / contrastive decoding (which roll the cache back with `crop()`, unsupported by sliding-window layers). 

#46600 started passing the config unconditionally, so sliding-window models (Gemma, Mistral, Phi-3, ...) now build `DynamicSlidingWindowLayer`s in that mode and `crop()` raises once generation runs past the window:

```
ValueError: Cannot `crop` a `DynamicSlidingWindowLayer` after it has seen more tokens than its sliding window
```

It also dropped the guard because MiniMax-M3 sparse layers need their dedicated `MiniMaxM3VLSparseCacheLayer` (built only when the config is passed). 

So instead of a plain revert, restore the guard but keep passing the config for the layer types that require it, now including `minimax_m3_sparse` (non-sliding and croppable, so it does not reintroduce the crash):

```python
text_config = self.config.get_text_config(decoder=True)
needs_config = any(
    x in ("mamba", "conv", "linear_attention", "minimax_m3_sparse")
    for x in (getattr(text_config, "layer_types", []) or [])
)
if generation_config.cache_implementation != "dynamic_full" or needs_config:
    dynamic_cache_kwargs["config"] = text_config
```

The list stays minimal on purpose: 
DeepSeek's `heavily_compressed_attention` / `compressed_sparse_attention` are left out because those models also carry `sliding_attention` layers, so forcing the config back for them would rebuild the sliding layers and reintroduce the crash. Only non-sliding, croppable layer types that need their own cache class belong here.

Regression test added (`test_assisted_generation_sliding_window_model`): a tiny sliding-window Gemma2 run under assisted + prompt-lookup decoding, which raises on `main` and passes with the fix.

<details>
<summary>Before / after on a tiny sliding-window Gemma2 (CPU, no downloads)</summary>

`Gemma2` with `sliding_window=4`, generating past the window under assisted and prompt-lookup decoding:

```
# before (on main)
[assisted]      ValueError: Cannot `crop` a `DynamicSlidingWindowLayer` after it has seen more tokens than its sliding window
[prompt_lookup] ValueError: Cannot `crop` a `DynamicSlidingWindowLayer` after it has seen more tokens than its sliding window

# after (this PR)
[assisted]      OK -> generated 20 tokens
[prompt_lookup] OK -> generated 20 tokens
```

</details>

cc @ArthurZucker (#46600 author), @zucchini-nlp
