### PR TITLE
Fix InputTokensDetails missing cache_write_tokens for openai>=2.34.0

### DIFF
--- a/src/transformers/cli/serving/response.py
+++ b/src/transformers/cli/serving/response.py
@@ -774,6 +774,9 @@ def compute_usage(input_tokens: int, output_tokens: int) -> ResponseUsage:
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=input_tokens + output_tokens,
-        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        input_tokens_details=InputTokensDetails(
+            cached_tokens=0,
+            **{"cache_write_tokens": 0} if "cache_write_tokens" in InputTokensDetails.model_fields else {},
+        ),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
     )


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47248)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47248)
<!-- ci-dashboard-badge:end -->

## What this does

`openai==2.34.0` added `cache_write_tokens` as a required field to `InputTokensDetails`. This causes `compute_usage` to fail with a `ValidationError` when running with `openai>=2.34.0` (CI currently uses `openai==2.45.0`).

## Fix

Passes `cache_write_tokens=0` when the installed openai version has that field, using `model_fields` to stay compatible with older versions (`openai<2.34.0`).