### PR TITLE
Fix check for interactive stdout in _style function

### DIFF
--- a/src/transformers/utils/loading_report.py
+++ b/src/transformers/utils/loading_report.py
@@ -120,7 +120,7 @@ PALETTE = {
 
 def _style(s, color):
     """Return color/style-formatted input `s` if `sys.stdout` is interactive, e.g. connected to a terminal."""
-    if sys.stdout.isatty():
+    if sys.stdout is not None and sys.stdout.isatty():
         return f"{PALETTE[color]}{s}{PALETTE['reset']}"
     else:
         return s


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47283)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47283)
<!-- ci-dashboard-badge:end -->

I encountered an error when I set 'sys.stdout' to 'None' to turn off logging.