### PR TITLE
Switch AMD daily CI to mi300 runners

### DIFF
--- a/.github/workflows/benchmark_v2_mi300_caller.yml
+++ b/.github/workflows/benchmark_v2_mi300_caller.yml
@@ -1,4 +1,4 @@
-name: Benchmark v2 Scheduled Runner - MI325 Single-GPU
+name: Benchmark v2 Scheduled Runner - MI300 Single-GPU
 
 on:
   workflow_dispatch:
@@ -11,7 +11,7 @@ jobs:
     name: Benchmark v2 - Default Models
     uses: ./.github/workflows/benchmark_v2.yml
     with:
-      runner: amd-mi325-ci-1gpu
+      runner: amd-mi300-ci-1gpu
       container_image: huggingface/transformers-pytorch-amd-gpu
       container_options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache
       commit_sha: ${{ github.sha }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -217,7 +217,7 @@ jobs:
     name: "Cache Latest Pytorch (AMD) Image"
     needs: latest-pytorch-amd
     runs-on:
-      group: amd-mi325-1gpu
+      group: hfc-amd-mi300-1gpu
     steps:
       -
         name: Login to DockerHub

--- a/.github/workflows/self-scheduled-amd-mi300-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi300-caller.yml
@@ -1,8 +1,8 @@
-name: Self-hosted runner scale set (AMD mi325 scheduled CI caller)
+name: Self-hosted runner scale set (AMD mi300 scheduled CI caller)
 
 # Note: For every job in this workflow, the name of the runner scale set is finalized in the runner yaml i.e. huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml
-# For example, 1gpu scale set: amd-mi325-ci-1gpu
-#              2gpu scale set: amd-mi325-ci-2gpu
+# For example, 1gpu scale set: amd-mi300-ci-1gpu
+#              2gpu scale set: amd-mi300-ci-2gpu
 # Important: Do not pin the reusable workflow ref to a SHA. AMD runner groups only route jobs for
 # workflows referenced at @main; a pinned SHA causes jobs to wait for a runner until the 24h timeout.
 
@@ -25,9 +25,9 @@ jobs:
     with:
       job: run_models_gpu
       slack_report_channel: "#amd-hf-ci"
-      runner_group: amd-mi325
+      runner_group: hfc-amd-mi300
       docker: huggingface/transformers-pytorch-amd-gpu
-      ci_event: Scheduled CI (AMD) - mi325
+      ci_event: Scheduled CI (AMD) - mi300
       report_repo_id: optimum-amd/transformers_daily_ci
       env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit
@@ -38,9 +38,9 @@ jobs:
     with:
       job: run_pipelines_torch_gpu
       slack_report_channel: "#amd-hf-ci"
-      runner_group: amd-mi325
+      runner_group: hfc-amd-mi300
       docker: huggingface/transformers-pytorch-amd-gpu
-      ci_event: Scheduled CI (AMD) - mi325
+      ci_event: Scheduled CI (AMD) - mi300
       report_repo_id: optimum-amd/transformers_daily_ci
       env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit
@@ -51,9 +51,9 @@ jobs:
     with:
       job: run_examples_gpu
       slack_report_channel: "#amd-hf-ci"
-      runner_group: amd-mi325
+      runner_group: hfc-amd-mi300
       docker: huggingface/transformers-pytorch-amd-gpu
-      ci_event: Scheduled CI (AMD) - mi325
+      ci_event: Scheduled CI (AMD) - mi300
       report_repo_id: optimum-amd/transformers_daily_ci
       env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit
@@ -64,9 +64,9 @@ jobs:
     with:
       job: run_torch_cuda_extensions_gpu
       slack_report_channel: "#amd-hf-ci"
-      runner_group: amd-mi325
+      runner_group: hfc-amd-mi300
       docker: huggingface/transformers-pytorch-deepspeed-amd-gpu
-      ci_event: Scheduled CI (AMD) - mi325
+      ci_event: Scheduled CI (AMD) - mi300
       report_repo_id: optimum-amd/transformers_daily_ci
       env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit

--- a/utils/collated_reports.py
+++ b/utils/collated_reports.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-DEFAULT_GPU_NAMES = ["mi300", "mi325", "mi355", "h100", "a10"]
+DEFAULT_GPU_NAMES = ["mi300", "mi355", "h100", "a10"]
 
 
 def simplify_gpu_name(gpu_name: str, simplified_names: list[str]) -> str:

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1411,7 +1411,7 @@ if __name__ == "__main__":
         "huggingface/transformers/.github/workflows/self-scheduled-flash-attn-caller.yml",
     )
     amd_daily_ci_workflows = (
-        "huggingface/transformers/.github/workflows/self-scheduled-amd-mi325-caller.yml",
+        "huggingface/transformers/.github/workflows/self-scheduled-amd-mi300-caller.yml",
         "huggingface/transformers/.github/workflows/self-scheduled-amd-mi355-caller.yml",
     )
     is_nvidia_daily_ci_workflow = os.environ.get("GITHUB_WORKFLOW_REF").startswith(nvidia_daily_ci_workflow)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47259)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47259)
<!-- ci-dashboard-badge:end -->

MI325 hardware is being retired; migrate the AMD daily CI to MI300.
Updates runner groups to `hfc-amd-mi300-{1,2}gpu` and labels to `amd-mi300-ci-{1,2}gpu`, and renames the mi325 caller workflows to mi300.