### PR TITLE
Update doc preprocessing regex to prevent ReDoS

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -2943,7 +2943,7 @@ def preprocess_string(string, skip_cuda_tests):
     cuda stuff is detective (with a heuristic), this method will return an empty string so no doctest will be run for
     `string`.
     """
-    codeblock_pattern = r"(```(?:python|py)\s*\n\s*>>> )(.*?```)"
+    codeblock_pattern = r"(```(?:python|py)[^\S\n]*\n\s*>>> )(.*?```)"
     codeblocks = re.split(codeblock_pattern, string, flags=re.DOTALL)
     is_cuda_found = False
     for i, codeblock in enumerate(codeblocks):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47187)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47187)
<!-- ci-dashboard-badge:end -->

# Update doc preprocessing regex to prevent ReDoS CWE-1333

Slightly improved variation on closed PR: https://github.com/huggingface/transformers/pull/43693

Yes, this is a silly vulnerability, but silly vulnerabilities still count in enterprise vulnerability scanners and this can block usage of transformers and any library that depends on transformers in environments with very cautious security policies.

In any case, it is still an inefficient regular expression and should be replaced with a better one.


The regular expression for capturing docstrings is theoretically vulnerable to a [ReDoS attack](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)

The previous change dramatically improved performance, but is still vulnerable to the pattern:
```python
data= "```py" + ("\n" * i)
```

As i grows, the processing time increases in greater than linear time:
```
Execution time: 0.156596 s , iteration (i=10000)
Execution time: 0.615783 s , iteration (i=20000)
Execution time: 1.404632 s , iteration (i=30000)
Execution time: 2.502577 s , iteration (i=40000)
Execution time: 4.122107 s , iteration (i=50000)
Execution time: 6.003960 s , iteration (i=60000)
Execution time: 7.687220 s , iteration (i=70000)
Execution time: 10.054976 s , iteration (i=80000)
Execution time: 12.749450 s , iteration (i=90000)
Execution time: 17.755118 s , iteration (i=100000)
Execution time: 20.584845 s , iteration (i=110000)
Execution time: 24.046818 s , iteration (i=120000)
Execution time: 28.025028 s , iteration (i=130000)
Execution time: 31.564563 s , iteration (i=140000)
Execution time: 36.151067 s , iteration (i=150000)
Execution time: 40.400584 s , iteration (i=160000)
Execution time: 50.993116 s , iteration (i=170000)
Execution time: 66.691314 s , iteration (i=180000)
Execution time: 73.058775 s , iteration (i=190000)
Execution time: 81.073598 s , iteration (i=200000)
Execution time: 89.698897 s , iteration (i=210000)
Execution time: 98.433263 s , iteration (i=220000)
```

## Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

@ArthurZucker
@Rocketknight1 @ydshieh