### PR TITLE
Fix tar-slip/zip-slip arbitrary file write vulnerabilities (CWE-22)

### DIFF
--- a/src/transformers/models/marian/convert_marian_to_pytorch.py
+++ b/src/transformers/models/marian/convert_marian_to_pytorch.py
@@ -28,6 +28,7 @@ from torch import nn
 from tqdm import tqdm
 
 from transformers import MarianConfig, MarianMTModel, MarianTokenizer
+from transformers.utils.generic import safe_extract_zip
 
 
 def remove_suffix(text: str, suffix: str):
@@ -691,7 +692,7 @@ def save_json(content: dict | list, path: str) -> None:
 
 def unzip(zip_path: str, dest_dir: str) -> None:
     with ZipFile(zip_path, "r") as zipObj:
-        zipObj.extractall(dest_dir)
+        safe_extract_zip(zipObj, dest_dir)
 
 
 if __name__ == "__main__":

--- a/src/transformers/models/nemotron/convert_nemotron_nemo_to_hf.py
+++ b/src/transformers/models/nemotron/convert_nemotron_nemo_to_hf.py
@@ -307,6 +307,14 @@ def extract_nemotron_tokenizer(nemo_file, model_config, output_hf_path, nemo_tok
 
             archive = tarfile.open(nemo_file, "r")
             tokenizer_filename = "./" + tokenizer_fn  # exclude 'nemo:' prefix
+            # Validate the member path to prevent path traversal attacks
+            resolved = os.path.realpath(os.path.join(output_hf_path, tokenizer_fn))
+            target_dir = os.path.realpath(output_hf_path)
+            if not (resolved + os.sep).startswith(target_dir + os.sep) and resolved != target_dir:
+                raise ValueError(
+                    f"Refusing to extract tokenizer file '{tokenizer_filename}' as it would write outside "
+                    f"the target directory. This could be a path traversal attack."
+                )
             archive.extract(tokenizer_filename, output_hf_path)
             archive.close()
             os.rename(f"{output_hf_path}/{tokenizer_fn}", output_tokenizer)

--- a/src/transformers/models/nemotron3_5_asr/convert_nemotron3_5_asr_to_hf.py
+++ b/src/transformers/models/nemotron3_5_asr/convert_nemotron3_5_asr_to_hf.py
@@ -45,6 +45,7 @@ from transformers import (
     ParakeetTokenizer,
 )
 from transformers.convert_slow_tokenizer import ParakeetConverter
+from transformers.utils.generic import safe_extract_tar
 from transformers.utils.hub import cached_file
 
 
@@ -94,7 +95,7 @@ def extract_nemo_archive(nemo_file_path: str, extract_dir: str) -> dict[str, str
     print(f"Extracting NeMo archive: {nemo_file_path}")
 
     with tarfile.open(nemo_file_path, "r", encoding="utf-8") as tar:
-        tar.extractall(extract_dir)
+        safe_extract_tar(tar, extract_dir)
 
     all_files = []
     for root, dirs, files in os.walk(extract_dir):

--- a/src/transformers/models/nemotron_asr_streaming/convert_nemotron_asr_streaming_to_hf.py
+++ b/src/transformers/models/nemotron_asr_streaming/convert_nemotron_asr_streaming_to_hf.py
@@ -41,6 +41,7 @@ from transformers import (
     ParakeetTokenizer,
 )
 from transformers.convert_slow_tokenizer import ParakeetConverter
+from transformers.utils.generic import safe_extract_tar
 from transformers.utils.hub import cached_file
 
 
@@ -86,7 +87,7 @@ def extract_nemo_archive(nemo_file_path: str, extract_dir: str) -> dict[str, str
     print(f"Extracting NeMo archive: {nemo_file_path}")
 
     with tarfile.open(nemo_file_path, "r", encoding="utf-8") as tar:
-        tar.extractall(extract_dir)
+        safe_extract_tar(tar, extract_dir)
 
     all_files = []
     for root, dirs, files in os.walk(extract_dir):

--- a/src/transformers/models/parakeet/convert_nemo_to_hf.py
+++ b/src/transformers/models/parakeet/convert_nemo_to_hf.py
@@ -35,6 +35,7 @@ from transformers import (
     ParakeetTokenizer,
 )
 from transformers.convert_slow_tokenizer import ParakeetConverter
+from transformers.utils.generic import safe_extract_tar
 from transformers.utils.hub import cached_file
 
 
@@ -72,7 +73,7 @@ def extract_nemo_archive(nemo_file_path: str, extract_dir: str) -> dict[str, str
     print(f"Extracting NeMo archive: {nemo_file_path}")
 
     with tarfile.open(nemo_file_path, "r", encoding="utf-8") as tar:
-        tar.extractall(extract_dir)
+        safe_extract_tar(tar, extract_dir)
 
     all_files = []
     for root, dirs, files in os.walk(extract_dir):

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -1156,3 +1156,53 @@ def retry(
         return wrapper
 
     return decorator
+
+
+def safe_extract_tar(tarfile_obj, extract_dir, filter=None):
+    """
+    Safely extract a tar archive, preventing path traversal attacks (tar-slip).
+
+    Validates that all member paths resolve within the target directory before extraction.
+
+    Args:
+        tarfile_obj: An open tarfile.TarFile object.
+        extract_dir: The target directory to extract into.
+        filter: Optional filter function for tar members (Python 3.12+ data_filter is recommended).
+    """
+    extract_dir = os.path.realpath(extract_dir)
+    members = tarfile_obj.getmembers()
+
+    for member in members:
+        member_path = os.path.join(extract_dir, member.name)
+        resolved_path = os.path.realpath(member_path)
+        if not (resolved_path + os.sep).startswith(extract_dir + os.sep) and resolved_path != extract_dir:
+            raise ValueError(
+                f"Refusing to extract tar member '{member.name}' as it would write outside the target "
+                f"directory '{extract_dir}' (resolved to '{resolved_path}'). This could be a path traversal attack."
+            )
+
+    tarfile_obj.extractall(extract_dir, filter=filter)
+
+
+def safe_extract_zip(zipfile_obj, extract_dir):
+    """
+    Safely extract a zip archive, preventing path traversal attacks (zip-slip).
+
+    Validates that all member paths resolve within the target directory before extraction.
+
+    Args:
+        zipfile_obj: An open zipfile.ZipFile object.
+        extract_dir: The target directory to extract into.
+    """
+    extract_dir = os.path.realpath(extract_dir)
+
+    for info in zipfile_obj.infolist():
+        member_path = os.path.join(extract_dir, info.filename)
+        resolved_path = os.path.realpath(member_path)
+        if not (resolved_path + os.sep).startswith(extract_dir + os.sep) and resolved_path != extract_dir:
+            raise ValueError(
+                f"Refusing to extract zip member '{info.filename}' as it would write outside the target "
+                f"directory '{extract_dir}' (resolved to '{resolved_path}'). This could be a path traversal attack."
+            )
+
+    zipfile_obj.extractall(extract_dir)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47183)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47183)
<!-- ci-dashboard-badge:end -->

## Summary

Fixes [#47177](https://github.com/huggingface/transformers/issues/47177).

Adds `safe_extract_tar()` and `safe_extract_zip()` utility functions to `src/transformers/utils/generic.py` that reject archive entries containing path traversal components (`..`), preventing arbitrary file writes outside the target directory.

## Vulnerable locations fixed

| File | Vulnerability |
|------|--------------|
| `models/parakeet/convert_nemo_to_hf.py` | `tar.extractall()` |
| `models/nemotron_asr_streaming/convert_nemotron_asr_streaming_to_hf.py` | `tar.extractall()` |
| `models/nemotron3_5_asr/convert_nemotron3_5_asr_to_hf.py` | `tar.extractall()` |
| `models/nemotron/convert_nemotron_nemo_to_hf.py` | `archive.extract()` (inline validation) |
| `models/marian/convert_marian_to_pytorch.py` | `zipObj.extractall()` |

## How it works

The new utilities use `os.path.realpath()` to resolve symlinks and `..` components, then verify the resolved path stays within the intended extraction directory. Malicious entries raise `ValueError`.

```python
safe_extract_tar(tar_handle, path="/output/dir")
safe_extract_zip(zip_handle, path="/output/dir")
```

## Testing

- `make fix-repo` — all 15 checks passed
- `make style` — all checks passed
- `make typing` — all checks passed
- Custom test verified that malicious archives with `../../` paths raise `ValueError`