### PR TITLE
Be more defensive with `remap_legacy_layer_types` for custom models

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -497,8 +497,10 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
                 return
             if self.is_custom_code():
                 # Custom code may have legacy layer types that need to be remapped
-                layers = remap_legacy_layer_types(layers)
-                setattr(self, layer_types, layers)
+                if (remapped := remap_legacy_layer_types(layers)) != layers:
+                    # Only try setattr if layers changed in case layer_types is a read-only property
+                    setattr(self, layer_types, remapped)
+                layers = remapped
             if not all(layer_type in ALLOWED_LAYER_TYPES for layer_type in layers):
                 raise ValueError(f"The `{layer_types}` entries must be in {ALLOWED_LAYER_TYPES} but got {layers}")
             elif self.num_hidden_layers is not None and self.num_hidden_layers != len(layers):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47245)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47245)
<!-- ci-dashboard-badge:end -->

https://github.com/huggingface/transformers/pull/47174 unconditionally calls `setattr` on `layer_types` even if they are unchanged. This causes errors on models where `layer_types` is a read-only property (i.e. Plamo3).

This PR updates this logic so `setattr` is only called if the the names changed, so this will happen less often.