### PR TITLE
Fix NaN loss in metrics when eval dataset produces no losses

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2833,7 +2833,7 @@ class Trainer:
 
         if isinstance(all_losses, list) and all_losses:
             metrics[f"{metric_key_prefix}_loss"] = np.concatenate(all_losses).mean().item()
-        elif isinstance(all_losses, np.ndarray):
+        elif isinstance(all_losses, np.ndarray) and all_losses.size > 0:
             metrics[f"{metric_key_prefix}_loss"] = all_losses.mean().item()
         if hasattr(self, "model_preparation_time"):
             metrics[f"{metric_key_prefix}_model_preparation_time"] = self.model_preparation_time


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47287)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47287)
<!-- ci-dashboard-badge:end -->

## Summary

When `all_losses` is an empty numpy array (no loss outputs in eval batch), `all_losses.mean()` returns `NaN`, which propagates into reported metrics.

## Root cause

`trainer.py:2834-2837`: The `elif isinstance(all_losses, np.ndarray)` branch does not guard against empty arrays. The `list` branch has `and all_losses` truthiness check, but the numpy branch is missing the equivalent guard.

## Fix

```
- elif isinstance(all_losses, np.ndarray):
+ elif isinstance(all_losses, np.ndarray) and all_losses.size > 0:
```

## AI Disclosure

This PR was prepared with assistance from an AI coding agent, under the supervision of a human contributor who reviewed all changes.

## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [ ] Did you read the contributor guideline?
- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you write any new necessary tests?

## Who can review?

@SunMarc