### PR TITLE
Fix MoE expert decompression for non-32-divisible bit widths

### DIFF
--- a/src/transformers/integrations/compressed_tensors.py
+++ b/src/transformers/integrations/compressed_tensors.py
@@ -58,6 +58,9 @@ class DecompressExperts(ConversionOps):
                 self.weight_shape = nn.Parameter(shape, requires_grad=False)
 
         # `pack_factor` low-bit weights are packed per int32 along the packed dim.
+        # Used only as a fallback for `weight_shape` (see below): rebuilding the
+        # unpacked in-dim as `packed_cols * pack_factor` is exact only when
+        # `num_bits` divides 32; for 3/5/6/7-bit dense packing it under-counts.
         pack_factor = 32 // quantization_scheme.weights.num_bits
 
         # Per-expert compressed projections of size (input-dim; output-dim)
@@ -67,16 +70,22 @@ class DecompressExperts(ConversionOps):
                 continue
             quantized = value
             scales = input_dict[key.replace("weight_packed", "weight_scale")]
+            shapes = input_dict.get(key.replace("weight_packed", "weight_shape"))
 
             # Pre-allocate the stacked output buffer to reduce cuda mem fragmentation
             # Without pre-allocation the loop accumulates N tensors per expert and next
             # `MergeModulelist` stacks the full list for MoE kernels compatipility, i.e. x2 memory
             output = None
             for i, (quant, scale) in enumerate(zip(quantized, scales)):
-                # The checkpoint's `weight_shape` is a 2D tensor of `(out-dim, in-dim)`
-                # Under TP/EP sharding it leaves the 2-element `weight_shape` empty on most ranks
-                # Packed tensor can be used instead to rebuild `weight_shape`
-                shape = torch.tensor([quant.shape[0], quant.shape[1] * pack_factor])
+                # Prefer the checkpoint's stored per-expert `weight_shape`
+                # (out-dim, in-dim); it is exact for any bit width. Fall back to
+                # rebuilding from the packed tensor only when it is missing/empty,
+                # e.g. left empty on most ranks under TP/EP sharding.
+                stored_shape = None if shapes is None else shapes[i]
+                if stored_shape is not None and stored_shape.numel():
+                    shape = stored_shape
+                else:
+                    shape = torch.tensor([quant.shape[0], quant.shape[1] * pack_factor])
                 module = DummyModule(quant, scale, shape)
                 module.quantization_scheme = quantization_scheme
                 compressor.decompress_module(module)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47315)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47315)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

`DecompressExperts.convert` (in `integrations/compressed_tensors.py`) rebuilds each MoE expert's unpacked input dimension as `packed_cols * (32 // num_bits)`. `compressed-tensors` uses **dense** bit-packing, so this reconstruction is only exact when `num_bits` divides 32 (i.e. 4-bit and 8-bit). For 3/5/6/7-bit weights it under-counts.

Concretely, a 3-bit `down_proj` stored as `weight_packed` of shape `(2048, 48)` reconstructs an input dim of `48 * (32 // 3) = 48 * 10 = 480`, whereas the true dim is `512`. The experts then decompress to the wrong shape and loading fails with:

```
RuntimeError: contraction dimension of mat_a and mat_b must match
```

from `torch._grouped_mm`. 4-bit and 8-bit checkpoints are unaffected because 8 and 4 divide 32 evenly.

### Fix

The checkpoint already stores an exact per-expert `weight_shape` (`(out-dim, in-dim)`), and it is already routed into `convert` via the `.weight_shape$` source pattern in `quantizer_compressed_tensors.py`. This PR uses that stored shape, and falls back to the packed-tensor reconstruction only when it is missing/empty (e.g. left empty on most ranks under TP/EP sharding — the case the previous code was written for).

### Testing

Verified on a 3-bit (W3A16) AWQ-quantized MoE checkpoint (`GlmMoeDsaForCausalLM`):

- **Before:** loading crashes with the `_grouped_mm` contraction error above.
- **After:** loads successfully; perplexity **1.0002** vs. **1.0000** for the bf16 base on the same text.

4-bit and 8-bit checkpoints load identically before and after (the stored shape matches the old reconstruction for those bit widths).

AI assistance was used for this change; every line was reviewed and the tests above were run.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Did you make sure to update the documentation with your changes? (n/a — bug fix, no API change)
- [ ] Did you write any new necessary tests? (happy to add a regression test if maintainers prefer)

## Who can review?

Quantization / compressed-tensors: @SunMarc @MekkCyber