### PR TITLE
chore(qa): fix Windows compatibility for type checker excludes

### DIFF
--- a/utils/check_types.py
+++ b/utils/check_types.py
@@ -62,7 +62,20 @@ def main():
     # possibly-missing-attribute), not just errors. Without it, warnings print but ty exits 0, so
     # `make typing` and CI both pass and the issue is never caught before commit.
     result = subprocess.run(
-        ["ty", "check", "--respect-ignore-files", "--error-on-warning", "--exclude", "**/*_pb*", *directories],
+        [
+            "ty",
+            "check",
+            "--respect-ignore-files",
+            "--error-on-warning",
+            "--force-exclude",
+            "--exclude",
+            "**/*_pb*",
+            "--exclude",
+            "src/transformers/utils/sentencepiece_model_pb2.py",
+            "--exclude",
+            "src/transformers/utils/sentencepiece_model_pb2_new.py",
+            *directories,
+        ],
     )
     sys.exit(result.returncode)
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47167)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47167)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This PR fixes type checker failures on Windows environments by enforcing the exclusion of generated Protocol Buffer files (`sentencepiece_model_pb2.py` and `sentencepiece_model_pb2_new.py`) when `utils/check_types.py` is executed.

Specifically, it:
1. Appends `--force-exclude` to the `ty check` arguments list to ensure that exclude rules are respected even when directories are passed to `ty` as explicit positional targets.
2. Specifies explicit relative file paths for the generated protobuf modules to ensure that Windows path resolution (backslashes) does not prevent glob matching.

Fixes # (no corresponding Github issue, found during developer environment setup on Windows)

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the forum?
- [x] Did you make sure to update the documentation with your changes according to the guidelines?
- [x] Did you write any new necessary tests? (No new tests required for developer tooling script modifications).

## Who can review?
- CIs/Tooling: @ydshieh
- Library / Typing: @ArthurZucker