### PR TITLE
tests: reduce processor test memory usage and use tiny test assets

### DIFF
--- a/src/transformers/models/colmodernvbert/processing_colmodernvbert.py
+++ b/src/transformers/models/colmodernvbert/processing_colmodernvbert.py
@@ -308,12 +308,18 @@ class ColModernVBertProcessor(ProcessorMixin):
 
             base_image_length = self.image_seq_len + 3
             col_length = self.image_seq_len + 2
+            # For split images the global section is preceded by "\n" which together with the
+            # row-trailing "\n" forms "\n\n". Some tokenizers merge "\n\n" into one token; others
+            # (e.g. trimmed/tiny tokenizers) keep them as two. Count accurately so the formula
+            # matches the actual tokenized output regardless of the tokenizer's merge rules.
+            extra_split_newline = len(self.tokenizer("\n\n", add_special_tokens=False)["input_ids"]) - 1
             num_image_tokens = []
             num_image_patches = []
 
             for num_patches, num_rows, num_cols in num_image_row_cols:
                 row_length = col_length * num_cols + 1
-                num_image_tokens.append(base_image_length + (row_length * num_rows))
+                split_extra = extra_split_newline if num_rows > 0 else 0
+                num_image_tokens.append(base_image_length + split_extra + (row_length * num_rows))
                 num_image_patches.append(num_patches)
 
             vision_data.update({"num_image_tokens": num_image_tokens, "num_image_patches": num_image_patches})

--- a/src/transformers/models/idefics3/processing_idefics3.py
+++ b/src/transformers/models/idefics3/processing_idefics3.py
@@ -288,12 +288,18 @@ class Idefics3Processor(ProcessorMixin):
 
             base_image_length = self.image_seq_len + 3
             col_length = self.image_seq_len + 2
+            # For split images the global section is preceded by "\n" which together with the
+            # row-trailing "\n" forms "\n\n". Some tokenizers merge "\n\n" into one token; others
+            # (e.g. trimmed/tiny tokenizers) keep them as two. Count accurately so the formula
+            # matches the actual tokenized output regardless of the tokenizer's merge rules.
+            extra_split_newline = len(self.tokenizer("\n\n", add_special_tokens=False)["input_ids"]) - 1
             num_image_tokens = []
             num_image_patches = []
 
             for num_patches, num_rows, num_cols in num_image_row_cols:
                 row_length = col_length * num_cols + 1
-                num_image_tokens.append(base_image_length + (row_length * num_rows))
+                split_extra = extra_split_newline if num_rows > 0 else 0
+                num_image_tokens.append(base_image_length + split_extra + (row_length * num_rows))
                 num_image_patches.append(num_patches)
 
             vision_data.update({"num_image_tokens": num_image_tokens, "num_image_patches": num_image_patches})

--- a/tests/models/aria/test_processing_aria.py
+++ b/tests/models/aria/test_processing_aria.py
@@ -40,15 +40,17 @@ class AriaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def _setup_test_attributes(cls, processor):
         cls.image1 = load_image(
             url_to_local_path(
-                "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/statue_of_liberty_64x64.jpg"
             )
         )
         cls.image2 = load_image(
-            url_to_local_path("https://cdn.britannica.com/59/94459-050-DBA42467/Skyline-Chicago.jpg")
+            url_to_local_path(
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/chicago_64x64.jpg"
+            )
         )
         cls.image3 = load_image(
             url_to_local_path(
-                "https://thumbs.dreamstime.com/b/golden-gate-bridge-san-francisco-purple-flowers-california-echium-candicans-36805947.jpg"
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/golden_gate_64x64.jpg"
             )
         )
         cls.bos_token = "<|im_start|>"

--- a/tests/models/aria/test_processing_aria.py
+++ b/tests/models/aria/test_processing_aria.py
@@ -94,8 +94,9 @@ class AriaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         # Test that a single image is processed correctly
         inputs = processor(images=self.image1, text="Ok<|img|>", images_kwargs={"split_image": True})
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (2, 3, 980, 980))
-        self.assertEqual(np.array(inputs["pixel_mask"]).shape, (2, 980, 980))
+        # 64x64 input is too small to split further; produces 1 tile (no sub-split)
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 3, 980, 980))
+        self.assertEqual(np.array(inputs["pixel_mask"]).shape, (1, 980, 980))
 
     def test_process_interleaved_images_prompts_no_image_splitting(self):
         processor = self.get_processor()

--- a/tests/models/aya_vision/test_processing_aya_vision.py
+++ b/tests/models/aya_vision/test_processing_aya_vision.py
@@ -82,13 +82,13 @@ class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "image",
                             "url": url_to_local_path(
-                                "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/statue_of_liberty_64x64.jpg"
                             ),
                         },
                         {
                             "type": "image",
                             "url": url_to_local_path(
-                                "https://thumbs.dreamstime.com/b/golden-gate-bridge-san-francisco-purple-flowers-california-echium-candicans-36805947.jpg"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/golden_gate_64x64.jpg"
                             ),
                         },
                         {"type": "text", "text": "What are the differences between these two images?"},
@@ -101,7 +101,9 @@ class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                     "content": [
                         {
                             "type": "image",
-                            "url": url_to_local_path("https://llava-vl.github.io/static/images/view.jpg"),
+                            "url": url_to_local_path(
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/view_64x64.jpg"
+                            ),
                         },
                         {"type": "text", "text": "Write a haiku for this image"},
                     ],

--- a/tests/models/cohere2_vision/test_processing_cohere2_vision.py
+++ b/tests/models/cohere2_vision/test_processing_cohere2_vision.py
@@ -29,7 +29,6 @@ if is_torchvision_available():
 
 
 @require_vision
-@unittest.skip("Model not released yet!")
 class Cohere2VisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Cohere2VisionProcessor
 
@@ -57,13 +56,13 @@ class Cohere2VisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "image",
                             "url": url_to_local_path(
-                                "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/statue_of_liberty_64x64.jpg"
                             ),
                         },
                         {
                             "type": "image",
                             "url": url_to_local_path(
-                                "https://thumbs.dreamstime.com/b/golden-gate-bridge-san-francisco-purple-flowers-california-echium-candicans-36805947.jpg"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/golden_gate_64x64.jpg"
                             ),
                         },
                         {"type": "text", "text": "What are the differences between these two images?"},
@@ -76,7 +75,9 @@ class Cohere2VisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                     "content": [
                         {
                             "type": "image",
-                            "url": url_to_local_path("https://llava-vl.github.io/static/images/view.jpg"),
+                            "url": url_to_local_path(
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/view_64x64.jpg"
+                            ),
                         },
                         {"type": "text", "text": "Write a haiku for this image"},
                     ],

--- a/tests/models/cohere2_vision/test_processing_cohere2_vision.py
+++ b/tests/models/cohere2_vision/test_processing_cohere2_vision.py
@@ -29,6 +29,7 @@ if is_torchvision_available():
 
 
 @require_vision
+@unittest.skip("Model not released yet!")
 class Cohere2VisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Cohere2VisionProcessor
 

--- a/tests/models/donut/test_processing_donut.py
+++ b/tests/models/donut/test_processing_donut.py
@@ -25,6 +25,13 @@ class DonutProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     tiny_model_id = "hf-internal-testing/tiny-processor-donut"
     processor_class = DonutProcessor
 
+    @classmethod
+    def _setup_image_processor(cls):
+        image_processor_class = cls._get_component_class_from_processor("image_processor")
+        # Default size=2560×1920 is the document-scanning resolution (~59 MB per image as float32).
+        # Use 64×64 for tests — no assertions check spatial dimensions.
+        return image_processor_class.from_pretrained(cls.tiny_model_id, size={"height": 64, "width": 64})
+
     def test_token2json(self):
         expected_json = {
             "name": "John Doe",

--- a/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
+++ b/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
@@ -284,7 +284,7 @@ class Ernie4_5_VLMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # Add video URL for return dict and load with `num_frames` arg
         messages[0][0]["content"][0] = {
             "type": "video",
-            "url": "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4",
+            "url": "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4",
         }
         num_frames = 3
         out_dict_with_video = processor.apply_chat_template(

--- a/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
+++ b/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
@@ -308,7 +308,7 @@ class Ernie4_5_VLMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             fps=fps,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 2160)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 2304)
 
         # Load with `fps` and `num_frames` args, should raise an error
         with self.assertRaises(ValueError):
@@ -329,7 +329,7 @@ class Ernie4_5_VLMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             return_dict=True,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 2160)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 2304)
 
         # Load video as a list of frames (i.e. images). NOTE: each frame should have same size
         # because we assume they come from one video

--- a/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
+++ b/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
@@ -296,7 +296,7 @@ class Ernie4_5_VLMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             min_frames=3,  # default is 16
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 720)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 768)
 
         # Load with `fps` arg
         fps = 1

--- a/tests/models/glm46v/test_processor_glm46v.py
+++ b/tests/models/glm46v/test_processor_glm46v.py
@@ -174,7 +174,7 @@ class Glm46VProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "video",
                             "url": url_to_local_path(
-                                "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
                             ),
                         },
                         {"type": "text", "text": "What is shown in this video?"},

--- a/tests/models/glm4v/test_processor_glm4v.py
+++ b/tests/models/glm4v/test_processor_glm4v.py
@@ -171,7 +171,7 @@ class Glm4vProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         messages[0][0]["content"][0] = {
             "type": "video",
             "url": url_to_local_path(
-                "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
             ),
         }
 

--- a/tests/models/idefics2/test_processing_idefics2.py
+++ b/tests/models/idefics2/test_processing_idefics2.py
@@ -36,18 +36,29 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     model_id = "HuggingFaceM4/idefics2-8b"
 
     @classmethod
+    def _setup_image_processor(cls):
+        image_processor_class = cls._get_component_class_from_processor("image_processor")
+        # Use size=64 to keep pixel_values tensors small in tests.
+        # Default shortest_edge=378 would upscale 64x64 inputs to 378x378 (~9x larger tensors).
+        return image_processor_class.from_pretrained(
+            cls.tiny_model_id, size={"shortest_edge": 64, "longest_edge": 64}
+        )
+
+    @classmethod
     def _setup_test_attributes(cls, processor):
         cls.image1 = load_image(
             url_to_local_path(
-                "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/statue_of_liberty_64x64.jpg"
             )
         )
         cls.image2 = load_image(
-            url_to_local_path("https://cdn.britannica.com/59/94459-050-DBA42467/Skyline-Chicago.jpg")
+            url_to_local_path(
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/chicago_64x64.jpg"
+            )
         )
         cls.image3 = load_image(
             url_to_local_path(
-                "https://thumbs.dreamstime.com/b/golden-gate-bridge-san-francisco-purple-flowers-california-echium-candicans-36805947.jpg"
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/golden_gate_64x64.jpg"
             )
         )
         cls.bos_token = processor.tokenizer.bos_token
@@ -74,8 +85,8 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         # Test that a single image is processed correctly
         inputs = processor(images=self.image1)
-        self.assertEqual(inputs["pixel_values"].shape, (1, 1, 3, 653, 980))
-        self.assertEqual(inputs["pixel_attention_mask"].shape, (1, 1, 653, 980))
+        self.assertEqual(inputs["pixel_values"].shape, (1, 1, 3, 64, 64))
+        self.assertEqual(inputs["pixel_attention_mask"].shape, (1, 1, 64, 64))
         # fmt: on
 
         # Test a single sample with image and text
@@ -89,8 +100,8 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         expected_input_ids = [[bos_token_id] + [fake_image_token_id] + [image_token_id] * image_seq_len + [fake_image_token_id] + tokenized_sentence["input_ids"]]
         self.assertEqual(inputs["input_ids"], expected_input_ids)
         self.assertEqual(inputs["attention_mask"], [[1] * len(expected_input_ids[0])])
-        self.assertEqual(inputs["pixel_values"].shape, (1, 1, 3, 653, 980))
-        self.assertEqual(inputs["pixel_attention_mask"].shape, (1, 1, 653, 980))
+        self.assertEqual(inputs["pixel_values"].shape, (1, 1, 3, 64, 64))
+        self.assertEqual(inputs["pixel_attention_mask"].shape, (1, 1, 64, 64))
         # fmt: on
 
         # Test that batch is correctly processed
@@ -122,8 +133,8 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             inputs["attention_mask"],
             [[0] * pad_len + [1] * len(expected_input_ids_1), [1] * len(expected_input_ids_2)]
         )
-        self.assertEqual(inputs['pixel_values'].shape, (2, 2, 3, 767, 980))
-        self.assertEqual(inputs['pixel_attention_mask'].shape, (2, 2, 767, 980))
+        self.assertEqual(inputs['pixel_values'].shape, (2, 2, 3, 64, 64))
+        self.assertEqual(inputs['pixel_attention_mask'].shape, (2, 2, 64, 64))
         # fmt: on
 
     def test_process_interleaved_images_prompts_image_splitting(self):
@@ -133,8 +144,8 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         # Test that a single image is processed correctly
         inputs = processor(images=self.image1)
-        self.assertEqual(inputs["pixel_values"].shape, (1, 5, 3, 653, 980))
-        self.assertEqual(inputs["pixel_attention_mask"].shape, (1, 5, 653, 980))
+        self.assertEqual(inputs["pixel_values"].shape, (1, 5, 3, 64, 64))
+        self.assertEqual(inputs["pixel_attention_mask"].shape, (1, 5, 64, 64))
         # fmt: on
 
         # Test a single sample with image and text
@@ -148,8 +159,8 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         expected_input_ids = [[self.bos_token_id] + ([self.fake_image_token_id] + [self.image_token_id] * self.image_seq_len) * 5 + [self.fake_image_token_id] + tokenized_sentence["input_ids"]]
         self.assertEqual(inputs["input_ids"], expected_input_ids)
         self.assertEqual(inputs["attention_mask"], [[1] * len(expected_input_ids[0])])
-        self.assertEqual(inputs["pixel_values"].shape, (1, 5, 3, 653, 980))
-        self.assertEqual(inputs["pixel_attention_mask"].shape, (1, 5, 653, 980))
+        self.assertEqual(inputs["pixel_values"].shape, (1, 5, 3, 64, 64))
+        self.assertEqual(inputs["pixel_attention_mask"].shape, (1, 5, 64, 64))
         # fmt: on
 
         # Test that batch is correctly processed
@@ -181,8 +192,8 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             inputs["attention_mask"],
             [[0] * pad_len + [1] * len(expected_input_ids_1), [1] * len(expected_input_ids_2)]
         )
-        self.assertEqual(inputs['pixel_values'].shape, (2, 10, 3, 767, 980))
-        self.assertEqual(inputs['pixel_attention_mask'].shape, (2, 10, 767, 980))
+        self.assertEqual(inputs['pixel_values'].shape, (2, 10, 3, 64, 64))
+        self.assertEqual(inputs['pixel_attention_mask'].shape, (2, 10, 64, 64))
         # fmt: on
 
     def test_add_special_tokens_processor(self):
@@ -221,8 +232,8 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         inputs = processor(text=text, images=images, padding=True)
 
-        self.assertEqual(inputs["pixel_values"].shape, (2, 2, 3, 767, 980))
-        self.assertEqual(inputs["pixel_attention_mask"].shape, (2, 2, 767, 980))
+        self.assertEqual(inputs["pixel_values"].shape, (2, 2, 3, 64, 64))
+        self.assertEqual(inputs["pixel_attention_mask"].shape, (2, 2, 64, 64))
 
     def test_process_interleaved_images_prompts_image_error(self):
         processor = self.get_processor()

--- a/tests/models/idefics2/test_processing_idefics2.py
+++ b/tests/models/idefics2/test_processing_idefics2.py
@@ -40,9 +40,7 @@ class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         image_processor_class = cls._get_component_class_from_processor("image_processor")
         # Use size=64 to keep pixel_values tensors small in tests.
         # Default shortest_edge=378 would upscale 64x64 inputs to 378x378 (~9x larger tensors).
-        return image_processor_class.from_pretrained(
-            cls.tiny_model_id, size={"shortest_edge": 64, "longest_edge": 64}
-        )
+        return image_processor_class.from_pretrained(cls.tiny_model_id, size={"shortest_edge": 64, "longest_edge": 64})
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/idefics3/test_processing_idefics3.py
+++ b/tests/models/idefics3/test_processing_idefics3.py
@@ -44,15 +44,17 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def _setup_test_attributes(cls, processor):
         cls.image1 = load_image(
             url_to_local_path(
-                "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/statue_of_liberty_64x64.jpg"
             )
         )
         cls.image2 = load_image(
-            url_to_local_path("https://cdn.britannica.com/59/94459-050-DBA42467/Skyline-Chicago.jpg")
+            url_to_local_path(
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/chicago_64x64.jpg"
+            )
         )
         cls.image3 = load_image(
             url_to_local_path(
-                "https://thumbs.dreamstime.com/b/golden-gate-bridge-san-francisco-purple-flowers-california-echium-candicans-36805947.jpg"
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/golden_gate_64x64.jpg"
             )
         )
         cls.bos_token = processor.tokenizer.bos_token
@@ -204,9 +206,10 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         processor.image_processor.do_image_splitting = True
 
         # Test that a single image is processed correctly
+        # 64x64 input → 1×1 tile split + 1 global = 2 tiles total
         inputs = processor(images=self.image1)
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 13, 3, 364, 364))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 13, 364, 364))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 364, 364))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 364, 364))
         # fmt: on
         self.maxDiff = None
 
@@ -218,12 +221,12 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         # fmt: off
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 3, 4)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
         expected_input_ids_1 = [[self.bos_token_id] + split_image1_tokens + tokenized_sentence["input_ids"]]
         self.assertEqual(inputs["input_ids"], expected_input_ids_1)
         self.assertEqual(inputs["attention_mask"], [[1] * len(expected_input_ids_1[0])])
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 13, 3, 364, 364))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 13, 364, 364))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 364, 364))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 364, 364))
         # fmt: on
 
         # Test that batch is correctly processed
@@ -243,9 +246,10 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         tokenized_sentence_1 = processor.tokenizer(text_str_1, add_special_tokens=False)
         tokenized_sentence_2 = processor.tokenizer(text_str_2, add_special_tokens=False)
 
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 3, 4)
-        split_image2_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
-        split_image3_tokens = self.get_split_image_expected_tokens(processor, 3, 4)
+        # 64x64 inputs → 1×1 tile each = 2 tiles per image; batch max = max(2, 4) = 4
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image2_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image3_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
         expected_input_ids_1 = [self.bos_token_id] + split_image1_tokens + tokenized_sentence_1["input_ids"]
         expected_input_ids_2 = [self.bos_token_id] + tokenized_sentence_2["input_ids"] + split_image2_tokens + split_image3_tokens
         # Pad the first input to match the second input
@@ -259,8 +263,8 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             inputs["attention_mask"],
             [[0] * pad_len + [1] * len(expected_input_ids_1), [1] * len(expected_input_ids_2)]
         )
-        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 30, 3, 364, 364))
-        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 30, 364, 364))
+        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 4, 3, 364, 364))
+        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 4, 364, 364))
         # fmt: on
 
     def test_add_special_tokens_processor(self):
@@ -273,7 +277,7 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # fmt: off
         inputs = processor(text=text, images=self.image1, add_special_tokens=False)
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 3, 4)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
         expected_input_ids = [tokenized_sentence["input_ids"] + split_image1_tokens]
         self.assertEqual(inputs["input_ids"], expected_input_ids)
 

--- a/tests/models/idefics3/test_processing_idefics3.py
+++ b/tests/models/idefics3/test_processing_idefics3.py
@@ -206,10 +206,10 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         processor.image_processor.do_image_splitting = True
 
         # Test that a single image is processed correctly
-        # 64x64 input → 1×1 tile split + 1 global = 2 tiles total
+        # 64x64 square input → 4×4 tile split (max square) + 1 global = 17 tiles total
         inputs = processor(images=self.image1)
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 364, 364))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 364, 364))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 17, 3, 364, 364))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 17, 364, 364))
         # fmt: on
         self.maxDiff = None
 
@@ -221,12 +221,12 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         # fmt: off
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
         expected_input_ids_1 = [[self.bos_token_id] + split_image1_tokens + tokenized_sentence["input_ids"]]
         self.assertEqual(inputs["input_ids"], expected_input_ids_1)
         self.assertEqual(inputs["attention_mask"], [[1] * len(expected_input_ids_1[0])])
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 364, 364))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 364, 364))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 17, 3, 364, 364))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 17, 364, 364))
         # fmt: on
 
         # Test that batch is correctly processed
@@ -246,10 +246,10 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         tokenized_sentence_1 = processor.tokenizer(text_str_1, add_special_tokens=False)
         tokenized_sentence_2 = processor.tokenizer(text_str_2, add_special_tokens=False)
 
-        # 64x64 inputs → 1×1 tile each = 2 tiles per image; batch max = max(2, 4) = 4
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
-        split_image2_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
-        split_image3_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        # 64x64 square inputs → 4×4 tile each = 17 tiles per image; batch max = max(17, 34) = 34
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
+        split_image2_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
+        split_image3_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
         expected_input_ids_1 = [self.bos_token_id] + split_image1_tokens + tokenized_sentence_1["input_ids"]
         expected_input_ids_2 = [self.bos_token_id] + tokenized_sentence_2["input_ids"] + split_image2_tokens + split_image3_tokens
         # Pad the first input to match the second input
@@ -263,8 +263,8 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             inputs["attention_mask"],
             [[0] * pad_len + [1] * len(expected_input_ids_1), [1] * len(expected_input_ids_2)]
         )
-        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 4, 3, 364, 364))
-        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 4, 364, 364))
+        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 34, 3, 364, 364))
+        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 34, 364, 364))
         # fmt: on
 
     def test_add_special_tokens_processor(self):
@@ -277,7 +277,7 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # fmt: off
         inputs = processor(text=text, images=self.image1, add_special_tokens=False)
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
         expected_input_ids = [tokenized_sentence["input_ids"] + split_image1_tokens]
         self.assertEqual(inputs["input_ids"], expected_input_ids)
 

--- a/tests/models/idefics3/test_processing_idefics3.py
+++ b/tests/models/idefics3/test_processing_idefics3.py
@@ -84,7 +84,9 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # Idefics3 checkpoints aren't supported on purpose. Idefics3 encodes special row/col
         # tokens as several token ids because they aren't added in `special_token_ids`. Thus
         # we can't correctly infer which tokens in input ids are used as placeholders for image/row/col!
-        # Use the tiny SmolVLM processor (same architecture) instead of loading the full model each iteration.
+        # Use the tiny SmolVLM processor (same architecture, row/col tokens are proper special tokens).
+        # The tiny model is sufficient now that _get_num_multimodal_tokens correctly handles "\n\n"
+        # tokenization (which may differ between full and trimmed tokenizers).
         base_processor = self.processor_class.from_pretrained(
             "hf-internal-testing/tiny-processor-smolvlm",
             add_bos_token=True,

--- a/tests/models/idefics3/test_processing_idefics3.py
+++ b/tests/models/idefics3/test_processing_idefics3.py
@@ -69,6 +69,18 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         cls.padding_token_id = processor.tokenizer.pad_token_id
         cls.image_seq_len = processor.image_seq_len
 
+        # Pre-load the SmolVLM processor used by test_get_num_multimodal_tokens_matches_processor_call.
+        # Loaded once here to avoid repeated Hub loads in the test body. size=1024 (2×2=5 tiles)
+        # instead of default 2048 (4×4=17 tiles) to speed up image processing in the test.
+        cls._smolvlm_processor = cls.processor_class.from_pretrained(
+            "hf-internal-testing/tiny-processor-smolvlm",
+            add_bos_token=True,
+            add_eos_token=False,
+            padding_side="left",
+            image_seq_len=2,
+        )
+        cls._smolvlm_processor.image_processor.size = {"longest_edge": 1024}
+
     @staticmethod
     def prepare_processor_dict():
         return {"image_seq_len": 2}
@@ -84,16 +96,9 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # Idefics3 checkpoints aren't supported on purpose. Idefics3 encodes special row/col
         # tokens as several token ids because they aren't added in `special_token_ids`. Thus
         # we can't correctly infer which tokens in input ids are used as placeholders for image/row/col!
-        # Use the tiny SmolVLM processor (same architecture, row/col tokens are proper special tokens).
-        # The tiny model is sufficient now that _get_num_multimodal_tokens correctly handles "\n\n"
-        # tokenization (which may differ between full and trimmed tokenizers).
-        base_processor = self.processor_class.from_pretrained(
-            "hf-internal-testing/tiny-processor-smolvlm",
-            add_bos_token=True,
-            add_eos_token=False,
-            padding_side="left",
-            image_seq_len=2,
-        )
+        # Use the tiny SmolVLM processor (same architecture, row/col tokens are proper special tokens),
+        # pre-loaded once in setUpClass with size=1024 (2×2 tiles) for speed.
+        base_processor = self._smolvlm_processor
         for do_image_splitting in [False, True]:
             with self.subTest(do_image_splitting=do_image_splitting):
                 processor = base_processor

--- a/tests/models/idefics3/test_processing_idefics3.py
+++ b/tests/models/idefics3/test_processing_idefics3.py
@@ -69,18 +69,6 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         cls.padding_token_id = processor.tokenizer.pad_token_id
         cls.image_seq_len = processor.image_seq_len
 
-        # Pre-load the SmolVLM processor used by test_get_num_multimodal_tokens_matches_processor_call.
-        # Loaded once here to avoid repeated Hub loads in the test body. size=1024 (2×2=5 tiles)
-        # instead of default 2048 (4×4=17 tiles) to speed up image processing in the test.
-        cls._smolvlm_processor = cls.processor_class.from_pretrained(
-            "hf-internal-testing/tiny-processor-smolvlm",
-            add_bos_token=True,
-            add_eos_token=False,
-            padding_side="left",
-            image_seq_len=2,
-        )
-        cls._smolvlm_processor.image_processor.size = {"longest_edge": 1024}
-
     @staticmethod
     def prepare_processor_dict():
         return {"image_seq_len": 2}
@@ -96,9 +84,16 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # Idefics3 checkpoints aren't supported on purpose. Idefics3 encodes special row/col
         # tokens as several token ids because they aren't added in `special_token_ids`. Thus
         # we can't correctly infer which tokens in input ids are used as placeholders for image/row/col!
-        # Use the tiny SmolVLM processor (same architecture, row/col tokens are proper special tokens),
-        # pre-loaded once in setUpClass with size=1024 (2×2 tiles) for speed.
-        base_processor = self._smolvlm_processor
+        # Use the tiny SmolVLM processor (same architecture, row/col tokens are proper special tokens).
+        base_processor = self.processor_class.from_pretrained(
+            "hf-internal-testing/tiny-processor-smolvlm",
+            add_bos_token=True,
+            add_eos_token=False,
+            padding_side="left",
+            image_seq_len=2,
+        )
+        # size=1024 (2×2=5 tiles) instead of default 2048 (4×4=17 tiles) to speed up image processing.
+        base_processor.image_processor.size = {"longest_edge": 1024}
         for do_image_splitting in [False, True]:
             with self.subTest(do_image_splitting=do_image_splitting):
                 processor = base_processor

--- a/tests/models/idefics3/test_processing_idefics3.py
+++ b/tests/models/idefics3/test_processing_idefics3.py
@@ -82,18 +82,20 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             image_inputs.append(np.random.randint(255, size=(h, w, 3), dtype=np.uint8))
 
         # Idefics3 checkpoints aren't supported on purpose. Idefics3 encodes special row/col
-        # tokens are several token ids ebcause they aren't added in `special_token_ids`. Thus
+        # tokens as several token ids because they aren't added in `special_token_ids`. Thus
         # we can't correctly infer which tokens in input ids are used as placeholders for image/row/col!
+        # Use the tiny SmolVLM processor (same architecture) instead of loading the full model each iteration.
+        base_processor = self.processor_class.from_pretrained(
+            "hf-internal-testing/tiny-processor-smolvlm",
+            add_bos_token=True,
+            add_eos_token=False,
+            padding_side="left",
+            image_seq_len=2,
+        )
         for do_image_splitting in [False, True]:
             with self.subTest(do_image_splitting=do_image_splitting):
-                processor = self.processor_class.from_pretrained(
-                    "HuggingFaceTB/SmolVLM-256M-Instruct",
-                    add_bos_token=True,
-                    add_eos_token=False,
-                    padding_side="left",
-                    image_seq_len=2,
-                    do_image_splitting=do_image_splitting,
-                )
+                processor = base_processor
+                processor.image_processor.do_image_splitting = do_image_splitting
 
                 text = [f"This is an image {processor.image_token}"] * len(image_inputs)
                 inputs = processor(

--- a/tests/models/internvl/test_processing_internvl.py
+++ b/tests/models/internvl/test_processing_internvl.py
@@ -98,13 +98,13 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "image",
                             "url": url_to_local_path(
-                                "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/statue_of_liberty_64x64.jpg"
                             ),
                         },
                         {
                             "type": "image",
                             "url": url_to_local_path(
-                                "https://thumbs.dreamstime.com/b/golden-gate-bridge-san-francisco-purple-flowers-california-echium-candicans-36805947.jpg"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/golden_gate_64x64.jpg"
                             ),
                         },
                         {"type": "text", "text": "What are the differences between these two images?"},
@@ -131,7 +131,9 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                     "content": [
                         {
                             "type": "image",
-                            "url": url_to_local_path("https://llava-vl.github.io/static/images/view.jpg"),
+                            "url": url_to_local_path(
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/view_64x64.jpg"
+                            ),
                         },
                         {"type": "text", "text": "Write a haiku for this image"},
                     ],

--- a/tests/models/internvl/test_processing_internvl.py
+++ b/tests/models/internvl/test_processing_internvl.py
@@ -369,7 +369,7 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "<video>\nAre there any cyan objects that enter the scene?\nno",
             "<video>\nAre there any red spheres that enter the scene?\nno",
         ]
-        frames = torch.ones((4, 448, 448, 3), dtype=torch.float32)
+        frames = torch.ones((4, 20, 20, 3), dtype=torch.float32)
         videos = [frames, frames]
 
         processor = self.get_processor()
@@ -378,7 +378,7 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             return_tensors="pt",
             padding=True,
             videos=videos[:batch_size],
-            videos_kwargs={"size": (448, 448)},
+            videos_kwargs={"size": (20, 20)},
         )
 
         actual_num_frames = inputs.pixel_values.shape[0]

--- a/tests/models/internvl/test_processing_internvl.py
+++ b/tests/models/internvl/test_processing_internvl.py
@@ -118,7 +118,7 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "video",
                             "url": url_to_local_path(
-                                "https://huggingface.co/datasets/hf-internal-testing/fixtures_videos/resolve/main/tennis.mp4"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tennis_320x240.mp4"
                             ),
                         },
                         {"type": "text", "text": "What type of shot is the man performing?"},

--- a/tests/models/internvl/test_processing_internvl.py
+++ b/tests/models/internvl/test_processing_internvl.py
@@ -196,7 +196,7 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "video",
                             "url": url_to_local_path(
-                                "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
                             ),
                         },
                         {"type": "text", "text": "What is shown in this video?"},

--- a/tests/models/kosmos2_5/test_processor_kosmos2_5.py
+++ b/tests/models/kosmos2_5/test_processor_kosmos2_5.py
@@ -237,10 +237,6 @@ class Kosmos2_5ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         self.assertEqual(len(inputs["input_ids"][0]), 76)
 
-    @unittest.skip(
-        "Integration test: loads full microsoft/kosmos-2.5 processor and checks golden pixel values. "
-        "Requires ~120 MB and the full microsoft/kosmos-2.5 checkpoint."
-    )
     @require_torch
     def test_full_processor(self):
         url = url_to_local_path("https://huggingface.co/microsoft/kosmos-2.5/resolve/main/receipt_00008.png")

--- a/tests/models/kosmos2_5/test_processor_kosmos2_5.py
+++ b/tests/models/kosmos2_5/test_processor_kosmos2_5.py
@@ -237,6 +237,10 @@ class Kosmos2_5ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         self.assertEqual(len(inputs["input_ids"][0]), 76)
 
+    @unittest.skip(
+        "Integration test: loads full microsoft/kosmos-2.5 processor and checks golden pixel values. "
+        "Requires ~120 MB and the full microsoft/kosmos-2.5 checkpoint."
+    )
     @require_torch
     def test_full_processor(self):
         url = url_to_local_path("https://huggingface.co/microsoft/kosmos-2.5/resolve/main/receipt_00008.png")

--- a/tests/models/llava_next_video/test_processing_llava_next_video.py
+++ b/tests/models/llava_next_video/test_processing_llava_next_video.py
@@ -15,6 +15,7 @@
 import json
 import unittest
 
+import numpy as np
 import torch
 
 from transformers import LlavaNextVideoProcessor
@@ -43,6 +44,14 @@ class LlavaNextVideoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "patch_size": 128,
             "vision_feature_select_strategy": "default",
         }
+
+    def prepare_video_inputs(self, batch_size=None):
+        """Use tiny frames to keep test_processor_text_has_no_visual memory-efficient."""
+        video_input = [np.random.randint(255, size=(3, 8, 8), dtype=np.uint8)] * 2
+        video_input = np.array(video_input)
+        if batch_size is None:
+            return video_input
+        return [video_input] * batch_size
 
     # Copied from tests.models.llava.test_processing_llava.LlavaProcessorTest.test_get_num_vision_tokens
     def test_get_num_vision_tokens(self):

--- a/tests/models/llava_onevision/test_processing_llava_onevision.py
+++ b/tests/models/llava_onevision/test_processing_llava_onevision.py
@@ -137,7 +137,7 @@ class LlavaOnevisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "video",
                             "url": url_to_local_path(
-                                "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
                             ),
                         },
                         {"type": "text", "text": "What is shown in this video?"},

--- a/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
@@ -243,7 +243,7 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "video",
                             "url": url_to_local_path(
-                                "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
                             ),
                         },
                         {"type": "text", "text": "What is shown in this video?"},

--- a/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
@@ -47,6 +47,15 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     image_unstructured_max_length = 100
 
     @classmethod
+    def _setup_image_processor(cls):
+        image_processor_class = cls._get_component_class_from_processor("image_processor")
+        # Default scale_resolution=448 with max_slice_nums=9 produces up to 21 MB pixel_values per image.
+        # Use scale_resolution=64 with max_slice_nums=1 for tests — shape[0]==1 assertion still passes.
+        return image_processor_class.from_pretrained(
+            cls.tiny_model_id, scale_resolution=64, max_slice_nums=1
+        )
+
+    @classmethod
     def _setup_test_attributes(cls, processor):
         cls.image_token = processor.image_token
         cls.video_token = processor.video_token

--- a/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
@@ -56,6 +56,16 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         )
 
     @classmethod
+    def _setup_video_processor(cls):
+        video_processor_class = cls._get_component_class_from_processor("video_processor")
+        # Default scale_resolution=448 with max_slice_nums=9 produces >14 KB per frame.
+        # Use scale_resolution=64 with max_slice_nums=1; shape assertions in
+        # test_apply_chat_template_video_frame_sampling are updated to match.
+        return video_processor_class.from_pretrained(
+            cls.tiny_model_id, scale_resolution=64, max_slice_nums=1
+        )
+
+    @classmethod
     def _setup_test_attributes(cls, processor):
         cls.image_token = processor.image_token
         cls.video_token = processor.video_token
@@ -286,8 +296,9 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
         self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1)
-        # 3 frames are inferred from input video's length and FPS, so can be hardcoded
-        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 14112)
+        # 1 frame is inferred from input video's length and FPS, so can be hardcoded
+        # (224 = 56*56/14 with scale_resolution=64; was 14112 = 392*504/14 at default scale_resolution=448)
+        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 224)
 
         # When `do_sample_frames=False` no sampling is done and whole video is loaded, even if number of frames is passed
         fps = 10
@@ -304,7 +315,8 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
         self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1)
-        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 155232)
+        # 2464 = 11 frames * 224 per frame (56*56/14); was 155232 = 11 * 14112 at default scale_resolution=448
+        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 2464)
 
         # Load without any arg should load the whole video
         out_dict_with_video = processor.apply_chat_template(
@@ -315,7 +327,8 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
         self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1)
-        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 14112)
+        # 224 per frame (56*56/14 at scale_resolution=64); was 14112 = 392*504/14 at scale_resolution=448
+        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 224)
 
         # Load video as a list of frames (i.e. images).
         # NOTE: each frame should have same size because we assume they come from one video
@@ -337,7 +350,9 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
         self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1)
-        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 203392)
+        # 448 = 2 frames * 224 per frame (56*56/14 at scale_resolution=64, no slicing);
+        # was 203392 = 2 frames * (source 15680 + 6 slices * 14336) at scale_resolution=448
+        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 448)
 
     @require_torch
     def test_apply_chat_template_tool_calls_no_content(self):

--- a/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
@@ -51,9 +51,7 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         image_processor_class = cls._get_component_class_from_processor("image_processor")
         # Default scale_resolution=448 with max_slice_nums=9 produces up to 21 MB pixel_values per image.
         # Use scale_resolution=64 with max_slice_nums=1 for tests — shape[0]==1 assertion still passes.
-        return image_processor_class.from_pretrained(
-            cls.tiny_model_id, scale_resolution=64, max_slice_nums=1
-        )
+        return image_processor_class.from_pretrained(cls.tiny_model_id, scale_resolution=64, max_slice_nums=1)
 
     @classmethod
     def _setup_video_processor(cls):
@@ -61,9 +59,7 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # Default scale_resolution=448 with max_slice_nums=9 produces >14 KB per frame.
         # Use scale_resolution=64 with max_slice_nums=1; shape assertions in
         # test_apply_chat_template_video_frame_sampling are updated to match.
-        return video_processor_class.from_pretrained(
-            cls.tiny_model_id, scale_resolution=64, max_slice_nums=1
-        )
+        return video_processor_class.from_pretrained(cls.tiny_model_id, scale_resolution=64, max_slice_nums=1)
 
     @classmethod
     def _setup_test_attributes(cls, processor):

--- a/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_processing_minicpmv4_6.py
@@ -278,7 +278,7 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertTrue(self.videos_input_name in out_dict_with_video)
         self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1)
         # 3 frames are inferred from input video's length and FPS, so can be hardcoded
-        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 129472)
+        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 14112)
 
         # When `do_sample_frames=False` no sampling is done and whole video is loaded, even if number of frames is passed
         fps = 10
@@ -295,7 +295,7 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
         self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1)
-        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 1424192)
+        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 155232)
 
         # Load without any arg should load the whole video
         out_dict_with_video = processor.apply_chat_template(
@@ -306,7 +306,7 @@ class MiniCPMV4_6ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
         self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1)
-        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 129472)
+        self.assertEqual(out_dict_with_video[self.videos_input_name].shape[-1], 14112)
 
         # Load video as a list of frames (i.e. images).
         # NOTE: each frame should have same size because we assume they come from one video

--- a/tests/models/owlv2/test_processing_owlv2.py
+++ b/tests/models/owlv2/test_processing_owlv2.py
@@ -11,3 +11,9 @@ class Owlv2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Owlv2Processor
     # Tiny processor created with make_tiny_processor.py from "google/owlv2-base-patch16-ensemble"
     tiny_model_id = "hf-internal-testing/tiny-processor-owlv2"
+
+    @classmethod
+    def _setup_image_processor(cls):
+        image_processor_class = cls._get_component_class_from_processor("image_processor")
+        # Default size=960×960 produces ~11 MB pixel_values per image. Use 64×64 for tests.
+        return image_processor_class.from_pretrained(cls.tiny_model_id, size={"height": 64, "width": 64})

--- a/tests/models/qianfan_ocr/test_processing_qianfan_ocr.py
+++ b/tests/models/qianfan_ocr/test_processing_qianfan_ocr.py
@@ -39,6 +39,15 @@ class QianfanOCRProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     videos_input_name = "pixel_values"
 
     @classmethod
+    def _setup_image_processor(cls):
+        image_processor_class = cls._get_component_class_from_processor("image_processor")
+        # Default size=448x448 with max_patches=12 produces up to 27 MB pixel_values tensors.
+        # Use 64x64 with max_patches=1 for tests — assertions only check patch count, not spatial dims.
+        return image_processor_class.from_pretrained(
+            cls.tiny_model_id, size={"height": 64, "width": 64}, max_patches=1
+        )
+
+    @classmethod
     def _setup_test_attributes(cls, processor):
         cls.image_token = processor.image_placeholder_token
 

--- a/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
+++ b/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
@@ -209,7 +209,7 @@ class Qwen2_5OmniProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             {
                 "type": "video",
                 "url": url_to_local_path(
-                    "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                    "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
                 ),
             }
         )

--- a/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
+++ b/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
@@ -315,7 +315,7 @@ class Qwen2_5OmniProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             self.skipTest(f"feature_extractor attribute not present in {self.processor_class}")
 
         video_file_path = hf_hub_download(
-            repo_id="raushan-testing-hf/videos-test", filename="sample_demo_1.mp4", repo_type="dataset"
+            repo_id="hf-internal-testing/test-videos", filename="sample_demo_1_320x240.mp4", repo_type="dataset"
         )
         messages = [
             {

--- a/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
+++ b/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
@@ -65,6 +65,14 @@ class Qwen2_5OmniProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             cls.tiny_model_id, size={"shortest_edge": 12 * 12, "longest_edge": 28 * 28}
         )
 
+    @classmethod
+    def _setup_feature_extractor(cls):
+        feature_extractor_class = cls._get_component_class_from_processor("feature_extractor")
+        # chunk_length=30s instead of the default 300s reduces input_features from
+        # (batch, 128, 30000) to (batch, 128, 3000), cutting the audio call's peak
+        # memory from ~178 MB to ~20 MB per test.
+        return feature_extractor_class.from_pretrained(cls.tiny_model_id, chunk_length=30)
+
     def prepare_audio_inputs(self, batch_size: int = 3):
         """This function prepares a list of numpy audios."""
         audio_inputs = [np.random.rand(160000) * 2 - 1] * batch_size

--- a/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
@@ -200,7 +200,7 @@ class Qwen2_5_VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             num_frames=num_frames,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 360)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 384)
 
         # Load with `fps` arg
         fps = 1
@@ -212,7 +212,7 @@ class Qwen2_5_VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             fps=fps,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 360)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 384)
 
         # Load with `fps` and `num_frames` args, should raise an error
         with self.assertRaises(ValueError):

--- a/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
@@ -233,7 +233,7 @@ class Qwen2_5_VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             return_dict=True,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1080)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1152)
 
         # Load video as a list of frames (i.e. images). NOTE: each frame should have same size
         # because we assume they come from one video

--- a/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
@@ -178,7 +178,7 @@ class Qwen2_5_VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "video",
                             "url": url_to_local_path(
-                                "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
                             ),
                         },
                         {"type": "text", "text": "What is shown in this video?"},

--- a/tests/models/qwen2_vl/test_processing_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_processing_qwen2_vl.py
@@ -189,7 +189,7 @@ class Qwen2VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             num_frames=num_frames,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 360)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 384)
 
         # Load with `fps` arg
         fps = 1
@@ -201,7 +201,7 @@ class Qwen2VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             fps=fps,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 360)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 384)
 
         # Load with `fps` and `num_frames` args, should raise an error
         with self.assertRaises(ValueError):

--- a/tests/models/qwen2_vl/test_processing_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_processing_qwen2_vl.py
@@ -171,7 +171,7 @@ class Qwen2VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "video",
                             "url": url_to_local_path(
-                                "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
                             ),
                         },
                         {"type": "text", "text": "What is shown in this video?"},

--- a/tests/models/qwen2_vl/test_processing_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_processing_qwen2_vl.py
@@ -222,7 +222,7 @@ class Qwen2VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             return_dict=True,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1080)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1152)
 
         # Load video as a list of frames (i.e. images). NOTE: each frame should have same size
         # because we assume they come from one video

--- a/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
@@ -307,7 +307,7 @@ class Qwen3OmniMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             self.skipTest(f"feature_extractor attribute not present in {self.processor_class}")
 
         video_file_path = hf_hub_download(
-            repo_id="raushan-testing-hf/videos-test", filename="sample_demo_1.mp4", repo_type="dataset"
+            repo_id="hf-internal-testing/test-videos", filename="sample_demo_1_320x240.mp4", repo_type="dataset"
         )
         messages = [
             {

--- a/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
@@ -347,4 +347,4 @@ class Qwen3OmniMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertEqual(len(out_dict["input_ids"]), 1)  # batch-size=1
         self.assertEqual(len(out_dict["attention_mask"]), 1)  # batch-size=1
         self.assertEqual(len(out_dict[self.audio_input_name]), 1)  # 1 audio in the conversation
-        self.assertEqual(len(out_dict[self.videos_input_name]), 145912)  # 1 video in the conversation
+        self.assertEqual(len(out_dict[self.videos_input_name]), 10800)  # 1 video in the conversation

--- a/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
@@ -257,7 +257,7 @@ class Qwen3OmniMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             return_dict=True,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 23184)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 4320)
 
         # Load video as a list of frames (i.e. images). NOTE: each frame should have same size
         # because we assume they come from one video

--- a/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
@@ -62,6 +62,13 @@ class Qwen3OmniMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             cls.tiny_model_id, size={"shortest_edge": 28 * 28, "longest_edge": 56 * 56}
         )
 
+    @classmethod
+    def _setup_feature_extractor(cls):
+        feature_extractor_class = cls._get_component_class_from_processor("feature_extractor")
+        # chunk_length=30s instead of the default 300s reduces input_features from
+        # (batch, 128, 30000) to (batch, 128, 3000), cutting peak memory per audio test.
+        return feature_extractor_class.from_pretrained(cls.tiny_model_id, chunk_length=30)
+
     def prepare_audio_inputs(self, batch_size: int = 3):
         """This function prepares a list of numpy audios."""
         audio_inputs = [np.random.rand(160000) * 2 - 1] * batch_size

--- a/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
@@ -224,7 +224,7 @@ class Qwen3OmniMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             num_frames=num_frames,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 7728)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1440)
 
         # Load with `fps` arg
         fps = 1
@@ -236,7 +236,7 @@ class Qwen3OmniMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             fps=fps,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 7728)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1440)
 
         # Load with `fps` and `num_frames` args, should raise an error
         with self.assertRaises(ValueError):

--- a/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_processing_qwen3_omni_moe.py
@@ -211,7 +211,7 @@ class Qwen3OmniMoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             {
                 "type": "video",
                 "url": url_to_local_path(
-                    "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                    "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
                 ),
             }
         )

--- a/tests/models/qwen3_vl/test_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_processing_qwen3_vl.py
@@ -182,7 +182,7 @@ class Qwen3VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "video",
                             "url": url_to_local_path(
-                                "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
                             ),
                         },
                         {"type": "text", "text": "What is shown in this video?"},
@@ -208,7 +208,7 @@ class Qwen3VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             fps=None,  # if pass num_frames, fps should be None
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 256)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 280)
 
         # Load with `fps` arg
         fps = 1
@@ -220,7 +220,7 @@ class Qwen3VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             fps=fps,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 224)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 192)
 
         # Load with `fps` and `num_frames` args, should raise an error
         with self.assertRaises(ValueError):
@@ -241,7 +241,7 @@ class Qwen3VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             return_dict=True,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 224)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 192)
 
         # Load video as a list of frames (i.e. images). NOTE: each frame should have same size
         # because we assume they come from one video

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -370,7 +370,7 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "video",
                             "url": url_to_local_path(
-                                "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
                             ),
                         },
                         {"type": "text", "text": "What is shown in this video?"},

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -296,8 +296,6 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     # Copied from tests.models.idefics2.test_processing_idefics2.Idefics2ProcessorTest.test_process_interleaved_images_prompts_image_error
     def test_process_interleaved_images_prompts_image_error(self):
-        import time
-
         processor = self.get_processor()
 
         text = [
@@ -305,56 +303,39 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "In this other sentence we try some good things",
         ]
         images = [[self.image1], [self.image2]]
-        t0 = time.perf_counter()
-        _err = None
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"\n[error_test] case 1 (no <image>, 2 imgs): {time.perf_counter() - t0:.3f}s")
         images = [[self.image1], []]
-        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 2 (no <image>, 1+empty): {time.perf_counter() - t0:.3f}s")
 
         text = [
             "This is a test sentence.<image>",
             "In this other sentence we try some good things<image>",
         ]
         images = [[self.image1], [self.image2, self.image3]]
-        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 3 (1 token each, 1+2 imgs): {time.perf_counter() - t0:.3f}s")
         images = [[], [self.image2]]
-        t0 = time.perf_counter()
         with self.assertRaises((ValueError, IndexError)):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 4 (empty+1 img): {time.perf_counter() - t0:.3f}s")
         images = [self.image1, self.image2, self.image3]
-        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 5 (flat list 3 imgs): {time.perf_counter() - t0:.3f}s")
         images = [self.image1]
-        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 6 (flat list 1 img): {time.perf_counter() - t0:.3f}s")
 
         text = [
             "This is a test sentence.",
             "In this other sentence we try some good things<image>",
         ]
         images = [[self.image1], []]
-        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 7 (mixed, 1+empty): {time.perf_counter() - t0:.3f}s")
         images = [self.image1, self.image2]
-        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 8 (mixed, flat 2 imgs): {time.perf_counter() - t0:.3f}s")
 
     def test_apply_chat_template(self):
         # Message contains content which a mix of lists with images and image urls and string

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -186,10 +186,10 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         processor = self.processor_class(**processor_components, **processor_kwargs)
 
         # Test that a single image is processed correctly
-        # 64x64 input → 1×1 tile split + 1 global = 2 tiles total
+        # 64x64 square input → 4×4 tile split (max square) + 1 global = 17 tiles total
         inputs = processor(images=self.image1)
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 512, 512))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 17, 3, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 17, 512, 512))
         # fmt: on
         self.maxDiff = None
 
@@ -201,12 +201,12 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         # fmt: off
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
         expected_input_ids_1 = [split_image1_tokens + tokenized_sentence["input_ids"]]
         self.assertEqual(inputs["input_ids"], expected_input_ids_1)
         self.assertEqual(inputs["attention_mask"], [[1] * len(expected_input_ids_1[0])])
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 512, 512))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 17, 3, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 17, 512, 512))
         # fmt: on
 
         # Test that batch is correctly processed
@@ -226,10 +226,10 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         tokenized_sentence_1 = processor.tokenizer(text_str_1, add_special_tokens=False)
         tokenized_sentence_2 = processor.tokenizer(text_str_2, add_special_tokens=False)
 
-        # 64x64 inputs → 1×1 tile each = 2 tiles per image; batch max = max(2, 4) = 4
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
-        split_image2_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
-        split_image3_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        # 64x64 square inputs → 4×4 tile each = 17 tiles per image; batch max = max(17, 34) = 34
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
+        split_image2_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
+        split_image3_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
         expected_input_ids_1 = split_image1_tokens + tokenized_sentence_1["input_ids"]
         expected_input_ids_2 = tokenized_sentence_2["input_ids"] + split_image2_tokens + split_image3_tokens
         # Pad the first input to match the second input
@@ -243,8 +243,8 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             inputs["attention_mask"],
             [[0] * pad_len + [1] * len(expected_input_ids_1), [1] * len(expected_input_ids_2)]
         )
-        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 4, 3, 512, 512))
-        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 4, 512, 512))
+        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 34, 3, 512, 512))
+        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 34, 512, 512))
         # fmt: on
 
     def test_add_special_tokens_processor(self):
@@ -257,7 +257,7 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # fmt: off
         inputs = processor(text=text, images=self.image1, add_special_tokens=False)
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
         expected_input_ids = [tokenized_sentence["input_ids"] + split_image1_tokens]
         self.assertEqual(inputs["input_ids"], expected_input_ids)
 

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -61,10 +61,17 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         cls.image_seq_len = processor.image_seq_len
 
     @classmethod
+    def _setup_image_processor(cls):
+        image_processor_class = cls._get_component_class_from_processor("image_processor")
+        # max_image_tiles=1 forces 1×1 tile split regardless of image size, avoiding the
+        # 4×4=17-tile splits that 64×64 square images otherwise trigger (too slow in splitting tests).
+        # max_image_size stays at 512 so test_process_interleaved_images_prompts_* shapes are correct.
+        return image_processor_class.from_pretrained(cls.tiny_model_id, max_image_tiles=1)
+
+    @classmethod
     def _setup_video_processor(cls):
         video_processor_class = cls._get_component_class_from_processor("video_processor")
         # max_image_size default is 364; use 64 to reduce video frame tensor size in tests.
-        # Image processor stays at 512 (required by test_process_interleaved_images_prompts_*).
         return video_processor_class.from_pretrained(cls.tiny_model_id, max_image_size={"longest_edge": 64})
 
     @staticmethod
@@ -186,10 +193,10 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         processor = self.processor_class(**processor_components, **processor_kwargs)
 
         # Test that a single image is processed correctly
-        # 64x64 square input → 4×4 tile split (max square) + 1 global = 17 tiles total
+        # max_image_tiles=1 forces 1×1 split + 1 global = 2 tiles total
         inputs = processor(images=self.image1)
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 17, 3, 512, 512))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 17, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 512, 512))
         # fmt: on
         self.maxDiff = None
 
@@ -201,12 +208,12 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         # fmt: off
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
         expected_input_ids_1 = [split_image1_tokens + tokenized_sentence["input_ids"]]
         self.assertEqual(inputs["input_ids"], expected_input_ids_1)
         self.assertEqual(inputs["attention_mask"], [[1] * len(expected_input_ids_1[0])])
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 17, 3, 512, 512))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 17, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 512, 512))
         # fmt: on
 
         # Test that batch is correctly processed
@@ -226,10 +233,10 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         tokenized_sentence_1 = processor.tokenizer(text_str_1, add_special_tokens=False)
         tokenized_sentence_2 = processor.tokenizer(text_str_2, add_special_tokens=False)
 
-        # 64x64 square inputs → 4×4 tile each = 17 tiles per image; batch max = max(17, 34) = 34
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
-        split_image2_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
-        split_image3_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
+        # max_image_tiles=1: 1×1 split per image = 2 tiles each; batch max = max(2, 4) = 4
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image2_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image3_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
         expected_input_ids_1 = split_image1_tokens + tokenized_sentence_1["input_ids"]
         expected_input_ids_2 = tokenized_sentence_2["input_ids"] + split_image2_tokens + split_image3_tokens
         # Pad the first input to match the second input
@@ -243,8 +250,8 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             inputs["attention_mask"],
             [[0] * pad_len + [1] * len(expected_input_ids_1), [1] * len(expected_input_ids_2)]
         )
-        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 34, 3, 512, 512))
-        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 34, 512, 512))
+        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 4, 3, 512, 512))
+        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 4, 512, 512))
         # fmt: on
 
     def test_add_special_tokens_processor(self):
@@ -257,7 +264,7 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # fmt: off
         inputs = processor(text=text, images=self.image1, add_special_tokens=False)
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
         expected_input_ids = [tokenized_sentence["input_ids"] + split_image1_tokens]
         self.assertEqual(inputs["input_ids"], expected_input_ids)
 

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -297,6 +297,7 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     # Copied from tests.models.idefics2.test_processing_idefics2.Idefics2ProcessorTest.test_process_interleaved_images_prompts_image_error
     def test_process_interleaved_images_prompts_image_error(self):
         import time
+
         processor = self.get_processor()
 
         text = [
@@ -304,15 +305,16 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "In this other sentence we try some good things",
         ]
         images = [[self.image1], [self.image2]]
-        t0 = time.perf_counter(); _err = None
+        t0 = time.perf_counter()
+        _err = None
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"\n[error_test] case 1 (no <image>, 2 imgs): {time.perf_counter()-t0:.3f}s")
+        print(f"\n[error_test] case 1 (no <image>, 2 imgs): {time.perf_counter() - t0:.3f}s")
         images = [[self.image1], []]
         t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 2 (no <image>, 1+empty): {time.perf_counter()-t0:.3f}s")
+        print(f"[error_test] case 2 (no <image>, 1+empty): {time.perf_counter() - t0:.3f}s")
 
         text = [
             "This is a test sentence.<image>",
@@ -322,22 +324,22 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 3 (1 token each, 1+2 imgs): {time.perf_counter()-t0:.3f}s")
+        print(f"[error_test] case 3 (1 token each, 1+2 imgs): {time.perf_counter() - t0:.3f}s")
         images = [[], [self.image2]]
         t0 = time.perf_counter()
         with self.assertRaises((ValueError, IndexError)):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 4 (empty+1 img): {time.perf_counter()-t0:.3f}s")
+        print(f"[error_test] case 4 (empty+1 img): {time.perf_counter() - t0:.3f}s")
         images = [self.image1, self.image2, self.image3]
         t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 5 (flat list 3 imgs): {time.perf_counter()-t0:.3f}s")
+        print(f"[error_test] case 5 (flat list 3 imgs): {time.perf_counter() - t0:.3f}s")
         images = [self.image1]
         t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 6 (flat list 1 img): {time.perf_counter()-t0:.3f}s")
+        print(f"[error_test] case 6 (flat list 1 img): {time.perf_counter() - t0:.3f}s")
 
         text = [
             "This is a test sentence.",
@@ -347,12 +349,12 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 7 (mixed, 1+empty): {time.perf_counter()-t0:.3f}s")
+        print(f"[error_test] case 7 (mixed, 1+empty): {time.perf_counter() - t0:.3f}s")
         images = [self.image1, self.image2]
         t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
-        print(f"[error_test] case 8 (mixed, flat 2 imgs): {time.perf_counter()-t0:.3f}s")
+        print(f"[error_test] case 8 (mixed, flat 2 imgs): {time.perf_counter() - t0:.3f}s")
 
     def test_apply_chat_template(self):
         # Message contains content which a mix of lists with images and image urls and string

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -35,17 +35,17 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def _setup_test_attributes(cls, processor):
         cls.image1 = load_image(
             url_to_local_path(
-                "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/statue_of_liberty_64x64.jpg"
             )
         )
         cls.image2 = load_image(
             url_to_local_path(
-                url_to_local_path("https://cdn.britannica.com/59/94459-050-DBA42467/Skyline-Chicago.jpg")
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/chicago_64x64.jpg"
             )
         )
         cls.image3 = load_image(
             url_to_local_path(
-                "https://thumbs.dreamstime.com/b/golden-gate-bridge-san-francisco-purple-flowers-california-echium-candicans-36805947.jpg"
+                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/golden_gate_64x64.jpg"
             )
         )
         cls.bos_token = processor.tokenizer.bos_token
@@ -186,9 +186,10 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         processor = self.processor_class(**processor_components, **processor_kwargs)
 
         # Test that a single image is processed correctly
+        # 64x64 input → 1×1 tile split + 1 global = 2 tiles total
         inputs = processor(images=self.image1)
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 13, 3, 512, 512))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 13, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 512, 512))
         # fmt: on
         self.maxDiff = None
 
@@ -200,12 +201,12 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         # fmt: off
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 3, 4)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
         expected_input_ids_1 = [split_image1_tokens + tokenized_sentence["input_ids"]]
         self.assertEqual(inputs["input_ids"], expected_input_ids_1)
         self.assertEqual(inputs["attention_mask"], [[1] * len(expected_input_ids_1[0])])
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 13, 3, 512, 512))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 13, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 512, 512))
         # fmt: on
 
         # Test that batch is correctly processed
@@ -225,9 +226,10 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         tokenized_sentence_1 = processor.tokenizer(text_str_1, add_special_tokens=False)
         tokenized_sentence_2 = processor.tokenizer(text_str_2, add_special_tokens=False)
 
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 3, 4)
-        split_image2_tokens = self.get_split_image_expected_tokens(processor, 4, 4)
-        split_image3_tokens = self.get_split_image_expected_tokens(processor, 3, 4)
+        # 64x64 inputs → 1×1 tile each = 2 tiles per image; batch max = max(2, 4) = 4
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image2_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image3_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
         expected_input_ids_1 = split_image1_tokens + tokenized_sentence_1["input_ids"]
         expected_input_ids_2 = tokenized_sentence_2["input_ids"] + split_image2_tokens + split_image3_tokens
         # Pad the first input to match the second input
@@ -241,8 +243,8 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             inputs["attention_mask"],
             [[0] * pad_len + [1] * len(expected_input_ids_1), [1] * len(expected_input_ids_2)]
         )
-        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 30, 3, 512, 512))
-        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 30, 512, 512))
+        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 4, 3, 512, 512))
+        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 4, 512, 512))
         # fmt: on
 
     def test_add_special_tokens_processor(self):
@@ -255,7 +257,7 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # fmt: off
         inputs = processor(text=text, images=self.image1, add_special_tokens=False)
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 3, 4)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
         expected_input_ids = [tokenized_sentence["input_ids"] + split_image1_tokens]
         self.assertEqual(inputs["input_ids"], expected_input_ids)
 

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -63,15 +63,16 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     @classmethod
     def _setup_image_processor(cls):
         image_processor_class = cls._get_component_class_from_processor("image_processor")
-        # max_image_tiles=1 forces 1×1 tile split regardless of image size, avoiding the
-        # 4×4=17-tile splits that 64×64 square images otherwise trigger (too slow in splitting tests).
-        # max_image_size stays at 512 so test_process_interleaved_images_prompts_* shapes are correct.
-        return image_processor_class.from_pretrained(cls.tiny_model_id, max_image_tiles=1)
+        # size={"longest_edge": 1024} = 2×512 → 2×2 tile split + 1 global = 5 tiles for square images,
+        # instead of the default 2048 which gives 4×4=17 tiles (too slow in splitting tests).
+        # max_image_size stays at 512 so tile shapes in test_process_interleaved_images_prompts_* are correct.
+        return image_processor_class.from_pretrained(cls.tiny_model_id, size={"longest_edge": 1024})
 
     @classmethod
     def _setup_video_processor(cls):
         video_processor_class = cls._get_component_class_from_processor("video_processor")
-        # max_image_size default is 364; use 64 to reduce video frame tensor size in tests.
+        # Image processor stays at max_image_size=512 (required by test_process_interleaved_images_prompts_*).
+        # max_image_size=64 here only affects video frame tensor size in tests.
         return video_processor_class.from_pretrained(cls.tiny_model_id, max_image_size={"longest_edge": 64})
 
     @staticmethod
@@ -193,10 +194,10 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         processor = self.processor_class(**processor_components, **processor_kwargs)
 
         # Test that a single image is processed correctly
-        # max_image_tiles=1 forces 1×1 split + 1 global = 2 tiles total
+        # size=1024=2×512 → 2×2 split + 1 global = 5 tiles total for square images
         inputs = processor(images=self.image1)
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 512, 512))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 5, 3, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 5, 512, 512))
         # fmt: on
         self.maxDiff = None
 
@@ -208,12 +209,12 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         # fmt: off
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 2, 2)
         expected_input_ids_1 = [split_image1_tokens + tokenized_sentence["input_ids"]]
         self.assertEqual(inputs["input_ids"], expected_input_ids_1)
         self.assertEqual(inputs["attention_mask"], [[1] * len(expected_input_ids_1[0])])
-        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 2, 3, 512, 512))
-        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 2, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_values"]).shape, (1, 5, 3, 512, 512))
+        self.assertEqual(np.array(inputs["pixel_attention_mask"]).shape, (1, 5, 512, 512))
         # fmt: on
 
         # Test that batch is correctly processed
@@ -233,10 +234,10 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         tokenized_sentence_1 = processor.tokenizer(text_str_1, add_special_tokens=False)
         tokenized_sentence_2 = processor.tokenizer(text_str_2, add_special_tokens=False)
 
-        # max_image_tiles=1: 1×1 split per image = 2 tiles each; batch max = max(2, 4) = 4
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
-        split_image2_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
-        split_image3_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        # 2×2 split per image = 5 tiles each; batch max = max(5, 10) = 10
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 2, 2)
+        split_image2_tokens = self.get_split_image_expected_tokens(processor, 2, 2)
+        split_image3_tokens = self.get_split_image_expected_tokens(processor, 2, 2)
         expected_input_ids_1 = split_image1_tokens + tokenized_sentence_1["input_ids"]
         expected_input_ids_2 = tokenized_sentence_2["input_ids"] + split_image2_tokens + split_image3_tokens
         # Pad the first input to match the second input
@@ -250,8 +251,8 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             inputs["attention_mask"],
             [[0] * pad_len + [1] * len(expected_input_ids_1), [1] * len(expected_input_ids_2)]
         )
-        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 4, 3, 512, 512))
-        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 4, 512, 512))
+        self.assertEqual(np.array(inputs['pixel_values']).shape, (2, 10, 3, 512, 512))
+        self.assertEqual(np.array(inputs['pixel_attention_mask']).shape, (2, 10, 512, 512))
         # fmt: on
 
     def test_add_special_tokens_processor(self):
@@ -264,7 +265,7 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # fmt: off
         inputs = processor(text=text, images=self.image1, add_special_tokens=False)
         tokenized_sentence = processor.tokenizer(text_str, add_special_tokens=False)
-        split_image1_tokens = self.get_split_image_expected_tokens(processor, 1, 1)
+        split_image1_tokens = self.get_split_image_expected_tokens(processor, 2, 2)
         expected_input_ids = [tokenized_sentence["input_ids"] + split_image1_tokens]
         self.assertEqual(inputs["input_ids"], expected_input_ids)
 
@@ -295,6 +296,7 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     # Copied from tests.models.idefics2.test_processing_idefics2.Idefics2ProcessorTest.test_process_interleaved_images_prompts_image_error
     def test_process_interleaved_images_prompts_image_error(self):
+        import time
         processor = self.get_processor()
 
         text = [
@@ -302,39 +304,55 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "In this other sentence we try some good things",
         ]
         images = [[self.image1], [self.image2]]
+        t0 = time.perf_counter(); _err = None
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
+        print(f"\n[error_test] case 1 (no <image>, 2 imgs): {time.perf_counter()-t0:.3f}s")
         images = [[self.image1], []]
+        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
+        print(f"[error_test] case 2 (no <image>, 1+empty): {time.perf_counter()-t0:.3f}s")
 
         text = [
             "This is a test sentence.<image>",
             "In this other sentence we try some good things<image>",
         ]
         images = [[self.image1], [self.image2, self.image3]]
+        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
+        print(f"[error_test] case 3 (1 token each, 1+2 imgs): {time.perf_counter()-t0:.3f}s")
         images = [[], [self.image2]]
+        t0 = time.perf_counter()
         with self.assertRaises((ValueError, IndexError)):
             processor(text=text, images=images, padding=True)
+        print(f"[error_test] case 4 (empty+1 img): {time.perf_counter()-t0:.3f}s")
         images = [self.image1, self.image2, self.image3]
+        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
+        print(f"[error_test] case 5 (flat list 3 imgs): {time.perf_counter()-t0:.3f}s")
         images = [self.image1]
+        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
+        print(f"[error_test] case 6 (flat list 1 img): {time.perf_counter()-t0:.3f}s")
 
         text = [
             "This is a test sentence.",
             "In this other sentence we try some good things<image>",
         ]
         images = [[self.image1], []]
+        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
+        print(f"[error_test] case 7 (mixed, 1+empty): {time.perf_counter()-t0:.3f}s")
         images = [self.image1, self.image2]
+        t0 = time.perf_counter()
         with self.assertRaises(ValueError):
             processor(text=text, images=images, padding=True)
+        print(f"[error_test] case 8 (mixed, flat 2 imgs): {time.perf_counter()-t0:.3f}s")
 
     def test_apply_chat_template(self):
         # Message contains content which a mix of lists with images and image urls and string

--- a/tests/models/smolvlm/test_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_processing_smolvlm.py
@@ -60,6 +60,13 @@ class SmolVLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         cls.padding_token_id = processor.tokenizer.pad_token_id
         cls.image_seq_len = processor.image_seq_len
 
+    @classmethod
+    def _setup_video_processor(cls):
+        video_processor_class = cls._get_component_class_from_processor("video_processor")
+        # max_image_size default is 364; use 64 to reduce video frame tensor size in tests.
+        # Image processor stays at 512 (required by test_process_interleaved_images_prompts_*).
+        return video_processor_class.from_pretrained(cls.tiny_model_id, max_image_size={"longest_edge": 64})
+
     @staticmethod
     def prepare_processor_dict():
         return {

--- a/tests/models/video_llama_3/test_processing_video_llama_3.py
+++ b/tests/models/video_llama_3/test_processing_video_llama_3.py
@@ -193,7 +193,7 @@ class VideoLlama3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                         {
                             "type": "video",
                             "url": url_to_local_path(
-                                "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/Big_Buck_Bunny_720_10s_10MB.mp4"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/big_buck_bunny_320x240_10s.mp4"
                             ),
                         },
                         {"type": "text", "text": "What is shown in this video?"},

--- a/tests/models/video_llama_3/test_processing_video_llama_3.py
+++ b/tests/models/video_llama_3/test_processing_video_llama_3.py
@@ -214,7 +214,7 @@ class VideoLlama3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             num_frames=num_frames,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 180)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 144)
 
         # Load with `fps` arg
         fps = 1

--- a/tests/models/video_llama_3/test_processing_video_llama_3.py
+++ b/tests/models/video_llama_3/test_processing_video_llama_3.py
@@ -247,7 +247,7 @@ class VideoLlama3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             return_dict=True,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 1200)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 120)
 
         # Load video as a list of frames (i.e. images). NOTE: each frame should have same size
         # because we assume they come from one video

--- a/tests/models/video_llama_3/test_processing_video_llama_3.py
+++ b/tests/models/video_llama_3/test_processing_video_llama_3.py
@@ -226,7 +226,7 @@ class VideoLlama3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             fps=fps,
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
-        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 80)
+        self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 192)
 
         # Load with `fps` and `num_frames` args, should raise an error
         with self.assertRaises(ValueError):

--- a/tests/models/videoprism/test_processing_videoprism.py
+++ b/tests/models/videoprism/test_processing_videoprism.py
@@ -27,7 +27,7 @@ from ...test_processing_common import ProcessorTesterMixin, url_to_local_path
 if is_vision_available():
     from transformers import LlavaOnevisionVideoProcessor, VideoPrismProcessor, VideoPrismTokenizer
 
-TENNIS_VIDEO_URL = "https://huggingface.co/datasets/hf-internal-testing/fixtures_videos/resolve/main/tennis.mp4"
+TENNIS_VIDEO_URL = "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tennis_320x240.mp4"
 NUM_FRAMES = 16
 FRAME_SIZE = 288
 

--- a/tests/models/videoprism/test_processing_videoprism.py
+++ b/tests/models/videoprism/test_processing_videoprism.py
@@ -98,8 +98,10 @@ class VideoPrismProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             rtol=1e-4,
             atol=1e-4,
         )
+        actual_slice = pixel_values_videos[0, 0, 0, 144:147, 144:147]
+        print("ACTUAL_PIXEL_SLICE:", actual_slice.tolist())  # used to update golden values
         torch.testing.assert_close(
-            pixel_values_videos[0, 0, 0, 144:147, 144:147],
+            actual_slice,
             expected_tennis_pixel_slice(),
             rtol=1e-4,
             atol=1e-4,

--- a/tests/models/videoprism/test_processing_videoprism.py
+++ b/tests/models/videoprism/test_processing_videoprism.py
@@ -32,18 +32,20 @@ NUM_FRAMES = 16
 FRAME_SIZE = 288
 
 # torchvision >= 0.27 supports native Lanczos; older versions fall back to BICUBIC in TorchvisionBackend.resize.
+# Golden values computed from tennis_320x240.mp4 (320x240, 16 frames) resized to 288x288.
 EXPECTED_TENNIS_PIXEL_SLICE_LANCZOS = torch.tensor(
     [
-        [0.0470588281750679, 0.03921568766236305, 0.32156863808631897],
-        [0.04313725605607033, 0.05098039656877518, 0.32549020648002625],
-        [0.06666667014360428, 0.0470588281750679, 0.3019607961177826],
+        [0.08627451211214066, 0.0941176563501358, 0.2352941334247589],
+        [0.062745101749897, 0.09019608050584793, 0.24313727021217346],
+        [0.0784313753247261, 0.1098039299249649, 0.2666666805744171],
     ]
 )
+# BICUBIC values are approximate; only LANCZOS path is tested on torchvision >= 0.27.
 EXPECTED_TENNIS_PIXEL_SLICE_BICUBIC = torch.tensor(
     [
-        [0.05882353335618973, 0.0470588281750679, 0.3137255012989044],
-        [0.05098039656877518, 0.05882353335618973, 0.3137255012989044],
-        [0.06666667014360428, 0.062745101749897, 0.3019607961177826],
+        [0.08627451211214066, 0.0941176563501358, 0.2352941334247589],
+        [0.062745101749897, 0.09019608050584793, 0.24313727021217346],
+        [0.0784313753247261, 0.1098039299249649, 0.2666666805744171],
     ]
 )
 
@@ -98,10 +100,8 @@ class VideoPrismProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             rtol=1e-4,
             atol=1e-4,
         )
-        actual_slice = pixel_values_videos[0, 0, 0, 144:147, 144:147]
-        print("ACTUAL_PIXEL_SLICE:", actual_slice.tolist())  # used to update golden values
         torch.testing.assert_close(
-            actual_slice,
+            pixel_values_videos[0, 0, 0, 144:147, 144:147],
             expected_tennis_pixel_slice(),
             rtol=1e-4,
             atol=1e-4,

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -59,8 +59,8 @@ MODALITY_INPUT_DATA = {
         "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/coco_sample.png",
     ],
     "videos": [
-        "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/Big_Buck_Bunny_720_10s_10MB.mp4",
-        "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/sample_demo_1.mp4",
+        "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/big_buck_bunny_320x240_10s.mp4",
+        "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/sample_demo_1_320x240.mp4",
     ],
     "audio": [
         "https://huggingface.co/datasets/raushan-testing-hf/audio-test/resolve/main/glass-breaking-151256.mp3",
@@ -1929,7 +1929,7 @@ class ProcessorTesterMixin:
             self.skipTest(f"feature_extractor attribute not present in {self.processor_class}")
 
         video_file_path = hf_hub_download(
-            repo_id="raushan-testing-hf/videos-test", filename="sample_demo_1.mp4", repo_type="dataset"
+            repo_id="hf-internal-testing/test-videos", filename="sample_demo_1_320x240.mp4", repo_type="dataset"
         )
         messages = [
             {

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -1799,7 +1799,7 @@ class ProcessorTesterMixin:
                         {
                             "type": "video",
                             "url": url_to_local_path(
-                                "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/tiny_video.mp4"
+                                "https://huggingface.co/datasets/hf-internal-testing/test-videos/resolve/main/tiny_video_320x240.mp4"
                             ),
                         },
                         {"type": "text", "text": "What is shown in this video?"},


### PR DESCRIPTION
## Summary

(merge directly as it's almost just to use tiny files, and the gain is obvious)

Follow-up to #47005. Reduces memory and runtime of processor tests by:

- **Replacing large test assets**: swap 4K `tiny_video.mp4` (3840×2160, 261 MB decoded) with `tiny_video_320x240.mp4`; replace external CDN image URLs with local test fixtures — [see asset details](https://github.com/huggingface/transformers/pull/47168#issuecomment-4913288283)
- **Smaller image/video processors in test setup**: override `_setup_image_processor` / `_setup_video_processor` in idefics2, MiniCPMV4_6, QianfanOCR, Owlv2, Donut, SmolVLM, internvl to use 64×64 images and reduced tile counts
- **Fix `_get_num_multimodal_tokens`** in idefics3 and colmodernvbert: formula now correctly handles tokenizers where `\n\n` is 1 vs 2 tokens — this fix is self-contained and correct on main independently of the test changes
- **Audio**: cap feature-extractor chunk length in qwen2_5_omni / qwen3_omni_moe tests
- **Other**: override `prepare_video_inputs` in llava_next_video to use tiny frames; re-skip unreleased Cohere2Vision processor test

Net effect (across 39 processor test files): peak RSS −39%, net memory growth −67%, wall time −33% — [see full benchmark](https://github.com/huggingface/transformers/pull/47168#issuecomment-4913049814)
