### PR TITLE
Fix double label shift in CohereAsr training loss

### DIFF
--- a/src/transformers/models/cohere_asr/modeling_cohere_asr.py
+++ b/src/transformers/models/cohere_asr/modeling_cohere_asr.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
+from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
@@ -637,7 +638,8 @@ class CohereAsrForConditionalGeneration(CohereAsrPreTrainedModel, GenerationMixi
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
+            loss_fct = CrossEntropyLoss()
+            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/cohere_asr/modular_cohere_asr.py
+++ b/src/transformers/models/cohere_asr/modular_cohere_asr.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
+from torch.nn import CrossEntropyLoss
 
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
 from ...generation import GenerationMixin
@@ -500,7 +501,8 @@ class CohereAsrForConditionalGeneration(MoonshineForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
+            loss_fct = CrossEntropyLoss()
+            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/tests/models/cohere_asr/test_modeling_cohere_asr.py
+++ b/tests/models/cohere_asr/test_modeling_cohere_asr.py
@@ -175,6 +175,37 @@ class CohereAsrModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_config(self):
         self.config_tester.run_common_tests()
 
+    def test_training_loss_no_double_shift(self):
+        # forward shifts labels into decoder_input_ids, so the loss must be plain CE against the
+        # labels (no second shift). A double shift would train against labels[..., 1:] instead.
+        from torch.nn import CrossEntropyLoss
+
+        config = self.model_tester.get_config()
+        config.pad_token_id = self.model_tester.pad_token_id
+        model = CohereAsrForConditionalGeneration(config).to(torch_device).eval()
+        vocab_size = config.vocab_size
+
+        torch.manual_seed(0)
+        bsz, seq_length, dec_len = 2, 40, 6
+        input_features = floats_tensor([bsz, seq_length, self.model_tester.num_mel_bins], scale=1.0)
+        labels = torch.randint(3, vocab_size, (bsz, dec_len), device=torch_device)
+        padded = labels.clone()
+        padded[0, -1] = -100
+        padded[1, -2:] = -100
+
+        def aligned_ce(logits, lbl):
+            return CrossEntropyLoss()(logits.reshape(-1, vocab_size), lbl.reshape(-1))
+
+        # What a double shift (the buggy behavior) would compute.
+        def double_shift_ce(logits, lbl):
+            return CrossEntropyLoss()(logits[..., :-1, :].reshape(-1, vocab_size), lbl[..., 1:].reshape(-1))
+
+        for lbl in (labels, padded):
+            with torch.no_grad():
+                out = model(input_features=input_features, labels=lbl, use_cache=False)
+            self.assertTrue(torch.allclose(out.loss, aligned_ce(out.logits, lbl)))
+            self.assertFalse(torch.allclose(out.loss, double_shift_ce(out.logits, lbl)))
+
     def test_reverse_loading_mapping(self):
         # proj_out conversion only applies to ForConditionalGeneration, not the base model
         super().test_reverse_loading_mapping(skip_base_model=True)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47200)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47200)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Fixes a training-loss bug in `CohereAsrForConditionalGeneration` where labels are shifted twice.

`CohereAsrForConditionalGeneration.forward()` (in both `modular_cohere_asr.py` and the generated `modeling_cohere_asr.py`) calls `shift_tokens_right()` on `labels` to build `decoder_input_ids`, then passes the **same** `labels` to `self.loss_function()`. That maps to `ForCausalLMLoss`, which shifts `labels` again internally (`labels[..., 1:]` in `src/transformers/loss/loss_utils.py`). The result is a double shift: the model trains against `labels[..., 1:]` instead of the real `labels`, degrading training.

This is the exact pattern that was fixed for Moonshine in PR #46784. CohereAsr inherits from Moonshine and overrides `forward()` but was never updated.

### Fix
Replace `self.loss_function(logits=..., labels=labels, vocab_size=...)` with a plain `CrossEntropyLoss` against the already-aligned `labels`, matching Whisper, Bart, and the fixed Moonshine:

```python
loss_fct = CrossEntropyLoss()
loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
```

Applied to the modular source file (source of truth) and mirrored in the auto-generated `modeling_cohere_asr.py`.

## Verification
- Confirmed at the loss level that `ForCausalLMLoss(logits, labels)` produces a value that differs from a direct `CrossEntropyLoss` on `(logits, labels)` (i.e. the double shift is real).
- Added `test_training_loss_no_double_shift` to `tests/models/cohere_asr/test_modeling_cohere_asr.py`, mirroring the Moonshine regression test: for both unpadded and `-100`-padded labels, the reported loss equals an aligned CE and is **not** equal to a double-shifted CE.
- `ruff check` passes on both edited files.

Fixes #46894.

## Before submitting
- [x] This PR fixes a bug (does not add new models/features)
- [x] Tests added/updated