### PR TITLE
Fix Swin2SR over-padding when dimensions are already aligned

### DIFF
--- a/src/transformers/models/swin2sr/image_processing_pil_swin2sr.py
+++ b/src/transformers/models/swin2sr/image_processing_pil_swin2sr.py
@@ -73,8 +73,8 @@ class Swin2SRImageProcessorPil(PilBackend):
     ) -> np.ndarray:
         """Pad image to make height and width divisible by size_divisor using symmetric padding."""
         height, width = image.shape[-2:]
-        pad_height = (height // size_divisor + 1) * size_divisor - height
-        pad_width = (width // size_divisor + 1) * size_divisor - width
+        pad_height = (size_divisor - height % size_divisor) % size_divisor
+        pad_width = (size_divisor - width % size_divisor) % size_divisor
         return np_pad(
             image,
             padding=((0, pad_height), (0, pad_width)),

--- a/src/transformers/models/swin2sr/image_processing_swin2sr.py
+++ b/src/transformers/models/swin2sr/image_processing_swin2sr.py
@@ -72,8 +72,8 @@ class Swin2SRImageProcessor(TorchvisionBackend):
     ) -> "torch.Tensor":
         """Pad images to make height and width divisible by size_divisor using symmetric padding."""
         height, width = images.shape[-2:]
-        pad_height = (height // size_divisor + 1) * size_divisor - height
-        pad_width = (width // size_divisor + 1) * size_divisor - width
+        pad_height = (size_divisor - height % size_divisor) % size_divisor
+        pad_width = (size_divisor - width % size_divisor) % size_divisor
         return tvF.pad(images, (0, 0, pad_width, pad_height), padding_mode="symmetric")
 
     def _preprocess(

--- a/tests/models/swin2sr/test_image_processing_swin2sr.py
+++ b/tests/models/swin2sr/test_image_processing_swin2sr.py
@@ -75,8 +75,8 @@ class Swin2SRImageProcessingTester:
         else:
             input_height, input_width = img.shape[-2:]
 
-        pad_height = (input_height // self.size_divisor + 1) * self.size_divisor - input_height
-        pad_width = (input_width // self.size_divisor + 1) * self.size_divisor - input_width
+        pad_height = (self.size_divisor - input_height % self.size_divisor) % self.size_divisor
+        pad_width = (self.size_divisor - input_width % self.size_divisor) % self.size_divisor
 
         return self.num_channels, input_height + pad_height, input_width + pad_width
 
@@ -115,8 +115,8 @@ class Swin2SRImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         old_height, old_width = get_image_size(image)
         size = self.image_processor_tester.size_divisor
 
-        pad_height = (old_height // size + 1) * size - old_height
-        pad_width = (old_width // size + 1) * size - old_width
+        pad_height = (size - old_height % size) % size
+        pad_width = (size - old_width % size) % size
         return old_height + pad_height, old_width + pad_width
 
     # Swin2SRImageProcessor does not support batched input
@@ -179,6 +179,17 @@ class Swin2SRImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
             encoded_images = image_processing(image_inputs[0], return_tensors="pt").pixel_values
             expected_output_image_shape = self.image_processor_tester.expected_output_image_shape([image_inputs[0]])
             self.assertEqual(tuple(encoded_images.shape), (1, *expected_output_image_shape))
+
+    def test_pad_divisible_size(self):
+        """An image whose dimensions are already divisible by size_divisor should not be padded."""
+        for image_processing_class in self.image_processing_classes.values():
+            image_processing = image_processing_class(**self.image_processor_dict)
+            # 64 is divisible by the default size_divisor of 8
+            img = Image.new("RGB", (64, 64))
+            encoded = image_processing(img, return_tensors="pt").pixel_values
+            _, _, h, w = encoded.shape
+            self.assertEqual(h, 64)
+            self.assertEqual(w, 64)
 
     def test_backends_equivalence_batched(self):
         """Swin2SR requires equal-resolution images for batched processing (returns stacked tensor)."""


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47207)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47207)
<!-- ci-dashboard-badge:end -->

Fixes #46697

The padding formula (dim // divisor + 1) * divisor - dim always adds an extra divisor of padding even when the dimension is perfectly divisible. For example, an 800px image with divisor=8 gets 8px of padding instead of 0.

Replace with (divisor - dim % divisor) % divisor, which returns 0 when already aligned and the correct amount otherwise.