### PR TITLE
Fix MPS crash in build_2d_sinusoidal_position_embedding (float64 → float32)

### DIFF
--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -847,7 +847,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype for the returned tensor.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -856,11 +856,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float32, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float32, device=device)
+    grid_w = torch.arange(width, dtype=torch.float32, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -869,7 +869,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float32, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -973,7 +973,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype for the returned tensor.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -982,11 +982,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float32, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float32, device=device)
+    grid_w = torch.arange(width, dtype=torch.float32, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -995,7 +995,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float32, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/vit_mae/modeling_vit_mae.py
+++ b/src/transformers/models/vit_mae/modeling_vit_mae.py
@@ -152,7 +152,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype for the returned tensor.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -161,11 +161,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float32, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float32, device=device)
+    grid_w = torch.arange(width, dtype=torch.float32, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -174,7 +174,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float32, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 

--- a/src/transformers/models/vit_mae/modular_vit_mae.py
+++ b/src/transformers/models/vit_mae/modular_vit_mae.py
@@ -62,7 +62,7 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype for the returned tensor.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -71,11 +71,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float32, device=device) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float32, device=device)
+    grid_w = torch.arange(width, dtype=torch.float32, device=device)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -84,7 +84,7 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float32, device=device), pos_embed], dim=0)
 
     return pos_embed.to(dtype)
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47234)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47234)
<!-- ci-dashboard-badge:end -->

Fixes #46159

## What happened

`build_2d_sinusoidal_position_embedding` (defined in `modular_vit_mae.py`, reused by RT-DETR and RT-DETRv2) already accepts a `dtype` parameter that defaults to `torch.float32` and converts its output via `.to(dtype)`. However, every internal tensor allocation hardcoded `torch.float64`, which MPS does not support, crashing with:

```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.
```

## Fix

Replace the three hardcoded `dtype=torch.float64` arguments inside the function body with `dtype=torch.float32`. The output is still cast to the caller-requested `dtype` at the end, so behaviour on CUDA/CPU is unchanged. Float32 precision is more than sufficient for sinusoidal position embeddings.

Changed files:
- `src/transformers/models/vit_mae/modular_vit_mae.py` (source of truth)
- `src/transformers/models/vit_mae/modeling_vit_mae.py` (generated)
- `src/transformers/models/rt_detr/modeling_rt_detr.py` (generated)
- `src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py` (generated)