### PR TITLE
Fix double-shift training loss in CohereAsrForConditionalGeneration

### DIFF
--- a/src/transformers/models/cohere_asr/modeling_cohere_asr.py
+++ b/src/transformers/models/cohere_asr/modeling_cohere_asr.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
+from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
@@ -637,7 +638,8 @@ class CohereAsrForConditionalGeneration(CohereAsrPreTrainedModel, GenerationMixi
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
+            loss_fct = CrossEntropyLoss()
+            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/src/transformers/models/cohere_asr/modular_cohere_asr.py
+++ b/src/transformers/models/cohere_asr/modular_cohere_asr.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
+from torch.nn import CrossEntropyLoss
 
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
 from ...generation import GenerationMixin
@@ -500,7 +501,8 @@ class CohereAsrForConditionalGeneration(MoonshineForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
+            loss_fct = CrossEntropyLoss()
+            loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
 
         return Seq2SeqLMOutput(
             loss=loss,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47235)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47235)
<!-- ci-dashboard-badge:end -->

Fixes #46894

## Problem

`CohereAsrForConditionalGeneration.forward()` has a double-shift bug that corrupts training loss:

1. When `labels` are provided, `shift_tokens_right()` is called to produce `decoder_input_ids` (line 483 of `modular_cohere_asr.py`).
2. The model runs with these shifted inputs and produces `logits`.
3. `self.loss_function()` is then called — but this maps to `ForCausalLMLoss`, which **shifts labels again** internally (`labels[..., 1:]`) in `loss/loss_utils.py`.

The net effect is training against `labels[..., 1:]` instead of `labels`, causing silent gradient corruption and divergent training loss.

This is the same bug that was fixed in Moonshine in #46784 (commit d8c235494e). `CohereAsr` inherits from Moonshine and overrides `forward`, but the fix was not carried over.

## Fix

Replace `self.loss_function(logits=logits, labels=labels, ...)` with a direct `CrossEntropyLoss()` call — identical to the Moonshine fix:

```python
loss_fct = CrossEntropyLoss()
loss = loss_fct(logits.reshape(-1, self.config.vocab_size), labels.reshape(-1))
```

Applied to both `modular_cohere_asr.py` (source) and `modeling_cohere_asr.py` (generated).