### PR TITLE
Fix Qwen Omni batched text postprocessing

### DIFF
--- a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
@@ -316,7 +316,9 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
         Returns:
             `list[str]`: The decoded text.
         """
-        return self.tokenizer.batch_decode(generated_outputs[0], skip_special_tokens=skip_special_tokens, **kwargs)
+        if isinstance(generated_outputs, (tuple, list)):
+            generated_outputs = generated_outputs[0]
+        return self.tokenizer.batch_decode(generated_outputs, skip_special_tokens=skip_special_tokens, **kwargs)
 
     def post_process_multimodal_output(
         self, generated_outputs, skip_special_tokens=True, generation_mode=None, **kwargs

--- a/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
@@ -337,7 +337,9 @@ class Qwen3OmniMoeProcessor(ProcessorMixin):
         Returns:
             `list[str]`: The decoded text.
         """
-        return self.tokenizer.batch_decode(generated_outputs[0], skip_special_tokens=skip_special_tokens, **kwargs)
+        if isinstance(generated_outputs, (tuple, list)):
+            generated_outputs = generated_outputs[0]
+        return self.tokenizer.batch_decode(generated_outputs, skip_special_tokens=skip_special_tokens, **kwargs)
 
     def post_process_multimodal_output(
         self, generated_outputs, skip_special_tokens=True, generation_mode=None, **kwargs

--- a/tests/pipelines/test_pipelines_any_to_any.py
+++ b/tests/pipelines/test_pipelines_any_to_any.py
@@ -17,7 +17,12 @@ import unittest
 
 import numpy as np
 
-from transformers import MODEL_FOR_MULTIMODAL_LM_MAPPING, is_vision_available
+from transformers import (
+    MODEL_FOR_MULTIMODAL_LM_MAPPING,
+    AutoProcessor,
+    Qwen2_5OmniForConditionalGeneration,
+    is_vision_available,
+)
 from transformers.pipelines import AnyToAnyPipeline, pipeline
 from transformers.testing_utils import (
     Expectations,
@@ -173,6 +178,26 @@ class AnyToAnyPipelineTests(unittest.TestCase):
                     ],
                 ],
             )
+
+    def test_qwen_omni_batched_text_only_outputs_all_rows(self):
+        model_id = "hf-internal-testing/tiny-random-Qwen2_5OmniForConditionalGeneration"
+        processor = AutoProcessor.from_pretrained(model_id)
+        model = Qwen2_5OmniForConditionalGeneration.from_pretrained(model_id).eval()
+        pipe = pipeline("any-to-any", model=model, processor=processor)
+
+        outputs = pipe(
+            text=["hello", "world"],
+            return_full_text=False,
+            generate_kwargs={
+                "generation_mode": "text",
+                "thinker_do_sample": False,
+                "thinker_max_new_tokens": 1,
+            },
+        )
+
+        self.assertEqual(len(outputs), 2)
+        self.assertEqual([output["input_text"] for output in outputs], ["hello", "world"])
+        self.assertTrue(all("generated_text" in output for output in outputs))
 
     @slow
     def test_small_model_pt_token_text_only(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47197)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47197)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Batched text-only `pipeline("any-to-any")` calls with Qwen Omni can return only the first row. The model returns a full `(batch, seq)` tensor for text generation, but the processor always decoded `generated_outputs[0]`. That indexing is correct for tuple/list multimodal outputs where text sequences are the first item; it is wrong for a plain text tensor.

This PR keeps the tuple/list path unchanged and decodes the whole tensor for text-only outputs. The same fix is applied to Qwen2.5-Omni and Qwen3-Omni's matching processor method.

This supersedes the closed PR #47060 with a real `pipeline("any-to-any")` repro.

<details>
<summary>End to end any-to-any pipeline repro</summary>

Environment:

```text
Hardware: AutoDL c4090, CPU-only run with CUDA_VISIBLE_DEVICES=""
Python: 3.12.3
PyTorch: 2.8.0+cu128
Transformers main: 187fda1bb179f5a2e261736bb4d91c292864ca0d
Model: hf-internal-testing/tiny-random-Qwen2_5OmniForConditionalGeneration
Entrypoint: pipeline("any-to-any", model=model, processor=processor)
Extra deps installed: librosa, soundfile, soxr
Command: CUDA_VISIBLE_DEVICES="" PYTHONPATH=src:. python repro.py
```

Script:

```python
import os

os.environ["CUDA_VISIBLE_DEVICES"] = ""

from transformers import AutoProcessor, Qwen2_5OmniForConditionalGeneration, pipeline


MODEL_ID = "hf-internal-testing/tiny-random-Qwen2_5OmniForConditionalGeneration"


processor = AutoProcessor.from_pretrained(MODEL_ID)
model = Qwen2_5OmniForConditionalGeneration.from_pretrained(MODEL_ID).eval()
pipe = pipeline("any-to-any", model=model, processor=processor)

outputs = pipe(
    text=["hello", "world"],
    return_full_text=False,
    generate_kwargs={
        "generation_mode": "text",
        "thinker_do_sample": False,
        "thinker_max_new_tokens": 1,
    },
)

print("PIPE_OUT_LEN", len(outputs))
print("PIPE_OUT", outputs)
if len(outputs) != 2:
    raise SystemExit("expected two outputs for a two-item text batch")
```

Current main:

```text
PIPE_OUT_LEN 1
PIPE_OUT [{'input_text': 'hello', 'generated_text': ' marvel'}]
expected two outputs for a two-item text batch
```

After this PR:

```text
PIPE_OUT_LEN 2
PIPE_OUT [{'input_text': 'hello', 'generated_text': ' marvel'}, {'input_text': 'world', 'generated_text': '_VOLUME'}]
```

Reverting only this patch makes the same script fail again with `PIPE_OUT_LEN 1`.

</details>

<details>
<summary>Checks</summary>

```text
git diff --check
passed
```

</details>

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

cc @Rocketknight1