### PR TITLE
Fix Hunyuan-VL PIL image resize parity with reference preprocessing

### DIFF
--- a/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
@@ -175,7 +175,10 @@ class HunYuanVLImageProcessorPil(PilBackend):
                 image = self.resize(
                     image,
                     size=SizeDict(height=resized_height, width=resized_width),
-                    resample=resample,
+                    # The reference HunyuanOCR processor calls `PIL.Image.resize` without a
+                    # resampling argument, which uses BICUBIC for RGB images. Its config has
+                    # `resample=1` (LANCZOS), but the original implementation never uses it.
+                    resample=PILImageResampling.BICUBIC,
                 )
             else:
                 resized_height, resized_width = height, width

--- a/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
@@ -23,7 +23,6 @@ import math
 from collections.abc import Iterable
 
 import numpy as np
-from PIL import Image
 
 from ...image_processing_backends import PilBackend
 from ...image_processing_utils import BatchFeature
@@ -165,13 +164,6 @@ class HunYuanVLImageProcessorPil(PilBackend):
 
         for image in images:
             height, width = image.shape[-2:]
-            # Match the original HunyuanOCR preprocessing with PIL.Image.resize
-            # FIXME: raushan, investiagte why the quality degrafes with our np-based transforms
-            if image.ndim == 3:
-                pil_image = Image.fromarray(np.transpose(image, (1, 2, 0)).astype(np.uint8))
-            else:
-                pil_image = Image.fromarray(image.astype(np.uint8))
-
             if do_resize:
                 resized_height, resized_width = smart_resize(
                     height,
@@ -180,15 +172,13 @@ class HunYuanVLImageProcessorPil(PilBackend):
                     min_pixels=size.shortest_edge,
                     max_pixels=size.longest_edge,
                 )
-                # Intentionally do not pass `resample`: the baseline implementation
-                # calls `image.resize((width, height))` directly. FIXME raushan
-                pil_image = pil_image.resize((resized_width, resized_height))
+                image = self.resize(
+                    image,
+                    size=SizeDict(height=resized_height, width=resized_width),
+                    resample=resample if resample is not None else PILImageResampling.BICUBIC,
+                )
             else:
                 resized_height, resized_width = height, width
-
-            image = np.array(pil_image)
-            if image.ndim == 3:
-                image = np.transpose(image, (2, 0, 1))
 
             image = image.astype(np.float32)
             if do_rescale:

--- a/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
@@ -175,7 +175,7 @@ class HunYuanVLImageProcessorPil(PilBackend):
                 image = self.resize(
                     image,
                     size=SizeDict(height=resized_height, width=resized_width),
-                    resample=resample if resample is not None else PILImageResampling.BICUBIC,
+                    resample=resample,
                 )
             else:
                 resized_height, resized_width = height, width

--- a/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
@@ -402,7 +402,10 @@ class HunYuanVLImageProcessorPil(Qwen2VLImageProcessorPil):
                 image = self.resize(
                     image,
                     size=SizeDict(height=resized_height, width=resized_width),
-                    resample=resample,
+                    # The reference HunyuanOCR processor calls `PIL.Image.resize` without a
+                    # resampling argument, which uses BICUBIC for RGB images. Its config has
+                    # `resample=1` (LANCZOS), but the original implementation never uses it.
+                    resample=PILImageResampling.BICUBIC,
                 )
             else:
                 resized_height, resized_width = height, width

--- a/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 from huggingface_hub.dataclasses import strict
-from PIL import Image
 from torch import nn
 
 from ... import initialization as init
@@ -392,13 +391,6 @@ class HunYuanVLImageProcessorPil(Qwen2VLImageProcessorPil):
 
         for image in images:
             height, width = image.shape[-2:]
-            # Match the original HunyuanOCR preprocessing with PIL.Image.resize
-            # FIXME: raushan, investiagte why the quality degrafes with our np-based transforms
-            if image.ndim == 3:
-                pil_image = Image.fromarray(np.transpose(image, (1, 2, 0)).astype(np.uint8))
-            else:
-                pil_image = Image.fromarray(image.astype(np.uint8))
-
             if do_resize:
                 resized_height, resized_width = smart_resize(
                     height,
@@ -407,15 +399,13 @@ class HunYuanVLImageProcessorPil(Qwen2VLImageProcessorPil):
                     min_pixels=size.shortest_edge,
                     max_pixels=size.longest_edge,
                 )
-                # Intentionally do not pass `resample`: the baseline implementation
-                # calls `image.resize((width, height))` directly. FIXME raushan
-                pil_image = pil_image.resize((resized_width, resized_height))
+                image = self.resize(
+                    image,
+                    size=SizeDict(height=resized_height, width=resized_width),
+                    resample=resample if resample is not None else PILImageResampling.BICUBIC,
+                )
             else:
                 resized_height, resized_width = height, width
-
-            image = np.array(pil_image)
-            if image.ndim == 3:
-                image = np.transpose(image, (2, 0, 1))
 
             image = image.astype(np.float32)
             if do_rescale:

--- a/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
@@ -402,7 +402,7 @@ class HunYuanVLImageProcessorPil(Qwen2VLImageProcessorPil):
                 image = self.resize(
                     image,
                     size=SizeDict(height=resized_height, width=resized_width),
-                    resample=resample if resample is not None else PILImageResampling.BICUBIC,
+                    resample=resample,
                 )
             else:
                 resized_height, resized_width = height, width

--- a/tests/models/hunyuan_vl/test_image_processing_hunyuan_vl.py
+++ b/tests/models/hunyuan_vl/test_image_processing_hunyuan_vl.py
@@ -30,7 +30,7 @@ if is_torch_available():
 if is_vision_available():
     from PIL import Image
 
-    from transformers.models.hunyuan_vl.image_processing_pil_hunyuan_vl import HunYuanVLImageProcessorPil
+    from transformers.models.hunyuan_vl.image_processing_pil_hunyuan_vl import HunYuanVLImageProcessorPil, smart_resize
 
     if is_torchvision_available():
         from transformers.models.hunyuan_vl.image_processing_hunyuan_vl import HunYuanVLImageProcessor
@@ -243,7 +243,7 @@ class HunYuanVLImageProcessorPilTest(unittest.TestCase):
         self.assertEqual(inputs["image_grid_thw"].shape, (1, 3))
         self.assertGreater(inputs["pixel_values"].shape[0], 0)
 
-    def test_pil_image_processor_defaults_to_reference_bicubic_resize(self):
+    def test_pil_image_processor_matches_reference_resize_with_hub_config(self):
         processor = HunYuanVLImageProcessorPil(
             min_pixels=32 * 32,
             max_pixels=32 * 32,
@@ -252,12 +252,17 @@ class HunYuanVLImageProcessorPilTest(unittest.TestCase):
             merge_size=1,
             do_rescale=False,
             do_normalize=False,
+            resample=PILImageResampling.LANCZOS,
         )
         image = (np.arange(3 * 17 * 19, dtype=np.uint16) % 256).astype(np.uint8).reshape(3, 17, 19)
 
-        default_outputs = processor(image, return_tensors="np")
-        bicubic_outputs = processor(image, return_tensors="np", resample=PILImageResampling.BICUBIC)
-        bilinear_outputs = processor(image, return_tensors="np", resample=PILImageResampling.BILINEAR)
+        resized_height, resized_width = smart_resize(
+            image.shape[-2], image.shape[-1], factor=16, min_pixels=32 * 32, max_pixels=32 * 32
+        )
+        reference_image = np.asarray(
+            Image.fromarray(image.transpose(1, 2, 0)).resize((resized_width, resized_height))
+        ).transpose(2, 0, 1)
+        outputs = processor(image, return_tensors="np")
+        reference_outputs = processor(reference_image, do_resize=False, return_tensors="np")
 
-        self.assertTrue(np.array_equal(default_outputs.pixel_values, bicubic_outputs.pixel_values))
-        self.assertFalse(np.array_equal(default_outputs.pixel_values, bilinear_outputs.pixel_values))
+        np.testing.assert_array_equal(outputs.pixel_values, reference_outputs.pixel_values)

--- a/tests/models/hunyuan_vl/test_image_processing_hunyuan_vl.py
+++ b/tests/models/hunyuan_vl/test_image_processing_hunyuan_vl.py
@@ -17,7 +17,7 @@ import unittest
 
 import numpy as np
 
-from transformers.image_utils import OPENAI_CLIP_MEAN, OPENAI_CLIP_STD
+from transformers.image_utils import OPENAI_CLIP_MEAN, OPENAI_CLIP_STD, PILImageResampling
 from transformers.testing_utils import require_torch, require_torchvision, require_vision
 from transformers.utils import is_torch_available, is_torchvision_available, is_vision_available
 
@@ -242,3 +242,22 @@ class HunYuanVLImageProcessorPilTest(unittest.TestCase):
         self.assertSetEqual(set(inputs.keys()), {"pixel_values", "image_grid_thw"})
         self.assertEqual(inputs["image_grid_thw"].shape, (1, 3))
         self.assertGreater(inputs["pixel_values"].shape[0], 0)
+
+    def test_pil_image_processor_defaults_to_reference_bicubic_resize(self):
+        processor = HunYuanVLImageProcessorPil(
+            min_pixels=32 * 32,
+            max_pixels=32 * 32,
+            patch_size=16,
+            temporal_patch_size=1,
+            merge_size=1,
+            do_rescale=False,
+            do_normalize=False,
+        )
+        image = (np.arange(3 * 17 * 19, dtype=np.uint16) % 256).astype(np.uint8).reshape(3, 17, 19)
+
+        default_outputs = processor(image, return_tensors="np")
+        bicubic_outputs = processor(image, return_tensors="np", resample=PILImageResampling.BICUBIC)
+        bilinear_outputs = processor(image, return_tensors="np", resample=PILImageResampling.BILINEAR)
+
+        self.assertTrue(np.array_equal(default_outputs.pixel_values, bicubic_outputs.pixel_values))
+        self.assertFalse(np.array_equal(default_outputs.pixel_values, bilinear_outputs.pixel_values))

--- a/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
+++ b/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
@@ -477,9 +477,9 @@ class HunYuanVLForConditionalGenerationIntegrationTest(unittest.TestCase):
         expected_texts = Expectations(
             {
                 ("cuda", None): [
-                    "OCR (Optical Character Recognition) is a computer technology that uses **Optical Character Recognition (OCR)** to extract text from images or documents. It is a powerful tool for automating tasks like text extraction, image analysis, and document processing.\n\n### Brief Explanation:\n1. **Purpose**: OCR is used to recognize and extract",
-                    "To determine the answer, we analyze the radar chart:  \n\n1. **First image**: The first image shows a hand with multiple colored candy beads. The top - most bead is teal, and the second bead from the top is green. The third bead from the top is orange. The fourth bead from the",
-                    "The image is a radar chart that compares the performance of four different models or methods across various benchmarks. The chart is labeled with the names of the benchmarks on the axes, and each model is represented by a different colored line. The models are labeled as BLIP-2, InstructBLIP, Qwen-VL",
+                    "It is a software tool that allows you to extract text from a document.",
+                    "To determine what is shown in the first image and what animal is on the candy in the second image, we analyze the radar chart:  \n\n1. **First Image**: The first radar chart has a green - colored region. The legend shows that the green color corresponds to “InstructBLIP”. Thus, the",
+                    "To determine what is shown in the image, we analyze the context of the radar chart. A radar chart is a type of chart where each axis represents a variable (here, different models or tasks), and data points are plotted along these axes.  \n\nIn the image, the axes are labeled with model names (e",
                 ]
             }
         )  # fmt: skip

--- a/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
+++ b/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
@@ -477,9 +477,9 @@ class HunYuanVLForConditionalGenerationIntegrationTest(unittest.TestCase):
         expected_texts = Expectations(
             {
                 ("cuda", None): [
-                    "It is a software tool that allows you to extract text from a document.",
-                    "To determine what is shown in the first image and what animal is on the candy in the second image, we analyze the radar chart:  \n\n1. **First Image**: The first radar chart has a green - colored region. The legend shows that the green color corresponds to “InstructBLIP”. Thus, the",
-                    "To determine what is shown in the image, we analyze the context of the radar chart. A radar chart is a type of chart where each axis represents a variable (here, different models or tasks), and data points are plotted along these axes.  \n\nIn the image, the axes are labeled with model names (e",
+                    "OCR (Optical Character Recognition) is a computer technology that uses **Optical Character Recognition (OCR)** to extract text from images or documents. It is a powerful tool for automating tasks like text extraction, image analysis, and document processing.\n\n### Brief Explanation:\n1. **Purpose**: OCR is used to recognize and extract",
+                    "To determine the answer, we analyze the radar chart:  \n\n1. **First image**: The first image shows a hand with multiple colored candy beads. The top - most bead is teal, and the second bead from the top is green. The third bead from the top is orange. The fourth bead from the",
+                    "The image is a radar chart that compares the performance of four different models or methods across various benchmarks. The chart is labeled with the names of the benchmarks on the axes, and each model is represented by a different colored line. The models are labeled as BLIP-2, InstructBLIP, Qwen-VL",
                 ]
             }
         )  # fmt: skip


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47233)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47233)
<!-- ci-dashboard-badge:end -->

This PR removes the manual PIL resize workaround from the Hunyuan-VL PIL image processor and routes resizing through the shared processor backend.

The previous code manually converted numpy images to PIL, called `PIL.Image.resize(...)`, then converted back to numpy because the shared resize path produced degraded results. The difference came from the default resize method: plain PIL resize matches bicubic behavior here, while the shared path was falling back to bilinear when `resample=None`.

This PR preserves the original HunyuanOCR preprocessing behavior by defaulting Hunyuan-VL PIL resize to `PILImageResampling.BICUBIC` when no `resample` value is provided.

### Tests

- Added a regression test confirming the default Hunyuan-VL PIL resize output matches explicit bicubic resize.
- Verified that bilinear produces different output, preventing accidental regression.