### PR TITLE
Add repeated n-gram stopping criterion

### DIFF
--- a/docs/source/en/internal/generation_utils.md
+++ b/docs/source/en/internal/generation_utils.md
@@ -190,6 +190,9 @@ A [`StoppingCriteria`] can be used to change when to stop generation (other than
 [[autodoc]] MaxTimeCriteria
     - __call__
 
+[[autodoc]] RepeatedNGramCriteria
+    - __call__
+
 [[autodoc]] StopStringCriteria
     - __call__
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -426,6 +426,7 @@ else:
             "NoBadWordsLogitsProcessor",
             "NoRepeatNGramLogitsProcessor",
             "PrefixConstrainedLogitsProcessor",
+            "RepeatedNGramCriteria",
             "RepetitionPenaltyLogitsProcessor",
             "SequenceBiasLogitsProcessor",
             "StoppingCriteria",
@@ -593,6 +594,7 @@ if TYPE_CHECKING:
     from .generation import NoBadWordsLogitsProcessor as NoBadWordsLogitsProcessor
     from .generation import NoRepeatNGramLogitsProcessor as NoRepeatNGramLogitsProcessor
     from .generation import PrefixConstrainedLogitsProcessor as PrefixConstrainedLogitsProcessor
+    from .generation import RepeatedNGramCriteria as RepeatedNGramCriteria
     from .generation import RepetitionPenaltyLogitsProcessor as RepetitionPenaltyLogitsProcessor
     from .generation import SequenceBiasLogitsProcessor as SequenceBiasLogitsProcessor
     from .generation import StoppingCriteria as StoppingCriteria

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -77,14 +77,15 @@ else:
         "WatermarkLogitsProcessor",
     ]
     _import_structure["stopping_criteria"] = [
-        "MaxLengthCriteria",
-        "MaxTimeCriteria",
         "ConfidenceCriteria",
         "EosTokenCriteria",
+        "MaxLengthCriteria",
+        "MaxTimeCriteria",
+        "RepeatedNGramCriteria",
+        "StopStringCriteria",
         "StoppingCriteria",
         "StoppingCriteriaList",
         "validate_stopping_criteria",
-        "StopStringCriteria",
     ]
     _import_structure["continuous_batching"] = [
         "ContinuousBatchingManager",
@@ -186,6 +187,7 @@ if TYPE_CHECKING:
             EosTokenCriteria,
             MaxLengthCriteria,
             MaxTimeCriteria,
+            RepeatedNGramCriteria,
             StoppingCriteria,
             StoppingCriteriaList,
             StopStringCriteria,

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -17,6 +17,8 @@ logger = logging.get_logger(__name__)
 # We maintain a module-level cache of the embedding vectors for the stop string criterion
 # because they are slow to compute
 STOP_STRING_EMBEDDING_CACHE = OrderedDict()
+# Target bound for the comparison elements produced when batching repeated n-gram sizes.
+MAX_REPEATED_NGRAM_COMPARISON_ELEMENTS = 2**20
 
 
 STOPPING_CRITERIA_INPUTS_DOCSTRING = r"""
@@ -105,6 +107,131 @@ class MaxTimeCriteria(StoppingCriteria):
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> torch.BoolTensor:
         is_done = time.time() - self.initial_timestamp > self.max_time
         return torch.full((input_ids.shape[0],), is_done, device=input_ids.device, dtype=torch.bool)
+
+
+class RepeatedNGramCriteria(StoppingCriteria):
+    """
+    This class can be used to stop generation when the sequence ends with consecutive copies of the same token block.
+    It can check one n-gram size or an inclusive range of sizes and returns a separate stopping decision for each batch
+    row. By default, the prompt participates in repetition detection; set `prompt_length_to_skip` to detect loops only
+    among newly generated tokens.
+
+    Args:
+        min_ngram_size (`int`):
+            The smallest repeated block size to detect, in tokens.
+        max_ngram_size (`int`, *optional*):
+            The largest repeated block size to detect, in tokens. Defaults to `min_ngram_size`, which checks one fixed
+            block size. Wider ranges and larger block sizes require more comparisons, so prefer the narrowest useful
+            range.
+        num_repetitions (`int`, *optional*, defaults to 4):
+            The number of consecutive copies required to stop generation. This counts the original block, so a value
+            of 3 detects `[A, B, A, B, A, B]` when the n-gram size is 2.
+        prompt_length_to_skip (`int`, *optional*, defaults to 0):
+            The number of initial tokens to exclude from repetition detection. Set this to the prompt length to detect
+            repetition only in newly generated tokens.
+        min_new_tokens (`int`, *optional*, defaults to 0):
+            The minimum number of tokens after `prompt_length_to_skip` that must be present before generation can stop.
+
+    Examples:
+
+    ```python
+    >>> import torch
+    >>> from transformers import RepeatedNGramCriteria, StoppingCriteriaList
+
+    >>> stopping_criteria = StoppingCriteriaList(
+    ...     [
+    ...         RepeatedNGramCriteria(
+    ...             min_ngram_size=2,
+    ...             max_ngram_size=8,
+    ...             num_repetitions=3,
+    ...         )
+    ...     ]
+    ... )
+    >>> input_ids = torch.tensor([[1, 2, 1, 2, 1, 2], [1, 2, 3, 4, 5, 6]])
+    >>> stopping_criteria(input_ids, scores=None)
+    tensor([ True, False])
+    ```
+    """
+
+    def __init__(
+        self,
+        min_ngram_size: int,
+        max_ngram_size: int | None = None,
+        num_repetitions: int = 4,
+        prompt_length_to_skip: int = 0,
+        min_new_tokens: int = 0,
+    ):
+        if not isinstance(min_ngram_size, int) or min_ngram_size <= 0:
+            raise ValueError(f"`min_ngram_size` has to be a strictly positive integer, but is {min_ngram_size}")
+        if max_ngram_size is None:
+            max_ngram_size = min_ngram_size
+        if not isinstance(max_ngram_size, int) or max_ngram_size < min_ngram_size:
+            raise ValueError(
+                "`max_ngram_size` has to be an integer greater than or equal to `min_ngram_size`, but is "
+                f"{max_ngram_size}"
+            )
+        if not isinstance(num_repetitions, int) or num_repetitions < 2:
+            raise ValueError(f"`num_repetitions` has to be an integer greater than 1, but is {num_repetitions}")
+        for arg_name, arg_value in [
+            ("prompt_length_to_skip", prompt_length_to_skip),
+            ("min_new_tokens", min_new_tokens),
+        ]:
+            if not isinstance(arg_value, int) or arg_value < 0:
+                raise ValueError(f"`{arg_name}` has to be a non-negative integer, but is {arg_value}")
+
+        self.min_ngram_size = min_ngram_size
+        self.max_ngram_size = max_ngram_size
+        self.num_repetitions = num_repetitions
+        self.prompt_length_to_skip = prompt_length_to_skip
+        self.min_new_tokens = min_new_tokens
+
+    @add_start_docstrings(STOPPING_CRITERIA_INPUTS_DOCSTRING)
+    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> torch.BoolTensor:
+        if input_ids.shape[0] == 0:
+            return torch.zeros(0, dtype=torch.bool, device=input_ids.device)
+
+        generated_ids = input_ids[:, self.prompt_length_to_skip :]
+        generated_length = generated_ids.shape[1]
+        largest_ngram_size = min(self.max_ngram_size, generated_length // self.num_repetitions)
+
+        if generated_length < self.min_new_tokens or largest_ngram_size < self.min_ngram_size:
+            return torch.zeros(input_ids.shape[0], dtype=torch.bool, device=input_ids.device)
+
+        if self.min_ngram_size == self.max_ngram_size:
+            suffix = generated_ids[:, -self.num_repetitions * self.min_ngram_size :]
+            repeated_blocks = suffix.unflatten(1, (self.num_repetitions, self.min_ngram_size))
+            return (repeated_blocks == repeated_blocks[:, :1]).all(dim=2).all(dim=1)
+
+        # Compare candidate suffixes against their final blocks in bounded, vectorized chunks. Reversing the suffix
+        # makes index 0 the beginning of the reference block for every candidate n-gram size. The common small-range
+        # case fits in one chunk; bounding larger ranges prevents the temporary comparison tensor from becoming
+        # quadratic in `max_ngram_size`.
+        result = torch.zeros(input_ids.shape[0], dtype=torch.bool, device=input_ids.device)
+        chunk_max_ngram_size = largest_ngram_size
+        max_suffix_length = self.num_repetitions * largest_ngram_size
+        reversed_suffix = generated_ids[:, -max_suffix_length:].flip(dims=(1,))
+        while chunk_max_ngram_size >= self.min_ngram_size:
+            max_suffix_length = self.num_repetitions * chunk_max_ngram_size
+            elements_per_ngram = max(1, input_ids.shape[0] * max_suffix_length)
+            chunk_size = max(1, MAX_REPEATED_NGRAM_COMPARISON_ELEMENTS // elements_per_ngram)
+            chunk_min_ngram_size = max(self.min_ngram_size, chunk_max_ngram_size - chunk_size + 1)
+
+            chunk_suffix = reversed_suffix[:, :max_suffix_length]
+            ngram_sizes = torch.arange(
+                chunk_min_ngram_size,
+                chunk_max_ngram_size + 1,
+                device=input_ids.device,
+            )
+            positions = torch.arange(max_suffix_length, device=input_ids.device)
+            reference_indices = positions.unsqueeze(0) % ngram_sizes.unsqueeze(1)
+            relevant_positions = positions.unsqueeze(0) < self.num_repetitions * ngram_sizes.unsqueeze(1)
+
+            expected_tokens = chunk_suffix[:, reference_indices]
+            mismatches = (chunk_suffix[:, None, :] != expected_tokens) & relevant_positions.unsqueeze(0)
+            result = result | (~mismatches.any(dim=2)).any(dim=1)
+            chunk_max_ngram_size = chunk_min_ngram_size - 1
+
+        return result
 
 
 class StopStringCriteria(StoppingCriteria):

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
 import time
 import unittest
 
@@ -24,11 +25,13 @@ from ..test_modeling_common import ids_tensor
 if is_torch_available():
     import torch
 
+    from transformers import RepeatedNGramCriteria as TopLevelRepeatedNGramCriteria
     from transformers.generation import (
         ConfidenceCriteria,
         EosTokenCriteria,
         MaxLengthCriteria,
         MaxTimeCriteria,
+        RepeatedNGramCriteria,
         StoppingCriteriaList,
         StopStringCriteria,
         validate_stopping_criteria,
@@ -92,6 +95,176 @@ class StoppingCriteriaTestCase(unittest.TestCase):
 
         criteria = MaxTimeCriteria(max_time=0.1, initial_timestamp=time.time() - 0.2)
         self.assertTrue(all(criteria(input_ids, scores)))
+
+    def test_repeated_ngram_criteria_fixed_size(self):
+        criteria = RepeatedNGramCriteria(min_ngram_size=2, num_repetitions=3, prompt_length_to_skip=1)
+        input_ids = torch.tensor(
+            [
+                [99, 1, 2, 1, 2, 1, 2],
+                [99, 1, 2, 1, 2, 1, 3],
+            ],
+            device=torch_device,
+        )
+
+        result = criteria(input_ids, scores=None)
+
+        self.assertListEqual(result.tolist(), [True, False])
+        self.assertEqual(result.shape, (2,))
+        self.assertEqual(result.dtype, torch.bool)
+        self.assertEqual(result.device, input_ids.device)
+
+    def test_repeated_ngram_criteria_size_range(self):
+        criteria = RepeatedNGramCriteria(min_ngram_size=2, max_ngram_size=4, num_repetitions=3)
+        min_size_input_ids = torch.tensor([[8, 9, 7, 8, 7, 8, 7, 8]], device=torch_device)
+        max_size_input_ids = torch.tensor(
+            [
+                [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4],
+                [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 5],
+            ],
+            device=torch_device,
+        )
+
+        self.assertTrue(criteria(min_size_input_ids, scores=None)[0])
+        self.assertListEqual(criteria(max_size_input_ids, scores=None).tolist(), [True, False])
+
+    def test_repeated_ngram_criteria_thresholds(self):
+        criteria = RepeatedNGramCriteria(min_ngram_size=2, num_repetitions=3)
+
+        one_copy_short = torch.tensor([[1, 2, 1, 2]], device=torch_device)
+        exact_threshold = torch.tensor([[1, 2, 1, 2, 1, 2]], device=torch_device)
+        near_match = torch.tensor([[1, 2, 1, 2, 1, 3]], device=torch_device)
+
+        self.assertFalse(criteria(one_copy_short, scores=None)[0])
+        self.assertTrue(criteria(exact_threshold, scores=None)[0])
+        self.assertFalse(criteria(near_match, scores=None)[0])
+
+    def test_repeated_ngram_criteria_skips_prompt(self):
+        input_ids = torch.tensor([[1, 2, 1, 2, 1, 2]], device=torch_device)
+
+        self.assertTrue(RepeatedNGramCriteria(2, num_repetitions=3)(input_ids, scores=None)[0])
+        self.assertFalse(
+            RepeatedNGramCriteria(2, num_repetitions=3, prompt_length_to_skip=input_ids.shape[1])(
+                input_ids, scores=None
+            )[0]
+        )
+
+    def test_repeated_ngram_criteria_min_new_tokens(self):
+        input_ids = torch.tensor([[9, 8, 1, 2, 1, 2, 1, 2]], device=torch_device)
+
+        self.assertFalse(RepeatedNGramCriteria(2, num_repetitions=3, min_new_tokens=9)(input_ids, scores=None)[0])
+        self.assertTrue(RepeatedNGramCriteria(2, num_repetitions=3, min_new_tokens=8)(input_ids, scores=None)[0])
+
+    def test_repeated_ngram_criteria_large_range(self):
+        block = torch.arange(1000, device=torch_device)
+        input_ids = torch.cat((block, block)).unsqueeze(0)
+        criteria = RepeatedNGramCriteria(min_ngram_size=1, max_ngram_size=1000, num_repetitions=2)
+
+        self.assertTrue(criteria(input_ids, scores=None)[0])
+
+        input_ids[0, -1] = -1
+        self.assertFalse(criteria(input_ids, scores=None)[0])
+
+    def test_repeated_ngram_criteria_empty_batch(self):
+        input_ids = torch.empty((0, 2000), dtype=torch.long, device=torch_device)
+        criteria = RepeatedNGramCriteria(min_ngram_size=1, max_ngram_size=1000, num_repetitions=2)
+
+        result = criteria(input_ids, scores=None)
+
+        self.assertEqual(result.shape, (0,))
+        self.assertEqual(result.dtype, torch.bool)
+        self.assertEqual(result.device, input_ids.device)
+
+    def test_repeated_ngram_criteria_is_stateless(self):
+        criteria = RepeatedNGramCriteria(min_ngram_size=2, max_ngram_size=4, num_repetitions=3)
+        input_ids = torch.tensor(
+            [
+                [1, 2, 1, 2, 1, 2],
+                [1, 2, 3, 4, 5, 6],
+            ],
+            device=torch_device,
+        )
+
+        first_result = criteria(input_ids, scores=None)
+        reordered_result = criteria(input_ids.flip(dims=(0,)), scores=None)
+
+        self.assertListEqual(first_result.tolist(), [True, False])
+        self.assertListEqual(reordered_result.tolist(), [False, True])
+
+    def test_repeated_ngram_criteria_validation(self):
+        invalid_kwargs = [
+            {"min_ngram_size": 0},
+            {"min_ngram_size": 2, "max_ngram_size": 1},
+            {"min_ngram_size": 2, "num_repetitions": 1},
+            {"min_ngram_size": 2, "prompt_length_to_skip": -1},
+            {"min_ngram_size": 2, "min_new_tokens": -1},
+        ]
+
+        for kwargs in invalid_kwargs:
+            with self.subTest(kwargs=kwargs), self.assertRaises(ValueError):
+                RepeatedNGramCriteria(**kwargs)
+
+    def test_repeated_ngram_criteria_matches_python_reference(self):
+        rng = random.Random(0)
+
+        for _ in range(100):
+            min_ngram_size = rng.randint(1, 4)
+            max_ngram_size = rng.randint(min_ngram_size, 6)
+            num_repetitions = rng.randint(2, 4)
+            prompt_length = rng.randint(0, 5)
+            generated_length = rng.randint(0, 30)
+            min_new_tokens = rng.randint(0, 20)
+            prompt = [rng.randrange(10) for _ in range(prompt_length)]
+            generated = [rng.randrange(10) for _ in range(generated_length)]
+
+            largest_injectable_size = min(max_ngram_size, generated_length // num_repetitions)
+            if largest_injectable_size >= min_ngram_size and rng.choice([False, True]):
+                ngram_size = rng.randint(min_ngram_size, largest_injectable_size)
+                block = [rng.randrange(10) for _ in range(ngram_size)]
+                generated[-ngram_size * num_repetitions :] = block * num_repetitions
+
+            expected = False
+            if generated_length >= min_new_tokens:
+                for ngram_size in range(min_ngram_size, max_ngram_size + 1):
+                    repeated_length = ngram_size * num_repetitions
+                    if generated_length < repeated_length:
+                        continue
+                    suffix = generated[-repeated_length:]
+                    if all(
+                        suffix[start : start + ngram_size] == suffix[:ngram_size]
+                        for start in range(ngram_size, repeated_length, ngram_size)
+                    ):
+                        expected = True
+                        break
+
+            input_ids = torch.tensor([prompt + generated], dtype=torch.long, device=torch_device)
+            criteria = RepeatedNGramCriteria(
+                min_ngram_size=min_ngram_size,
+                max_ngram_size=max_ngram_size,
+                num_repetitions=num_repetitions,
+                prompt_length_to_skip=prompt_length,
+                min_new_tokens=min_new_tokens,
+            )
+
+            self.assertEqual(bool(criteria(input_ids, scores=None)[0]), expected)
+
+    def test_repeated_ngram_criteria_top_level_export(self):
+        self.assertIs(TopLevelRepeatedNGramCriteria, RepeatedNGramCriteria)
+
+    def test_repeated_ngram_criteria_compile(self):
+        if not hasattr(torch, "compile"):
+            self.skipTest("torch.compile is not available")
+
+        input_ids = torch.tensor([[1, 2, 3, 1, 2, 3, 1, 2, 3]], device=torch_device)
+        for max_ngram_size in [None, 4]:
+            with self.subTest(max_ngram_size=max_ngram_size):
+                criteria = RepeatedNGramCriteria(
+                    min_ngram_size=3,
+                    max_ngram_size=max_ngram_size,
+                    num_repetitions=3,
+                )
+                compiled_criteria = torch.compile(criteria, backend="eager", fullgraph=True)
+
+                self.assertTrue(compiled_criteria(input_ids, scores=None)[0])
 
     def test_eos_token_criteria(self):
         criteria = EosTokenCriteria(eos_token_id=0)

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -72,6 +72,7 @@ if is_torch_available():
         BartForConditionalGeneration,
         BartTokenizer,
         DataCollatorWithFlattening,
+        GPT2Config,
         GPT2LMHeadModel,
         GPT2Tokenizer,
         ImageGPTForCausalImageModeling,
@@ -93,10 +94,12 @@ if is_torch_available():
         GenerateDecoderOnlyOutput,
         GenerateEncoderDecoderOutput,
         GenerationConfig,
+        LogitsProcessor,
         LogitsProcessorList,
         MaxLengthCriteria,
         MinLengthLogitsProcessor,
         PromptLookupCandidateGenerator,
+        RepeatedNGramCriteria,
         StoppingCriteria,
         StoppingCriteriaList,
         SynthIDTextWatermarkingConfig,
@@ -3253,6 +3256,51 @@ class GenerationIntegrationTests(unittest.TestCase):
             list(bart_model.generate(input_ids, stopping_criteria=stopping_criteria, max_length=18).shape),
             [1, 18],
         )
+
+    def test_repeated_ngram_stopping_criteria(self):
+        prompt_length = 2
+        pattern = (1, 2)
+
+        class ForcePatternLogitsProcessor(LogitsProcessor):
+            def __call__(self, input_ids, scores):
+                next_token = pattern[(input_ids.shape[1] - prompt_length) % len(pattern)]
+                scores.fill_(-float("inf"))
+                scores[:, next_token] = 0
+                return scores
+
+        model = GPT2LMHeadModel(
+            GPT2Config(
+                vocab_size=10,
+                n_positions=16,
+                n_embd=8,
+                n_layer=1,
+                n_head=1,
+                bos_token_id=0,
+                eos_token_id=None,
+                pad_token_id=0,
+            )
+        ).to(torch_device)
+        model.eval()
+        input_ids = torch.tensor([[5, 6]], device=torch_device)
+        stopping_criteria = StoppingCriteriaList(
+            [
+                RepeatedNGramCriteria(
+                    min_ngram_size=len(pattern),
+                    num_repetitions=3,
+                    prompt_length_to_skip=prompt_length,
+                )
+            ]
+        )
+
+        output_ids = model.generate(
+            input_ids,
+            max_new_tokens=10,
+            logits_processor=LogitsProcessorList([ForcePatternLogitsProcessor()]),
+            stopping_criteria=stopping_criteria,
+        )
+
+        self.assertEqual(output_ids.shape[1], prompt_length + len(pattern) * 3)
+        self.assertListEqual(output_ids[0, prompt_length:].tolist(), list(pattern) * 3)
 
     # TODO (joao): replace `stop_sequence` in the pipeline by the more recent `generate` functionality
     def test_stop_sequence_stopping_criteria(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47271)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47271)
<!-- ci-dashboard-badge:end -->

> **AI-generated PR disclosure:** This is an AI-generated PR. It is being submitted after three days of implementation, testing, benchmarking, and review in our own Cohere batch-inference script, [AliOsm/cohere-transcribe-arabic-batch-inference](https://github.com/AliOsm/cohere-transcribe-arabic-batch-inference). The production implementation that motivated this contribution is [here](https://github.com/AliOsm/cohere-transcribe-arabic-batch-inference/blob/5035d8ef5787bde147681d6760122a00f8a21303/transcribe.py#L1477-L1560).

# What does this PR do?

Adds an opt-in `RepeatedNGramCriteria` that stops individual batch rows when their suffix contains a configurable number of consecutive copies of the same token block.

It supports:

- one fixed n-gram size or an inclusive size range;
- a configurable repetition count (four by default, matching the production-tested setting);
- prompt exclusion through `prompt_length_to_skip`;
- a `min_new_tokens` gate to reduce premature matches;
- independent per-row results with no sticky criterion state;
- pure tensor operations compatible with `torch.compile(fullgraph=True)`;
- a fast fixed-size path and bounded temporary memory for wide ranges.

The criterion is exported from both `transformers` and `transformers.generation`, documented in the internal generation API, and covered by unit, randomized-reference, compile, stress, export, and real `generate()` integration tests.

Fixes #32902. The issue was explicitly approved for a `StoppingCriteria` contribution in [this maintainer comment](https://github.com/huggingface/transformers/issues/32902#issuecomment-2302674622).

## Scope and prior work

This PR adds the reusable criterion first. It intentionally does not add serialized `GenerationConfig` fields yet: the exact configuration surface (one size versus a range, repetition count, prompt handling, and a minimum-token gate) deserves maintainer agreement before becoming a persisted API. The criterion is fully usable today through `stopping_criteria=StoppingCriteriaList([...])`; config wiring can follow if maintainers prefer it.

Closed draft #44708 contains an adjacent scheduler callback, but not this implementation. That callback inspected only batch row 0, synchronized with `.item()`, counted non-consecutive occurrences, and retained mutable detection state. This PR detects consecutive suffix blocks per row, uses tensor-only operations, and remains stateless so beam/candidate reordering cannot attach completion state to the wrong row. `generate()` already retains stopped rows through its unfinished-sequence mask.

## Production evidence

The deployed Cohere ASR guard uses the same core detection policy used here: check every generated token after a 96-token gate for four consecutive copies of blocks sized 8 through 32. Its wrapper additionally caches invariant index tensors and records audit/EOS state, so these are production implementation results rather than a benchmark of this exact upstream diff.

Matched 500-clip ablation, with every other inference setting held constant (RTX 3060 12 GB, BF16, batch 24, `max_new_tokens=445`, 5,032.699 seconds of Arabic audio):

| Configuration | Wall time | Generation time | Lexical WER |
|---|---:|---:|---:|
| Projection cache, repetition guard off | 59.603 s | 37.034 s | 23.2035% |
| Projection cache, repetition guard on | 51.723 s | 29.116 s | 22.9551% |
| Change | **-13.22%** | **-21.38%** | **-0.2483 pp** |

Only 5 of 500 hypotheses changed. All five were visible punctuation, character, or phrase loops; their combined output length fell from 3,048 to 784 characters. This is why WER improved rather than regressed.

As supplemental scale evidence, a 24,414-clip / 36.393-hour evaluation changed 125 hypotheses (0.512%), reduced lexical WER from 32.2576% to 31.3205% (paired 95% CI for the delta: -1.4766 to -0.4781 percentage points), and reduced insertions from 9,800 to 7,629. Its timing comparison also includes an invariant encoder-projection cache, so the 23.54% generation-time reduction in that larger run is not attributed solely to this stopping policy.

## Exact criterion microbenchmark

This exact diff was measured independently on CPU and an RTX 3060 with PyTorch 2.11.0+cu128. The input was a non-repeating random batch of 24 rows; each trial invoked the criterion for all 350 eligible lengths from 96 through 445 tokens. Results are medians of 100 trials after 10 warmups, with one CUDA synchronization around each complete trial.

| Criterion | CPU, 350 calls | RTX 3060, 350 calls | CUDA per call |
|---|---:|---:|---:|
| Fixed 32-token block, four copies | 7.273 ms | 9.676 ms | 0.0276 ms |
| Range 8–32, four copies | 46.279 ms | 43.375 ms | 0.1239 ms |

The benchmark intentionally uses healthy, non-looping rows so it measures the full detector overhead without early termination. There are no timing assertions in the test suite.

## Validation

```text
make style
  4/4 checks passed

make check-repo
  24/24 checks passed

PYTHONPATH=src python -m pytest -q tests/generation/test_stopping_criteria.py
  31 passed

PYTHONPATH=src python -m pytest -q \
  tests/generation/test_utils.py::GenerationIntegrationTests::test_repeated_ngram_stopping_criteria
  1 passed
```

The tests cover constructor validation, fixed and ranged matching, mixed batch rows, exact and near-miss thresholds, prompt exclusion, minimum-token gating, row reordering/statelessness, empty batches, bounded wide-range processing, 100 randomized cases against a Python reference, fixed/range full-graph compilation, top-level exports, and deterministic generation stopping.

## Code Agent Policy

- [ ] (First-time contributors only): not applicable. `AliOsm` is an existing Transformers contributor, and the AI-generated nature of this PR is disclosed at the top rather than checking this attestation.

## Before submitting

- [x] I read the contributor and pull-request guidance.
- [x] This was discussed and approved in #32902.
- [x] The API documentation and public exports are updated.
- [x] Necessary tests were added and the repository checks pass.

Reviewers: @gante for the original issue context and @Cyrilvallez for generation.