### PR TITLE
Route packed sdpa rows through torch.nn.attention.varlen.varlen_attn

### DIFF
--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -1,5 +1,9 @@
+import inspect
+
 import torch
 
+from ..masking_utils import find_packed_sequence_indices
+from ..modeling_flash_attention_utils import prepare_fa_kwargs_from_position_ids
 from ..utils import is_torch_npu_available, is_torch_xpu_available, logging
 from ..utils.import_utils import is_torch_greater_or_equal
 
@@ -9,8 +13,30 @@ logger = logging.get_logger(__name__)
 
 _is_torch_greater_or_equal_than_2_5 = is_torch_greater_or_equal("2.5", accept_dev=True)
 _is_torch_greater_or_equal_than_2_8 = is_torch_greater_or_equal("2.8", accept_dev=True)
+_is_torch_greater_or_equal_than_2_10 = is_torch_greater_or_equal("2.10", accept_dev=True)
 _is_torch_xpu_available = is_torch_xpu_available()
 _is_torch_npu_available = is_torch_npu_available()
+
+# `varlen_attn` runs true variable-length attention from `cu_seqlens`, so packed (multi-document) rows can skip
+# the O(seq_len^2) block-diagonal mask. Guarded import: unavailable below torch 2.10.
+try:
+    from torch.nn.attention.varlen import varlen_attn
+except ImportError:
+    varlen_attn = None
+
+_is_torch_varlen_attn_available = _is_torch_greater_or_equal_than_2_10 and varlen_attn is not None
+
+# `varlen_attn`'s signature varies across torch>=2.10 builds; inspect the optional kwargs it supports once.
+# `window_size` expresses sliding windows (a build with only `is_causal` cannot, so it refuses those layers),
+# `enable_gqa` avoids manually repeating K/V, and `scale` passes a custom softmax scale through.
+_varlen_attn_parameters = set(inspect.signature(varlen_attn).parameters) if _is_torch_varlen_attn_available else set()
+_varlen_attn_supports_window_size = "window_size" in _varlen_attn_parameters
+_varlen_attn_supports_enable_gqa = "enable_gqa" in _varlen_attn_parameters
+_varlen_attn_supports_scale = "scale" in _varlen_attn_parameters
+_varlen_attn_supports_is_causal = "is_causal" in _varlen_attn_parameters
+
+# head_dim limit of the flash-attention kernel backing `varlen_attn`.
+_VARLEN_MAX_HEAD_DIM = 256
 
 
 def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
@@ -38,6 +64,88 @@ def use_gqa_in_sdpa(attention_mask: torch.Tensor | None, key: torch.Tensor, valu
     return _is_torch_greater_or_equal_than_2_5 and attention_mask is None and key.shape[-1] == value.shape[-1] <= 256
 
 
+def _is_packed_row(position_ids: torch.Tensor) -> bool:
+    """Whether `position_ids` packs more than one document per row, using the same detection as
+    `masking_utils` so the two files agree on which rows are packed."""
+    pid = position_ids if position_ids.dim() > 1 else position_ids[None]
+    return find_packed_sequence_indices(pid) is not None
+
+
+def _packed_block_diagonal_mask(
+    position_ids: torch.Tensor, seq_len: int, sliding_window: int | None = None
+) -> torch.Tensor:
+    """
+    Build a boolean `(batch, 1, seq_len, seq_len)` block-diagonal causal mask from `position_ids` (which reset to
+    0 at each document boundary). Fallback for packed rows ineligible for the `varlen_attn` fast path, so stock
+    SDPA still cannot attend across documents.
+    """
+    pid = position_ids if position_ids.dim() > 1 else position_ids[None]
+    document_ids = (pid == 0).cumsum(-1)
+    same_document = document_ids[:, :, None] == document_ids[:, None, :]
+    token_idx = torch.arange(seq_len, device=pid.device)
+    causal = token_idx[:, None] >= token_idx[None, :]
+    mask = same_document & causal[None]
+    if sliding_window is not None:
+        mask = mask & (token_idx[:, None] - token_idx[None, :] < sliding_window)
+    return mask[:, None]
+
+
+def _sdpa_varlen_attention_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    position_ids: torch.Tensor,
+    scaling: float | None,
+    sliding_window: int | None,
+) -> tuple[torch.Tensor, None]:
+    """
+    Run a packed row through `varlen_attn`, deriving `cu_seqlens` from `position_ids` via
+    `prepare_fa_kwargs_from_position_ids`. Skips materializing the O(seq_len^2) mask and the compute on its
+    masked-out cross-document blocks.
+    """
+    batch_size, num_heads_q, seq_len, head_dim = query.shape
+    num_heads_kv = key.shape[1]
+
+    varlen_kwargs = {}
+    if num_heads_q != num_heads_kv:
+        if _varlen_attn_supports_enable_gqa:
+            varlen_kwargs["enable_gqa"] = True
+        else:
+            key = repeat_kv(key, num_heads_q // num_heads_kv)
+            value = repeat_kv(value, num_heads_q // num_heads_kv)
+
+    if _varlen_attn_supports_scale:
+        varlen_kwargs["scale"] = scaling
+    if _varlen_attn_supports_window_size:
+        # (left, right): (-1, 0) = causal; (W-1, 0) = causal sliding window of W.
+        varlen_kwargs["window_size"] = (sliding_window - 1, 0) if sliding_window else (-1, 0)
+    elif _varlen_attn_supports_is_causal:
+        # The caller already refuses sliding-window layers on an `is_causal`-only build.
+        varlen_kwargs["is_causal"] = True
+
+    (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(position_ids)
+
+    q = query.transpose(1, 2).reshape(batch_size * seq_len, num_heads_q, head_dim)
+    k = key.transpose(1, 2).reshape(batch_size * seq_len, key.shape[1], head_dim)
+    v = value.transpose(1, 2).reshape(batch_size * seq_len, value.shape[1], head_dim)
+
+    attn_output = varlen_attn(
+        q,
+        k,
+        v,
+        cu_seq_lens_q.to(torch.int32),
+        cu_seq_lens_k.to(torch.int32),
+        int(max_length_q),
+        int(max_length_k),
+        **varlen_kwargs,
+    )
+    if isinstance(attn_output, tuple):
+        attn_output = attn_output[0]
+
+    # match sdpa_attention_forward's return contract: (attn_output [batch, seq, heads, head_dim], None)
+    return attn_output.reshape(batch_size, seq_len, num_heads_q, head_dim), None
+
+
 def sdpa_attention_forward(
     module: torch.nn.Module,
     query: torch.Tensor,
@@ -54,6 +162,39 @@ def sdpa_attention_forward(
             "`sdpa` attention does not support `output_attentions=True`."
             " Please set your attention to `eager` if you want any of these features."
         )
+
+    # Instead of relying on the value set in the module directly, we use the is_causal passed in kwargs if it is presented
+    is_causal = is_causal if is_causal is not None else getattr(module, "is_causal", True)
+
+    # Mask creation may skip materialization for a packed row and pass `attention_mask=None` (see
+    # `allow_torch_varlen_skip` in `masking_utils.py`). We re-detect packing from `position_ids` and own document
+    # isolation for such a row: either the `varlen_attn` fast path, or a locally-rebuilt block-diagonal mask
+    # before stock SDPA. A packed row must never reach SDPA with `attn_mask=None, is_causal=True`, or it would
+    # attend across document boundaries.
+    position_ids = kwargs.get("position_ids")
+    sliding_window = kwargs.get("sliding_window") or getattr(module, "sliding_window", None)
+    packed_row = is_causal and attention_mask is None and position_ids is not None and _is_packed_row(position_ids)
+
+    if packed_row:
+        head_dim = query.shape[-1]
+        standard_scale = _varlen_attn_supports_scale or scaling is None or abs(scaling - head_dim**-0.5) < 1e-9
+        use_varlen = (
+            _is_torch_varlen_attn_available
+            and (_varlen_attn_supports_window_size or _varlen_attn_supports_is_causal)
+            and dropout == 0.0
+            and head_dim <= _VARLEN_MAX_HEAD_DIM
+            and query.is_cuda
+            and standard_scale
+            and (not sliding_window or _varlen_attn_supports_window_size)
+        )
+        if use_varlen:
+            return _sdpa_varlen_attention_forward(
+                query, key, value, position_ids, scaling=scaling, sliding_window=sliding_window
+            )
+        # Ineligible for the fast path (head_dim too large, dropout, non-CUDA tensors, or an inexpressible
+        # sliding window): rebuild the isolation the skipped mask no longer provides.
+        attention_mask = _packed_block_diagonal_mask(position_ids, query.shape[2], sliding_window)
+
     sdpa_kwargs = {}
     if hasattr(module, "num_key_value_groups") and module.num_key_value_groups > 1:
         if not use_gqa_in_sdpa(attention_mask, key, value):
@@ -64,9 +205,6 @@ def sdpa_attention_forward(
 
     q_length = query.shape[2]
     kv_length = key.shape[2]
-
-    # Instead of relying on the value set in the module directly, we use the is_causal passed in kwargs if it is presented
-    is_causal = is_causal if is_causal is not None else getattr(module, "is_causal", True)
 
     # SDPA's Flash Attention (and cuDNN) kernels rely on the `is_causal` flag. However, there are certain conditions:
     # - Not in decoding phase (otherwise we want full attention on the single query token)

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -36,10 +36,20 @@ else:
 
 _is_torch_greater_or_equal_than_2_5 = is_torch_greater_or_equal("2.5", accept_dev=True)
 _is_torch_greater_or_equal_than_2_6 = is_torch_greater_or_equal("2.6", accept_dev=True)
+_is_torch_greater_or_equal_than_2_10 = is_torch_greater_or_equal("2.10", accept_dev=True)
 _is_torch_xpu_available = is_torch_xpu_available()
 
 if _is_torch_greater_or_equal_than_2_6:
     from torch._dynamo._trace_wrapped_higher_order_op import TransformGetItemToIndex
+
+# When `varlen_attn` (torch>=2.10) is available, `sdpa_attention_forward` can run packed rows as variable-length
+# attention, so we can skip materializing the block-diagonal mask here (see `integrations/sdpa_attention.py`).
+try:
+    from torch.nn.attention.varlen import varlen_attn as _torch_varlen_attn  # noqa: F401
+
+    _is_torch_varlen_attn_available = True
+except ImportError:
+    _is_torch_varlen_attn_available = False
 
 
 logger = logging.get_logger(__name__)
@@ -368,6 +378,24 @@ def _non_vmap_expansion_sdpa(
     return batch_indices, head_indices, q_indices, kv_indices
 
 
+def _allow_torch_varlen_skip(
+    config: PreTrainedConfig, packed_sequence_mask: torch.Tensor | None, device: torch.device
+) -> bool:
+    """
+    Whether mask creation can be skipped (return `None`) for a packed-sequence row, letting
+    `sdpa_attention_forward` own document isolation via `varlen_attn` (or a block-diagonal mask it rebuilds from
+    `position_ids`). Only for packed `sdpa` rows on CUDA where `varlen_attn` is available; other devices keep
+    materializing the mask.
+    """
+    return (
+        packed_sequence_mask is not None
+        and config._attn_implementation == "sdpa"
+        and _is_torch_greater_or_equal_than_2_10
+        and _is_torch_varlen_attn_available
+        and device.type == "cuda"
+    )
+
+
 def sdpa_mask(
     batch_size: int,
     q_length: int,
@@ -379,6 +407,7 @@ def sdpa_mask(
     local_size: int | None = None,
     allow_is_causal_skip: bool = True,
     allow_is_bidirectional_skip: bool = False,
+    allow_torch_varlen_skip: bool = False,
     allow_torch_fix: bool = True,
     use_vmap: bool = False,
     device: torch.device | str = "cpu",
@@ -413,6 +442,10 @@ def sdpa_mask(
         allow_is_bidirectional_skip (`bool`, optional):
             Whether to allow to return `None` for the mask under conditions where we do not have to add any bias,
             i.e. full attention without any padding. Default to `False`.
+        allow_torch_varlen_skip (`bool`, optional):
+            Whether to allow returning `None` for a packed-sequence row that `sdpa_attention_forward` will itself
+            isolate via `varlen_attn` (or a mask it rebuilds locally). Takes priority over the other skip
+            conditions. Default to `False`.
         allow_torch_fix (`bool`, optional):
             Whether to update the mask in case a query is not attending to any tokens, to solve a bug in torch's older
             versions. We need an arg to skip it when using eager. By default `True`.
@@ -487,6 +520,11 @@ def sdpa_mask(
     ```
 
     """
+    # `sdpa_attention_forward` handles document isolation for this row (via `varlen_attn` or a locally-rebuilt
+    # mask), so skip materializing anything here. Checked ahead of the narrower skip conditions below.
+    if allow_torch_varlen_skip:
+        return None
+
     # Potentially pad the 2D mask
     padding_mask = prepare_padding_mask(attention_mask, kv_length, kv_offset)
 
@@ -966,6 +1004,14 @@ def create_causal_mask(
     if packed_sequence_mask is not None:
         mask_factory_function = and_masks(mask_factory_function, packed_sequence_mask_function(packed_sequence_mask))
         allow_is_causal_skip = False
+    # `sdpa_attention_forward` only reconstructs plain per-document (optionally windowed) causal isolation from
+    # `position_ids`; it knows nothing about a custom overlay, so those must disable the skip.
+    allow_torch_varlen_skip = (
+        or_mask_function is None
+        and and_mask_function is None
+        and block_sequence_ids is None
+        and _allow_torch_varlen_skip(config, packed_sequence_mask, device)
+    )
     if block_sequence_ids is not None:
         block_sequence_ids = maybe_pad_block_sequence_ids(block_sequence_ids, attention_mask, kv_length, kv_offset)
         mask_factory_function = or_masks(mask_factory_function, blockwise_overlay(block_sequence_ids))
@@ -981,6 +1027,7 @@ def create_causal_mask(
         mask_function=mask_factory_function,
         attention_mask=attention_mask,
         allow_is_causal_skip=allow_is_causal_skip,  # additional kwarg for sdpa
+        allow_torch_varlen_skip=allow_torch_varlen_skip,  # additional kwarg for sdpa
         dtype=dtype,  # Additional kwarg for eager
         config=config,  # Pass the config as well, in case someone wants to easily have their own mask_interface
         use_vmap=use_vmap,  # Short-circuit to non-vmap expansions for the mask
@@ -1191,6 +1238,14 @@ def create_sliding_window_causal_mask(
     if packed_sequence_mask is not None:
         mask_factory_function = and_masks(mask_factory_function, packed_sequence_mask_function(packed_sequence_mask))
         allow_is_causal_skip = False
+    # `sdpa_attention_forward` only reconstructs plain per-document (optionally windowed) causal isolation from
+    # `position_ids`; it knows nothing about a custom overlay, so those must disable the skip.
+    allow_torch_varlen_skip = (
+        or_mask_function is None
+        and and_mask_function is None
+        and block_sequence_ids is None
+        and _allow_torch_varlen_skip(config, packed_sequence_mask, device)
+    )
     if block_sequence_ids is not None:
         block_sequence_ids = maybe_pad_block_sequence_ids(block_sequence_ids, attention_mask, kv_length, kv_offset)
         mask_factory_function = or_masks(mask_factory_function, blockwise_overlay(block_sequence_ids))
@@ -1206,6 +1261,7 @@ def create_sliding_window_causal_mask(
         mask_function=mask_factory_function,
         attention_mask=attention_mask,
         allow_is_causal_skip=allow_is_causal_skip,  # additional kwarg for sdpa
+        allow_torch_varlen_skip=allow_torch_varlen_skip,  # additional kwarg for sdpa
         local_size=sliding_window,  # Additional kwarg for sdpa
         dtype=dtype,  # Additional kwarg for eager
         config=config,  # Pass the config as well, in case someone wants to easily have their own mask_interface

--- a/tests/utils/test_sdpa_varlen_packing.py
+++ b/tests/utils/test_sdpa_varlen_packing.py
@@ -1,0 +1,139 @@
+# Copyright 2025 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for the `sdpa` packed-sequence `varlen_attn` fast path and its block-diagonal-mask fallback
+(`integrations/sdpa_attention.py` and the `allow_torch_varlen_skip` signal in `masking_utils.py`).
+"""
+
+import unittest
+from unittest import mock
+
+from transformers.testing_utils import require_torch_gpu, torch_device
+from transformers.utils import is_torch_available
+
+
+if is_torch_available():
+    import torch
+
+    from transformers import LlamaConfig, LlamaModel
+    from transformers.integrations import sdpa_attention
+
+
+def _tiny_llama_config() -> "LlamaConfig":
+    # Tiny random-weight config; GQA (heads != kv_heads) also exercises the `enable_gqa` passthrough.
+    return LlamaConfig(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        attn_implementation="sdpa",
+    )
+
+
+def _build_packed_inputs(doc_lengths: list[int], vocab_size: int, device: str):
+    position_ids = torch.cat([torch.arange(length, device=device) for length in doc_lengths]).unsqueeze(0)
+    total_len = position_ids.shape[1]
+    input_ids = torch.randint(0, vocab_size, (1, total_len), device=device)
+    return input_ids, position_ids
+
+
+@require_torch_gpu
+class SdpaVarlenPackingTest(unittest.TestCase):
+    def setUp(self):
+        if not sdpa_attention._is_torch_varlen_attn_available:
+            self.skipTest("torch.nn.attention.varlen.varlen_attn is unavailable (needs torch>=2.10)")
+        torch.manual_seed(0)
+        self.doc_lengths = [6, 5, 7]
+        self.config = _tiny_llama_config()
+        self.model = LlamaModel(self.config).to(device=torch_device, dtype=torch.bfloat16).eval()
+        self.input_ids, self.position_ids = _build_packed_inputs(
+            self.doc_lengths, self.config.vocab_size, torch_device
+        )
+
+    def _per_document_reference(self) -> "torch.Tensor":
+        """Run each document on its own and concatenate the results -- the ground truth that the packed forward
+        must match, since packing must be numerically transparent."""
+        outputs = []
+        offset = 0
+        for length in self.doc_lengths:
+            doc_input_ids = self.input_ids[:, offset : offset + length]
+            doc_position_ids = torch.arange(length, device=torch_device).unsqueeze(0)
+            with torch.no_grad():
+                out = self.model(
+                    input_ids=doc_input_ids,
+                    position_ids=doc_position_ids,
+                    attention_mask=None,
+                    use_cache=False,
+                ).last_hidden_state
+            outputs.append(out)
+            offset += length
+        return torch.cat(outputs, dim=1)
+
+    def _packed_forward(self):
+        with torch.no_grad():
+            return self.model(
+                input_ids=self.input_ids,
+                position_ids=self.position_ids,
+                attention_mask=None,
+                use_cache=False,
+            ).last_hidden_state
+
+    def test_varlen_fast_path_matches_per_document_reference(self):
+        """The eligible packed row must route to `varlen_attn` and match the per-document reference."""
+        with mock.patch.object(sdpa_attention, "varlen_attn", wraps=sdpa_attention.varlen_attn) as varlen_attn_spy:
+            packed_output = self._packed_forward()
+            self.assertGreater(
+                varlen_attn_spy.call_count,
+                0,
+                "varlen_attn was never invoked for an eligible packed row; the fast path did not engage.",
+            )
+
+        reference_output = self._per_document_reference()
+        torch.testing.assert_close(packed_output, reference_output, atol=2e-2, rtol=2e-2)
+
+    def test_fallback_block_diagonal_mask_matches_per_document_reference(self):
+        """When the packed row is ineligible for the fast path (forced here), `sdpa_attention_forward` must
+        rebuild an equivalent block-diagonal mask from `position_ids` and still isolate documents correctly."""
+        with mock.patch.object(sdpa_attention, "_is_torch_varlen_attn_available", False):
+            with mock.patch.object(sdpa_attention, "varlen_attn", wraps=sdpa_attention.varlen_attn) as varlen_attn_spy:
+                packed_output = self._packed_forward()
+                self.assertEqual(
+                    varlen_attn_spy.call_count,
+                    0,
+                    "varlen_attn should not be invoked once the fast path is made ineligible.",
+                )
+
+        reference_output = self._per_document_reference()
+        torch.testing.assert_close(packed_output, reference_output, atol=2e-2, rtol=2e-2)
+
+    def test_masking_utils_skips_mask_for_eligible_packed_row(self):
+        """`create_causal_mask` must return `None` for an eligible packed `sdpa` row, letting
+        `sdpa_attention_forward` own document isolation."""
+        from transformers.masking_utils import create_causal_mask
+
+        causal_mask = create_causal_mask(
+            config=self.config,
+            inputs_embeds=torch.empty((1, self.position_ids.shape[1]), dtype=torch.bfloat16, device=torch_device),
+            attention_mask=None,
+            past_key_values=None,
+            position_ids=self.position_ids,
+        )
+        self.assertIsNone(causal_mask)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47210)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47210)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

PyTorch recently added varlen support to SDPA. Upstreaming this from axolotl to transformers. 

see https://docs.pytorch.org/tutorials/intermediate/variable_length_attention_tutorial.html


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.

Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
for reviewers and other users and will almost certainly get you blocked.

For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->