### PR TITLE
fix(musicflamingo): Fix dtype mismatch with _keep_in_fp32_modules_strict override

### DIFF
--- a/src/transformers/models/musicflamingo/modeling_musicflamingo.py
+++ b/src/transformers/models/musicflamingo/modeling_musicflamingo.py
@@ -408,7 +408,7 @@ class MusicFlamingoCausalLMOutputWithPast(ModelOutput):
     """
 )
 class MusicFlamingoForConditionalGeneration(MusicFlamingoPreTrainedModel, GenerationMixin):
-    _keep_in_fp32_modules_strict = ["embed_positions"]
+    _keep_in_fp32_modules_strict = None
     _tied_weights_keys = None
 
     def __init__(self, config: MusicFlamingoConfig):

--- a/src/transformers/models/musicflamingo/modular_musicflamingo.py
+++ b/src/transformers/models/musicflamingo/modular_musicflamingo.py
@@ -395,6 +395,8 @@ class MusicFlamingoModel(AudioFlamingo3Model):
     """
 )
 class MusicFlamingoForConditionalGeneration(AudioFlamingo3ForConditionalGeneration):
+    _keep_in_fp32_modules_strict = None
+
     def __init__(self, config: MusicFlamingoConfig):
         super().__init__(config)
         self.model = MusicFlamingoModel(config)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47300)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47300)
<!-- ci-dashboard-badge:end -->

### What does this PR do?

→ Restores the `_keep_in_fp32_modules_strict` override on `MusicFlamingoForConditionalGeneration` so half-precision works again.
→ Regression from #45534; the split into Model + head kept the None override only on the base-model class so the head class now inherits `["embed_positions"]` from Voxtral (via AudioFlamingo3). As for whether any other models from the same PR are afflicted, AF3 has the [same regression](https://github.com/harshaljanjani/transformers/blob/main/src/transformers/models/audioflamingo3/modeling_audioflamingo3.py#L569) but is already being addressed in `#47258` so it's left untouched here; `GlmAsrForConditionalGeneration` inherits the same attr but has no `embed_positions` param at all (rotary embeddings) so it's a [harmless no-op there](https://github.com/harshaljanjani/transformers/blob/main/src/transformers/models/glmasr/modeling_glmasr.py#L523) (happy to add the same override for clarity if wanted).
→ Made sure this doesn't cause any regressions in `tests/models/musicflamingo/`

cc: @eustlb

**Before ([CI Failures](https://github.com/huggingface/transformers/actions/runs/29221731474/job/86728607936))**

<img alt="image" src="https://github.com/user-attachments/assets/109b1a59-a319-454f-a944-87e20e12323d" /><br>

**After**

<img alt="3" src="https://github.com/user-attachments/assets/e2493654-e4b6-4f9d-8c83-d08cd0b18c15" />

### Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

### Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you fix any necessary existing tests?