### PR TITLE
Fix half-precision torch.compile crash in DETR-family sine position embeddings

### DIFF
--- a/src/transformers/models/conditional_detr/modeling_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modeling_conditional_detr.py
@@ -324,14 +324,23 @@ class ConditionalDetrSinePositionEmbedding(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/conditional_detr/modeling_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modeling_conditional_detr.py
@@ -326,8 +326,12 @@ class ConditionalDetrSinePositionEmbedding(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -373,8 +373,12 @@ class DeformableDetrSinePositionEmbedding(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = (y_embed - 0.5) / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -371,14 +371,23 @@ class DeformableDetrSinePositionEmbedding(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = (y_embed - 0.5) / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/deformable_detr/modular_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modular_deformable_detr.py
@@ -401,8 +401,12 @@ class DeformableDetrSinePositionEmbedding(DetrSinePositionEmbedding):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = (y_embed - 0.5) / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/deformable_detr/modular_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modular_deformable_detr.py
@@ -399,14 +399,23 @@ class DeformableDetrSinePositionEmbedding(DetrSinePositionEmbedding):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = (y_embed - 0.5) / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/detr/modeling_detr.py
+++ b/src/transformers/models/detr/modeling_detr.py
@@ -324,14 +324,23 @@ class DetrSinePositionEmbedding(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/detr/modeling_detr.py
+++ b/src/transformers/models/detr/modeling_detr.py
@@ -326,8 +326,12 @@ class DetrSinePositionEmbedding(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/edgetam/modeling_edgetam.py
+++ b/src/transformers/models/edgetam/modeling_edgetam.py
@@ -348,14 +348,23 @@ class EdgeTamSinePositionEmbedding(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/edgetam/modeling_edgetam.py
+++ b/src/transformers/models/edgetam/modeling_edgetam.py
@@ -350,8 +350,12 @@ class EdgeTamSinePositionEmbedding(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/edgetam_video/modeling_edgetam_video.py
+++ b/src/transformers/models/edgetam_video/modeling_edgetam_video.py
@@ -640,8 +640,12 @@ class EdgeTamVideoPositionEmbeddingSine(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/edgetam_video/modeling_edgetam_video.py
+++ b/src/transformers/models/edgetam_video/modeling_edgetam_video.py
@@ -638,14 +638,23 @@ class EdgeTamVideoPositionEmbeddingSine(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/mask2former/modeling_mask2former.py
+++ b/src/transformers/models/mask2former/modeling_mask2former.py
@@ -871,14 +871,23 @@ class Mask2FormerSinePositionEmbedding(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/mask2former/modeling_mask2former.py
+++ b/src/transformers/models/mask2former/modeling_mask2former.py
@@ -873,8 +873,12 @@ class Mask2FormerSinePositionEmbedding(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/maskformer/modeling_maskformer.py
+++ b/src/transformers/models/maskformer/modeling_maskformer.py
@@ -1483,8 +1483,12 @@ class MaskFormerSinePositionEmbedding(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/maskformer/modeling_maskformer.py
+++ b/src/transformers/models/maskformer/modeling_maskformer.py
@@ -1481,14 +1481,23 @@ class MaskFormerSinePositionEmbedding(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/oneformer/modeling_oneformer.py
+++ b/src/transformers/models/oneformer/modeling_oneformer.py
@@ -2388,8 +2388,12 @@ class OneFormerSinePositionEmbedding(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/oneformer/modeling_oneformer.py
+++ b/src/transformers/models/oneformer/modeling_oneformer.py
@@ -2386,14 +2386,23 @@ class OneFormerSinePositionEmbedding(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/sam2/modeling_sam2.py
+++ b/src/transformers/models/sam2/modeling_sam2.py
@@ -171,8 +171,12 @@ class Sam2SinePositionEmbedding(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/sam2/modeling_sam2.py
+++ b/src/transformers/models/sam2/modeling_sam2.py
@@ -169,14 +169,23 @@ class Sam2SinePositionEmbedding(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/sam2_video/modeling_sam2_video.py
+++ b/src/transformers/models/sam2_video/modeling_sam2_video.py
@@ -402,8 +402,12 @@ class Sam2VideoPositionEmbeddingSine(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/sam2_video/modeling_sam2_video.py
+++ b/src/transformers/models/sam2_video/modeling_sam2_video.py
@@ -400,14 +400,23 @@ class Sam2VideoPositionEmbeddingSine(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/sam3/modeling_sam3.py
+++ b/src/transformers/models/sam3/modeling_sam3.py
@@ -938,14 +938,23 @@ class Sam3SinePositionEmbedding(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/sam3/modeling_sam3.py
+++ b/src/transformers/models/sam3/modeling_sam3.py
@@ -940,8 +940,12 @@ class Sam3SinePositionEmbedding(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/sam3_lite_text/modeling_sam3_lite_text.py
+++ b/src/transformers/models/sam3_lite_text/modeling_sam3_lite_text.py
@@ -753,8 +753,12 @@ class Sam3LiteTextSinePositionEmbedding(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/sam3_lite_text/modeling_sam3_lite_text.py
+++ b/src/transformers/models/sam3_lite_text/modeling_sam3_lite_text.py
@@ -751,14 +751,23 @@ class Sam3LiteTextSinePositionEmbedding(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
+++ b/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
@@ -405,14 +405,23 @@ class Sam3TrackerVideoPositionEmbeddingSine(nn.Module):
         temperature: int = 10000,
         mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        batch_size, _, height, width = shape
         if mask is None:
-            mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
-        # matches an inductor rewrite pattern that drops the dtype argument, breaking
-        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
-        embed_mask = mask.to(dtype)
-        y_embed = embed_mask.cumsum(1)
-        x_embed = embed_mask.cumsum(2)
+            # Without a mask this is just a cumsum over ones, written out as arange
+            # instead: inductor's cumsum(ones) rewrite drops the requested dtype
+            # (https://github.com/pytorch/pytorch/issues/189518), which breaks
+            # float16/bfloat16 under torch.compile — don't revert to cumsum here
+            # until that fix is widely released.
+            y_embed = torch.arange(1, height + 1, dtype=dtype, device=device)[None, :, None].expand(
+                batch_size, height, width
+            )
+            x_embed = torch.arange(1, width + 1, dtype=dtype, device=device)[None, None, :].expand(
+                batch_size, height, width
+            )
+        else:
+            embed_mask = mask.to(dtype)
+            y_embed = embed_mask.cumsum(1)
+            x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
+++ b/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
@@ -407,8 +407,12 @@ class Sam3TrackerVideoPositionEmbeddingSine(nn.Module):
     ) -> torch.Tensor:
         if mask is None:
             mask = torch.ones((shape[0], shape[2], shape[3]), device=device, dtype=torch.bool)
-        y_embed = mask.cumsum(1, dtype=dtype)
-        x_embed = mask.cumsum(2, dtype=dtype)
+        # Cast before the cumsum instead of passing dtype= to it: cumsum(ones(bool), dtype=...)
+        # matches an inductor rewrite pattern that drops the dtype argument, breaking
+        # float16/bfloat16 under torch.compile (https://github.com/huggingface/transformers/issues/47228)
+        embed_mask = mask.to(dtype)
+        y_embed = embed_mask.cumsum(1)
+        x_embed = embed_mask.cumsum(2)
         if normalize:
             eps = 1e-6
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * scale

--- a/tests/models/sam3/test_modeling_sam3.py
+++ b/tests/models/sam3/test_modeling_sam3.py
@@ -14,6 +14,7 @@
 """Testing suite for the PyTorch SAM3 model."""
 
 import gc
+import math
 import tempfile
 import unittest
 
@@ -1544,3 +1545,29 @@ class Sam3ModelIntegrationTest(unittest.TestCase):
         torch.testing.assert_close(outputs_with_embeds.pred_logits, outputs_direct.pred_logits, atol=1e-5, rtol=1e-5)
         torch.testing.assert_close(outputs_with_embeds.pred_boxes, outputs_direct.pred_boxes, atol=1e-5, rtol=1e-5)
         torch.testing.assert_close(outputs_with_embeds.pred_masks, outputs_direct.pred_masks, atol=1e-5, rtol=1e-5)
+
+
+@require_torch
+class Sam3SinePositionEmbeddingTest(unittest.TestCase):
+    def test_compiled_build_keeps_requested_dtype(self):
+        """Regression test for #47228: the cumsum-on-bool-ones formulation matched an
+        inductor rewrite that dropped the requested dtype, so half-precision models
+        crashed under torch.compile with a Float/BFloat16 matmul mismatch."""
+        from transformers.models.sam3.modeling_sam3 import Sam3SinePositionEmbedding
+
+        def build(pixel_values):
+            return Sam3SinePositionEmbedding.build_sine_position_embedding(
+                pixel_values.shape,
+                pixel_values.device,
+                pixel_values.dtype,
+                num_position_features=32,
+                normalize=True,
+                scale=2 * math.pi,
+            )
+
+        pixel_values = torch.zeros(1, 3, 8, 8, device=torch_device, dtype=torch.bfloat16)
+        eager = build(pixel_values)
+        compiled = torch.compile(build)(pixel_values)
+
+        self.assertEqual(compiled.dtype, torch.bfloat16)
+        torch.testing.assert_close(compiled, eager, atol=2e-2, rtol=2e-2)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47238)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47238)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47228 (Sam3 bf16 compilation regression, v5.8.0 → v5.9.0).

**Root cause.** #45922 rewrote the sine position embedding to `torch.ones(..., dtype=torch.bool).cumsum(dim, dtype=dtype)`. That exact shape matches TorchInductor's `pointless_cumsum_replacement` post-grad pattern (`torch/_inductor/fx_passes/post_grad.py`), which rewrites `cumsum(full(...))` into an `arange`-based expression using the *ones tensor's* dtype — silently dropping the explicit `dtype=` argument. The embeddings come out `int64`, get promoted to `float32` by the normalize division, and the encoder q/k/v `addmm` crashes with `mat1 and mat2 must have the same dtype, but got Float and BFloat16`. Eager mode never runs the pass (hence eager works); the pre-#45922 formulation didn't match the pattern (hence v5.8.0 works). Bisect confirmation: `torch._inductor.config.pattern_matcher=False` makes v5.9.0+ pass.

**Fix.** Cast before the cumsum (`embed_mask = mask.to(dtype)` → `cumsum(dim)`), which restores the pre-#45922 numerics exactly and no longer matches the inductor pattern. The same construct was inherited by 13 other modeling files (sam2/sam3/edgetam families via modular from DETR; maskformer→mask2former/oneformer via copies), so the identical minimal patch is applied uniformly to all 14 (+ the deformable_detr modular source). The dtype-dropping pattern itself is arguably an inductor soundness bug — I'll file it upstream and link it here; regardless, transformers shouldn't emit the fragile construct in half precision.

**Verification** (Apple Silicon, torch 2.13, commit 0bc355418):
- Tiny randomly-initialized `Sam3Model` (mirroring `Sam3ModelTester` config, `HF_HUB_OFFLINE=1`): `torch.compile` forward in bf16 crashes with the reporter's exact error on both `cpu` and `mps` before this patch; passes on both after, with values matching eager.
- New regression test (`Sam3SinePositionEmbeddingTest::test_compiled_build_keeps_requested_dtype`): compiled build returns `bfloat16` — fails on the unpatched code (returns `float32`), passes with the fix.
- `tests/models/sam3` + `tests/models/detr` fast suites: identical results to `main` (same 7 pre-existing env-dependent failures on my machine, both sides; my new test passes).

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed via a GitHub issue? → #47228
- [x] Did you write any new necessary tests?

## Who can review?

@Cyrilvallez @molbap (vision / DETR-family; compile)

*Prepared with AI assistance; I reviewed and stand by every line, and reproduced the failure and fix locally before submitting.*