### PR TITLE
Guard torchcodec imports against OSError

### DIFF
--- a/src/transformers/pipelines/audio_classification.py
+++ b/src/transformers/pipelines/audio_classification.py
@@ -185,9 +185,12 @@ class AudioClassificationPipeline(Pipeline):
 
         if is_torchcodec_available():
             import torch
-            import torchcodec
+            try:
+                import torchcodec
+            except (ImportError, OSError):
+                torchcodec = None
 
-            if isinstance(inputs, torchcodec.decoders.AudioDecoder):
+            if torchcodec is not None and isinstance(inputs, torchcodec.decoders.AudioDecoder):
                 _audio_samples = inputs.get_all_samples()
                 _array = _audio_samples.data
                 inputs = {"array": _array, "sampling_rate": _audio_samples.sample_rate}

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -365,9 +365,12 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 inputs = inputs.cpu().numpy()
 
         if is_torchcodec_available():
-            import torchcodec
+            try:
+                import torchcodec
+            except (ImportError, OSError):
+                torchcodec = None
 
-            if isinstance(inputs, torchcodec.decoders.AudioDecoder):
+            if torchcodec is not None and isinstance(inputs, torchcodec.decoders.AudioDecoder):
                 _audio_samples = inputs.get_all_samples()
 
                 # torchcodec always returns (num_channels, num_samples)

--- a/src/transformers/video_utils.py
+++ b/src/transformers/video_utils.py
@@ -590,7 +590,13 @@ def read_video_torchcodec(
     """
     # Lazy import torchcodec
     requires_backends(read_video_torchcodec, ["torchcodec"])
-    from torchcodec.decoders import VideoDecoder
+    try:
+        from torchcodec.decoders import VideoDecoder
+    except (ImportError, OSError) as e:
+        raise ImportError(
+            "torchcodec is installed but cannot be imported. This may be due to missing native dependencies. "
+            f"Original error: {e}"
+        ) from e
 
     # VideoDecoder expects a string for device, default to "cpu" if None
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47206)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47206)
<!-- ci-dashboard-badge:end -->

Fixes #47070

torchcodec can be installed but fail to import (OSError) when its native extension has missing dependencies. Wrap the import in the ASR and audio-classification pipelines, plus video_utils, so these failures don't crash pipelines that don't actually need torchcodec.