### PR TITLE
[generation] Fix misleading synced_gpus warning in continuous batching

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2418,7 +2418,7 @@ class GenerationMixin(ContinuousMixin):
 
             # others are ignored
             if synced_gpus is not None:
-                logger.warning(f"synced_gpus is not ignored for continuous batching. Got {synced_gpus = }")
+                logger.warning(f"synced_gpus is ignored for continuous batching. Got {synced_gpus = }")
             num_beams = kwargs.get("num_beams", 1)
             if num_beams > 1:  # FIXME: remove this once CB supports num_beams (which is planned)
                 logger.warning(f"num_beams is not supported for continuous batching yet. Got {num_beams = }. ")

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -706,19 +706,6 @@ class ContinuousBatchingNoAcceleratorTest(unittest.TestCase):
             else:
                 os.environ["WORLD_SIZE"] = original_ws
 
-    def test_synced_gpus_warning_in_continuous_batching(self):
-        config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
-        model = AutoModelForCausalLM.from_config(config)
-        input_ids = torch.tensor([[1, 2, 3]])
-
-        with (
-            patch.object(model, "generate_batch", return_value={}),
-            self.assertLogs("transformers.generation.utils", level="WARNING") as cm,
-        ):
-            model.generate(input_ids, synced_gpus=True, cache_implementation="paged")
-
-        self.assertTrue(any("synced_gpus is ignored for continuous batching" in log for log in cm.output))
-
 
 @require_torch_accelerator
 class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -706,6 +706,19 @@ class ContinuousBatchingNoAcceleratorTest(unittest.TestCase):
             else:
                 os.environ["WORLD_SIZE"] = original_ws
 
+    def test_synced_gpus_warning_in_continuous_batching(self):
+        config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        model = AutoModelForCausalLM.from_config(config)
+        input_ids = torch.tensor([[1, 2, 3]])
+
+        with (
+            patch.object(model, "generate_batch", return_value={}),
+            self.assertLogs("transformers.generation.utils", level="WARNING") as cm,
+        ):
+            model.generate(input_ids, synced_gpus=True, cache_implementation="paged")
+
+        self.assertTrue(any("synced_gpus is ignored for continuous batching" in log for log in cm.output))
+
 
 @require_torch_accelerator
 class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47158)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47158)
<!-- ci-dashboard-badge:end -->
# What does this PR do?
This PR fixes a misleading user-facing warning message when calling `generate()` with `synced_gpus=True` in continuous batching mode (e.g. `cache_implementation="paged"`). 
Closes #47276
## Summary
The warning message previously stated:
`synced_gpus is not ignored for continuous batching. Got synced_gpus = True`
This double negative incorrectly implies that `synced_gpus` is active or supported. In fact, `synced_gpus` is discarded during continuous batching execution. The comment directly above the warning also explicitly reads `# others are ignored`.
This PR corrects the warning to state:
`synced_gpus is ignored for continuous batching. Got synced_gpus = True`
## Root Cause
A simple negation typo in the warning string format.
## Solution
Change `"is not ignored"` to `"is ignored"` in the warning message in `src/transformers/generation/utils.py`.
### Why This Is a Standalone Fix
This PR addresses a user-facing negation typo in the warning message logged
when `synced_gpus` is passed during continuous batching. Because continuous
batching ignores `synced_gpus`, the warning mistakenly read "synced_gpus is
not ignored...", which can cause significant confusion for users debugging
distributed setups who believe the parameter is active. As this is a highly
visible, misleading warning specifically affecting the continuous batching
entry point, and a search of the generation codebase confirmed no other
stale warning negation bugs nearby, it is submitted as a targeted, standalone
fix rather than bundled into a broader cleanup.
## Tests Run
- Verified the fix manually and confirmed no regressions via the full existing test suite: `pytest tests/generation/test_continuous_batching.py -v` → 49 passed, 71 skipped, 0 failed.
- Checked code style and formatting via `ruff check` and `ruff format` locally.
### AI-Assisted Tooling & Guidelines Compliance
- **AI Tooling Used**: Google Antigravity was used to review the codebase and
  assist in understanding the continuous batching parameter validation flow.
  The fix was authored directly by the developer.
- **Coordination Link**: huggingface/transformers#47276
- **Duplicate-PR Check**: Searched open and recently-closed pull requests on
  huggingface/transformers for PRs touching the same warning string or file
  (src/transformers/generation/utils.py). No duplicates or similar
  sweeping cleanup PRs were found.
- **Verification & Test Output**:
```bash
  $ ruff check src/transformers/generation/utils.py
  All checks passed!
```
```bash
  $ ruff format --check src/transformers/generation/utils.py
  1 file already formatted
```
```bash
  $ pytest tests/generation/test_continuous_batching.py -v
  ======================= 49 passed, 71 skipped in 12.14s =======================
```