### PR TITLE
Fix token not propagated to get_config_dict in PreTrainedConfig.from_pretrained

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -676,6 +676,8 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin, Heterogeneous
         kwargs["force_download"] = force_download
         kwargs["local_files_only"] = local_files_only
         kwargs["revision"] = revision
+        if token is not None:
+            kwargs["token"] = token
 
         config_dict, kwargs = cls.get_config_dict(pretrained_model_name_or_path, **kwargs)
         if cls.base_config_key and cls.base_config_key in config_dict:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47288)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47288)
<!-- ci-dashboard-badge:end -->

## Summary

When calling `PreTrainedConfig.from_pretrained("model", token="xxx")`, the `token` parameter is captured as a named argument but never forwarded to `get_config_dict` → `_get_config_dict`. The token is silently ignored, causing downloads of gated/config-restricted models to fail even with a valid token.

## Root cause

`configuration_utils.py:675-678`: `cache_dir`, `force_download`, `local_files_only`, and `revision` are all explicitly added to kwargs, but `token` is not. `_get_config_dict` (line 743) pops `token` from kwargs and gets `None`.

## Fix

```python
kwargs["cache_dir"] = cache_dir
kwargs["force_download"] = force_download
kwargs["local_files_only"] = local_files_only
kwargs["revision"] = revision
+ if token is not None:
+     kwargs["token"] = token
```

## Note

The `_set_token_in_kwargs` mechanism in `AutoConfig` (auto_factory.py) works around this for the Auto class path, but direct `from_pretrained` calls were missed.

## AI Disclosure

This PR was prepared with assistance from an AI coding agent, under the supervision of a human contributor who reviewed all changes.

## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [ ] Did you read the contributor guideline?
- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you write any new necessary tests?

## Who can review?

@CyrilValleys @ArthurZucker