### PR TITLE
Fix pad_token_id=0 silently replaced by eos_token_id in beam search

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3305,7 +3305,7 @@ class GenerationMixin(ContinuousMixin):
         # 3. init running tensors and static-shaped placeholders
 
         # per batch, beam-item holding current token in loop and completed sequences
-        output_fill_value = pad_token_id or eos_token_id[0] if eos_token_id is not None else -1
+        output_fill_value = pad_token_id if pad_token_id is not None else (eos_token_id[0] if eos_token_id is not None else -1)
         running_sequences = torch.full(
             (batch_size, num_beams, max_length),
             fill_value=output_fill_value,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47286)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47286)
<!-- ci-dashboard-badge:end -->

## Summary

When `pad_token_id` is 0 (the most common value, e.g., BERT, GPT-2), the expression `pad_token_id or eos_token_id[0]` evaluates to `eos_token_id[0]` because `bool(0)` is `False` in Python. This causes beam search to use the wrong fill value for padding, corrupting output sequences.

## Root cause

`generation/utils.py:3308`: `output_fill_value = pad_token_id or eos_token_id[0] if eos_token_id is not None else -1`

Python's `or` operator tests truthiness. `pad_token_id=0` is falsy, so it falls through to `eos_token_id[0]`.

## Fix

```
- output_fill_value = pad_token_id or eos_token_id[0] if eos_token_id is not None else -1
+ output_fill_value = pad_token_id if pad_token_id is not None else (eos_token_id[0] if eos_token_id is not None else -1)
```

Uses explicit `is not None` instead of truthiness.

## Impact

Any model with `pad_token_id=0` using beam search will silently produce wrong outputs. One-line change with no side effects.

## AI Disclosure

This PR was prepared with assistance from an AI coding agent, under the supervision of a human contributor who reviewed all changes.

## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [ ] Did you read the contributor guideline?
- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you write any new necessary tests?

## Who can review?

@gante