### PR TITLE
Fix ZeroDivisionError in polynomial decay when warmup equals training steps

### DIFF
--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -233,7 +233,7 @@ def _get_polynomial_decay_schedule_with_warmup_lr_lambda(
         return lr_end / lr_init  # as LambdaLR multiplies by lr_init
     else:
         lr_range = lr_init - lr_end
-        decay_steps = num_training_steps - num_warmup_steps
+        decay_steps = max(1, num_training_steps - num_warmup_steps)
         pct_remaining = 1 - (current_step - num_warmup_steps) / decay_steps
         decay = lr_range * pct_remaining**power + lr_end
         return decay / lr_init  # as LambdaLR multiplies by lr_init


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47285)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47285)
<!-- ci-dashboard-badge:end -->

## Summary

When `num_warmup_steps == num_training_steps` in `get_polynomial_decay_schedule_with_warmup`, `decay_steps` becomes 0, causing a `ZeroDivisionError` at `optimization.py:236`.

## Root cause

`decay_steps = num_training_steps - num_warmup_steps` — when warmup fills the entire schedule, `decay_steps = 0`.

## Fix

`decay_steps = max(1, num_training_steps - num_warmup_steps)`

This gracefully skips the decay phase when there are no decay steps.

## How to reproduce

```python
from transformers import get_polynomial_decay_schedule_with_warmup
from torch.optim import SGD
from torch.nn import Linear

model = Linear(2, 1)
optimizer = SGD(model.parameters(), lr=0.01)
scheduler = get_polynomial_decay_schedule_with_warmup(
    optimizer, num_warmup_steps=100, num_training_steps=100, power=2.0, lr_end=1e-7,
)
scheduler.step()  # ZeroDivisionError
```

## AI Disclosure

This PR was prepared with assistance from an AI coding agent, under the supervision of a human contributor who reviewed all changes.

First-time contributor checkbox: leaving unchecked per policy.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that is the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing)?
- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you write any new necessary tests?

## Who can review?

@muellerzr