### PR TITLE
Avoid ~2x transient host memory when loading to a unified-memory device

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import functools
 import math
 import os
 import re
@@ -32,7 +33,7 @@ import torch
 
 from .integrations.accelerate import get_device, offload_weight
 from .integrations.tensor_parallel import ALL_PARALLEL_STYLES
-from .utils import is_env_variable_true
+from .utils import is_env_variable_true, is_torch_cuda_available
 from .utils.loading_report import LoadStateDictInfo
 from .utils.logging import get_logger, tqdm
 
@@ -1178,9 +1179,55 @@ class WeightConverter(WeightTransform):
 GLOBAL_WORKERS = min(4, os.cpu_count() or 4)
 
 
+@functools.cache
+def _accelerator_is_integrated(device_type: str, index: int) -> bool:
+    """Whether the device at ``device_type:index`` uses unified memory, i.e. shares its
+    physical memory with the host, as on NVIDIA GB10/GH200 and Jetson.
+
+    Only CUDA (including ROCm, which reuses the ``torch.cuda`` API) reports this through
+    ``is_integrated``; every other backend is treated as discrete. Cached because a
+    device's properties are constant for the lifetime of the process.
+    """
+    if device_type != "cuda" or not is_torch_cuda_available():
+        return False
+    return bool(getattr(torch.cuda.get_device_properties(index), "is_integrated", False))
+
+
+def _should_break_mmap_alias(tensor: torch.Tensor, device, dtype) -> bool:
+    """Whether to copy ``tensor`` off its (mmap-backed) storage before an H2D copy.
+
+    On unified-memory accelerators (e.g. NVIDIA GB10/GH200, Jetson), copying a weight to
+    the device straight from the ``MAP_PRIVATE`` safetensors mmap makes the driver pin —
+    and copy-on-write-duplicate — every transferred page into unreclaimable host memory.
+    As tensors stream in with all shard handles still open, this grows ~1 byte of
+    anonymous memory per byte loaded and is only released once the whole load finishes,
+    transiently doubling the footprint and OOM-ing large models. Breaking the alias with
+    a plain ``clone()`` first avoids it, and is a no-op on discrete GPUs whose
+    separate-VRAM copy path does not duplicate into the host memory budget.
+
+    Only the zero-copy path reads from the mmap: a genuine dtype cast materializes a
+    fresh tensor, so ``dtype`` different from the source needs no clone, but a no-op cast
+    (``dtype`` equal to the source dtype) still reads it and must be broken like the
+    no-cast path.
+    """
+    if device is None or tensor.device.type != "cpu":
+        return False
+    if dtype is not None and dtype != tensor.dtype:
+        return False
+    device = torch.device(device)
+    if device.type in ("cpu", "meta"):
+        return False
+    index = device.index if device.index is not None else 0
+    return _accelerator_is_integrated(device.type, index)
+
+
 def _materialize_copy(tensor: torch.Tensor, device=None, dtype=None) -> torch.Tensor:
     # This slicing is what actually loads the tensor from the safetensors slice object
     tensor = tensor[...]
+    if _should_break_mmap_alias(tensor, device, dtype):
+        # Break the aliasing with the MAP_PRIVATE checkpoint mmap so the H2D copy
+        # does not COW-duplicate it into unreclaimable host memory (see helper).
+        tensor = tensor.clone()
     if dtype is not None or device is not None:
         tensor = tensor.to(device=device, dtype=dtype)
     return tensor

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -14,6 +14,7 @@
 import copy
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 import torch
 import torch.nn as nn
@@ -38,6 +39,8 @@ from transformers.core_model_loading import (
     VisionUnfuseAndPermuteForRope,
     WeightConverter,
     WeightRenaming,
+    _materialize_copy,
+    _should_break_mmap_alias,
     build_glob_alternation,
     convert_and_load_state_dict_in_model,
     rename_source_key,
@@ -1521,6 +1524,44 @@ class TestConversionMapping(unittest.TestCase):
         # Only one unscoped transform (from the root); child must be suppressed.
         self.assertEqual(len(transforms), 1)
         self.assertIsNone(transforms[0].scope_prefix)
+
+
+class MaterializeCopyUnifiedMemoryTest(unittest.TestCase):
+    """The load path must not COW-duplicate mmap'd weights on unified-memory devices."""
+
+    def test_should_break_mmap_alias_decision_table(self):
+        cpu_tensor = torch.zeros(4, dtype=torch.bfloat16)
+        cuda = torch.device("cuda:0")
+        with mock.patch("transformers.core_model_loading._accelerator_is_integrated", return_value=True):
+            # Integrated device + on-mmap cpu source: the H2D copy reads the mmap -> break the alias.
+            self.assertTrue(_should_break_mmap_alias(cpu_tensor, cuda, None))
+            # A no-op cast (target dtype == source dtype) still reads the mmap -> break it too.
+            self.assertTrue(_should_break_mmap_alias(cpu_tensor, cuda, torch.bfloat16))
+            # A genuine cast materializes a fresh tensor off the mmap -> nothing to break.
+            self.assertFalse(_should_break_mmap_alias(cpu_tensor, cuda, torch.float16))
+            # cpu / meta targets never DMA, and a missing device is a no-op.
+            self.assertFalse(_should_break_mmap_alias(cpu_tensor, torch.device("cpu"), None))
+            self.assertFalse(_should_break_mmap_alias(cpu_tensor, torch.device("meta"), None))
+            self.assertFalse(_should_break_mmap_alias(cpu_tensor, None, None))
+            # A source that is not on the host cannot alias a host mmap.
+            self.assertFalse(_should_break_mmap_alias(cpu_tensor.to("meta"), cuda, None))
+        with mock.patch("transformers.core_model_loading._accelerator_is_integrated", return_value=False):
+            # Discrete GPU: keep the existing zero-copy path untouched.
+            self.assertFalse(_should_break_mmap_alias(cpu_tensor, cuda, None))
+
+    def test_materialize_copy_clones_off_mmap_when_flagged(self):
+        src = torch.arange(16)
+        with mock.patch("transformers.core_model_loading._should_break_mmap_alias", return_value=True):
+            # device="cpu" keeps the follow-up `.to()` a no-op so the storage check stays host-only.
+            out = _materialize_copy(src, device="cpu")
+        self.assertNotEqual(out.data_ptr(), src.data_ptr())
+        self.assertTrue(torch.equal(out, src))
+
+    def test_materialize_copy_is_zero_copy_when_not_flagged(self):
+        src = torch.arange(16)
+        with mock.patch("transformers.core_model_loading._should_break_mmap_alias", return_value=False):
+            out = _materialize_copy(src)
+        self.assertEqual(out.data_ptr(), src.data_ptr())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47257)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47257)
<!-- ci-dashboard-badge:end -->

## What & why

On integrated (unified-memory) accelerators — NVIDIA GB10 / GH200, Jetson — the CPU and GPU share one physical memory pool. `_materialize_copy` copies each weight to the device straight from the `MAP_PRIVATE` safetensors mmap; pinning those pages for the H2D DMA **copy-on-write-duplicates** every transferred page into unreclaimable host (anonymous) memory. Tensors stream in with all shard handles still open, so the duplicate grows ~1 byte per byte loaded and is only released at the end — a model of size `M` transiently needs **~2·M** and OOMs when `2·M` exceeds unified RAM.

Measured on a GB10 (128 GB): `Qwen/Qwen3.6-35B-A3B` bf16 (~70 GB) climbs toward ~148 GB and is **OOM-killed at ~60% of loading**, every time. Throughout the load `RssAnon` tracks `torch.cuda.memory_allocated()` 1:1, and `/proc/self/smaps` shows the growing `Anonymous` bytes charged to the checkpoint file's mappings.

## Fix

When copying a CPU tensor to an **integrated** device **without a dtype cast**, `clone()` it off the mmap first. The clone's read-faults are ordinary reclaimable page cache and it frees the moment the copy lands, so the peak drops back to ~M. Discrete GPUs keep the current zero-copy path byte-for-byte (their separate-VRAM copy never enters the host budget), and a dtype cast already allocates a fresh tensor.

On the same GB10 the Qwen3.6-35B bf16 load then completes at **~80 GB peak / ~77.6 GB steady in ~50 s** instead of OOM-ing — and faster, because COW-faulting every page was itself a large part of the load time.

## Minimal reproducer (no model download, needs an integrated GPU)

```python
import os, torch
from safetensors.torch import save_file
from safetensors import safe_open

PATH = os.path.expanduser("~/cow_repro.safetensors")  # must be on a real disk, not tmpfs

def file_anon_gb(real):
    total, cur = 0, False
    for line in open("/proc/self/smaps"):
        h = line.split()
        if h and "-" in h[0] and (line[0].isdigit() or line[0] in "abcdef"):
            cur = real in line
        elif cur and line.startswith("Anonymous:"):
            total += int(h[1])
    return total / 1048576

save_file({"w": torch.zeros(1024**3, dtype=torch.bfloat16)}, PATH)  # 2 GB
real = os.path.realpath(PATH)
f = safe_open(PATH, framework="pt")
f.get_slice("w")[...].to("cuda"); torch.cuda.synchronize()
print("direct .to('cuda'):        Anonymous =", round(file_anon_gb(real), 2), "GB")
```

```
NVIDIA GB10  is_integrated=1
direct  .to('cuda'):   file-mapping Anonymous = 2.0 GB   # COW duplicate of the whole tensor
clone().to('cuda'):    file-mapping Anonymous = 0.0 GB   # no duplicate
```

## Test

Adds `MaterializeCopyUnifiedMemoryTest` in `tests/utils/test_core_model_loading.py` — CPU-only, mocks the integrated-device check, covers the gating truth table and that the guard produces a storage-independent copy while the default path stays zero-copy.

cc @SunMarc @Cyrilvallez — happy to adjust the gating (broaden to discrete GPUs, or reuse a pinned staging buffer instead of a fresh clone). `diffusers` has the identical issue where it installs mmap-backed `load_file` tensors via `accelerate.set_module_tensor_to_device`; I can file that separately.