### PR TITLE
Fix inter-chunk recurrence in the Zamba2 / Nemotron-H Mamba2 slow path

### DIFF
--- a/src/transformers/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modeling_nemotron_h.py
@@ -551,9 +551,8 @@ class NemotronHMamba2Mixer(nn.Module):
             states = torch.cat([previous_states, states], dim=1)
             decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:, :, :, -1], (1, 0))))
 
-            states_permuted = states.permute(0, 2, 1, 3, 4)
-            result = (decay_chunk[..., None, None] * states_permuted[:, :, None, ...]).sum(dim=2)
-            new_states = result.permute(0, 2, 1, 3, 4)
+            decay_chunk = decay_chunk.transpose(1, 3)
+            new_states = (decay_chunk[..., None, None] * states[:, :, None, ...]).sum(dim=1)
             states, ssm_state = new_states[:, :-1], new_states[:, -1]
 
             # Compute state -> output conversion per chunk

--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -839,9 +839,8 @@ class Zamba2MambaMixer(nn.Module):
             states = torch.cat([previous_states, states], dim=1)
             decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:, :, :, -1], (1, 0))))
 
-            states_permuted = states.permute(0, 2, 1, 3, 4)
-            result = (decay_chunk[..., None, None] * states_permuted[:, :, None, ...]).sum(dim=2)
-            new_states = result.permute(0, 2, 1, 3, 4)
+            decay_chunk = decay_chunk.transpose(1, 3)
+            new_states = (decay_chunk[..., None, None] * states[:, :, None, ...]).sum(dim=1)
             states, ssm_state = new_states[:, :-1], new_states[:, -1]
 
             # Compute state -> output conversion per chunk

--- a/src/transformers/models/zamba2/modular_zamba2.py
+++ b/src/transformers/models/zamba2/modular_zamba2.py
@@ -627,9 +627,8 @@ class Zamba2MambaMixer(nn.Module):
             states = torch.cat([previous_states, states], dim=1)
             decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:, :, :, -1], (1, 0))))
 
-            states_permuted = states.permute(0, 2, 1, 3, 4)
-            result = (decay_chunk[..., None, None] * states_permuted[:, :, None, ...]).sum(dim=2)
-            new_states = result.permute(0, 2, 1, 3, 4)
+            decay_chunk = decay_chunk.transpose(1, 3)
+            new_states = (decay_chunk[..., None, None] * states[:, :, None, ...]).sum(dim=1)
             states, ssm_state = new_states[:, :-1], new_states[:, -1]
 
             # Compute state -> output conversion per chunk

--- a/tests/models/nemotron_h/test_modeling_nemotron_h.py
+++ b/tests/models/nemotron_h/test_modeling_nemotron_h.py
@@ -361,29 +361,30 @@ class NemotronHModelTester:
         """
         Regression test for the inter-chunk recurrence of the Mamba2 slow (torch) path: a
         single chunked forward over a multi-chunk sequence must reproduce a token-by-token
-        recurrent decode.
+        recurrent decode. Forced onto CPU so the slow (`torch_forward`) path is exercised.
 
-        The mixer is fed a large-magnitude input so the SSM state is O(1). With a normal
-        activation scale the inter-chunk contribution is ~1e-7, i.e. below any tolerance,
-        which is why neither `create_and_check_mamba2_slow_vs_fast_forward` (single chunk,
-        needs the kernels) nor a plain `prepare_config_and_inputs` input surfaces the bug.
-        A small `chunk_size` lets a short sequence span several chunks. Runs on CPU without
-        the fast-path kernels.
+        A small `chunk_size` lets the short `prepare_config_and_inputs` sequence span several
+        chunks, and the embedded input is rescaled so the SSM state is O(1) -- at the natural
+        activation scale the inter-chunk contribution is ~1e-7 (below any tolerance), which is
+        why the single-chunk `slow_vs_fast` check does not surface this regression.
         """
         config = copy.deepcopy(config)
-        config.chunk_size = 8
-        model = NemotronHModel(config).eval().to(torch_device)
+        config.chunk_size = 2
+        torch.manual_seed(0)
+        model = NemotronHModel(config).eval().to("cpu")
         mixer = next(layer.mixer for layer in model.layers if getattr(layer, "block_type", None) == "linear_attention")
 
-        seq_len = 4 * config.chunk_size + 1
-        torch.manual_seed(0)
-        hidden_states = 100.0 * torch.randn(1, seq_len, config.hidden_size, device=torch_device)
+        embeds = model.embeddings(input_ids[:1].to("cpu"))
+        hidden_states = 100.0 * embeds / embeds.std()
 
         with torch.no_grad():
             chunked = mixer.torch_forward(hidden_states)
             cache = DynamicCache(config=config)
             recurrent = torch.cat(
-                [mixer.torch_forward(hidden_states[:, t : t + 1], cache_params=cache) for t in range(seq_len)],
+                [
+                    mixer.torch_forward(hidden_states[:, t : t + 1], cache_params=cache)
+                    for t in range(hidden_states.shape[1])
+                ],
                 dim=1,
             )
 

--- a/tests/models/nemotron_h/test_modeling_nemotron_h.py
+++ b/tests/models/nemotron_h/test_modeling_nemotron_h.py
@@ -520,6 +520,48 @@ class NemotronHModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mamba2_slow_vs_fast_forward(*config_and_inputs)
 
+    def test_mamba2_slow_path_multi_chunk(self):
+        """
+        Regression test for the inter-chunk recurrence in the Mamba2 slow (torch) path.
+
+        A single chunked forward over a multi-chunk sequence must match a token-by-token
+        recurrent decode. The input is deliberately large-magnitude so the SSM state is
+        O(1) and the inter-chunk contribution is not numerically negligible; with the
+        previous `.sum(dim=2)` reduction the two disagree by orders of magnitude. Runs on
+        CPU without the fast-path kernels.
+        """
+        config = NemotronHConfig(
+            vocab_size=99,
+            hidden_size=32,
+            mamba_num_heads=8,
+            mamba_head_dim=8,
+            ssm_state_size=16,
+            n_groups=1,
+            mamba_chunk_size=8,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=8,
+            intermediate_size=32,
+            use_mamba_kernels=False,
+            layers_block_type=["mamba"],
+        )
+        torch.manual_seed(0)
+        mixer = NemotronHModel(config).eval().to(torch_device).layers[0].mixer
+
+        seq_len = 5 * config.chunk_size + 3
+        hidden_states = 50.0 * torch.randn(1, seq_len, config.hidden_size, device=torch_device)
+
+        with torch.no_grad():
+            chunked = mixer.torch_forward(hidden_states)
+            cache = DynamicCache(config=config)
+            recurrent = torch.cat(
+                [mixer.torch_forward(hidden_states[:, t : t + 1], cache_params=cache) for t in range(seq_len)],
+                dim=1,
+            )
+
+        max_diff = (chunked - recurrent).abs().max().item()
+        self.assertLess(max_diff, 1e-3, f"slow-path chunked forward disagrees with recurrent decode: {max_diff}")
+
     def test_attention_outputs(self):
         r"""
         Overriding the test_attention_outputs test as the NemotronH model outputs attention only for its attention layers

--- a/tests/models/nemotron_h/test_modeling_nemotron_h.py
+++ b/tests/models/nemotron_h/test_modeling_nemotron_h.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Testing suite for the PyTorch NemotronH model."""
 
+import copy
 import tempfile
 import unittest
 
@@ -356,6 +357,41 @@ class NemotronHModelTester:
             msg=f"Max diff: {(ref_first - under_test_first).abs().max().item():.6f}",
         )
 
+    def create_and_check_nemotron_h_slow_path_multi_chunk(self, config, input_ids, *args):
+        """
+        Regression test for the inter-chunk recurrence of the Mamba2 slow (torch) path: a
+        single chunked forward over a multi-chunk sequence must reproduce a token-by-token
+        recurrent decode.
+
+        The mixer is fed a large-magnitude input so the SSM state is O(1). With a normal
+        activation scale the inter-chunk contribution is ~1e-7, i.e. below any tolerance,
+        which is why neither `create_and_check_mamba2_slow_vs_fast_forward` (single chunk,
+        needs the kernels) nor a plain `prepare_config_and_inputs` input surfaces the bug.
+        A small `chunk_size` lets a short sequence span several chunks. Runs on CPU without
+        the fast-path kernels.
+        """
+        config = copy.deepcopy(config)
+        config.chunk_size = 8
+        model = NemotronHModel(config).eval().to(torch_device)
+        mixer = next(layer.mixer for layer in model.layers if getattr(layer, "block_type", None) == "linear_attention")
+
+        seq_len = 4 * config.chunk_size + 1
+        torch.manual_seed(0)
+        hidden_states = 100.0 * torch.randn(1, seq_len, config.hidden_size, device=torch_device)
+
+        with torch.no_grad():
+            chunked = mixer.torch_forward(hidden_states)
+            cache = DynamicCache(config=config)
+            recurrent = torch.cat(
+                [mixer.torch_forward(hidden_states[:, t : t + 1], cache_params=cache) for t in range(seq_len)],
+                dim=1,
+            )
+
+        max_diff = (chunked - recurrent).abs().max().item()
+        self.parent.assertLess(
+            max_diff, 1e-3, f"slow-path chunked forward disagrees with recurrent decode: {max_diff}"
+        )
+
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
         (
@@ -521,46 +557,9 @@ class NemotronHModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         self.model_tester.create_and_check_mamba2_slow_vs_fast_forward(*config_and_inputs)
 
     def test_mamba2_slow_path_multi_chunk(self):
-        """
-        Regression test for the inter-chunk recurrence in the Mamba2 slow (torch) path.
-
-        A single chunked forward over a multi-chunk sequence must match a token-by-token
-        recurrent decode. The input is deliberately large-magnitude so the SSM state is
-        O(1) and the inter-chunk contribution is not numerically negligible; with the
-        previous `.sum(dim=2)` reduction the two disagree by orders of magnitude. Runs on
-        CPU without the fast-path kernels.
-        """
-        config = NemotronHConfig(
-            vocab_size=99,
-            hidden_size=32,
-            mamba_num_heads=8,
-            mamba_head_dim=8,
-            ssm_state_size=16,
-            n_groups=1,
-            mamba_chunk_size=8,
-            num_attention_heads=2,
-            num_key_value_heads=2,
-            head_dim=8,
-            intermediate_size=32,
-            use_mamba_kernels=False,
-            layers_block_type=["mamba"],
-        )
-        torch.manual_seed(0)
-        mixer = NemotronHModel(config).eval().to(torch_device).layers[0].mixer
-
-        seq_len = 5 * config.chunk_size + 3
-        hidden_states = 50.0 * torch.randn(1, seq_len, config.hidden_size, device=torch_device)
-
-        with torch.no_grad():
-            chunked = mixer.torch_forward(hidden_states)
-            cache = DynamicCache(config=config)
-            recurrent = torch.cat(
-                [mixer.torch_forward(hidden_states[:, t : t + 1], cache_params=cache) for t in range(seq_len)],
-                dim=1,
-            )
-
-        max_diff = (chunked - recurrent).abs().max().item()
-        self.assertLess(max_diff, 1e-3, f"slow-path chunked forward disagrees with recurrent decode: {max_diff}")
+        """The Mamba2 slow path must reproduce the token-by-token recurrence across chunks."""
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_nemotron_h_slow_path_multi_chunk(*config_and_inputs)
 
     def test_attention_outputs(self):
         r"""

--- a/tests/models/zamba2/test_modeling_zamba2.py
+++ b/tests/models/zamba2/test_modeling_zamba2.py
@@ -315,29 +315,30 @@ class Zamba2ModelTester:
         """
         Regression test for the inter-chunk recurrence of the Mamba2 slow (torch) path: a
         single chunked forward over a multi-chunk sequence must reproduce a token-by-token
-        recurrent decode.
+        recurrent decode. Forced onto CPU so the slow (`torch_forward`) path is exercised.
 
-        The mixer is fed a large-magnitude input so the SSM state is O(1). With a normal
-        activation scale the inter-chunk contribution is ~1e-7, i.e. below any tolerance,
-        which is why neither `create_and_check_zamba2_slow_vs_fast_forward` (single chunk,
-        needs the kernels) nor a plain `prepare_config_and_inputs` input surfaces the bug.
-        A small `chunk_size` lets a short sequence span several chunks. Runs on CPU without
-        the fast-path kernels.
+        A small `chunk_size` lets the short `prepare_config_and_inputs` sequence span several
+        chunks, and the embedded input is rescaled so the SSM state is O(1) -- at the natural
+        activation scale the inter-chunk contribution is ~1e-7 (below any tolerance), which is
+        why the single-chunk `slow_vs_fast` check does not surface this regression.
         """
         config = copy.deepcopy(config)
-        config.chunk_size = 8
-        model = Zamba2Model(config).eval().to(torch_device)
+        config.chunk_size = 2
+        torch.manual_seed(0)
+        model = Zamba2Model(config).eval().to("cpu")
         mixer = next(layer.mamba for layer in model.layers if hasattr(layer, "mamba"))
 
-        seq_len = 4 * config.chunk_size + 1
-        torch.manual_seed(0)
-        hidden_states = 100.0 * torch.randn(1, seq_len, config.hidden_size, device=torch_device)
+        embeds = model.embed_tokens(input_ids[:1].to("cpu"))
+        hidden_states = 100.0 * embeds / embeds.std()
 
         with torch.no_grad():
             chunked = mixer.torch_forward(hidden_states)
             cache = DynamicCache(config=config)
             recurrent = torch.cat(
-                [mixer.torch_forward(hidden_states[:, t : t + 1], cache_params=cache) for t in range(seq_len)],
+                [
+                    mixer.torch_forward(hidden_states[:, t : t + 1], cache_params=cache)
+                    for t in range(hidden_states.shape[1])
+                ],
                 dim=1,
             )
 

--- a/tests/models/zamba2/test_modeling_zamba2.py
+++ b/tests/models/zamba2/test_modeling_zamba2.py
@@ -30,6 +30,7 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
+from transformers.utils.import_utils import is_causal_conv1d_available, is_mamba_ssm_available
 
 from ...generation.test_utils import GenerationTesterMixin
 from ...test_configuration_common import ConfigTester
@@ -298,6 +299,34 @@ class Zamba2ModelTester:
             msg=f"Max diff: {(ref_first - under_test_first).abs().max().item():.6f}",
         )
 
+    def create_and_check_zamba2_slow_vs_fast_forward(self, config, input_ids, *args):
+        """
+        Test that cuda_kernels_forward and torch_forward produce consistent outputs for the
+        Mamba2 mixer, i.e. that the optimized CUDA kernel path and the pure PyTorch path are
+        equivalent. Guarded by the availability of the fast-path kernels and a CUDA device.
+        """
+        if not (is_mamba_ssm_available() and is_causal_conv1d_available()):
+            self.parent.skipTest(
+                "This test needs the Mamba2 fast path. Skipping as the necessary packages have not been found."
+            )
+        if torch_device != "cuda":
+            self.parent.skipTest("This test needs the Mamba2 fast path. Skipping as we need a cuda capable device.")
+
+        model = Zamba2Model(config)
+        model.eval()
+        model.to(torch_device)
+
+        # Find the first Mamba mixer in the model
+        mamba_mixer = next((layer.mamba for layer in model.layers if hasattr(layer, "mamba")), None)
+        if mamba_mixer is None:
+            self.parent.skipTest("No mamba layer found in the model configuration.")
+
+        hidden_states = model.embed_tokens(input_ids.to(torch_device))
+
+        outputs_fast = mamba_mixer.cuda_kernels_forward(hidden_states)
+        outputs_slow = mamba_mixer.torch_forward(hidden_states)
+        self.parent.assertTrue(torch.allclose(outputs_fast, outputs_slow, atol=1e-3, rtol=1e-3))
+
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
         (
@@ -350,6 +379,55 @@ class Zamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     def setUp(self):
         self.model_tester = Zamba2ModelTester(self)
         self.config_tester = ConfigTester(self, config_class=Zamba2Config, hidden_size=32)
+
+    def test_mamba2_slow_vs_fast_forward(self):
+        """
+        Test that cuda_kernels_forward and torch_forward produce consistent outputs.
+        """
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_zamba2_slow_vs_fast_forward(*config_and_inputs)
+
+    def test_mamba2_slow_path_multi_chunk(self):
+        """
+        Regression test for the inter-chunk recurrence in the Mamba2 slow (torch) path.
+
+        A single chunked forward over a multi-chunk sequence must match a token-by-token
+        recurrent decode. The input is deliberately large-magnitude so the SSM state is
+        O(1) and the inter-chunk contribution is not numerically negligible; with the
+        previous `.sum(dim=2)` reduction the two disagree by orders of magnitude. Runs on
+        CPU without the fast-path kernels.
+        """
+        config = Zamba2Config(
+            vocab_size=99,
+            hidden_size=32,
+            mamba_d_state=16,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            n_mamba_heads=8,
+            intermediate_size=8,
+            chunk_size=8,
+            mamba_ngroups=1,
+            use_mamba_kernels=False,
+            layers_block_type=["mamba"],
+            num_mem_blocks=1,
+            use_mem_rope=True,
+        )
+        torch.manual_seed(0)
+        mixer = Zamba2Model(config).eval().to(torch_device).layers[0].mamba
+
+        seq_len = 5 * config.chunk_size + 3
+        hidden_states = 50.0 * torch.randn(1, seq_len, config.hidden_size, device=torch_device)
+
+        with torch.no_grad():
+            chunked = mixer.torch_forward(hidden_states)
+            cache = DynamicCache(config=config)
+            recurrent = torch.cat(
+                [mixer.torch_forward(hidden_states[:, t : t + 1], cache_params=cache) for t in range(seq_len)],
+                dim=1,
+            )
+
+        max_diff = (chunked - recurrent).abs().max().item()
+        self.assertLess(max_diff, 1e-3, f"slow-path chunked forward disagrees with recurrent decode: {max_diff}")
 
     @unittest.skip("We need at leat 3 layers to test weight tying!")
     def test_num_layers_is_small(self):

--- a/tests/models/zamba2/test_modeling_zamba2.py
+++ b/tests/models/zamba2/test_modeling_zamba2.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Testing suite for the PyTorch Zamba model."""
 
+import copy
 import tempfile
 import unittest
 
@@ -30,7 +31,6 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
-from transformers.utils.import_utils import is_causal_conv1d_available, is_mamba_ssm_available
 
 from ...generation.test_utils import GenerationTesterMixin
 from ...test_configuration_common import ConfigTester
@@ -300,32 +300,51 @@ class Zamba2ModelTester:
         )
 
     def create_and_check_zamba2_slow_vs_fast_forward(self, config, input_ids, *args):
-        """
-        Test that cuda_kernels_forward and torch_forward produce consistent outputs for the
-        Mamba2 mixer, i.e. that the optimized CUDA kernel path and the pure PyTorch path are
-        equivalent. Guarded by the availability of the fast-path kernels and a CUDA device.
-        """
-        if not (is_mamba_ssm_available() and is_causal_conv1d_available()):
-            self.parent.skipTest(
-                "This test needs the Mamba2 fast path. Skipping as the necessary packages have not been found."
-            )
-        if torch_device != "cuda":
-            self.parent.skipTest("This test needs the Mamba2 fast path. Skipping as we need a cuda capable device.")
-
+        """Slow vs fast path check guarded by require kernels to enable fast path"""
         model = Zamba2Model(config)
         model.eval()
         model.to(torch_device)
 
-        # Find the first Mamba mixer in the model
-        mamba_mixer = next((layer.mamba for layer in model.layers if hasattr(layer, "mamba")), None)
-        if mamba_mixer is None:
-            self.parent.skipTest("No mamba layer found in the model configuration.")
-
-        hidden_states = model.embed_tokens(input_ids.to(torch_device))
-
+        mamba_mixer = next(layer.mamba for layer in model.layers if hasattr(layer, "mamba"))
+        hidden_states = model.embed_tokens(input_ids)
         outputs_fast = mamba_mixer.cuda_kernels_forward(hidden_states)
         outputs_slow = mamba_mixer.torch_forward(hidden_states)
         self.parent.assertTrue(torch.allclose(outputs_fast, outputs_slow, atol=1e-3, rtol=1e-3))
+
+    def create_and_check_zamba2_slow_path_multi_chunk(self, config, input_ids, *args):
+        """
+        Regression test for the inter-chunk recurrence of the Mamba2 slow (torch) path: a
+        single chunked forward over a multi-chunk sequence must reproduce a token-by-token
+        recurrent decode.
+
+        The mixer is fed a large-magnitude input so the SSM state is O(1). With a normal
+        activation scale the inter-chunk contribution is ~1e-7, i.e. below any tolerance,
+        which is why neither `create_and_check_zamba2_slow_vs_fast_forward` (single chunk,
+        needs the kernels) nor a plain `prepare_config_and_inputs` input surfaces the bug.
+        A small `chunk_size` lets a short sequence span several chunks. Runs on CPU without
+        the fast-path kernels.
+        """
+        config = copy.deepcopy(config)
+        config.chunk_size = 8
+        model = Zamba2Model(config).eval().to(torch_device)
+        mixer = next(layer.mamba for layer in model.layers if hasattr(layer, "mamba"))
+
+        seq_len = 4 * config.chunk_size + 1
+        torch.manual_seed(0)
+        hidden_states = 100.0 * torch.randn(1, seq_len, config.hidden_size, device=torch_device)
+
+        with torch.no_grad():
+            chunked = mixer.torch_forward(hidden_states)
+            cache = DynamicCache(config=config)
+            recurrent = torch.cat(
+                [mixer.torch_forward(hidden_states[:, t : t + 1], cache_params=cache) for t in range(seq_len)],
+                dim=1,
+            )
+
+        max_diff = (chunked - recurrent).abs().max().item()
+        self.parent.assertLess(
+            max_diff, 1e-3, f"slow-path chunked forward disagrees with recurrent decode: {max_diff}"
+        )
 
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
@@ -380,54 +399,16 @@ class Zamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         self.model_tester = Zamba2ModelTester(self)
         self.config_tester = ConfigTester(self, config_class=Zamba2Config, hidden_size=32)
 
+    @require_torch_accelerator
+    @require_kernels
     def test_mamba2_slow_vs_fast_forward(self):
-        """
-        Test that cuda_kernels_forward and torch_forward produce consistent outputs.
-        """
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_zamba2_slow_vs_fast_forward(*config_and_inputs)
 
     def test_mamba2_slow_path_multi_chunk(self):
-        """
-        Regression test for the inter-chunk recurrence in the Mamba2 slow (torch) path.
-
-        A single chunked forward over a multi-chunk sequence must match a token-by-token
-        recurrent decode. The input is deliberately large-magnitude so the SSM state is
-        O(1) and the inter-chunk contribution is not numerically negligible; with the
-        previous `.sum(dim=2)` reduction the two disagree by orders of magnitude. Runs on
-        CPU without the fast-path kernels.
-        """
-        config = Zamba2Config(
-            vocab_size=99,
-            hidden_size=32,
-            mamba_d_state=16,
-            num_hidden_layers=1,
-            num_attention_heads=2,
-            n_mamba_heads=8,
-            intermediate_size=8,
-            chunk_size=8,
-            mamba_ngroups=1,
-            use_mamba_kernels=False,
-            layers_block_type=["mamba"],
-            num_mem_blocks=1,
-            use_mem_rope=True,
-        )
-        torch.manual_seed(0)
-        mixer = Zamba2Model(config).eval().to(torch_device).layers[0].mamba
-
-        seq_len = 5 * config.chunk_size + 3
-        hidden_states = 50.0 * torch.randn(1, seq_len, config.hidden_size, device=torch_device)
-
-        with torch.no_grad():
-            chunked = mixer.torch_forward(hidden_states)
-            cache = DynamicCache(config=config)
-            recurrent = torch.cat(
-                [mixer.torch_forward(hidden_states[:, t : t + 1], cache_params=cache) for t in range(seq_len)],
-                dim=1,
-            )
-
-        max_diff = (chunked - recurrent).abs().max().item()
-        self.assertLess(max_diff, 1e-3, f"slow-path chunked forward disagrees with recurrent decode: {max_diff}")
+        """The Mamba2 slow path must reproduce the token-by-token recurrence across chunks."""
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_zamba2_slow_path_multi_chunk(*config_and_inputs)
 
     @unittest.skip("We need at leat 3 layers to test weight tying!")
     def test_num_layers_is_small(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47250)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47250)
<!-- ci-dashboard-badge:end -->

### What does this PR do?

Fixes an incorrect reduction dimension in the inter-chunk SSM recurrence of the pure-PyTorch (no-kernel) `torch_forward` path shared by `Zamba2MambaMixer` and `NemotronHMamba2Mixer`.

The current code

```python
states_permuted = states.permute(0, 2, 1, 3, 4)
result = (decay_chunk[..., None, None] * states_permuted[:, :, None, ...]).sum(dim=2)
new_states = result.permute(0, 2, 1, 3, 4)
```

sums over the *target*-chunk axis while `states` is broadcast over it, so `states` factors out of the sum. This collapses the intended recurrence

```
new_state[j] = Σ_i decay_chunk[j, i] · state[i]
```

into

```
new_state[q] = state[q] · Σ_p decay_chunk[p, q]
```

i.e. the per-chunk states are no longer propagated across chunk boundaries.

This is the same bug that was reported for `mamba2` in #34817 and fixed in #35154; the fix was never propagated to `zamba2`, and therefore to `nemotron_h`, whose mixer inherits `torch_forward` from `Zamba2MambaMixer`. All other Mamba2 descendants (`bamba`, `falcon_h1`, `granitemoehybrid`) already use the corrected form. The change aligns these two models with `mamba2`:

```python
decay_chunk = decay_chunk.transpose(1, 3)
new_states = (decay_chunk[..., None, None] * states[:, :, None, ...]).sum(dim=1)
```

It was applied to `modular_zamba2.py` and mirrored into the generated `modeling_zamba2.py` and `modeling_nemotron_h.py` (identical lines, no name substitution), so `check_modular_conversion` stays green.

### Scope of impact

Only the slow path is affected (no `mamba-ssm` / `causal-conv1d` kernels — e.g. CPU, or `use_mamba_kernels=False`); the CUDA kernel path is correct. The bug is masked for a single chunk with an empty cache (`seq_len <= chunk_size`, fresh prefill), which is why existing short-sequence tests pass. It produces wrong outputs and wrong cached SSM states when:

- the input is longer than `chunk_size` (prefill spanning ≥ 2 chunks), or
- generation is continued from a populated SSM cache.

### Reproduction

<details>
<summary>Standalone numerical check (no model download)</summary>

```python
import torch


def segment_sum(input_tensor):  # verbatim from modeling_*.py
    chunk_size = input_tensor.size(-1)
    input_tensor = input_tensor[..., None].expand(*input_tensor.size(), chunk_size)
    mask = torch.tril(torch.ones(chunk_size, chunk_size, dtype=torch.bool), diagonal=-1)
    input_tensor = input_tensor.masked_fill(~mask, 0)
    tensor_segsum = torch.cumsum(input_tensor, dim=-2)
    mask = torch.tril(torch.ones(chunk_size, chunk_size, dtype=torch.bool), diagonal=0)
    return tensor_segsum.masked_fill(~mask, -torch.inf)


def run(num_chunks, zero_previous_state):
    b, h, d, n = 1, 2, 4, 5
    A_cumsum_last = torch.randn(b, h, num_chunks)          # == A_cumsum[:, :, :, -1]
    states = torch.randn(b, num_chunks + 1, h, d, n)       # cat([previous_states, per-chunk states])
    if zero_previous_state:
        states[:, :1] = 0                                  # fresh prefill => no cached state
    decay_chunk = torch.exp(segment_sum(torch.nn.functional.pad(A_cumsum_last, (1, 0))))

    # current (buggy): sum over dim=2
    sp = states.permute(0, 2, 1, 3, 4)
    buggy = (decay_chunk[..., None, None] * sp[:, :, None, ...]).sum(dim=2).permute(0, 2, 1, 3, 4)
    # fixed (mamba2 form): transpose(1, 3) + sum over dim=1
    dc_t = decay_chunk.transpose(1, 3)
    fixed = (dc_t[..., None, None] * states[:, :, None, ...]).sum(dim=1)
    # brute-force reference: new[j] = sum_i decay_chunk[h, j, i] * states[i]
    ref = torch.einsum("bhji,bihdn->bjhdn", decay_chunk, states)
    return (buggy - ref).abs().max().item(), (fixed - ref).abs().max().item()


torch.manual_seed(0)
for label, c, zero in [
    ("seq <= chunk_size, fresh prefill (empty cache)", 1, True),
    ("seq <= chunk_size, continuing from SSM cache",   1, False),
    ("seq  > chunk_size, fresh prefill",               3, True),
    ("seq  > chunk_size, continuing from SSM cache",   3, False),
]:
    bug, ok = run(c, zero)
    print(f"{label:48s}  buggy_vs_ref={bug:9.5f}  fixed_vs_ref={ok:9.5f}")
```

Output:

```
seq <= chunk_size, fresh prefill (empty cache)    buggy_vs_ref=  0.00000  fixed_vs_ref=  0.00000
seq <= chunk_size, continuing from SSM cache      buggy_vs_ref=  1.92688  fixed_vs_ref=  0.00000
seq  > chunk_size, fresh prefill                  buggy_vs_ref=  5.26675  fixed_vs_ref=  0.00000
seq  > chunk_size, continuing from SSM cache      buggy_vs_ref= 10.68568  fixed_vs_ref=  0.00000
```

</details>

Fixes #47246

### Who can review?

@vasqu (fixed the equivalent `mamba2` bug in #35154)