### PR TITLE
Add regression test for register() with a string config_class key

### DIFF
--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -525,6 +525,19 @@ class AutoModelTest(unittest.TestCase):
         _MODEL_MAPPING = _LazyAutoMapping(_CONFIG_MAPPING_NAMES, _MODEL_MAPPING_NAMES)
         self.assertEqual(_MODEL_MAPPING[BertConfig], GPT2Model)
 
+    def test_register_with_string_key(self):
+        from transformers.models.auto.auto_factory import _LazyAutoMapping
+
+        _CONFIG_MAPPING_NAMES = OrderedDict([("bert", "BertConfig")])
+        _MODEL_MAPPING_NAMES = OrderedDict([("bert", "BertModel")])
+        _MODEL_MAPPING = _LazyAutoMapping(_CONFIG_MAPPING_NAMES, _MODEL_MAPPING_NAMES)
+
+        # Downstream libraries sometimes register with a plain string instead of a config class
+        # (e.g. `AutoImageProcessor.register(config_class="SomeConfigName", ...)`). A string has
+        # no `__module__`, so it must not raise and must land in `_extra_content`.
+        _MODEL_MAPPING.register("custom-string-key", GPT2Model)
+        self.assertEqual(_MODEL_MAPPING._extra_content["custom-string-key"], GPT2Model)
+
     def test_custom_model_patched_generation_inheritance(self):
         """
         Tests that our inheritance patching for generate-compatible models works as expected. Without this feature,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47263)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47263)
<!-- ci-dashboard-badge:end -->

#46876 added an unconditional key.__module__ read in _LazyAutoMapping.register, which broke downstream code that registers with a plain string instead of a config class (strings have no __module__). #47148 fixed this with a getattr fallback and widened the type hint to type[PreTrainedConfig] | str, but shipped without a test. This adds one, exercising _LazyAutoMapping.register directly with a string key and checking it lands in _extra_content instead of raising.

- [✅] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent