### PR TITLE
[Improvement] Re-structure sonic MoE kernel interface to use a Handle object

### DIFF
--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -25,7 +25,7 @@ from ..utils.import_utils import (
     is_torchdynamo_compiling,
 )
 from .deepgemm import deepgemm_bf16_experts_forward
-from .sonicmoe import sonicmoe_experts_forward
+from .sonicmoe import SONIC_MOE_HANDLE
 
 
 if is_torch_available():
@@ -491,7 +491,7 @@ class ExpertsInterface(GeneralInterface):
         "deepgemm": deepgemm_bf16_experts_forward,
         "batched_mm": batched_mm_experts_forward,
         "grouped_mm": grouped_mm_experts_forward,
-        "sonicmoe": sonicmoe_experts_forward,
+        "sonicmoe": SONIC_MOE_HANDLE.sonicmoe_experts_forward,
     }
 
     def get_interface(self, experts_implementation: str, default: Callable) -> Callable:

--- a/src/transformers/integrations/sonicmoe.py
+++ b/src/transformers/integrations/sonicmoe.py
@@ -109,6 +109,10 @@ def _load_sonicmoe_kernel() -> SonicMoE:
 
 
 class SonicMoeHandle:
+    """An handle to the sonicmoe kernel. This object is meant to be instancied only once, and then provides an entry
+    point to the kernel. Having an object allows to cache the kernel after the first call to `_load_sonicmoe_kernel`,
+    or to cache the error that occurred then.
+    """
 
     # Map activation function names from HF config to SonicMoE epilogue names
     ACT_MAP = {"silu": "SWIGLU", "gelu": "GEGLU", "relu": "REGLU"}

--- a/src/transformers/integrations/sonicmoe.py
+++ b/src/transformers/integrations/sonicmoe.py
@@ -14,7 +14,7 @@
 
 """SonicMoE integration: fused MoE using CuteDSL kernels from `kernels-community/sonic-moe`.
 
-Provides `sonicmoe_experts_forward` registered as "sonicmoe" in the ExpertsInterface.
+Provides `SONIC_MOE_HANDLE` registered as "sonicmoe" in the ExpertsInterface.
 Requirements: CUDA, `kernels`, `nvidia-cutlass-dsl`, has_gate=True.
 """
 
@@ -105,49 +105,6 @@ def _load_sonicmoe_kernel() -> SonicMoE:
     )
 
 
-@torch._dynamo.allow_in_graph
-def _sonicmoe_wrapper(
-    sonicmoe_fn: Callable,
-    hidden_states: torch.Tensor,
-    router_scores: torch.Tensor,
-    expert_ids: torch.Tensor,
-    token_idx: torch.Tensor,
-    w1: torch.Tensor,
-    b1: torch.Tensor | None,
-    w2: torch.Tensor,
-    b2: torch.Tensor | None,
-    activation_type: int,
-    num_experts: int,
-    concat_layout: bool,
-    is_inference_mode_enabled: bool,
-) -> torch.Tensor:
-    """Module-level shim around `moe_general_routing_inputs` so `allow_in_graph` can wrap it.
-
-    sonicmoe asserts `not torch.compiler.is_compiling()` internally because it dispatches
-    CuteDSL kernels, which Dynamo can't trace. `allow_in_graph` keeps the call in the FX
-    graph as a single opaque node (no tracing into the body, no graph break) while still
-    running the real Python at runtime — autograd through `_UpProjection` / `_DownProjection`
-    flows normally. The decorator must be applied at module load time, not inside the compiled
-    function — hence this shim plus the `allow_in_graph` decorator above.
-    """
-    output, _ = sonicmoe_fn(
-        hidden_states,
-        router_scores,
-        token_idx,
-        expert_ids,
-        w1,
-        b1,
-        w2,
-        b2,
-        E=num_experts,
-        activation_type=activation_type,
-        is_inference_mode_enabled=is_inference_mode_enabled,
-        concat_layout=concat_layout,
-        stream_id=None,
-    )
-    return output
-
-
 
 
 class SonicMoeHandle:
@@ -171,12 +128,14 @@ class SonicMoeHandle:
         """
         # If this is the first time loading the kernel, it is not cached, so we need to actually load it
         if not self._loaded:
-            self._loaded = True
             try:
                 self._cached_sonicmoe = _load_sonicmoe_kernel()
-            except Exception as e:
+                self._loaded = True
+            # Guard only against import errors: other errors are unexpected, so we raise them
+            except ImportError as e:
                 self._loading_error = e
-                raise e
+                self._loaded = False
+                raise
         # Otherwise, re-raise the loading error if it occurred the first time
         if self._loading_error is not None:
             raise ImportError(
@@ -193,7 +152,7 @@ class SonicMoeHandle:
         """A boolean indicating whether the sonicmoe kernel is available. Silences regular import errors that would
         indicate that the kernel is not available, but not other errors that are unexpected."""
         try:
-            _ = self._load_sonicmoe_kernel()
+            self._load_sonicmoe_kernel()
             return True
         except ImportError:
             pass
@@ -214,18 +173,9 @@ class SonicMoeHandle:
         if hidden_states.device.type != "cuda":
             raise ValueError("sonicmoe requires CUDA device")
 
-        # Look up the kernel (no-op if already loaded)
-        sonicmoe = self._load_sonicmoe_kernel()
-
         # Retrieve sonicmoe-compatible activation type
         activation_hf = getattr(module.config, "hidden_act", "silu").lower()
-        activation_sonicmoe = self.ACT_MAP.get(activation_hf, "SWIGLU")
-        # Default to SwiGLU if the activation type is not found
-        activation_type = getattr(
-            sonicmoe.activation_type_enum,
-            activation_sonicmoe,
-            sonicmoe.activation_type_enum.SWIGLU  # type: ignore
-        )
+        activation_type = self.ACT_MAP.get(activation_hf, "SWIGLU")
 
         # Prepare auxilary inputs
         device = hidden_states.device
@@ -256,8 +206,7 @@ class SonicMoeHandle:
         w1 = w1.permute(*perm)  # (2*I, H, E)
         w2 = w2.permute(*perm)  # (I, H, E)
 
-        return _sonicmoe_wrapper(
-            sonicmoe_fn=sonicmoe.moe_general_routing_inputs,
+        return self._sonicmoe_wrapper(
             hidden_states=hidden_states,
             router_scores=router_scores,
             expert_ids=expert_ids,
@@ -271,6 +220,58 @@ class SonicMoeHandle:
             concat_layout=module.is_concatenated,
             is_inference_mode_enabled=not torch.is_grad_enabled(),
         )
+
+    @torch._dynamo.allow_in_graph
+    def _sonicmoe_wrapper(
+        self,
+        hidden_states: torch.Tensor,
+        router_scores: torch.Tensor,
+        expert_ids: torch.Tensor,
+        token_idx: torch.Tensor,
+        w1: torch.Tensor,
+        b1: torch.Tensor | None,
+        w2: torch.Tensor,
+        b2: torch.Tensor | None,
+        activation_type: str,
+        num_experts: int,
+        concat_layout: bool,
+        is_inference_mode_enabled: bool,
+    ) -> torch.Tensor:
+        """Handle-level shim around `moe_general_routing_inputs` so `allow_in_graph` can wrap it.
+
+        sonicmoe asserts `not torch.compiler.is_compiling()` internally because it dispatches
+        CuteDSL kernels, which Dynamo can't trace. `allow_in_graph` keeps the call in the FX
+        graph as a single opaque node (no tracing into the body, no graph break) while still
+        running the real Python at runtime — autograd through `_UpProjection` / `_DownProjection`
+        flows normally. The decorator must be applied at module load time, not inside the compiled
+        function — hence this shim plus the `allow_in_graph` decorator above.
+        """
+        sonicmoe = self._load_sonicmoe_kernel()
+
+        # Default to SwiGLU if the activation type is not found
+        activation_type = getattr(
+            sonicmoe.activation_type_enum,
+            activation_type,
+            sonicmoe.activation_type_enum.SWIGLU  # type: ignore
+        )
+
+        output, _ = sonicmoe.moe_general_routing_inputs(
+            hidden_states,
+            router_scores,
+            token_idx,
+            expert_ids,
+            w1,
+            b1,
+            w2,
+            b2,
+            E=num_experts,
+            activation_type=activation_type,
+            is_inference_mode_enabled=is_inference_mode_enabled,
+            concat_layout=concat_layout,
+            stream_id=None,
+        )
+        return output
+
 
 # Singleton object: this should be the only SonicMoeHandle object instantiated in the codebase
 SONIC_MOE_HANDLE = SonicMoeHandle()

--- a/src/transformers/integrations/sonicmoe.py
+++ b/src/transformers/integrations/sonicmoe.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 import torch
 
@@ -37,7 +38,7 @@ logger = logging.get_logger(__name__)
 class SonicMoE:
     """Entry points exposed by the `kernels-community/sonic-moe` kernel."""
 
-    activation_type_enum: type
+    activation_type_enum: Any  # an Enum defined kernel-side
     moe_general_routing_inputs: Callable
 
 
@@ -134,17 +135,17 @@ class SonicMoeHandle:
             # Guard only against import errors: other errors are unexpected, so we raise them
             except ImportError as e:
                 self._loading_error = e
-                self._loaded = False
+                self._loaded = True
                 raise
         # Otherwise, re-raise the loading error if it occurred the first time
         if self._loading_error is not None:
             raise ImportError(
                 "Tried calling sonicmoe_experts_forward but the kernel failed to load on the first call. You can call "
-                "`reset on the handle if you want to retry loading the kernel"
+                "`reset` on the handle if you want to retry loading the kernel"
             ) from self._loading_error
         # Sanity check to see if the kernel was loaded successfully
         elif self._cached_sonicmoe is None:
-            raise RuntimeError("sonicmoe kernel was marked has loaded but cannot be found. This should never happen.")
+            raise RuntimeError("sonicmoe kernel was marked as loaded but cannot be found. This should never happen.")
         return self._cached_sonicmoe
 
     @property
@@ -177,7 +178,7 @@ class SonicMoeHandle:
         activation_hf = getattr(module.config, "hidden_act", "silu").lower()
         activation_type = self.ACT_MAP.get(activation_hf, "SWIGLU")
 
-        # Prepare auxilary inputs
+        # Prepare auxiliary inputs
         device = hidden_states.device
         num_top_k = top_k_index.size(-1)
         num_tokens = hidden_states.size(0)
@@ -252,7 +253,7 @@ class SonicMoeHandle:
         activation_type = getattr(
             sonicmoe.activation_type_enum,
             activation_type,
-            sonicmoe.activation_type_enum.SWIGLU  # type: ignore
+            sonicmoe.activation_type_enum.SWIGLU
         )
 
         output, _ = sonicmoe.moe_general_routing_inputs(

--- a/src/transformers/integrations/sonicmoe.py
+++ b/src/transformers/integrations/sonicmoe.py
@@ -20,7 +20,6 @@ Requirements: CUDA, `kernels`, `nvidia-cutlass-dsl`, has_gate=True.
 
 from __future__ import annotations
 
-import functools
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -33,9 +32,6 @@ from .tensor_parallel import to_local
 
 logger = logging.get_logger(__name__)
 
-# Map activation function names from HF config to SonicMoE epilogue names
-ACT_MAP = {"silu": "swiglu", "gelu": "geglu", "relu": "reglu"}
-
 
 @dataclass(frozen=True)
 class SonicMoE:
@@ -45,7 +41,6 @@ class SonicMoE:
     moe_general_routing_inputs: Callable
 
 
-@functools.cache
 def _load_sonicmoe_kernel() -> SonicMoE:
     """
     Load sonic-moe once and return its entry points.
@@ -65,6 +60,19 @@ def _load_sonicmoe_kernel() -> SonicMoE:
         raise ImportError(
             f"sonic-moe requires a Hopper (SM90+) or newer GPU, but the current device "
             f"has compute capability {major}.x. Use a different `experts_implementation`."
+        )
+
+    # check if cutlass-dsl is installed
+    from cutlass.utils.hardware_info import HardwareInfo
+
+    # sonic-moe JIT-builds CuteDSL kernels; bail early if the driver can't load their device image.
+    try:
+        HardwareInfo().get_max_active_clusters(1)
+    except Exception as e:  # cutlass wraps the CUDA driver error in a bare RuntimeError
+        raise ImportError(
+            f"Image error: sonic-moe's CuteDSL kernels cannot load a device image on this GPU/driver "
+            f"({type(e).__name__}: {e}). This usually means cutlass-dsl's bundled CUDA toolchain is "
+            f"newer than the driver (e.g. cu13 libs on a CUDA 12.x driver)."
         )
 
     kernel = lazy_load_kernel("sonic-moe")
@@ -99,6 +107,7 @@ def _load_sonicmoe_kernel() -> SonicMoE:
 
 @torch._dynamo.allow_in_graph
 def _sonicmoe_wrapper(
+    sonicmoe_fn: Callable,
     hidden_states: torch.Tensor,
     router_scores: torch.Tensor,
     expert_ids: torch.Tensor,
@@ -107,7 +116,7 @@ def _sonicmoe_wrapper(
     b1: torch.Tensor | None,
     w2: torch.Tensor,
     b2: torch.Tensor | None,
-    act_name: str,
+    activation_type: int,
     num_experts: int,
     concat_layout: bool,
     is_inference_mode_enabled: bool,
@@ -121,12 +130,7 @@ def _sonicmoe_wrapper(
     flows normally. The decorator must be applied at module load time, not inside the compiled
     function — hence this shim plus the `allow_in_graph` decorator above.
     """
-    sonicmoe = _load_sonicmoe_kernel()
-    activation_type_enum = sonicmoe.activation_type_enum
-    activation_type = getattr(
-        activation_type_enum, ACT_MAP.get(act_name, "swiglu").upper(), activation_type_enum.SWIGLU
-    )
-    output, _ = sonicmoe.moe_general_routing_inputs(
+    output, _ = sonicmoe_fn(
         hidden_states,
         router_scores,
         token_idx,
@@ -144,57 +148,129 @@ def _sonicmoe_wrapper(
     return output
 
 
-def sonicmoe_experts_forward(
-    self: torch.nn.Module,
-    hidden_states: torch.Tensor,
-    top_k_index: torch.Tensor,
-    top_k_weights: torch.Tensor,
-) -> torch.Tensor:
-    if not self.has_gate:
-        raise ValueError("sonicmoe requires gated experts (has_gate=True)")
-    if hidden_states.device.type != "cuda":
-        raise ValueError("sonicmoe requires CUDA device")
 
-    device = hidden_states.device
-    num_top_k = top_k_index.size(-1)
-    num_tokens = hidden_states.size(0)
 
-    # Flatten — token_indices must be int32, sorted ascending (required by sonic-moe)
-    token_idx = torch.arange(num_tokens, device=device).unsqueeze(1).expand(-1, num_top_k).reshape(-1).int()
-    router_scores = top_k_weights.reshape(-1).to(hidden_states.dtype)
-    expert_ids = top_k_index.reshape(-1).int()
+class SonicMoeHandle:
 
-    # EP sentinel handling: leave `expert_ids` unclamped — the kernel's metadata stage drops
-    # `expert_ids >= num_experts` from the per-expert histogram and masks them out of the
-    # scatter indices, so sentinels never enter the grouped GEMM. Their routing weights are
-    # already zero (RouterParallel masks them at dispatch), so the per-token reduction
-    # contributes nothing for sentinel slots.
+    # Map activation function names from HF config to SonicMoE epilogue names
+    ACT_MAP = {"silu": "SWIGLU", "gelu": "GEGLU", "relu": "REGLU"}
 
-    w1 = to_local(self.gate_up_proj)
-    w2 = to_local(self.down_proj)
-    b1 = to_local(self.gate_up_proj_bias) if self.has_bias else None
-    b2 = to_local(self.down_proj_bias) if self.has_bias else None
+    def __init__(self) -> None:
+        self.reset()
 
-    # Map activation function
-    act_name = getattr(self.config, "hidden_act", "silu").lower()
-    # Permute weights as expected by sonic-moe (E=num_experts, H=hidden_size, I=intermediate_size).
-    # Non-transposed: gate_up_proj is (E, 2*I, H), down_proj is (E, H, I) -> permute(1, 2, 0).
-    # Transposed: gate_up_proj is (E, H, 2*I), down_proj is (E, I, H) -> permute(2, 1, 0).
-    perm = (2, 1, 0) if self.is_transposed else (1, 2, 0)
-    w1 = w1.permute(*perm)  # (2*I, H, E)
-    w2 = w2.permute(*perm)  # (I, H, E)
+    def reset(self) -> None:
+        """Resets the state of the handle, for instance to retry loading the kernel after the first attempt failed."""
+        self._loaded: bool = False
+        self._loading_error: Exception | None = None
+        self._cached_sonicmoe: SonicMoE | None = None
 
-    return _sonicmoe_wrapper(
-        hidden_states=hidden_states,
-        router_scores=router_scores,
-        expert_ids=expert_ids,
-        token_idx=token_idx,
-        w1=w1,
-        b1=b1,
-        w2=w2,
-        b2=b2,
-        act_name=act_name,
-        num_experts=self.num_experts,
-        concat_layout=self.is_concatenated,
-        is_inference_mode_enabled=not torch.is_grad_enabled(),
-    )
+    def _load_sonicmoe_kernel(self) -> SonicMoE:
+        """Loads and return a SonicMoE object which contains what's necessary to call the kernel. After the first call
+        to this function, the output or the Exception is cached: call `.reset` to reset the cached state. Private
+        method because the sonicmoe kernel is meant to be called from the handle.
+        """
+        # If this is the first time loading the kernel, it is not cached, so we need to actually load it
+        if not self._loaded:
+            self._loaded = True
+            try:
+                self._cached_sonicmoe = _load_sonicmoe_kernel()
+            except Exception as e:
+                self._loading_error = e
+                raise e
+        # Otherwise, re-raise the loading error if it occurred the first time
+        if self._loading_error is not None:
+            raise ImportError(
+                "Tried calling sonicmoe_experts_forward but the kernel failed to load on the first call. You can call "
+                "`reset on the handle if you want to retry loading the kernel"
+            ) from self._loading_error
+        # Sanity check to see if the kernel was loaded successfully
+        elif self._cached_sonicmoe is None:
+            raise RuntimeError("sonicmoe kernel was marked has loaded but cannot be found. This should never happen.")
+        return self._cached_sonicmoe
+
+    @property
+    def sonicmoe_is_available(self) -> bool:
+        """A boolean indicating whether the sonicmoe kernel is available. Silences regular import errors that would
+        indicate that the kernel is not available, but not other errors that are unexpected."""
+        try:
+            _ = self._load_sonicmoe_kernel()
+            return True
+        except ImportError:
+            pass
+        return False
+
+    def sonicmoe_experts_forward(
+        self,
+        module: torch.nn.Module,
+        hidden_states: torch.Tensor,
+        top_k_index: torch.Tensor,
+        top_k_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        """Calls the underlying sonicmoe kernel with the given inputs. If the kernel has not been loaded yet, it will be
+        loaded and cached."""
+        # Check arguments before kernel loading: we might avoid loading altogether if the checks don't pass
+        if not module.has_gate:
+            raise ValueError("sonicmoe requires gated experts (has_gate=True)")
+        if hidden_states.device.type != "cuda":
+            raise ValueError("sonicmoe requires CUDA device")
+
+        # Look up the kernel (no-op if already loaded)
+        sonicmoe = self._load_sonicmoe_kernel()
+
+        # Retrieve sonicmoe-compatible activation type
+        activation_hf = getattr(module.config, "hidden_act", "silu").lower()
+        activation_sonicmoe = self.ACT_MAP.get(activation_hf, "SWIGLU")
+        # Default to SwiGLU if the activation type is not found
+        activation_type = getattr(
+            sonicmoe.activation_type_enum,
+            activation_sonicmoe,
+            sonicmoe.activation_type_enum.SWIGLU  # type: ignore
+        )
+
+        # Prepare auxilary inputs
+        device = hidden_states.device
+        num_top_k = top_k_index.size(-1)
+        num_tokens = hidden_states.size(0)
+
+        # Flatten — token_indices must be int32, sorted ascending (required by sonic-moe)
+        token_idx = torch.arange(num_tokens, device=device, dtype=torch.int32)
+        token_idx = token_idx.unsqueeze(1).expand(-1, num_top_k).reshape(-1)
+        router_scores = top_k_weights.reshape(-1).to(hidden_states.dtype)
+        expert_ids = top_k_index.reshape(-1).int()
+
+        # EP sentinel handling: leave `expert_ids` unclamped — the kernel's metadata stage drops
+        # `expert_ids >= num_experts` from the per-expert histogram and masks them out of the
+        # scatter indices, so sentinels never enter the grouped GEMM. Their routing weights are
+        # already zero (RouterParallel masks them at dispatch), so the per-token reduction
+        # contributes nothing for sentinel slots.
+
+        w1 = to_local(module.gate_up_proj)
+        w2 = to_local(module.down_proj)
+        b1 = to_local(module.gate_up_proj_bias) if module.has_bias else None
+        b2 = to_local(module.down_proj_bias) if module.has_bias else None
+
+        # Permute weights as expected by sonic-moe (E=num_experts, H=hidden_size, I=intermediate_size).
+        # Non-transposed: gate_up_proj is (E, 2*I, H), down_proj is (E, H, I) -> permute(1, 2, 0).
+        # Transposed: gate_up_proj is (E, H, 2*I), down_proj is (E, I, H) -> permute(2, 1, 0).
+        perm = (2, 1, 0) if module.is_transposed else (1, 2, 0)
+        w1 = w1.permute(*perm)  # (2*I, H, E)
+        w2 = w2.permute(*perm)  # (I, H, E)
+
+        return _sonicmoe_wrapper(
+            sonicmoe_fn=sonicmoe.moe_general_routing_inputs,
+            hidden_states=hidden_states,
+            router_scores=router_scores,
+            expert_ids=expert_ids,
+            token_idx=token_idx,
+            w1=w1,
+            b1=b1,
+            w2=w2,
+            b2=b2,
+            activation_type=activation_type,
+            num_experts=module.num_experts,
+            concat_layout=module.is_concatenated,
+            is_inference_mode_enabled=not torch.is_grad_enabled(),
+        )
+
+# Singleton object: this should be the only SonicMoeHandle object instantiated in the codebase
+SONIC_MOE_HANDLE = SonicMoeHandle()

--- a/src/transformers/integrations/sonicmoe.py
+++ b/src/transformers/integrations/sonicmoe.py
@@ -20,6 +20,7 @@ Requirements: CUDA, `kernels`, `nvidia-cutlass-dsl`, has_gate=True.
 
 from __future__ import annotations
 
+import traceback
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -124,7 +125,7 @@ class SonicMoeHandle:
     def reset(self) -> None:
         """Resets the state of the handle, for instance to retry loading the kernel after the first attempt failed."""
         self._loaded: bool = False
-        self._loading_error: Exception | None = None
+        self._error_traceback: Exception | None = None
         self._cached_sonicmoe: SonicMoE | None = None
 
     def _load_sonicmoe_kernel(self) -> SonicMoE:
@@ -138,16 +139,16 @@ class SonicMoeHandle:
                 self._cached_sonicmoe = _load_sonicmoe_kernel()
                 self._loaded = True
             # Guard only against import errors: other errors are unexpected, so we raise them
-            except ImportError as e:
-                self._loading_error = e
+            except ImportError:
+                self._error_traceback = traceback.format_exc()
                 self._loaded = True
                 raise
         # Otherwise, re-raise the loading error if it occurred the first time
-        if self._loading_error is not None:
+        if self._error_traceback is not None:
             raise ImportError(
-                "Tried calling sonicmoe_experts_forward but the kernel failed to load on the first call. You can call "
-                "`reset` on the handle if you want to retry loading the kernel"
-            ) from self._loading_error
+                "Tried calling sonicmoe_experts_forward but the kernel failed to load on the first call. Call `reset` "
+                f"on the handle if you want to retry loading the kernel. Original traceback:\n{self._error_traceback}"
+            )
         # Sanity check to see if the kernel was loaded successfully
         elif self._cached_sonicmoe is None:
             raise RuntimeError("sonicmoe kernel was marked as loaded but cannot be found. This should never happen.")

--- a/src/transformers/integrations/sonicmoe.py
+++ b/src/transformers/integrations/sonicmoe.py
@@ -110,9 +110,9 @@ def _load_sonicmoe_kernel() -> SonicMoE:
 
 
 class SonicMoeHandle:
-    """An handle to the sonicmoe kernel. This object is meant to be instancied only once, and then provides an entry
-    point to the kernel. Having an object allows to cache the kernel after the first call to `_load_sonicmoe_kernel`,
-    or to cache the error that occurred then.
+    """A handle to the sonicmoe kernel. This object is meant to be instantiated only once, and then provides an entry
+    point to the kernel. Having an object allows caching the kernel after the first call to `_load_sonicmoe_kernel`,
+    or caching the error that occurred then.
     """
 
     # Map activation function names from HF config to SonicMoE epilogue names
@@ -128,7 +128,7 @@ class SonicMoeHandle:
         self._cached_sonicmoe: SonicMoE | None = None
 
     def _load_sonicmoe_kernel(self) -> SonicMoE:
-        """Loads and return a SonicMoE object which contains what's necessary to call the kernel. After the first call
+        """Loads and returns a SonicMoE object which contains what's necessary to call the kernel. After the first call
         to this function, the output or the Exception is cached: call `.reset` to reset the cached state. Private
         method because the sonicmoe kernel is meant to be called from the handle.
         """

--- a/src/transformers/integrations/sonicmoe.py
+++ b/src/transformers/integrations/sonicmoe.py
@@ -67,6 +67,9 @@ def _load_sonicmoe_kernel() -> SonicMoE:
     from cutlass.utils.hardware_info import HardwareInfo
 
     # sonic-moe JIT-builds CuteDSL kernels; bail early if the driver can't load their device image.
+    # HardwareInfo uses the CUDA driver API directly and needs a current context, which torch only
+    # creates lazily — without this, the probe fails with CUDA_ERROR_INVALID_CONTEXT.
+    torch.cuda.synchronize()
     try:
         HardwareInfo().get_max_active_clusters(1)
     except Exception as e:  # cutlass wraps the CUDA driver error in a bare RuntimeError
@@ -104,8 +107,6 @@ def _load_sonicmoe_kernel() -> SonicMoE:
         activation_type_enum=activation_type_enum,
         moe_general_routing_inputs=moe_general_routing_inputs,
     )
-
-
 
 
 class SonicMoeHandle:
@@ -211,7 +212,7 @@ class SonicMoeHandle:
         w1 = w1.permute(*perm)  # (2*I, H, E)
         w2 = w2.permute(*perm)  # (I, H, E)
 
-        return self._sonicmoe_wrapper(
+        return _sonicmoe_wrapper(
             hidden_states=hidden_states,
             router_scores=router_scores,
             expert_ids=expert_ids,
@@ -226,57 +227,58 @@ class SonicMoeHandle:
             is_inference_mode_enabled=not torch.is_grad_enabled(),
         )
 
-    @torch._dynamo.allow_in_graph
-    def _sonicmoe_wrapper(
-        self,
-        hidden_states: torch.Tensor,
-        router_scores: torch.Tensor,
-        expert_ids: torch.Tensor,
-        token_idx: torch.Tensor,
-        w1: torch.Tensor,
-        b1: torch.Tensor | None,
-        w2: torch.Tensor,
-        b2: torch.Tensor | None,
-        activation_type: str,
-        num_experts: int,
-        concat_layout: bool,
-        is_inference_mode_enabled: bool,
-    ) -> torch.Tensor:
-        """Handle-level shim around `moe_general_routing_inputs` so `allow_in_graph` can wrap it.
-
-        sonicmoe asserts `not torch.compiler.is_compiling()` internally because it dispatches
-        CuteDSL kernels, which Dynamo can't trace. `allow_in_graph` keeps the call in the FX
-        graph as a single opaque node (no tracing into the body, no graph break) while still
-        running the real Python at runtime — autograd through `_UpProjection` / `_DownProjection`
-        flows normally. The decorator must be applied at module load time, not inside the compiled
-        function — hence this shim plus the `allow_in_graph` decorator above.
-        """
-        sonicmoe = self._load_sonicmoe_kernel()
-
-        # Default to SwiGLU if the activation type is not found
-        activation_type = getattr(
-            sonicmoe.activation_type_enum,
-            activation_type,
-            sonicmoe.activation_type_enum.SWIGLU
-        )
-
-        output, _ = sonicmoe.moe_general_routing_inputs(
-            hidden_states,
-            router_scores,
-            token_idx,
-            expert_ids,
-            w1,
-            b1,
-            w2,
-            b2,
-            E=num_experts,
-            activation_type=activation_type,
-            is_inference_mode_enabled=is_inference_mode_enabled,
-            concat_layout=concat_layout,
-            stream_id=None,
-        )
-        return output
-
 
 # Singleton object: this should be the only SonicMoeHandle object instantiated in the codebase
 SONIC_MOE_HANDLE = SonicMoeHandle()
+
+
+@torch._dynamo.allow_in_graph
+def _sonicmoe_wrapper(
+    hidden_states: torch.Tensor,
+    router_scores: torch.Tensor,
+    expert_ids: torch.Tensor,
+    token_idx: torch.Tensor,
+    w1: torch.Tensor,
+    b1: torch.Tensor | None,
+    w2: torch.Tensor,
+    b2: torch.Tensor | None,
+    activation_type: str,
+    num_experts: int,
+    concat_layout: bool,
+    is_inference_mode_enabled: bool,
+) -> torch.Tensor:
+    """Module-level shim around `moe_general_routing_inputs` so `allow_in_graph` can wrap it.
+
+    sonicmoe asserts `not torch.compiler.is_compiling()` internally because it dispatches
+    CuteDSL kernels, which Dynamo can't trace. `allow_in_graph` keeps the call in the FX
+    graph as a single opaque node (no tracing into the body, no graph break) while still
+    running the real Python at runtime — autograd through `_UpProjection` / `_DownProjection`
+    flows normally. This must be a plain module-level function: `allow_in_graph` registers the
+    function object itself, and Dynamo does not honor it through bound-method attribute access,
+    so it cannot live on `SonicMoeHandle`.
+    """
+    sonicmoe = SONIC_MOE_HANDLE._load_sonicmoe_kernel()
+
+    # Default to SwiGLU if the activation type is not found
+    activation_type = getattr(
+        sonicmoe.activation_type_enum,
+        activation_type,
+        sonicmoe.activation_type_enum.SWIGLU,
+    )
+
+    output, _ = sonicmoe.moe_general_routing_inputs(
+        hidden_states,
+        router_scores,
+        token_idx,
+        expert_ids,
+        w1,
+        b1,
+        w2,
+        b2,
+        E=num_experts,
+        activation_type=activation_type,
+        is_inference_mode_enabled=is_inference_mode_enabled,
+        concat_layout=concat_layout,
+        stream_id=None,
+    )
+    return output

--- a/tests/integrations/test_sonicmoe.py
+++ b/tests/integrations/test_sonicmoe.py
@@ -1,0 +1,83 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run the test: CUDA_VISIBLE_DEVICES=0 pytest -sv tests/integrations/test_sonicmoe.py
+# Requires an SM90+ (Hopper/Blackwell) GPU with a working `nvidia-cutlass-dsl` toolchain; skipped otherwise.
+
+import unittest
+
+import torch
+
+from transformers import Qwen3MoeConfig
+from transformers.integrations.sonicmoe import SONIC_MOE_HANDLE
+from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeExperts
+from transformers.testing_utils import require_kernels, require_torch_gpu, torch_device
+
+
+@require_torch_gpu
+@require_kernels
+class SonicMoeCompileIntegrationTest(unittest.TestCase):
+    """Exercises the sonicmoe experts path under `torch.compile`. Kept out of the common suite because it needs the
+    real CuteDSL kernel; it skips wherever `sonicmoe_is_available` is False (e.g. non-Hopper GPUs or a driver/toolchain
+    mismatch)."""
+
+    def _build_tiny_experts(self):
+        # Tiny but kernel-aligned dims (multiples of 128) so the CuteDSL GEMMs are happy.
+        config = Qwen3MoeConfig(
+            hidden_size=256,
+            moe_intermediate_size=256,
+            num_experts=8,
+            num_experts_per_tok=2,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            vocab_size=100,
+            hidden_act="silu",
+            experts_implementation="sonicmoe",
+        )
+        experts = Qwen3MoeExperts(config).eval().to(torch_device, dtype=torch.bfloat16)
+        with torch.no_grad():
+            for param in experts.parameters():
+                param.normal_(mean=0.0, std=0.02)
+        return experts, config
+
+    def test_sonicmoe_compiled_matches_eager(self):
+        if not SONIC_MOE_HANDLE.sonicmoe_is_available:
+            self.skipTest("sonic-moe kernel is not available on this machine")
+
+        torch.manual_seed(0)
+        experts, config = self._build_tiny_experts()
+
+        num_tokens, top_k = 128, config.num_experts_per_tok
+        hidden_states = torch.randn(num_tokens, config.hidden_size, device=torch_device, dtype=torch.bfloat16)
+        router_logits = torch.randn(num_tokens, config.num_experts, device=torch_device)
+        top_k_weights, top_k_index = torch.softmax(router_logits, dim=-1).topk(top_k, dim=-1)
+        top_k_weights = top_k_weights.to(torch.bfloat16)
+
+        with torch.no_grad():
+            eager_out = experts(hidden_states, top_k_index, top_k_weights)
+
+        # fullgraph=True is the point: the sonicmoe kernel must stay in-graph as one opaque node. If the
+        # `allow_in_graph` shim is broken, this either errors here or graph-breaks — it cannot silently pass.
+        torch._dynamo.reset()
+        compiled_experts = torch.compile(experts, fullgraph=True)
+        with torch.no_grad():
+            compiled_out = compiled_experts(hidden_states, top_k_index, top_k_weights)
+
+        self.assertEqual(compiled_out.shape, eager_out.shape)
+        torch.testing.assert_close(compiled_out, eager_out, rtol=2e-2, atol=2e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -53,10 +53,10 @@ from transformers.integrations.deepspeed import (
     unset_hf_deepspeed_config,
 )
 from transformers.integrations.moe import (
+    SONIC_MOE_HANDLE,
     batched_mm_experts_forward,
     deepgemm_bf16_experts_forward,
     grouped_mm_experts_forward,
-    sonicmoe_experts_forward,
 )
 from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_utils import FLASH_ATTN_KERNEL_FALLBACK, _get_tied_weight_keys
@@ -600,14 +600,9 @@ def _test_eager_matches_batched_and_grouped_inference(self, name, dtype):
             "grouped_mm": Mock(wraps=grouped_mm_experts_forward),
         }
 
-        if (
-            dtype != torch.float32
-            and is_kernels_available()
-            and torch.cuda.is_available()
-            and torch.cuda.get_device_capability() >= (9, 0)
-        ):
+        if dtype != torch.float32 and is_kernels_available() and SONIC_MOE_HANDLE.sonicmoe_is_available:
             # we also need nvidia-cutlass-dsl and apache-tvm-ffi
-            mocks["sonicmoe"] = Mock(wraps=sonicmoe_experts_forward)
+            mocks["sonicmoe"] = Mock(wraps=SONIC_MOE_HANDLE.sonicmoe_experts_forward)
             implementations.append("sonicmoe")
 
         nvcc_version = _get_nvcc_version() or (0, 0)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47316)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47316)
<!-- ci-dashboard-badge:end -->

In #47126 and offline we talked about how we want to take care of loading kernels like `DeepGEMM`.

Notably, we can put everything related to loading and calling the kernel inside a singleton `Handle` object. This object would only keep track of a few state variable and provide a single entry point to access the kernel. This has the following advantages:
- we can keep track of the cached state without using `@lru_cache` which can be opaque and cause memory leaks
- failures are actually cached: `@lru_cache` does not cache exceptions, so the cache never worked in a machine / env that did not support `sonicmoe`
- we can reset the cached state of the handle whenever we want through a simple `reset` method
- we can check the availability of the kernel easily through a `sonicmoe_is_available` property, that accesses the same underlying cached kernel as the function call itself (quite convenient, as is shown in the reworked `_test_eager_matches_batched_and_grouped_inference`)

The downside of the Handle API are that transient failures are also cached (hence the `reset` method, but it is not called automatically) and it's beefier than `@lru_cache`. IMO this is an ok tradeoff, but I would love some feedback on this.

Since I was fixing a failure in `sonicmoe`, I thought this was a good occasion to try out the Handle API. The fail was an image failure, which is now guarded against.

I also added a test for sonicmoe + compile and it passes on B200. Also tested the sonicmoe regular tests on a qwen and they pass.