### PR TITLE
Remove executorch from all-latest-gpu image + add torch smoke test

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -84,11 +84,9 @@ RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/opt
 # For kernels
 RUN python3 -m pip install --no-cache-dir kernels
 
-# For ONNX export tests (onnxscript pulls in onnx + onnx_ir; onnxruntime validates the exported graph)
-RUN python3 -m pip install --no-cache-dir onnxscript onnxruntime
-
-# For ExecuTorch export tests
-RUN python3 -m pip install --no-cache-dir executorch
+# For ONNX export tests (onnxscript pulls in onnx + onnx_ir; onnxruntime-gpu validates the exported
+# graph on GPU for faster export testing)
+RUN python3 -m pip install --no-cache-dir onnxscript onnxruntime-gpu
 
 # For video model testing
 RUN python3 -m pip install --no-cache-dir av
@@ -128,3 +126,16 @@ RUN python3 -m pip uninstall -y kernels
 # When installing in editable mode, `transformers` is not recognized as a package.
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop
+
+# Smoke test: fail the image build immediately if a later `pip install` replaced or broke the pinned
+# CUDA torch stack (e.g. a dep that drags in a different torch/CUDA/NCCL — which surfaces as
+# `undefined symbol: ncclCommResume` at `import torch`; see run 28991812987). We import torch (which
+# eagerly loads `libtorch_cuda.so`) AND assert the version still matches the `${PYTORCH}` pin, since
+# transformers only requires `torch>=2.4` — a silent swap to a newer torch otherwise passes every
+# version check and reaches the GPU test jobs. No GPU is present at build time, so we only exercise
+# the import + CUDA runtime load, not device availability.
+RUN set -e; \
+    python3 -c "import torch; print('torch version:', torch.__version__); torch.cuda.is_available()"; \
+    if [ "$PYTORCH" != "pre" ]; then \
+        python3 -c "import torch, sys; v = torch.__version__.split('+')[0]; sys.exit(0 if v.startswith('${PYTORCH}') else 'ERROR: torch is ' + torch.__version__ + ', expected ${PYTORCH}.* - the pinned CUDA build was clobbered')"; \
+    fi


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47196)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47196)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

executorch is only used for CPU tests, and it was breaking the GPU image because it pulled torch 2.13

this patch removes it but :
- keeps onnxruntime (gpu flavor)
- do a smoke test to verify it imports correctly
