### PR TITLE
Fix wrong method name call in TimesFM 2.5 preprocessing

### DIFF
--- a/src/transformers/models/timesfm2_5/modeling_timesfm2_5.py
+++ b/src/transformers/models/timesfm2_5/modeling_timesfm2_5.py
@@ -777,7 +777,7 @@ class TimesFm2_5ModelForPrediction(TimesFm2_5PreTrainedModel):
         if window_size is not None:
             new_inputs: list[torch.Tensor] = []
             for ts in inputs:
-                new_inputs.extend(self._timesfm_moving_average(ts, window_size))
+                new_inputs.extend(self._timesfm2_5_moving_average(ts, window_size))
             inputs = new_inputs
 
         if truncate_negative is None:

--- a/src/transformers/models/timesfm2_5/modular_timesfm2_5.py
+++ b/src/transformers/models/timesfm2_5/modular_timesfm2_5.py
@@ -564,7 +564,7 @@ class TimesFm2_5ModelForPrediction(TimesFmModelForPrediction):
         if window_size is not None:
             new_inputs: list[torch.Tensor] = []
             for ts in inputs:
-                new_inputs.extend(self._timesfm_moving_average(ts, window_size))
+                new_inputs.extend(self._timesfm2_5_moving_average(ts, window_size))
             inputs = new_inputs
 
         if truncate_negative is None:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47229)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47229)
<!-- ci-dashboard-badge:end -->

## What

`_preprocess_inputs` in `modeling_timesfm2_5.py` calls `self._timesfm_moving_average` at line 780, but the method defined in the same class is `_timesfm2_5_moving_average`. The name was copied from the original TimesFM 1.0 model and never updated.

## Reproduction

Any call that passes `window_size` to a TimesFM 2.5 model raises `AttributeError: 'TimesFM2_5ForPrediction' object has no attribute '_timesfm_moving_average'`. Python also helpfully suggests `Did you mean: '_timesfm2_5_moving_average'?`.

## Fix

One-character change at the call site: rename `_timesfm_moving_average` → `_timesfm2_5_moving_average` to match the actual definition.

Closes #46821.