### PR TITLE
Better deepgemm errors

### DIFF
--- a/src/transformers/integrations/deepgemm.py
+++ b/src/transformers/integrations/deepgemm.py
@@ -27,7 +27,10 @@ Requirements: CUDA, Hopper (SM90+), CUDA runtime ≥ 12.3, kernels-community/dee
 from __future__ import annotations
 
 import functools
+import json
 import os
+import re
+import shutil
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -37,8 +40,6 @@ from ..utils import logging
 from ..utils.import_utils import (
     KERNELS_MAX_VERSION,
     KERNELS_MIN_VERSION,
-    get_cuda_home,
-    get_nvcc_version,
     is_kernels_available,
     is_torchdynamo_compiling,
     resolve_internal_import,
@@ -76,6 +77,72 @@ class DeepGEMM:
 
 
 @functools.cache
+def _get_cuda_home() -> str | None:
+    """Resolve the CUDA toolkit root the way DeepGEMM's JIT does:
+    ``CUDA_HOME`` → ``CUDA_PATH`` → dir of ``which nvcc`` → ``/usr/local/cuda`` (``None`` if none found).
+
+    Mirrors DeepGEMM's own ``_find_cuda_home`` so we agree on the path it will actually use, rather than
+    reusing ``torch.utils.cpp_extension.CUDA_HOME`` whose resolution inits a CUDA context (fork-unsafe).
+    """
+    cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
+    if cuda_home:
+        return cuda_home
+    nvcc = shutil.which("nvcc")
+    if nvcc:
+        return os.path.dirname(os.path.dirname(nvcc))
+    if os.path.isdir("/usr/local/cuda"):
+        return "/usr/local/cuda"
+    return None
+
+
+@functools.cache
+def _get_nvcc_version() -> tuple[int, int] | None:
+    """Version of the CUDA toolkit nvcc will use, as ``(major, minor)``, read off disk without a
+    subprocess from (in order) ``{CUDA_HOME}/version.json``, ``version.txt``, or the ``CUDA_VERSION``
+    define in ``include/cuda.h``. ``None`` if unreadable. This is the compiler that builds the kernels,
+    unlike ``torch.version.cuda`` (torch's bundled runtime, which never drives a JIT compile).
+    """
+    cuda_home = _get_cuda_home()
+    if cuda_home is None:
+        return None
+
+    version_json = os.path.join(cuda_home, "version.json")
+    if os.path.isfile(version_json):
+        try:
+            with open(version_json) as f:
+                components = json.load(f)
+            version = components.get("cuda_nvcc", components.get("cuda", {})).get("version", "")
+            major, minor = version.split(".")[:2]
+            return int(major), int(minor)
+        except (OSError, ValueError, AttributeError):
+            pass
+
+    version_txt = os.path.join(cuda_home, "version.txt")
+    if os.path.isfile(version_txt):
+        try:
+            with open(version_txt) as f:
+                match = re.search(r"CUDA Version (\d+)\.(\d+)", f.read())
+            if match:
+                return int(match.group(1)), int(match.group(2))
+        except (OSError, ValueError):  # ValueError covers UnicodeDecodeError on a non-text file
+            pass
+
+    # `cuda.h` ships with every toolkit (incl. distro packages that have no version file).
+    cuda_h = os.path.join(cuda_home, "include", "cuda.h")
+    if os.path.isfile(cuda_h):
+        try:
+            with open(cuda_h) as f:
+                match = re.search(r"#define CUDA_VERSION (\d+)", f.read())
+            if match:
+                cuda_version = int(match.group(1))
+                return cuda_version // 1000, (cuda_version % 1000) // 10
+        except (OSError, ValueError):  # ValueError covers UnicodeDecodeError on a non-text file
+            pass
+
+    return None
+
+
+@functools.cache
 def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
     """Load DeepGEMM once or returns an error message if env or any required symbol is missing. This is wrapped in a
     function that will raise an `ImportError` with the error message. The reason we raise in the wrapper rather than
@@ -102,28 +169,34 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
             arch = "Blackwell (SM100)" if requires_sm100 else "Hopper (SM90) or Blackwell (SM100)"
             return f"DeepGEMM requires {arch}; current device is SM{major}{minor}."
 
-        # DeepGEMM's JIT needs a resolvable CUDA toolkit: nvcc compiles the kernels and `deep_gemm`
-        # asserts `CUDA_HOME` on its first compile. Per the DeepGEMM README: SM90 needs CUDA 12.3+,
-        # SM100 needs CUDA 12.9+.
+        # DeepGEMM JIT-compiles kernels with the system nvcc, so a resolvable CUDA toolkit is required.
+        # Per the DeepGEMM README: SM90 needs CUDA 12.3+, SM100 needs CUDA 12.9+.
         min_cuda = (12, 9) if major == 10 else (12, 3)
-        cuda_home = get_cuda_home()
+        cuda_home = _get_cuda_home()
         if cuda_home is None:
             return (
                 f"DeepGEMM's JIT needs a CUDA toolkit ≥ {min_cuda[0]}.{min_cuda[1]}, but none was found. "
                 "Set `CUDA_HOME` to a CUDA toolkit."
             )
 
-        # The Kernel Hub `deep-gemm` build always compiles with nvcc: it ignores `DG_JIT_USE_NVRTC`
-        # ("DG_JIT_USE_NVRTC is ignored in Kernel Hub builds; using NVCC"), so there is no NVRTC fallback
-        # to torch's bundled libnvrtc. `CUDA_HOME` must therefore hold an nvcc of the required version.
+        # The Kernel Hub `deep-gemm` build always uses nvcc and ignores `DG_JIT_USE_NVRTC` (there is no
+        # NVRTC fallback), so `CUDA_HOME` must hold an nvcc of the required version.
         if not os.path.isfile(os.path.join(cuda_home, "bin", "nvcc")):
             return (
                 f"DeepGEMM's JIT compiles with nvcc, but none was found in `{cuda_home}/bin`. Point "
                 f"`CUDA_HOME` at a full CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit (not a runtime-only install)."
             )
 
-        nvcc_version = get_nvcc_version()
-        if nvcc_version is not None and nvcc_version < min_cuda:
+        # Treat an unreadable version as unsupported: `cuda.h` (with `CUDA_VERSION`) ships with every real
+        # toolkit, so `None` here means an incomplete install we can't vouch for — fail early to Triton.
+        nvcc_version = _get_nvcc_version()
+        if nvcc_version is None:
+            return (
+                f"DeepGEMM found nvcc in `{cuda_home}/bin` but could not read its CUDA version "
+                f"(no parseable `version.json`, `version.txt`, or `include/cuda.h`). Point `CUDA_HOME` at a "
+                f"complete CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit."
+            )
+        if nvcc_version < min_cuda:
             return (
                 f"DeepGEMM on SM{major}{minor} needs a CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit, but nvcc "
                 f"{nvcc_version[0]}.{nvcc_version[1]} in `{cuda_home}` is too old. Point `CUDA_HOME` at a "
@@ -187,18 +260,12 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
 
 @torch._dynamo.allow_in_graph
 def _populate_deepgemm_kernel(requires_sm100: bool = False) -> None:
-    """Warm the `_load_deepgemm_kernel` cache from inside a Dynamo graph without Dynamo tracing the loader.
+    """Warm the `_load_deepgemm_kernel` cache as an `@allow_in_graph` leaf.
 
-    Dynamo ignores `@functools.cache` and re-traces `_load_deepgemm_kernel` on every compile. Cold, that
-    trace descends into `lazy_load_kernel` -> `get_kernel` (a hub download + dynamic import) which Dynamo
-    can't trace and errors under `fullgraph`. Marking this `@allow_in_graph` makes Dynamo run it as an
-    opaque leaf, loading the kernel eagerly so the subsequent traced `_load_deepgemm_kernel` hits
-    `lazy_load_kernel`'s already-cached fast path.
-
-    It must return `None`, not the `DeepGEMM` bundle: an `@allow_in_graph` op's return value has to be
-    graph-representable (tensors / simple types), so returning the dataclass of Python callables makes
-    Dynamo raise `Unsupported: torch.* op returned non-Tensor`. Hence it only warms the cache; the real
-    `DeepGEMM` object is fetched by the plain `_load_deepgemm_kernel` call that follows.
+    Dynamo ignores `@functools.cache` and re-traces `_load_deepgemm_kernel`, whose cold path hits an
+    untraceable hub download (`lazy_load_kernel`) and errors under `fullgraph`. Running it as an opaque
+    leaf loads the kernel eagerly so the later traced call hits the cached fast path. Returns `None`
+    (not the `DeepGEMM` bundle): an `@allow_in_graph` return must be graph-representable.
     """
     _load_deepgemm_kernel(requires_sm100=requires_sm100)
 

--- a/src/transformers/integrations/deepgemm.py
+++ b/src/transformers/integrations/deepgemm.py
@@ -27,6 +27,7 @@ Requirements: CUDA, Hopper (SM90+), CUDA runtime ≥ 12.3, kernels-community/dee
 from __future__ import annotations
 
 import functools
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -36,7 +37,8 @@ from ..utils import logging
 from ..utils.import_utils import (
     KERNELS_MAX_VERSION,
     KERNELS_MIN_VERSION,
-    get_cuda_runtime_version,
+    get_cuda_home,
+    get_nvcc_version,
     is_kernels_available,
     is_torchdynamo_compiling,
     resolve_internal_import,
@@ -100,14 +102,47 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
             arch = "Blackwell (SM100)" if requires_sm100 else "Hopper (SM90) or Blackwell (SM100)"
             return f"DeepGEMM requires {arch}; current device is SM{major}{minor}."
 
+        # A resolvable CUDA toolkit is required for *both* backends: nvcc compiles the kernels, and
+        # even NVRTC pulls headers from `$CUDA_HOME/include` (and `deep_gemm` asserts CUDA_HOME at import).
         # Per the DeepGEMM README: SM90 needs CUDA 12.3+, SM100 needs CUDA 12.9+.
-        cuda_major, cuda_minor = get_cuda_runtime_version()
         min_cuda = (12, 9) if major == 10 else (12, 3)
-        if (cuda_major, cuda_minor) < min_cuda:
+        cuda_home = get_cuda_home()
+        if cuda_home is None:
             return (
-                f"DeepGEMM on SM{major}{minor} requires CUDA runtime ≥ {min_cuda[0]}.{min_cuda[1]}, "
-                f"found {cuda_major}.{cuda_minor}."
+                f"DeepGEMM's JIT needs a CUDA toolkit ≥ {min_cuda[0]}.{min_cuda[1]}, but none was found. "
+                "Set `CUDA_HOME` to a CUDA toolkit."
             )
+
+        # The default (nvcc) backend also needs the nvcc binary at the right version. When it's missing or
+        # too old we switch to DeepGEMM's NVRTC backend rather than fail: NVRTC compiles via the already-loaded
+        # libnvrtc (torch preloads its bundled copy at import, which the linker reuses by soname) and only
+        # reuses the toolkit's headers, present now that CUDA_HOME resolved — so nvcc's absence/version is moot.
+        # `DG_JIT_USE_NVRTC` is read once by DeepGEMM's compiler singleton on first compile; nothing has
+        # compiled yet, so setting it here takes effect.
+        if os.environ.get("DG_JIT_USE_NVRTC", "0") == "0":
+            nvcc_version = get_nvcc_version()
+            if not os.path.isfile(os.path.join(cuda_home, "bin", "nvcc")):
+                reason = f"no `nvcc` found in `{cuda_home}`"
+            elif nvcc_version is not None and nvcc_version < min_cuda:
+                reason = f"nvcc {nvcc_version[0]}.{nvcc_version[1]} in `{cuda_home}` is older than {min_cuda[0]}.{min_cuda[1]}"
+            else:
+                reason = None
+            if reason is not None:
+                # Only fall back to NVRTC if torch's bundled libnvrtc (tracked by `torch.version.cuda`) is
+                # itself new enough — otherwise we'd just swap one too-old compiler for another.
+                torch_cuda = tuple(int(v) for v in (torch.version.cuda or "0.0").split(".")[:2])
+                if torch_cuda < min_cuda:
+                    return (
+                        f"DeepGEMM needs a CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolchain ({reason}), and torch's "
+                        f"bundled NVRTC ({torch_cuda[0]}.{torch_cuda[1]}) is too old to fall back to. Install a "
+                        f"CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit at `CUDA_HOME`, or torch built against it."
+                    )
+                logger.warning_once(
+                    f"DeepGEMM: {reason}; setting `DG_JIT_USE_NVRTC=1` to compile with the NVRTC backend "
+                    f"(torch's bundled libnvrtc {torch_cuda[0]}.{torch_cuda[1]}) instead. This applies to all "
+                    "DeepGEMM compiles in this process."
+                )
+                os.environ["DG_JIT_USE_NVRTC"] = "1"
 
     kernel = lazy_load_kernel("deep-gemm")
     if kernel is None:
@@ -149,25 +184,6 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
             f"e.g. `pip install kernels=={KERNELS_MIN_VERSION}`"
         )
 
-    try:
-        m_alignment = int(get_mk_alignment())
-    except Exception as e:
-        return f"Failure when calling `get_mk_alignment`: {type(e).__name__}: {e}"
-
-    # Everything up to this point checks that the kernels can be compiled, but never run an actual compilation. This is
-    # done here to can catch a broken CUDA toolchain or version mismatch. A small call but better to fall back early on
-    # Triton rather than failing hard mid-forward.
-    if not is_torchdynamo_compiling():
-        try:
-            sf = torch.zeros(128, 1, dtype=torch.float32, device="cuda")
-            transform_sf_into_required_layout(sf, 128, 128, recipe=(1, 128))
-        except Exception as e:
-            return (
-                f"DeepGEMM failed to JIT-compile a probe kernel, which usually means a broken or version-mismatched "
-                "CUDA toolchain. Check that `CUDA_HOME` points to a complete and version-consistent CUDA toolkit. You "
-                f"can re-run with `DG_JIT_DEBUG=1` for the compiler output. Original error: {type(e).__name__}: {e}"
-            )
-
     return DeepGEMM(
         fp8_fp4_matmul=fp8_fp4_matmul,
         grouped_fp8_fp4_matmul_nt=grouped_fp8_fp4_matmul_nt,
@@ -179,22 +195,30 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
         transform_weights_for_mega_moe=transform_weights_for_mega_moe,
         get_symm_buffer_for_mega_moe=get_symm_buffer_for_mega_moe,
         fp8_fp4_mega_moe=fp8_fp4_mega_moe,
-        m_alignment=m_alignment,
+        m_alignment=get_mk_alignment(),
     )
 
 
 @torch._dynamo.allow_in_graph
 def _populate_deepgemm_kernel(requires_sm100: bool = False) -> None:
-    deepgemm_or_error_msg = _load_deepgemm_kernel(requires_sm100=requires_sm100)
-    if isinstance(deepgemm_or_error_msg, str):
-        raise ImportError(deepgemm_or_error_msg)
-    return None
+    """Warm the `_load_deepgemm_kernel` cache from inside a Dynamo graph without Dynamo tracing the loader.
+
+    Dynamo ignores `@functools.cache` and re-traces `_load_deepgemm_kernel` on every compile. Cold, that
+    trace descends into `lazy_load_kernel` -> `get_kernel` (a hub download + dynamic import) which Dynamo
+    can't trace and errors under `fullgraph`. Marking this `@allow_in_graph` makes Dynamo run it as an
+    opaque leaf, loading the kernel eagerly so the subsequent traced `_load_deepgemm_kernel` hits
+    `lazy_load_kernel`'s already-cached fast path.
+
+    It must return `None`, not the `DeepGEMM` bundle: an `@allow_in_graph` op's return value has to be
+    graph-representable (tensors / simple types), so returning the dataclass of Python callables makes
+    Dynamo raise `Unsupported: torch.* op returned non-Tensor`. Hence it only warms the cache; the real
+    `DeepGEMM` object is fetched by the plain `_load_deepgemm_kernel` call that follows.
+    """
+    _load_deepgemm_kernel(requires_sm100=requires_sm100)
 
 
 def load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM:
-    if is_torchdynamo_compiling():
-        _populate_deepgemm_kernel(requires_sm100=requires_sm100)
-
+    _populate_deepgemm_kernel(requires_sm100=requires_sm100)
     deepgemm_or_error = _load_deepgemm_kernel(requires_sm100=requires_sm100)
     if isinstance(deepgemm_or_error, str):
         raise ImportError(deepgemm_or_error)

--- a/src/transformers/integrations/deepgemm.py
+++ b/src/transformers/integrations/deepgemm.py
@@ -116,9 +116,6 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
         # The Kernel Hub `deep-gemm` build always compiles with nvcc: it ignores `DG_JIT_USE_NVRTC`
         # ("DG_JIT_USE_NVRTC is ignored in Kernel Hub builds; using NVCC"), so there is no NVRTC fallback
         # to torch's bundled libnvrtc. `CUDA_HOME` must therefore hold an nvcc of the required version.
-        # A runtime-only install (headers, no nvcc) or a too-old toolkit is rejected here — returning an
-        # error routes the caller to the Triton fallback instead of aborting mid-forward when the JIT can't
-        # find (or can't use) nvcc.
         if not os.path.isfile(os.path.join(cuda_home, "bin", "nvcc")):
             return (
                 f"DeepGEMM's JIT compiles with nvcc, but none was found in `{cuda_home}/bin`. Point "

--- a/src/transformers/integrations/deepgemm.py
+++ b/src/transformers/integrations/deepgemm.py
@@ -102,9 +102,9 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
             arch = "Blackwell (SM100)" if requires_sm100 else "Hopper (SM90) or Blackwell (SM100)"
             return f"DeepGEMM requires {arch}; current device is SM{major}{minor}."
 
-        # A resolvable CUDA toolkit is required for *both* backends: nvcc compiles the kernels, and
-        # even NVRTC pulls headers from `$CUDA_HOME/include` (and `deep_gemm` asserts CUDA_HOME at import).
-        # Per the DeepGEMM README: SM90 needs CUDA 12.3+, SM100 needs CUDA 12.9+.
+        # DeepGEMM's JIT needs a resolvable CUDA toolkit: nvcc compiles the kernels and `deep_gemm`
+        # asserts `CUDA_HOME` on its first compile. Per the DeepGEMM README: SM90 needs CUDA 12.3+,
+        # SM100 needs CUDA 12.9+.
         min_cuda = (12, 9) if major == 10 else (12, 3)
         cuda_home = get_cuda_home()
         if cuda_home is None:
@@ -113,36 +113,25 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
                 "Set `CUDA_HOME` to a CUDA toolkit."
             )
 
-        # The default (nvcc) backend also needs the nvcc binary at the right version. When it's missing or
-        # too old we switch to DeepGEMM's NVRTC backend rather than fail: NVRTC compiles via the already-loaded
-        # libnvrtc (torch preloads its bundled copy at import, which the linker reuses by soname) and only
-        # reuses the toolkit's headers, present now that CUDA_HOME resolved — so nvcc's absence/version is moot.
-        # `DG_JIT_USE_NVRTC` is read once by DeepGEMM's compiler singleton on first compile; nothing has
-        # compiled yet, so setting it here takes effect.
-        if os.environ.get("DG_JIT_USE_NVRTC", "0") == "0":
-            nvcc_version = get_nvcc_version()
-            if not os.path.isfile(os.path.join(cuda_home, "bin", "nvcc")):
-                reason = f"no `nvcc` found in `{cuda_home}`"
-            elif nvcc_version is not None and nvcc_version < min_cuda:
-                reason = f"nvcc {nvcc_version[0]}.{nvcc_version[1]} in `{cuda_home}` is older than {min_cuda[0]}.{min_cuda[1]}"
-            else:
-                reason = None
-            if reason is not None:
-                # Only fall back to NVRTC if torch's bundled libnvrtc (tracked by `torch.version.cuda`) is
-                # itself new enough — otherwise we'd just swap one too-old compiler for another.
-                torch_cuda = tuple(int(v) for v in (torch.version.cuda or "0.0").split(".")[:2])
-                if torch_cuda < min_cuda:
-                    return (
-                        f"DeepGEMM needs a CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolchain ({reason}), and torch's "
-                        f"bundled NVRTC ({torch_cuda[0]}.{torch_cuda[1]}) is too old to fall back to. Install a "
-                        f"CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit at `CUDA_HOME`, or torch built against it."
-                    )
-                logger.warning_once(
-                    f"DeepGEMM: {reason}; setting `DG_JIT_USE_NVRTC=1` to compile with the NVRTC backend "
-                    f"(torch's bundled libnvrtc {torch_cuda[0]}.{torch_cuda[1]}) instead. This applies to all "
-                    "DeepGEMM compiles in this process."
-                )
-                os.environ["DG_JIT_USE_NVRTC"] = "1"
+        # The Kernel Hub `deep-gemm` build always compiles with nvcc: it ignores `DG_JIT_USE_NVRTC`
+        # ("DG_JIT_USE_NVRTC is ignored in Kernel Hub builds; using NVCC"), so there is no NVRTC fallback
+        # to torch's bundled libnvrtc. `CUDA_HOME` must therefore hold an nvcc of the required version.
+        # A runtime-only install (headers, no nvcc) or a too-old toolkit is rejected here — returning an
+        # error routes the caller to the Triton fallback instead of aborting mid-forward when the JIT can't
+        # find (or can't use) nvcc.
+        if not os.path.isfile(os.path.join(cuda_home, "bin", "nvcc")):
+            return (
+                f"DeepGEMM's JIT compiles with nvcc, but none was found in `{cuda_home}/bin`. Point "
+                f"`CUDA_HOME` at a full CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit (not a runtime-only install)."
+            )
+
+        nvcc_version = get_nvcc_version()
+        if nvcc_version is not None and nvcc_version < min_cuda:
+            return (
+                f"DeepGEMM on SM{major}{minor} needs a CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit, but nvcc "
+                f"{nvcc_version[0]}.{nvcc_version[1]} in `{cuda_home}` is too old. Point `CUDA_HOME` at a "
+                f"CUDA ≥ {min_cuda[0]}.{min_cuda[1]} toolkit."
+            )
 
     kernel = lazy_load_kernel("deep-gemm")
     if kernel is None:

--- a/src/transformers/integrations/deepgemm.py
+++ b/src/transformers/integrations/deepgemm.py
@@ -260,12 +260,15 @@ def _load_deepgemm_kernel(requires_sm100: bool = False) -> DeepGEMM | str:
 
 @torch._dynamo.allow_in_graph
 def _populate_deepgemm_kernel(requires_sm100: bool = False) -> None:
-    """Warm the `_load_deepgemm_kernel` cache as an `@allow_in_graph` leaf.
+    """Warm the `_load_deepgemm_kernel` cache from an opaque graph node, so Dynamo never traces the loader.
 
-    Dynamo ignores `@functools.cache` and re-traces `_load_deepgemm_kernel`, whose cold path hits an
-    untraceable hub download (`lazy_load_kernel`) and errors under `fullgraph`. Running it as an opaque
-    leaf loads the kernel eagerly so the later traced call hits the cached fast path. Returns `None`
-    (not the `DeepGEMM` bundle): an `@allow_in_graph` return must be graph-representable.
+    Under `torch.compile`, Dynamo ignores `@functools.cache` and traces into `_load_deepgemm_kernel`,
+    whose cold path (hub download + dynamic import via `lazy_load_kernel`) is untraceable and errors under
+    `fullgraph`. `@allow_in_graph` turns the call into an opaque fx node instead — but an fx node's return
+    must be proxyable, and the `DeepGEMM` bundle of Python callables isn't (`Unsupported: torch.* op
+    returned non-Tensor`), so we can't just decorate the real loader. Hence two loaders: this one is
+    opaque, returns `None`, and only warms the cache; the real `_load_deepgemm_kernel` right after is then
+    a plain cache lookup.
     """
     _load_deepgemm_kernel(requires_sm100=requires_sm100)
 

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -269,7 +269,10 @@ def fp8_linear(
         except ImportError as e:
             # Forward the original reason so the user knows whether DeepGEMM is unavailable
             # (env/build issue) or refused this specific input (e.g. multi-device on SM100).
-            logger.warning_once(f"DeepGEMM unavailable for this call, falling back to Triton. Reason: {e}")
+            logger.warning_once(
+                f"DeepGEMM unavailable for this call, falling back to Triton. Reason: {e}. "
+                "Set `TRANSFORMERS_DISABLE_DEEPGEMM_LINEAR=1` to skip DeepGEMM for FP8 linear entirely."
+            )
 
     return finegrained_fp8_linear(input, weight, weight_scale_inv, block_size, bias, activation_scale, output_dtype)
 

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -225,88 +225,10 @@ def is_cuda_platform() -> bool:
 
 
 @lru_cache
-def get_cuda_home() -> str | None:
-    """Resolve the system CUDA toolkit root the way JIT backends (e.g. DeepGEMM) do:
-    ``CUDA_HOME`` → ``CUDA_PATH`` → directory of ``which nvcc`` → ``/usr/local/cuda``.
-
-    This mirrors DeepGEMM's own ``_find_cuda_home`` (so we agree with the path it will actually use)
-    rather than reusing ``torch.utils.cpp_extension.CUDA_HOME``: torch's variant calls
-    ``torch.cuda.is_available()`` while resolving, which initializes a CUDA context — unwanted here
-    (and fork-unsafe, the reason DeepGEMM reimplemented it too).
-    """
-
-    cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
-    if cuda_home:
-        return cuda_home
-
-    nvcc = shutil.which("nvcc")
-    if nvcc:
-        return os.path.dirname(os.path.dirname(nvcc))
-
-    if os.path.isdir("/usr/local/cuda"):
-        return "/usr/local/cuda"
-    return None
-
-
-@lru_cache
-def get_nvcc_version() -> tuple[int, int] | None:
-    """Version of the CUDA toolkit ``nvcc`` will use as ``(major, minor)``, read without a
-    subprocess from (in order) ``{CUDA_HOME}/version.json``, legacy ``version.txt``, or the
-    ``CUDA_VERSION`` define in ``include/cuda.h``. ``None`` if the toolkit is absent.
-
-    This is the compiler that builds the kernels — unlike ``torch.version.cuda``, torch's
-    privately-bundled runtime, which never touches a source JIT compile.
-
-    ``version.json``/``version.txt`` are NVIDIA's documented toolkit version files (``version.txt`` is
-    also what CMake's ``FindCUDAToolkit`` parses); ``cuda.h``'s ``CUDA_VERSION`` is ``1000*major +
-    10*minor``. The ``version.txt`` → ``cuda.h`` fallback mirrors Clang (LLVM D89832).
-    """
-    cuda_home = get_cuda_home()
-    if cuda_home is None:
-        return None
-
-    version_json = os.path.join(cuda_home, "version.json")
-    if os.path.isfile(version_json):
-        try:
-            with open(version_json) as f:
-                components = json.load(f)
-            version = components.get("cuda_nvcc", components.get("cuda", {})).get("version", "")
-            major, minor = version.split(".")[:2]
-            return int(major), int(minor)
-        except (OSError, ValueError, AttributeError):
-            pass
-
-    version_txt = os.path.join(cuda_home, "version.txt")
-    if os.path.isfile(version_txt):
-        try:
-            with open(version_txt) as f:
-                match = re.search(r"CUDA Version (\d+)\.(\d+)", f.read())
-            if match:
-                return int(match.group(1)), int(match.group(2))
-        except (OSError, ValueError):  # ValueError covers UnicodeDecodeError on a non-text file
-            pass
-
-    # `cuda.h` ships with every toolkit (incl. distro-packaged installs that have no version file).
-    cuda_h = os.path.join(cuda_home, "include", "cuda.h")
-    if os.path.isfile(cuda_h):
-        try:
-            with open(cuda_h) as f:
-                match = re.search(r"#define CUDA_VERSION (\d+)", f.read())
-            if match:
-                cuda_version = int(match.group(1))
-                return cuda_version // 1000, (cuda_version % 1000) // 10
-        except (OSError, ValueError):  # ValueError covers UnicodeDecodeError on a non-text file
-            pass
-
-    return None
-
-
-@lru_cache
 def get_cuda_runtime_version() -> tuple[int, int]:
     """Deprecated. Return the CUDA runtime version as (major, minor).
 
-    Deprecated in favor of :func:`get_nvcc_version` for the CUDA toolkit compiler version, or
-    ``torch.version.cuda`` for the runtime version.
+    Deprecated in favor of ``torch.version.cuda`` for the CUDA runtime version.
 
     Prefers a direct query of ``cudaRuntimeGetVersion`` via ``libcudart.so``. If that's
     not on the system loader path (common with pip-installed torch that bundles its own
@@ -314,8 +236,8 @@ def get_cuda_runtime_version() -> tuple[int, int]:
     runtime's version for pip wheels. Returns ``(0, 0)`` for CPU-only torch.
     """
     warnings.warn(
-        "`get_cuda_runtime_version` is deprecated and will be removed in a future version. Use "
-        "`get_nvcc_version` for the CUDA toolkit compiler version, or `torch.version.cuda` for the runtime version.",
+        "`get_cuda_runtime_version` is deprecated and will be removed in v5.16. "
+        "Use `torch.version.cuda` for the CUDA runtime version.",
         FutureWarning,
         stacklevel=2,
     )

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -225,14 +225,100 @@ def is_cuda_platform() -> bool:
 
 
 @lru_cache
+def get_cuda_home() -> str | None:
+    """Resolve the system CUDA toolkit root the way JIT backends (e.g. DeepGEMM) do:
+    ``CUDA_HOME`` → ``CUDA_PATH`` → directory of ``which nvcc`` → ``/usr/local/cuda``.
+
+    This mirrors DeepGEMM's own ``_find_cuda_home`` (so we agree with the path it will actually use)
+    rather than reusing ``torch.utils.cpp_extension.CUDA_HOME``: torch's variant calls
+    ``torch.cuda.is_available()`` while resolving, which initializes a CUDA context — unwanted here
+    (and fork-unsafe, the reason DeepGEMM reimplemented it too).
+    """
+
+    cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
+    if cuda_home:
+        return cuda_home
+
+    nvcc = shutil.which("nvcc")
+    if nvcc:
+        return os.path.dirname(os.path.dirname(nvcc))
+
+    if os.path.isdir("/usr/local/cuda"):
+        return "/usr/local/cuda"
+    return None
+
+
+@lru_cache
+def get_nvcc_version() -> tuple[int, int] | None:
+    """Version of the CUDA toolkit ``nvcc`` will use as ``(major, minor)``, read without a
+    subprocess from (in order) ``{CUDA_HOME}/version.json``, legacy ``version.txt``, or the
+    ``CUDA_VERSION`` define in ``include/cuda.h``. ``None`` if the toolkit is absent.
+
+    This is the compiler that builds the kernels — unlike ``torch.version.cuda``, torch's
+    privately-bundled runtime, which never touches a source JIT compile.
+
+    ``version.json``/``version.txt`` are NVIDIA's documented toolkit version files (``version.txt`` is
+    also what CMake's ``FindCUDAToolkit`` parses); ``cuda.h``'s ``CUDA_VERSION`` is ``1000*major +
+    10*minor``. The ``version.txt`` → ``cuda.h`` fallback mirrors Clang (LLVM D89832).
+    """
+    cuda_home = get_cuda_home()
+    if cuda_home is None:
+        return None
+
+    version_json = os.path.join(cuda_home, "version.json")
+    if os.path.isfile(version_json):
+        try:
+            with open(version_json) as f:
+                components = json.load(f)
+            version = components.get("cuda_nvcc", components.get("cuda", {})).get("version", "")
+            major, minor = version.split(".")[:2]
+            return int(major), int(minor)
+        except (OSError, ValueError, AttributeError):
+            pass
+
+    version_txt = os.path.join(cuda_home, "version.txt")
+    if os.path.isfile(version_txt):
+        try:
+            with open(version_txt) as f:
+                match = re.search(r"CUDA Version (\d+)\.(\d+)", f.read())
+            if match:
+                return int(match.group(1)), int(match.group(2))
+        except (OSError, ValueError):  # ValueError covers UnicodeDecodeError on a non-text file
+            pass
+
+    # `cuda.h` ships with every toolkit (incl. distro-packaged installs that have no version file).
+    cuda_h = os.path.join(cuda_home, "include", "cuda.h")
+    if os.path.isfile(cuda_h):
+        try:
+            with open(cuda_h) as f:
+                match = re.search(r"#define CUDA_VERSION (\d+)", f.read())
+            if match:
+                cuda_version = int(match.group(1))
+                return cuda_version // 1000, (cuda_version % 1000) // 10
+        except (OSError, ValueError):  # ValueError covers UnicodeDecodeError on a non-text file
+            pass
+
+    return None
+
+
+@lru_cache
 def get_cuda_runtime_version() -> tuple[int, int]:
-    """Return the CUDA runtime version as (major, minor).
+    """Deprecated. Return the CUDA runtime version as (major, minor).
+
+    Deprecated in favor of :func:`get_nvcc_version` for the CUDA toolkit compiler version, or
+    ``torch.version.cuda`` for the runtime version.
 
     Prefers a direct query of ``cudaRuntimeGetVersion`` via ``libcudart.so``. If that's
     not on the system loader path (common with pip-installed torch that bundles its own
     CUDA runtime), falls back to ``torch.version.cuda`` — which equals the bundled
     runtime's version for pip wheels. Returns ``(0, 0)`` for CPU-only torch.
     """
+    warnings.warn(
+        "`get_cuda_runtime_version` is deprecated and will be removed in a future version. Use "
+        "`get_nvcc_version` for the CUDA toolkit compiler version, or `torch.version.cuda` for the runtime version.",
+        FutureWarning,
+        stacklevel=2,
+    )
     import ctypes
 
     try:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -46,6 +46,7 @@ from transformers import (
 from transformers.conversion_mapping import get_model_conversion_mapping
 from transformers.core_model_loading import PrefixChange, WeightRenaming, process_target_pattern
 from transformers.integrations import HfDeepSpeedConfig
+from transformers.integrations.deepgemm import _get_nvcc_version
 from transformers.integrations.deepspeed import (
     is_deepspeed_available,
     is_deepspeed_zero3_enabled,
@@ -119,7 +120,6 @@ from transformers.utils import (
     is_torch_bf16_available_on_device,
     is_torch_fp16_available_on_device,
 )
-from transformers.utils.import_utils import get_nvcc_version
 from transformers.utils.output_capturing import CompileableContextVar
 
 from .exporters.test_export import ExportTesterMixin
@@ -610,16 +610,13 @@ def _test_eager_matches_batched_and_grouped_inference(self, name, dtype):
             mocks["sonicmoe"] = Mock(wraps=sonicmoe_experts_forward)
             implementations.append("sonicmoe")
 
-        nvcc_version = get_nvcc_version() or (0, 0)
-        device_capability = torch.cuda.get_device_capability() if torch.cuda.is_available() else (0, 0)
+        nvcc_version = _get_nvcc_version() or (0, 0)
+        device_major = torch.cuda.get_device_capability()[0] if torch.cuda.is_available() else 0
         # DeepGEMM ships kernels only for Hopper (SM90, needs nvcc 12.3+) and Blackwell (SM100, needs 12.9+).
         if (
             dtype == torch.bfloat16
             and is_kernels_available()
-            and (
-                (device_capability[0] == 9 and nvcc_version >= (12, 3))
-                or (device_capability[0] == 10 and nvcc_version >= (12, 9))
-            )
+            and ((device_major == 9 and nvcc_version >= (12, 3)) or (device_major == 10 and nvcc_version >= (12, 9)))
         ):
             # DeepGEMM BF16 grouped forward requires Hopper+, a new-enough nvcc toolkit, and bf16 hidden states
             mocks["deepgemm"] = Mock(wraps=deepgemm_bf16_experts_forward)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -119,7 +119,7 @@ from transformers.utils import (
     is_torch_bf16_available_on_device,
     is_torch_fp16_available_on_device,
 )
-from transformers.utils.import_utils import get_cuda_runtime_version
+from transformers.utils.import_utils import get_nvcc_version
 from transformers.utils.output_capturing import CompileableContextVar
 
 from .exporters.test_export import ExportTesterMixin
@@ -610,14 +610,18 @@ def _test_eager_matches_batched_and_grouped_inference(self, name, dtype):
             mocks["sonicmoe"] = Mock(wraps=sonicmoe_experts_forward)
             implementations.append("sonicmoe")
 
+        nvcc_version = get_nvcc_version() or (0, 0)
+        device_capability = torch.cuda.get_device_capability() if torch.cuda.is_available() else (0, 0)
+        # DeepGEMM ships kernels only for Hopper (SM90, needs nvcc 12.3+) and Blackwell (SM100, needs 12.9+).
         if (
             dtype == torch.bfloat16
             and is_kernels_available()
-            and torch.cuda.is_available()
-            and torch.cuda.get_device_capability() >= (9, 0)
-            and get_cuda_runtime_version() >= (12, 3)
+            and (
+                (device_capability[0] == 9 and nvcc_version >= (12, 3))
+                or (device_capability[0] == 10 and nvcc_version >= (12, 9))
+            )
         ):
-            # DeepGEMM BF16 grouped forward requires Hopper+, CUDA runtime 12.3+, and bf16 hidden states
+            # DeepGEMM BF16 grouped forward requires Hopper+, a new-enough nvcc toolkit, and bf16 hidden states
             mocks["deepgemm"] = Mock(wraps=deepgemm_bf16_experts_forward)
             implementations.append("deepgemm")
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47154)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47154)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Okay so I fully went down the rabbit hole of DeepGEMM requirements, and what can and can't be done with the Hub kernel build.

TLDR; Statically verifying that the environment can compile DeepGEMM kernels before loading them lets us avoid downloading the kernel files entirely (there are too many, and it even causes rate limits 🥲).

DeepGEMM doesn't ship compiled kernels — it JIT-compiles them at runtime with the system CUDA toolkit. So the only thing that determines whether it'll work is whether that toolkit can compile, which we can read straight off disk (nvcc presence + version from version.json/version.txt/cuda.h), with no GPU, no probe compile, and no side effects.

Checking this up front is better on three counts:

- Correctness: we gate on the compiler that actually builds the kernels (nvcc under CUDA_HOME), not the CUDA runtime (the old signal), which can be a different, stray, or mismatched version and silently disable DeepGEMM on a perfectly capable box. Version floors follow the DeepGEMM README: SM90 needs CUDA ≥ 12.3, SM100 needs ≥ 12.9.
- Speed: the DeepGEMM kernel is a large tree of many small files, so downloading it is slow. Validating the env before the load short-circuits that download entirely when the toolchain can't use it — instead of paying minutes to fetch it only to fail.
- Predictable failure: if the env claims to support DeepGEMM it takes the fast path; otherwise it fails early with an actionable message and auto-falls back to Triton — never a cryptic crash deep in the first forward.

On NVRTC: I initially added an NVRTC fallback (compile via torch's bundled libnvrtc when nvcc is missing/too old), but the Hub deep-gemm build ignores DG_JIT_USE_NVRTC and always uses nvcc ("DG_JIT_USE_NVRTC is ignored in Kernel Hub builds; using NVCC", baked into the compiled .so). So there's no real NVRTC path with the Hub build — a resolvable CUDA_HOME must contain an nvcc of the required version, and anything short of that (unset CUDA_HOME, runtime-only install with headers but no nvcc, or a too-old nvcc) is rejected up front and routed to Triton.

Verified on B200 (SM100) across four CUDA_HOME settings — unset, cuda-12.8 (too old), cuda-12.9 (works), and a headers-only pip CUDA-13 dir (no nvcc): the three unusable configs fall back to Triton cleanly (previously the headers-only one crashed mid-forward), and 12.9 runs through DeepGEMM.

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->