### PR TITLE
Fix FA2 long-context perf regression from removed .item() sync (#46693)

### DIFF
--- a/bench_fa2_unpad.py
+++ b/bench_fa2_unpad.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+"""
+Microbenchmark for FA2 _get_unpad_data + _index_first_axis performance.
+
+Tests the performance difference between passing max_seqlen_in_batch as:
+- Python int (via .item())
+- 0-dim CUDA tensor (no .item())
+
+This isolates the kernel dispatch / sync overhead under large KV cache / 
+bandwidth-saturated conditions.
+"""
+import argparse
+import torch
+import torch.nn.functional as F
+import time
+import sys
+
+# Add transformers to path
+sys.path.insert(0, "src")
+
+from transformers.modeling_flash_attention_utils import (
+    _get_unpad_data,
+    _index_first_axis,
+    _unpad_input,
+)
+
+
+def create_attention_mask(batch_size, seq_len, device, pad_ratio=0.0):
+    """Create attention mask with optional padding."""
+    if pad_ratio > 0:
+        # Create variable length sequences
+        lengths = torch.randint(
+            int(seq_len * (1 - pad_ratio)), seq_len + 1, (batch_size,), device=device
+        )
+        mask = torch.arange(seq_len, device=device).expand(batch_size, -1) < lengths.unsqueeze(1)
+    else:
+        mask = torch.ones(batch_size, seq_len, dtype=torch.bool, device=device)
+    return mask
+
+
+def benchmark_unpad_data(attention_mask, num_iters=100, warmup=10):
+    """Benchmark _get_unpad_data + downstream _index_first_axis."""
+    device = attention_mask.device
+    batch_size, seq_len = attention_mask.shape
+    
+    # Create dummy hidden states
+    hidden_dim = 128
+    num_heads = 32
+    dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
+    hidden_states = torch.randn(
+        batch_size, seq_len, num_heads, hidden_dim, 
+        device=device, dtype=dtype
+    )
+    
+    # Warmup
+    for _ in range(warmup):
+        indices, cu_seqlens, max_seqlen = _get_unpad_data(attention_mask)
+        _ = _index_first_axis(hidden_states, indices)
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+    
+    # Benchmark with scalar max_seqlen (via .item())
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    start = time.perf_counter()
+    for _ in range(num_iters):
+        indices, cu_seqlens, max_seqlen = _get_unpad_data(attention_mask)
+        # Simulate downstream usage: pass max_seqlen to flash_attn_varlen_func
+        # Here we just use it in a dummy op to prevent optimization
+        _ = _index_first_axis(hidden_states, indices)
+        _ = max_seqlen + 1  # Use the scalar
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    scalar_time = time.perf_counter() - start
+    
+    return scalar_time / num_iters * 1000  # ms per iter
+
+
+def benchmark_unpad_data_tensor_max_seqlen(attention_mask, num_iters=100, warmup=10):
+    """Benchmark _get_unpad_data WITHOUT .item() - keeping max_seqlen as tensor."""
+    device = attention_mask.device
+    batch_size, seq_len = attention_mask.shape
+    
+    hidden_dim = 128
+    num_heads = 32
+    dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
+    hidden_states = torch.randn(
+        batch_size, seq_len, num_heads, hidden_dim, 
+        device=device, dtype=dtype
+    )
+    
+    # Monkey-patch to remove .item() call
+    def patched_get_unpad_data(attention_mask):
+        seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
+        indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
+        max_seqlen_in_batch = seqlens_in_batch.max()  # NO .item()
+        cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
+        return indices, cu_seqlens, max_seqlen_in_batch
+    
+    # Warmup
+    for _ in range(warmup):
+        indices, cu_seqlens, max_seqlen = patched_get_unpad_data(attention_mask)
+        _ = _index_first_axis(hidden_states, indices)
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+    
+    # Benchmark with tensor max_seqlen
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    start = time.perf_counter()
+    for _ in range(num_iters):
+        indices, cu_seqlens, max_seqlen = patched_get_unpad_data(attention_mask)
+        _ = _index_first_axis(hidden_states, indices)
+        _ = max_seqlen + 1  # Use the tensor
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    tensor_time = time.perf_counter() - start
+    
+    return tensor_time / num_iters * 1000  # ms per iter
+
+
+def benchmark_with_profiler(attention_mask, num_iters=20):
+    """Run with torch.profiler to analyze kernel dispatch differences."""
+    device = attention_mask.device
+    batch_size, seq_len = attention_mask.shape
+    hidden_dim = 128
+    num_heads = 32
+    dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
+    hidden_states = torch.randn(
+        batch_size, seq_len, num_heads, hidden_dim, 
+        device=device, dtype=dtype
+    )
+    
+    activities = [torch.profiler.ProfilerActivity.CPU]
+    if device.type == "cuda":
+        activities.append(torch.profiler.ProfilerActivity.CUDA)
+    
+    # Profile scalar path
+    print("\n=== Profiling SCALAR max_seqlen path ===")
+    with torch.profiler.profile(
+        activities=activities,
+        record_shapes=True,
+        profile_memory=True,
+        with_stack=True,
+    ) as prof:
+        for _ in range(num_iters):
+            indices, cu_seqlens, max_seqlen = _get_unpad_data(attention_mask)
+            _ = _index_first_axis(hidden_states, indices)
+            _ = max_seqlen + 1
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+    
+    print(prof.key_averages().table(sort_by="cuda_time_total" if device.type == "cuda" else "cpu_time_total", row_limit=20))
+    
+    # Profile tensor path
+    def patched_get_unpad_data(attention_mask):
+        seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
+        indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
+        max_seqlen_in_batch = seqlens_in_batch.max()  # NO .item()
+        cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
+        return indices, cu_seqlens, max_seqlen_in_batch
+    
+    print("\n=== Profiling TENSOR max_seqlen path ===")
+    with torch.profiler.profile(
+        activities=activities,
+        record_shapes=True,
+        profile_memory=True,
+        with_stack=True,
+    ) as prof:
+        for _ in range(num_iters):
+            indices, cu_seqlens, max_seqlen = patched_get_unpad_data(attention_mask)
+            _ = _index_first_axis(hidden_states, indices)
+            _ = max_seqlen + 1
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+    
+    print(prof.key_averages().table(sort_by="cuda_time_total" if device.type == "cuda" else "cpu_time_total", row_limit=20))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="FA2 unpad microbenchmark")
+    parser.add_argument("--batch", type=int, default=4, help="Batch size")
+    parser.add_argument("--seq-len", type=int, default=8192, help="Sequence length")
+    parser.add_argument("--pad-ratio", type=float, default=0.0, help="Padding ratio (0-1)")
+    parser.add_argument("--iters", type=int, default=100, help="Number of iterations")
+    parser.add_argument("--warmup", type=int, default=10, help="Warmup iterations")
+    parser.add_argument("--profile", action="store_true", help="Run with profiler")
+    parser.add_argument("--device", type=str, default="cuda", help="Device (cuda/cpu)")
+    args = parser.parse_args()
+    
+    if not torch.cuda.is_available() and args.device == "cuda":
+        print("CUDA not available, falling back to CPU")
+        args.device = "cpu"
+    
+    device = torch.device(args.device)
+    print(f"Device: {device}")
+    print(f"Batch size: {args.batch}, Seq len: {args.seq_len}, Pad ratio: {args.pad_ratio}")
+    
+    attention_mask = create_attention_mask(args.batch, args.seq_len, device, args.pad_ratio)
+    
+    print(f"\nMask shape: {attention_mask.shape}, Non-zero: {attention_mask.sum().item()}")
+    
+    if args.profile:
+        benchmark_with_profiler(attention_mask, num_iters=min(args.iters, 20))
+    else:
+        scalar_ms = benchmark_unpad_data(attention_mask, args.iters, args.warmup)
+        tensor_ms = benchmark_unpad_data_tensor_max_seqlen(attention_mask, args.iters, args.warmup)
+        
+        print(f"\nResults (avg over {args.iters} iters):")
+        print(f"  Scalar max_seqlen (.item()):  {scalar_ms:.3f} ms/iter")
+        print(f"  Tensor max_seqlen (no .item()): {tensor_ms:.3f} ms/iter")
+        print(f"  Slowdown: {tensor_ms / scalar_ms:.2f}x ({(tensor_ms - scalar_ms) / scalar_ms * 100:.1f}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -33,7 +33,7 @@ from .utils import (
     logging,
 )
 from .utils.generic import split_attention_implementation
-from .utils.import_utils import PACKAGE_DISTRIBUTION_MAPPING, is_tracing
+from .utils.import_utils import PACKAGE_DISTRIBUTION_MAPPING, is_torchdynamo_compiling
 
 
 logger = logging.get_logger(__name__)
@@ -317,6 +317,8 @@ def _unpad_input(hidden_states, attention_mask, unused_mask=None):
     used_seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
     indices = torch.nonzero(all_masks.flatten(), as_tuple=False).flatten()
     max_seqlen_in_batch = seqlens_in_batch.max()
+    if not is_torchdynamo_compiling():
+        max_seqlen_in_batch = max_seqlen_in_batch.item()
     cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
 
     return (
@@ -366,6 +368,8 @@ def _get_unpad_data(attention_mask: torch.Tensor) -> tuple[torch.Tensor, torch.T
     seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
     indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
     max_seqlen_in_batch = seqlens_in_batch.max()
+    if not is_torchdynamo_compiling():
+        max_seqlen_in_batch = max_seqlen_in_batch.item()
     cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
     return (
         indices,
@@ -487,6 +491,9 @@ def prepare_fa_kwargs_from_position_ids(position_ids):
     # for some models (e.g. qwen2-vl).
     max_length_q = cu_seq_lens_q.diff().max()
     max_length_k = max_length_q
+    if not is_torchdynamo_compiling():
+        max_length_q = max_length_q.item()
+        max_length_k = max_length_k.item()
 
     return (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k)
 
@@ -673,15 +680,23 @@ def _process_flash_attention_kwargs(
     # to allow torch compile to handle scalar outputs in those cases.
     same_max_seqlen = max_seqlen_q is max_seqlen_k  # to avoid 2x device syncs
     if supports_mapping["max_seqlen_q"] and max_seqlen_q is not None:
-        if not isinstance(max_seqlen_q, int) and is_tracing(max_seqlen_q):
-            max_seqlen_q = max_seqlen_q.item()
+        if not isinstance(max_seqlen_q, int):
+            if is_torchdynamo_compiling():
+                # Under compile, keep as tensor to avoid graph break
+                pass
+            else:
+                max_seqlen_q = max_seqlen_q.item()
         flash_kwargs["max_seqlen_q"] = max_seqlen_q
 
     if supports_mapping["max_seqlen_k"] and max_seqlen_k is not None:
         if same_max_seqlen and flash_kwargs["max_seqlen_q"] is not None:
             max_seqlen_k = flash_kwargs["max_seqlen_q"]
-        elif not isinstance(max_seqlen_k, int) and is_tracing(max_seqlen_k):
-            max_seqlen_k = max_seqlen_k.item()
+        elif not isinstance(max_seqlen_k, int):
+            if is_torchdynamo_compiling():
+                # Under compile, keep as tensor to avoid graph break
+                pass
+            else:
+                max_seqlen_k = max_seqlen_k.item()
         flash_kwargs["max_seqlen_k"] = max_seqlen_k
 
     return flash_kwargs

--- a/tests/utils/test_flash_attention_utils.py
+++ b/tests/utils/test_flash_attention_utils.py
@@ -1,0 +1,95 @@
+# Copyright 2025 HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import torch
+
+from transformers.modeling_flash_attention_utils import _get_unpad_data, _unpad_input
+from transformers.utils.import_utils import is_torchdynamo_compiling
+
+
+class FlashAttentionUtilsTest(unittest.TestCase):
+    def test_get_unpad_data_returns_scalar_when_not_compiling(self):
+        """
+        Regression test for #46693: _get_unpad_data should return max_seqlen_in_batch
+        as a Python int (not a 0-dim tensor) when not under torch.compile,
+        to avoid performance regression on large KV caches.
+        """
+        # Skip if we're somehow compiling during test collection
+        if is_torchdynamo_compiling():
+            self.skipTest("Test not valid under torch.compile")
+        
+        batch_size = 4
+        seq_len = 1024
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        
+        # Create attention mask (all ones = no padding)
+        attention_mask = torch.ones(batch_size, seq_len, dtype=torch.int32, device=device)
+        
+        indices, cu_seqlens, max_seqlen_in_batch = _get_unpad_data(attention_mask)
+        
+        # max_seqlen_in_batch should be a Python int, not a tensor
+        self.assertIsInstance(max_seqlen_in_batch, int, 
+            f"Expected max_seqlen_in_batch to be int, got {type(max_seqlen_in_batch)}")
+        self.assertEqual(max_seqlen_in_batch, seq_len)
+        
+        # indices and cu_seqlens should still be tensors
+        self.assertIsInstance(indices, torch.Tensor)
+        self.assertIsInstance(cu_seqlens, torch.Tensor)
+
+    def test_unpad_input_returns_scalar_when_not_compiling(self):
+        """
+        Regression test for #46693: _unpad_input should return max_seqlen_in_batch
+        as a Python int when not under torch.compile.
+        """
+        if is_torchdynamo_compiling():
+            self.skipTest("Test not valid under torch.compile")
+        
+        batch_size = 2
+        seq_len = 512
+        hidden_dim = 64
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        
+        hidden_states = torch.randn(batch_size, seq_len, hidden_dim, device=device)
+        attention_mask = torch.ones(batch_size, seq_len, dtype=torch.int32, device=device)
+        
+        _, _, _, max_seqlen_in_batch, _ = _unpad_input(hidden_states, attention_mask)
+        
+        self.assertIsInstance(max_seqlen_in_batch, int,
+            f"Expected max_seqlen_in_batch to be int, got {type(max_seqlen_in_batch)}")
+        self.assertEqual(max_seqlen_in_batch, seq_len)
+
+    def test_get_unpad_data_with_padding(self):
+        """Test _get_unpad_data with variable sequence lengths (padding)."""
+        if is_torchdynamo_compiling():
+            self.skipTest("Test not valid under torch.compile")
+        
+        batch_size = 4
+        seq_len = 1024
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        
+        # Create attention mask with padding (last 256 tokens masked)
+        attention_mask = torch.ones(batch_size, seq_len, dtype=torch.int32, device=device)
+        attention_mask[:, -256:] = 0
+        
+        indices, cu_seqlens, max_seqlen_in_batch = _get_unpad_data(attention_mask)
+        
+        self.assertIsInstance(max_seqlen_in_batch, int)
+        self.assertEqual(max_seqlen_in_batch, seq_len - 256)
+        self.assertEqual(cu_seqlens.shape[0], batch_size + 1)
+        self.assertEqual(cu_seqlens[-1].item(), batch_size * (seq_len - 256))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
What does this PR do?
Fixes #46693 — FA2 long-context generation perf regression (5.2.0 → 5.4.0+, ~17% slower on large KV caches).
Supersedes #47215 (closed — that branch had picked up unrelated commits from other local branches, causing CI/security-gate noise unrelated to this fix). This PR is scoped to exactly 3 files.
Root cause
PR #42435 removed .item() calls on max_seqlen_in_batch in three places, leaving it as a 0-dim CUDA tensor instead of a Python int:

_get_unpad_data()
_unpad_input()
prepare_fa_kwargs_from_position_ids()

These tensors are passed directly into flash_attn_varlen_func(max_seqlen_q=..., max_seqlen_k=...). On bandwidth-saturated GPUs with large KV caches (RTX 6000 Pro noticeably more than RTX 4090), this adds kernel-dispatch/sync overhead per decode step that compounds over long generations.
Fix
Restored .item() at all three call sites, guarded by is_torchdynamo_compiling() so torch.compile graph capture isn't broken — tensor form preserved under compile, scalar form used in eager. Also updated _process_flash_attention_kwargs() to convert to int in eager mode consistently (previously only converted during tracing).
Verification

Regression test asserting scalar type in eager mode (tests/utils/test_flash_attention_utils.py)
Standalone microbenchmark isolating the mechanism (bench_fa2_unpad.py)
ruff check / ruff format --check clean, utils/check_copies.py passes

Relates to the investigation in #47134 (draft) — this should close the residual gap flagged there.
cc @vasqu @zucchini-nlp @andreasgoulas
Before submitting

 Did you read the contributor guideline and the Pull Request checks?
 Was this discussed/approved via a GitHub issue? Yes — #46693
 Did you write any new necessary tests?