### PR TITLE
Switch mlinter to 0.1.2

### DIFF
--- a/docs/source/en/modeling_rules.md
+++ b/docs/source/en/modeling_rules.md
@@ -228,6 +228,74 @@ When a PreTrainedModel subclass defines _tied_weights_keys as a non-empty collec
 +    tie_word_embeddings: bool = True
 ```
 
+### TRF016
+
+When an image_processing_*.py or video_processing_*.py class declares boolean do_* attributes (e.g. do_resize, do_rescale, do_normalize, do_convert_rgb) and overrides preprocess() or _preprocess(), checks that each declared flag is still consumed along the override path. That can be a direct reference in the override body, delegating back to the base implementation via super().preprocess(..., **kwargs) or super()._preprocess(..., **kwargs), or, for image processors, forwarding do_convert_rgb into the shared image-preparation path via _preprocess_image_like_inputs(...) or _prepare_image_like_inputs(...). The allowlist of base-handled flags (do_sample_frames) is exempted because the base preprocess() consumes them before _preprocess() runs. A do_X attribute that is not referenced by the override is a dead flag: setting do_X=False at construction or call time has no effect, and the underlying operation runs unconditionally. This silently breaks user expectations and makes per-call overrides ineffective.
+
+```diff
+class AcmeVideoProcessor(BaseVideoProcessor):
+     do_resize = True
+     do_normalize = True
+
+     def _preprocess(
+         self,
+         videos,
++        do_resize: bool,
++        do_normalize: bool,
+         size,
+         image_mean,
+         image_std,
+         **kwargs,
+     ):
+         for video in videos:
+-            video = self.resize(video, size=size)
+-            video = self.normalize(video, image_mean, image_std)
++            if do_resize:
++                video = self.resize(video, size=size)
++            if do_normalize:
++                video = self.normalize(video, image_mean, image_std)
+```
+
+### TRF017
+
+Checks classes decorated with both @auto_docstring and @dataclass for source ordering: @auto_docstring must appear above @dataclass. Decorators are applied bottom-up. When @dataclass is listed above @auto_docstring, @auto_docstring runs first on a class that has no synthesized __init__ yet and ends up modifying the parent class's __init__.__doc__ instead of the subclass's.
+
+```diff
+-@dataclass
+ @auto_docstring(
+     custom_intro="""
+     Output type of [`AcmeForPreTraining`].
+     """
+ )
++@dataclass
+ class AcmeForPreTrainingOutput(ModelOutput):
+     ...
+```
+
+### TRF018
+
+Checks that every PreTrainedModel subclass that overrides `_init_weights(self, module, ...)` chains the call up via `super()._init_weights(...)`. In modular files, `PreTrainedModel._init_weights(self, module)` and `raise AttributeError(...)` are accepted because they are modularization sentinels. If a model intentionally fully overrides initialization, suppress with `# trf-ignore: TRF018` on the line above the method. The base `_init_weights` covers standard module types (Linear, Embedding, LayerNorm, RotaryEmbedding, ...). Skipping `super()._init_weights(...)` silently leaves submodules unhandled by the override uninitialized, which can pass tests and surface much later as subtle weight-init bugs (cf. https://github.com/huggingface/transformers/pull/45597).
+
+```diff
+def _init_weights(self, module):
++    super()._init_weights(module)
+     if isinstance(module, AcmeCustomLayer):
+         module.gate.data.zero_()
+```
+
+### TRF019
+
+Checks that `*ProcessorKwargs` TypedDict classes in `processing_*.py` files do not set a non-empty `_defaults` dict. Old models released before cutoff date are not checked against the rule for backwards compatibility; new models must not hardcode defaults in Python. Hardcoding defaults in `_defaults` scatters processor configuration across Python source files, makes it unintuitive when it comes to overriding defaults via config, and bloats up the code. The canonical home for processor defaults is `processor_config.json` on the hub, which is shipped with the checkpoint and can be updated without touching code.
+
+```diff
+class Gemma4ProcessorKwargs(ProcessingKwargs, total=False):
+-    _defaults = {
+-        "text_kwargs": {"padding": False},
+-        "images_kwargs": {"return_tensors": "pt"},
+-    }
+     images_kwargs: Gemma4ImageProcessorKwargs
+```
+
 <!-- END RULES REFERENCE -->
 
 ## Suppressing violations

--- a/docs/source/en/modeling_rules.md
+++ b/docs/source/en/modeling_rules.md
@@ -277,10 +277,13 @@ Checks classes decorated with both @auto_docstring and @dataclass for source ord
 Checks that every PreTrainedModel subclass that overrides `_init_weights(self, module, ...)` chains the call up via `super()._init_weights(...)`. In modular files, `PreTrainedModel._init_weights(self, module)` and `raise AttributeError(...)` are accepted because they are modularization sentinels. If a model intentionally fully overrides initialization, suppress with `# trf-ignore: TRF018` on the line above the method. The base `_init_weights` covers standard module types (Linear, Embedding, LayerNorm, RotaryEmbedding, ...). Skipping `super()._init_weights(...)` silently leaves submodules unhandled by the override uninitialized, which can pass tests and surface much later as subtle weight-init bugs (cf. https://github.com/huggingface/transformers/pull/45597).
 
 ```diff
-def _init_weights(self, module):
+from ... import initialization as init
+
+ def _init_weights(self, module):
 +    super()._init_weights(module)
      if isinstance(module, AcmeCustomLayer):
-         module.gate.data.zero_()
+-        module.gate.data.zero_()
++        init.zeros_(module.gate)
 ```
 
 ### TRF019

--- a/setup.py
+++ b/setup.py
@@ -125,8 +125,7 @@ _deps = [
     "ruff==0.14.10",
     # When bumping `transformers-mlinter`, sync repo-local rule overrides from
     # `utils/rules.toml` back into the released package.
-    # Temporarily tracking the development branch to validate the next release.
-    "transformers-mlinter @ git+https://github.com/huggingface/transformers-mlinter@main",
+    "transformers-mlinter==0.1.2",
     "ty==0.0.20",
     # `sacrebleu` not used in `transformers`. However, it is needed in several tests, when a test calls
     # `evaluate.load("sacrebleu")`. This metric is used in the examples that we use to test the `Trainer` with, in the

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,8 @@ _deps = [
     "ruff==0.14.10",
     # When bumping `transformers-mlinter`, sync repo-local rule overrides from
     # `utils/rules.toml` back into the released package.
-    "transformers-mlinter==0.1.1",
+    # Temporarily tracking the development branch to validate the next release.
+    "transformers-mlinter @ git+https://github.com/huggingface/transformers-mlinter@main",
     "ty==0.0.20",
     # `sacrebleu` not used in `transformers`. However, it is needed in several tests, when a test calls
     # `evaluate.load("sacrebleu")`. This metric is used in the examples that we use to test the `Trainer` with, in the

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -55,7 +55,7 @@ deps = {
     "rjieba": "rjieba",
     "rouge-score": "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff": "ruff==0.14.10",
-    "transformers-mlinter": "transformers-mlinter==0.1.1",
+    "transformers-mlinter": "transformers-mlinter @ git+https://github.com/huggingface/transformers-mlinter@main",
     "ty": "ty==0.0.20",
     "sacrebleu": "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses": "sacremoses",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -55,7 +55,7 @@ deps = {
     "rjieba": "rjieba",
     "rouge-score": "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff": "ruff==0.14.10",
-    "transformers-mlinter": "transformers-mlinter @ git+https://github.com/huggingface/transformers-mlinter@main",
+    "transformers-mlinter": "transformers-mlinter==0.1.2",
     "ty": "ty==0.0.20",
     "sacrebleu": "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses": "sacremoses",

--- a/utils/rules.toml
+++ b/utils/rules.toml
@@ -314,10 +314,13 @@ allowlist_models = ["cosmos3_omni", "diffusion_gemma", "eomt_dinov3", "exaone4_5
 what_it_does = "Checks that every PreTrainedModel subclass that overrides `_init_weights(self, module, ...)` chains the call up via `super()._init_weights(...)`. In modular files, `PreTrainedModel._init_weights(self, module)` and `raise AttributeError(...)` are accepted because they are modularization sentinels. If a model intentionally fully overrides initialization, suppress with `# trf-ignore: TRF018` on the line above the method."
 why_bad = "The base `_init_weights` covers standard module types (Linear, Embedding, LayerNorm, RotaryEmbedding, ...). Skipping `super()._init_weights(...)` silently leaves submodules unhandled by the override uninitialized, which can pass tests and surface much later as subtle weight-init bugs (cf. https://github.com/huggingface/transformers/pull/45597)."
 diff = '''
+ from ... import initialization as init
+
  def _init_weights(self, module):
 +    super()._init_weights(module)
      if isinstance(module, AcmeCustomLayer):
-         module.gate.data.zero_()
+-        module.gate.data.zero_()
++        init.zeros_(module.gate)
 '''
 
 [rules.TRF019]

--- a/utils/rules.toml
+++ b/utils/rules.toml
@@ -221,7 +221,10 @@ diff = '''
 [rules.TRF014]
 description = "`trust_remote_code` should never be used in native model integrations."
 default_enabled = true
-allowlist_models = []
+# The `auto` package is the loader layer that *implements* the `trust_remote_code`
+# feature, forwarding the user-supplied flag to `*.from_pretrained`. It is not a native
+# model integration, so it is exempt from this rule.
+allowlist_models = ["auto"]
 
 [rules.TRF014.explanation]
 what_it_does = "Checks whether `trust_remote_code` is passed or used in code (e.g. as kwarg) within native model integration files."
@@ -248,4 +251,89 @@ diff = '''
  class FooConfig(PreTrainedConfig):
      hidden_size: int = 768
 +    tie_word_embeddings: bool = True
+'''
+
+[rules.TRF016]
+description = "do_* flags declared on a processor class must be referenced by overridden preprocess/_preprocess."
+default_enabled = true
+allowlist_models = ["kimi_k25", "minimax_m3_vl"]
+
+[rules.TRF016.explanation]
+what_it_does = "When an image_processing_*.py or video_processing_*.py class declares boolean do_* attributes (e.g. do_resize, do_rescale, do_normalize, do_convert_rgb) and overrides preprocess() or _preprocess(), checks that each declared flag is still consumed along the override path. That can be a direct reference in the override body, delegating back to the base implementation via super().preprocess(..., **kwargs) or super()._preprocess(..., **kwargs), or, for image processors, forwarding do_convert_rgb into the shared image-preparation path via _preprocess_image_like_inputs(...) or _prepare_image_like_inputs(...). The allowlist of base-handled flags (do_sample_frames) is exempted because the base preprocess() consumes them before _preprocess() runs."
+why_bad = "A do_X attribute that is not referenced by the override is a dead flag: setting do_X=False at construction or call time has no effect, and the underlying operation runs unconditionally. This silently breaks user expectations and makes per-call overrides ineffective."
+diff = '''
+ class AcmeVideoProcessor(BaseVideoProcessor):
+     do_resize = True
+     do_normalize = True
+
+     def _preprocess(
+         self,
+         videos,
++        do_resize: bool,
++        do_normalize: bool,
+         size,
+         image_mean,
+         image_std,
+         **kwargs,
+     ):
+         for video in videos:
+-            video = self.resize(video, size=size)
+-            video = self.normalize(video, image_mean, image_std)
++            if do_resize:
++                video = self.resize(video, size=size)
++            if do_normalize:
++                video = self.normalize(video, image_mean, image_std)
+'''
+
+[rules.TRF017]
+description = "@auto_docstring must be placed above @dataclass on output classes."
+default_enabled = true
+allowlist_models = []
+
+[rules.TRF017.explanation]
+what_it_does = "Checks classes decorated with both @auto_docstring and @dataclass for source ordering: @auto_docstring must appear above @dataclass."
+why_bad = "Decorators are applied bottom-up. When @dataclass is listed above @auto_docstring, @auto_docstring runs first on a class that has no synthesized __init__ yet and ends up modifying the parent class's __init__.__doc__ instead of the subclass's."
+diff = '''
+-@dataclass
+ @auto_docstring(
+     custom_intro="""
+     Output type of [`AcmeForPreTraining`].
+     """
+ )
++@dataclass
+ class AcmeForPreTrainingOutput(ModelOutput):
+     ...
+'''
+
+[rules.TRF018]
+description = "_init_weights overrides should call super()._init_weights(module), except modular-file sentinels."
+default_enabled = true
+allowlist_models = ["cosmos3_omni", "diffusion_gemma", "eomt_dinov3", "exaone4_5", "gemma4", "higgs_audio_v2", "kimi_k25", "olmo3", "pp_formulanet", "pp_lcnet_v3", "radio", "sam3_lite_text", "sam3_tracker", "slanet", "voxtral_realtime", "xcodec2"]
+
+[rules.TRF018.explanation]
+what_it_does = "Checks that every PreTrainedModel subclass that overrides `_init_weights(self, module, ...)` chains the call up via `super()._init_weights(...)`. In modular files, `PreTrainedModel._init_weights(self, module)` and `raise AttributeError(...)` are accepted because they are modularization sentinels. If a model intentionally fully overrides initialization, suppress with `# trf-ignore: TRF018` on the line above the method."
+why_bad = "The base `_init_weights` covers standard module types (Linear, Embedding, LayerNorm, RotaryEmbedding, ...). Skipping `super()._init_weights(...)` silently leaves submodules unhandled by the override uninitialized, which can pass tests and surface much later as subtle weight-init bugs (cf. https://github.com/huggingface/transformers/pull/45597)."
+diff = '''
+ def _init_weights(self, module):
++    super()._init_weights(module)
+     if isinstance(module, AcmeCustomLayer):
+         module.gate.data.zero_()
+'''
+
+[rules.TRF019]
+description = "A processor TypedDict class must not define `_defaults`, instead push them upstream to the hub (`processor_config.json`)."
+default_enabled = true
+allowlist_models = ["blip_2", "grounding_dino", "hunyuan_vl", "kosmos2", "omdet_turbo", "qwen3_asr"]
+cutoff_date = "2026-06-20"
+
+[rules.TRF019.explanation]
+what_it_does = "Checks that `*ProcessorKwargs` TypedDict classes in `processing_*.py` files do not set a non-empty `_defaults` dict. Old models released before cutoff date are not checked against the rule for backwards compatibility; new models must not hardcode defaults in Python."
+why_bad = "Hardcoding defaults in `_defaults` scatters processor configuration across Python source files, makes it unintuitive when it comes to overriding defaults via config, and bloats up the code. The canonical home for processor defaults is `processor_config.json` on the hub, which is shipped with the checkpoint and can be updated without touching code."
+diff = '''
+ class Gemma4ProcessorKwargs(ProcessingKwargs, total=False):
+-    _defaults = {
+-        "text_kwargs": {"padding": False},
+-        "images_kwargs": {"return_tensors": "pt"},
+-    }
+     images_kwargs: Gemma4ImageProcessorKwargs
 '''


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47172)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47172)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

runs on current mlinter 0.1.2 

models that fail to pass the linter

- TRF014 (trust_remote_code) │ auto,  legitimate loader exemption we can keep that
- TRF016 (dead do_* flags)   │ kimi_k25, minimax_m3_vl    
- TRF018 (super()._init_weights) | cosmos3_omni, diffusion_gemma, eomt_dinov3, exaone4_5, gemma4, higgs_audio_v2, kimi_k25, olmo3, pp_formulanet                      
- TRF019 (processor _default) |  blip_2, grounding_dino, hunyuan_vl, kosmos2, omdet_turbo, qwen3_asr

We will address failing models in follow-up PRs