### PR TITLE
Respect min_tokens_to_keep in TopHLogitsWarper

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -615,6 +615,9 @@ class TopHLogitsWarper(LogitsProcessor):
         filter_value (`float`, *optional*, defaults to -inf):
             All filtered values will be set to this float value.
 
+        min_tokens_to_keep (`int`, *optional*, defaults to 1):
+            Minimum number of highest probability tokens that will be kept.
+
     Example:
 
     ```python
@@ -631,12 +634,14 @@ class TopHLogitsWarper(LogitsProcessor):
     ```
     """
 
-    def __init__(self, top_h: float, filter_value: float = -float("Inf")):
+    def __init__(self, top_h: float, filter_value: float = -float("Inf"), min_tokens_to_keep: int = 1):
         super().__init__()
 
         # input checks
         if not (0 < top_h <= 1):
             raise ValueError("`top_h` must be in the range (0, 1].")
+        if not isinstance(min_tokens_to_keep, int) or min_tokens_to_keep < 1:
+            raise ValueError(f"`min_tokens_to_keep` has to be a positive integer, but is {min_tokens_to_keep}")
 
         # Maximum number of top tokens to consider before applying the entropy-based filter.
         # Acts as a cap for efficiency and numerical stability — increasing this allows more
@@ -645,6 +650,7 @@ class TopHLogitsWarper(LogitsProcessor):
 
         self.top_h = top_h
         self.filter_value = filter_value
+        self.min_tokens_to_keep = min_tokens_to_keep
 
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor) -> torch.FloatTensor:
         """
@@ -663,7 +669,7 @@ class TopHLogitsWarper(LogitsProcessor):
         batch_size, vocab_size = scores.shape
         device = scores.device
         keep_mask = torch.zeros((batch_size, vocab_size), dtype=torch.bool, device=device)
-        top_n = min(self.top_n, vocab_size)
+        top_n = min(max(self.top_n, self.min_tokens_to_keep), vocab_size)
 
         # 1. Get top-k logits and indices for the whole batch
         top_logits, top_idx = torch.topk(scores, top_n, dim=-1, largest=True, sorted=True)
@@ -688,7 +694,7 @@ class TopHLogitsWarper(LogitsProcessor):
         # exceeds the threshold τ = H(p) * top_h. This ensures diversity (via entropy) while
         # guaranteeing at least the most probable token is always included.
         selection_mask = cumulative_entropy <= tau
-        selection_mask[:, 0] = True
+        selection_mask[:, : min(self.min_tokens_to_keep, top_n)] = True
 
         # 6. Update the final keep_mask for the entire batch in one operation
         # The scatter_ operation efficiently updates the keep_mask at the indices

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1275,7 +1275,9 @@ class GenerationMixin(ContinuousMixin):
             if generation_config.temperature is not None and generation_config.temperature != 1.0:
                 processors.append(TemperatureLogitsWarper(generation_config.temperature))
             if generation_config.top_h is not None:
-                processors.append(TopHLogitsWarper(top_h=generation_config.top_h))
+                processors.append(
+                    TopHLogitsWarper(top_h=generation_config.top_h, min_tokens_to_keep=min_tokens_to_keep)
+                )
             if generation_config.top_k is not None and generation_config.top_k != 0:
                 processors.append(
                     TopKLogitsWarper(top_k=generation_config.top_k, min_tokens_to_keep=min_tokens_to_keep)

--- a/tests/generation/test_logits_process.py
+++ b/tests/generation/test_logits_process.py
@@ -450,6 +450,11 @@ class LogitsProcessorTest(unittest.TestCase):
         out_again = top_h_warp(input_ids, dist3)
         assert not torch.all(out_again == dist3)
 
+        # check special case: keep at least min_tokens_to_keep, matching other sampling warpers
+        top_h_warp_safety_check = TopHLogitsWarper(top_h=0.3, min_tokens_to_keep=2)
+        filtered_logits = top_h_warp_safety_check(input_ids, dist1.clone())
+        self.assertListEqual(torch.isfinite(filtered_logits).to(torch.long).sum(dim=-1).tolist(), [2])
+
     def test_min_p_dist_warper(self):
         input_ids = None
         vocab_size = 10


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47262)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47262)
<!-- ci-dashboard-badge:end -->

> This replaces #46643, which I accidentally closed when its source fork was detached. The change has been rebased onto current `main`; the original discussion remains in #46643.

# What does this PR do?

`generate()` computes a `min_tokens_to_keep` value for sampling, using a larger value for beam methods so at least one non-EOS continuation can survive. That value is already passed to the top-k, top-p, min-p, typical, epsilon, and eta warpers, but `TopHLogitsWarper` was constructed without it.

As a result, with peaked logits and beam sampling, top-h can keep only the single highest-probability token while the other sampling warpers keep the beam-safe minimum. This PR adds `min_tokens_to_keep` to `TopHLogitsWarper` and passes the generation-level value through, matching the behavior of the other truncation samplers.

The default remains `1`, so existing non-beam top-h behavior is unchanged.

## Tests

Added a regression case to `test_top_h_dist_warper` that checks `TopHLogitsWarper(top_h=0.3, min_tokens_to_keep=2)` keeps two tokens on a highly peaked distribution.

Local:

```bash
PYTHONPATH=src python -m pytest tests/generation/test_logits_process.py -q
# 44 passed
```

## Code Agent Policy

- [X] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [X] Did you write any new necessary tests?

## Validation
- `pytest -q tests/generation/test_logits_process.py::LogitsProcessorTest::test_top_h_dist_warper` (1 passed)