### PR TITLE
Fix off-by-one in MoonshineStreaming sliding_window_mask_function right window

### DIFF
--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1922,7 +1922,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask

--- a/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
@@ -356,7 +356,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask

--- a/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
@@ -269,7 +269,7 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 
         dist = q_idx - kv_idx
         left_mask = (dist >= 0) & (dist < left_window_size)
-        right_mask = (dist < 0) & (-dist < right_window_size)
+        right_mask = (dist < 0) & (-dist <= right_window_size)
         return left_mask | right_mask
 
     return inner_mask

--- a/tests/models/moonshine_streaming/test_modeling_moonshine_streaming.py
+++ b/tests/models/moonshine_streaming/test_modeling_moonshine_streaming.py
@@ -472,6 +472,31 @@ class MoonshineStreamingModelTest(ModelTesterMixin, PipelineTesterMixin, unittes
             model(**self._prepare_for_class(inputs_dict, model_class))
 
 
+class MoonshineStreamingSlidingWindowMaskTest(unittest.TestCase):
+    def test_sliding_window_mask_function_right_window(self):
+        from transformers.models.moonshine_streaming.modeling_moonshine_streaming import (
+            sliding_window_mask_function,
+        )
+
+        # left_window_size=16, right_window_size=4
+        mask_fn = sliding_window_mask_function((16, 4))
+        q_idx = 10
+
+        # A query at position 10 should attend to the 4 future frames {11, 12, 13, 14}
+        # (right window includes right_window_size frames, not right_window_size - 1).
+        future = [kv_idx for kv_idx in range(q_idx + 1, 20) if mask_fn(0, 0, q_idx, kv_idx)]
+        self.assertEqual(future, [11, 12, 13, 14])
+
+        # The frame right after the right window (dist = -5) must not be attended to.
+        self.assertFalse(mask_fn(0, 0, q_idx, q_idx + 5))
+
+        # The left window must still be respected: 16 frames back (including the current one),
+        # i.e. positions {0, ..., 10} here, and nothing beyond the window.
+        past = [kv_idx for kv_idx in range(0, q_idx + 1) if mask_fn(0, 0, q_idx, kv_idx)]
+        self.assertEqual(past, list(range(0, q_idx + 1)))
+        self.assertFalse(mask_fn(0, 0, 20, 3))  # dist = 17 >= left_window_size (16)
+
+
 @require_torch
 class MoonshineStreamingModelIntegrationTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47162)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47162)
<!-- ci-dashboard-badge:end -->

## What

`sliding_window_mask_function` in `modeling_moonshine_streaming.py` (and its
`modular_` source) builds the right (future) side of the sliding-window
attention mask with a strict inequality:

```python
right_mask = (dist < 0) & (-dist < right_window_size)
```

With `dist = q_idx - kv_idx`, a future key is `dist < 0`, and `-dist` is the
number of frames the key is ahead of the query. The strict `<` drops the
frame exactly `right_window_size` steps ahead, so a configured right window of
`w_right = 4` only attends to 3 future frames instead of 4.

Concretely, `sliding_window_mask_function((16, 4))` for a query at position 10
returned future positions `{11, 12, 13}` instead of the expected
`{11, 12, 13, 14}`.

This does not match the Moonshine v2 definition, where `w_right = 4` implies an
algorithmic lookahead of `4 x 20 ms = 80 ms` (4 frames at 50 Hz), not 60 ms.

## Change

Use `<=` for the right-window comparison so the full right window is included:

```python
right_mask = (dist < 0) & (-dist <= right_window_size)
```

The left window and causal semantics are unchanged. The same generated copy in
`gemma4/modeling_gemma4.py` (which reuses this function via `modular`) is
updated to stay in sync.

Fixes #46305

## How tested

Added a unit test (`MoonshineStreamingSlidingWindowMaskTest`) asserting that a
query at position 10 with window `(16, 4)` attends to exactly
`{11, 12, 13, 14}`, that the frame 5 steps ahead is excluded, and that the left
window is unaffected.

```
python -m pytest tests/models/moonshine_streaming/test_modeling_moonshine_streaming.py::MoonshineStreamingSlidingWindowMaskTest -v
```

The fix logic was confirmed with a standalone reproduction script mirroring
the issue's repro case — output changed from `[11, 12, 13]` to `[11, 12, 13, 14]`.