### PR TITLE
[Nit] Add kernels_fallback_ok kwarg to is_flash_attn_N_available

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -693,7 +693,7 @@ def require_flash_attn(test_case):
     These tests are skipped when Flash Attention isn't installed.
 
     """
-    flash_attn_available = is_flash_attn_2_available(kernel_fallback_ok=True)
+    flash_attn_available = is_flash_attn_2_available(kernels_fallback_ok=True)
     return unittest.skipUnless(flash_attn_available, "test requires Flash Attention")(test_case)
 
 
@@ -726,7 +726,7 @@ def require_flash_attn_4(test_case):
 
 
 def require_all_flash_attn(test_case):
-    flash_attn_available = is_flash_attn_2_available(kernel_fallback_ok=True)
+    flash_attn_available = is_flash_attn_2_available(kernels_fallback_ok=True)
 
     return unittest.skipUnless(
         all(

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -270,7 +270,7 @@ if is_torch_available():
     import torch
     from safetensors.torch import load_file
 
-    from .modeling_utils import FLASH_ATTN_KERNEL_FALLBACK, PreTrainedModel
+    from .modeling_utils import PreTrainedModel
 
     IS_ROCM_SYSTEM = torch.version.hip is not None
     IS_CUDA_SYSTEM = torch.version.cuda is not None
@@ -693,16 +693,8 @@ def require_flash_attn(test_case):
     These tests are skipped when Flash Attention isn't installed.
 
     """
-    flash_attn_available = is_flash_attn_2_available()
-    kernels_available = is_kernels_available()
-    try:
-        from kernels import get_kernel
-
-        get_kernel(FLASH_ATTN_KERNEL_FALLBACK["flash_attention_2"], version=1)
-    except Exception as _:
-        kernels_available = False
-
-    return unittest.skipUnless(kernels_available | flash_attn_available, "test requires Flash Attention")(test_case)
+    flash_attn_available = is_flash_attn_2_available(kernel_fallback_ok=True)
+    return unittest.skipUnless(flash_attn_available, "test requires Flash Attention")(test_case)
 
 
 def require_kernels(test_case):
@@ -734,19 +726,12 @@ def require_flash_attn_4(test_case):
 
 
 def require_all_flash_attn(test_case):
-    flash_attn_available = is_flash_attn_2_available()
-    kernels_available = is_kernels_available()
-    try:
-        from kernels import get_kernel
-
-        get_kernel(FLASH_ATTN_KERNEL_FALLBACK["flash_attention_2"], version=1)
-    except Exception as _:
-        kernels_available = False
+    flash_attn_available = is_flash_attn_2_available(kernel_fallback_ok=True)
 
     return unittest.skipUnless(
         all(
             (
-                flash_attn_available | kernels_available,
+                flash_attn_available,
                 is_flash_attn_3_available(),
                 is_flash_attn_4_available(),
             )

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1088,7 +1088,6 @@ def is_flash_attn_3_available(kernel_fallback_ok: bool = False) -> bool:
 
             from transformers.modeling_flash_attention_utils import FLASH_ATTN_KERNEL_FALLBACK
 
-
             get_kernel(FLASH_ATTN_KERNEL_FALLBACK["flash_attention_3"], version=1)
             return True
         except Exception:  # noqa: S110  # we don't care about the Exception here: we just want to check availability

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -38,7 +38,6 @@ from typing import Any
 import packaging.version
 from packaging import version
 
-from ..modeling_utils import FLASH_ATTN_KERNEL_FALLBACK
 from . import logging
 
 
@@ -1047,11 +1046,6 @@ def is_bitsandbytes_available(min_version: str = BITSANDBYTES_MIN_VERSION) -> bo
 
 @lru_cache
 def is_flash_attn_2_available(kernel_fallback_ok: bool = False) -> bool:
-    # If those conditions are not met, then FA2 is not available anyway
-    if not (is_torch_cuda_available() or is_torch_mlu_available()):
-        return False
-
-    # Check package availability
     is_available, flash_attn_version = _is_package_available("flash_attn", return_version=True)
     # FA4 is also distributed under "flash_attn", hence we need to check the naming here
     is_available = is_available and "flash-attn" in [
@@ -1059,7 +1053,7 @@ def is_flash_attn_2_available(kernel_fallback_ok: bool = False) -> bool:
     ]
 
     # Only allow versions >= 2.3.3 to avoid very old legacy workarounds that are now 2+ years old
-    if is_available:
+    if is_available and (is_torch_cuda_available() or is_torch_mlu_available()):
         return version.parse(flash_attn_version) >= version.parse("2.3.3")
 
     # If the kernels fallback is allowed, check if it is available
@@ -1067,7 +1061,10 @@ def is_flash_attn_2_available(kernel_fallback_ok: bool = False) -> bool:
         try:
             from kernels import get_kernel
 
-            get_kernel(FLASH_ATTN_KERNEL_FALLBACK["flash_attention_2"], version=2)
+            from transformers.modeling_flash_attention_utils import FLASH_ATTN_KERNEL_FALLBACK
+
+            get_kernel(FLASH_ATTN_KERNEL_FALLBACK["flash_attention_2"], version=1)
+            return True
         except Exception:  # noqa: S110  # we don't care about the Exception here: we just want to check availability
             pass
     return False
@@ -1075,17 +1072,13 @@ def is_flash_attn_2_available(kernel_fallback_ok: bool = False) -> bool:
 
 @lru_cache
 def is_flash_attn_3_available(kernel_fallback_ok: bool = False) -> bool:
-    # If cuda is not available, then FA3 is not available anyway
-    if not is_torch_cuda_available():
-        return False
-
     # Universally available under `flash_attn_interface`
     is_available = _is_package_available("flash_attn_interface")[0]
     # Resolving and ensuring the proper name of FA3 being associated
     is_available = is_available and "flash-attn-3" in [
         pkg.replace("_", "-") for pkg in PACKAGE_DISTRIBUTION_MAPPING.get("flash_attn_interface", [])
     ]
-    if is_available:
+    if is_available and is_torch_cuda_available():
         return True
 
     # If the kernels fallback is allowed, check if it is available
@@ -1093,7 +1086,11 @@ def is_flash_attn_3_available(kernel_fallback_ok: bool = False) -> bool:
         try:
             from kernels import get_kernel
 
+            from transformers.modeling_flash_attention_utils import FLASH_ATTN_KERNEL_FALLBACK
+
+
             get_kernel(FLASH_ATTN_KERNEL_FALLBACK["flash_attention_3"], version=1)
+            return True
         except Exception:  # noqa: S110  # we don't care about the Exception here: we just want to check availability
             pass
     return False

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -38,6 +38,7 @@ from typing import Any
 import packaging.version
 from packaging import version
 
+from ..modeling_utils import FLASH_ATTN_KERNEL_FALLBACK
 from . import logging
 
 
@@ -1045,32 +1046,57 @@ def is_bitsandbytes_available(min_version: str = BITSANDBYTES_MIN_VERSION) -> bo
 
 
 @lru_cache
-def is_flash_attn_2_available() -> bool:
+def is_flash_attn_2_available(kernel_fallback_ok: bool = False) -> bool:
+    # If those conditions are not met, then FA2 is not available anyway
+    if not (is_torch_cuda_available() or is_torch_mlu_available()):
+        return False
+
+    # Check package availability
     is_available, flash_attn_version = _is_package_available("flash_attn", return_version=True)
     # FA4 is also distributed under "flash_attn", hence we need to check the naming here
     is_available = is_available and "flash-attn" in [
         pkg.replace("_", "-") for pkg in PACKAGE_DISTRIBUTION_MAPPING.get("flash_attn", [])
     ]
 
-    if not is_available or not (is_torch_cuda_available() or is_torch_mlu_available()):
-        return False
-
     # Only allow versions >= 2.3.3 to avoid very old legacy workarounds that are now 2+ years old
-    try:
+    if is_available:
         return version.parse(flash_attn_version) >= version.parse("2.3.3")
-    except packaging.version.InvalidVersion:
-        return False
+
+    # If the kernels fallback is allowed, check if it is available
+    if kernel_fallback_ok and is_kernels_available():
+        try:
+            from kernels import get_kernel
+
+            get_kernel(FLASH_ATTN_KERNEL_FALLBACK["flash_attention_2"], version=2)
+        except Exception:  # noqa: S110  # we don't care about the Exception here: we just want to check availability
+            pass
+    return False
 
 
 @lru_cache
-def is_flash_attn_3_available() -> bool:
+def is_flash_attn_3_available(kernel_fallback_ok: bool = False) -> bool:
+    # If cuda is not available, then FA3 is not available anyway
+    if not is_torch_cuda_available():
+        return False
+
     # Universally available under `flash_attn_interface`
     is_available = _is_package_available("flash_attn_interface")[0]
     # Resolving and ensuring the proper name of FA3 being associated
     is_available = is_available and "flash-attn-3" in [
         pkg.replace("_", "-") for pkg in PACKAGE_DISTRIBUTION_MAPPING.get("flash_attn_interface", [])
     ]
-    return is_available and is_torch_cuda_available()
+    if is_available:
+        return True
+
+    # If the kernels fallback is allowed, check if it is available
+    if kernel_fallback_ok and is_kernels_available():
+        try:
+            from kernels import get_kernel
+
+            get_kernel(FLASH_ATTN_KERNEL_FALLBACK["flash_attention_3"], version=1)
+        except Exception:  # noqa: S110  # we don't care about the Exception here: we just want to check availability
+            pass
+    return False
 
 
 @lru_cache

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1054,7 +1054,10 @@ def is_flash_attn_2_available(kernels_fallback_ok: bool = False) -> bool:
 
     # Only allow versions >= 2.3.3 to avoid very old legacy workarounds that are now 2+ years old
     if is_available and (is_torch_cuda_available() or is_torch_mlu_available()):
-        return version.parse(flash_attn_version) >= version.parse("2.3.3")
+        try:
+            return version.parse(flash_attn_version) >= version.parse("2.3.3")
+        except packaging.version.InvalidVersion:
+            return False
 
     # If the kernels fallback is allowed, check if it is available
     if kernels_fallback_ok and is_kernels_available():

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1045,7 +1045,7 @@ def is_bitsandbytes_available(min_version: str = BITSANDBYTES_MIN_VERSION) -> bo
 
 
 @lru_cache
-def is_flash_attn_2_available(kernel_fallback_ok: bool = False) -> bool:
+def is_flash_attn_2_available(kernels_fallback_ok: bool = False) -> bool:
     is_available, flash_attn_version = _is_package_available("flash_attn", return_version=True)
     # FA4 is also distributed under "flash_attn", hence we need to check the naming here
     is_available = is_available and "flash-attn" in [
@@ -1057,7 +1057,7 @@ def is_flash_attn_2_available(kernel_fallback_ok: bool = False) -> bool:
         return version.parse(flash_attn_version) >= version.parse("2.3.3")
 
     # If the kernels fallback is allowed, check if it is available
-    if kernel_fallback_ok and is_kernels_available():
+    if kernels_fallback_ok and is_kernels_available():
         try:
             from kernels import get_kernel
 
@@ -1071,7 +1071,7 @@ def is_flash_attn_2_available(kernel_fallback_ok: bool = False) -> bool:
 
 
 @lru_cache
-def is_flash_attn_3_available(kernel_fallback_ok: bool = False) -> bool:
+def is_flash_attn_3_available(kernels_fallback_ok: bool = False) -> bool:
     # Universally available under `flash_attn_interface`
     is_available = _is_package_available("flash_attn_interface")[0]
     # Resolving and ensuring the proper name of FA3 being associated
@@ -1082,7 +1082,7 @@ def is_flash_attn_3_available(kernel_fallback_ok: bool = False) -> bool:
         return True
 
     # If the kernels fallback is allowed, check if it is available
-    if kernel_fallback_ok and is_kernels_available():
+    if kernels_fallback_ok and is_kernels_available():
         try:
             from kernels import get_kernel
 

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -726,7 +726,8 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
 
         # Skip the test if Flash Attention is required but not available
         is_fa = is_flash_attention_requested(requested_attention_implementation=attn_implementation)
-        if is_fa and not (is_flash_attn_2_available() or is_kernels_available()):
+        # CPU flash attention can run without CUDA, but we need to check if the kernels library is available
+        if is_fa and not (is_flash_attn_2_available(kernel_fallback_ok=True) or is_kernels_available()):
             self.skipTest("Flash Attention is not available and neither is the kernels library. Skipping test.")
         # Skip the test if cuda graph is on but the device is not CUDA
         if continuous_batching_config.use_cuda_graph and torch_device != "cuda":

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -65,7 +65,6 @@ from transformers.testing_utils import (
 )
 from transformers.utils import (
     is_flash_attn_2_available,
-    is_kernels_available,
     is_torch_xpu_available,
 )
 from transformers.utils.generic import is_flash_attention_requested
@@ -726,7 +725,7 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
 
         # Skip the test if Flash Attention is required but not available
         is_fa = is_flash_attention_requested(requested_attention_implementation=attn_implementation)
-        if is_fa and not is_flash_attn_2_available(kernel_fallback_ok=True):
+        if is_fa and not is_flash_attn_2_available(kernels_fallback_ok=True):
             self.skipTest("Flash Attention is not available and neither is the kernels library. Skipping test.")
         # Skip the test if cuda graph is on but the device is not CUDA
         if continuous_batching_config.use_cuda_graph and torch_device != "cuda":

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -726,8 +726,7 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
 
         # Skip the test if Flash Attention is required but not available
         is_fa = is_flash_attention_requested(requested_attention_implementation=attn_implementation)
-        # CPU flash attention can run without CUDA, but we need to check if the kernels library is available
-        if is_fa and not (is_flash_attn_2_available(kernel_fallback_ok=True) or is_kernels_available()):
+        if is_fa and not is_flash_attn_2_available(kernel_fallback_ok=True):
             self.skipTest("Flash Attention is not available and neither is the kernels library. Skipping test.")
         # Skip the test if cuda graph is on but the device is not CUDA
         if continuous_batching_config.use_cuda_graph and torch_device != "cuda":

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,9 +1,18 @@
 import sys
+from contextlib import contextmanager
 from types import ModuleType
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+from packaging.version import parse as parse_version
+from parameterized import parameterized
 
 from transformers.testing_utils import run_test_using_subprocess
-from transformers.utils.import_utils import _is_package_available, clear_import_cache
+from transformers.utils.import_utils import (
+    _is_package_available,
+    clear_import_cache,
+    is_flash_attn_2_available,
+    is_flash_attn_3_available,
+)
 
 
 @run_test_using_subprocess
@@ -48,3 +57,136 @@ def test_is_package_available_edge_cases():
             patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
         ):
             assert _is_package_available(pkg_name, return_version=True) == expected
+
+
+@contextmanager
+def mock_flash_attn_env(
+    installed_packages: dict[str, str] | None = None,
+    cuda_available: bool = False,
+    kernels_available: bool = False,
+    kernel_download_fails: bool = False,
+):
+    """Mock the environment probed by `is_flash_attn_{2,3}_available`. Args:
+    - `installed_packages`: maps import names to versions, e.g. `{"flash_attn": "2.6.0"}`. The distribution name is
+      assumed to match the import name (with underscores replaced by hyphens), except for `flash_attn_interface`
+      which is distributed as `flash-attn-3`.
+    - `cuda_available`: whether CUDA is available or not.
+    - `kernels_available`: whether the kernels library is available.
+    - `kernel_download_fails`: if this flag is set to True, the get_kernel method of the fake kernels module will raise
+        a RuntimeError to simulate a kernel download failure.
+    """
+    installed_packages = {} if installed_packages is None else installed_packages
+    distribution_names = {"flash_attn_interface": "flash-attn-3"}
+
+    def fake_is_package_available(pkg_name: str, return_version: bool = False) -> tuple[bool, str]:
+        is_available = pkg_name in installed_packages
+        version = installed_packages.get(pkg_name, "N/A") if return_version else None
+        return is_available, version
+
+    fake_distribution_mapping = {
+        pkg: [distribution_names.get(pkg, pkg.replace("_", "-"))] for pkg in installed_packages
+    }
+    fake_kernels_module = ModuleType("kernels")
+    fake_kernels_module.get_kernel = MagicMock(
+        side_effect=RuntimeError("kernel unavailable") if kernel_download_fails else None
+    )
+
+    is_flash_attn_2_available.cache_clear()
+    is_flash_attn_3_available.cache_clear()
+    try:
+        with (
+            patch("transformers.utils.import_utils._is_package_available", side_effect=fake_is_package_available),
+            patch("transformers.utils.import_utils.PACKAGE_DISTRIBUTION_MAPPING", fake_distribution_mapping),
+            patch("transformers.utils.import_utils.is_torch_cuda_available", return_value=cuda_available),
+            patch("transformers.utils.import_utils.is_torch_mlu_available", return_value=False),
+            patch("transformers.utils.import_utils.is_kernels_available", return_value=kernels_available),
+            patch.dict(sys.modules, {"kernels": fake_kernels_module}),
+        ):
+            yield fake_kernels_module.get_kernel
+    finally:
+        is_flash_attn_2_available.cache_clear()
+        is_flash_attn_3_available.cache_clear()
+
+
+@parameterized.expand([("2.0.0",), ("2.3.3",), ("2.6.0",)])
+def test_flash_attn_2_available_with_package(version: str):
+    # If the package version is below 2.3.3, the package is too old, and FA should be unavailable
+    expected = parse_version(version) >= parse_version("2.3.3")
+
+    with mock_flash_attn_env(installed_packages={"flash_attn": version}, cuda_available=True) as get_kernel:
+        # Check the result is the expected one
+        is_available = is_flash_attn_2_available()
+        assert is_available == expected, (
+            f"Expected is_flash_attn_2_available() to be {expected} but got {is_available}"
+        )
+        # Check the kernels fallback was not probed (kernels_fallback_ok default value is False)
+        get_kernel.assert_not_called()
+        # Ensure the kernels fallback is not probed (should not happen when the package is present and cuda available)
+        assert is_flash_attn_2_available(kernels_fallback_ok=True) == expected
+        get_kernel.assert_not_called()
+
+
+def test_flash_attn_3_available_with_package():
+    with mock_flash_attn_env(installed_packages={"flash_attn_interface": "3.0.0"}, cuda_available=True) as get_kernel:
+        assert is_flash_attn_3_available()
+        assert is_flash_attn_3_available(kernels_fallback_ok=True)
+        get_kernel.assert_not_called()
+
+
+@parameterized.expand(
+    [(2, False, False), (2, True, False), (2, True, True), (3, False, False), (3, True, False), (3, True, True)]
+)
+def test_flash_attn_cuda_kernels_fallback(fa_version: int, kernels_available: bool, download_fails: bool):
+    from transformers.modeling_flash_attention_utils import FLASH_ATTN_KERNEL_FALLBACK
+
+    # Test is expected to pass only if the kernels library is available and the kernel download does not fail
+    expected = kernels_available and not download_fails
+
+    # Mock an env where the package is not available and kernels availability depends on the parameters
+    with mock_flash_attn_env(kernels_available=kernels_available, kernel_download_fails=download_fails) as get_kernel:
+        # Ensure the FA is not available without kernels fallback
+        if fa_version == 2:
+            assert not is_flash_attn_2_available()
+        elif fa_version == 3:
+            assert not is_flash_attn_3_available()
+        else:
+            raise ValueError(f"Invalid FA version: {fa_version}")
+
+        # Check expected value
+        if fa_version == 2:
+            is_available = is_flash_attn_2_available(kernels_fallback_ok=True)
+        elif fa_version == 3:
+            is_available = is_flash_attn_3_available(kernels_fallback_ok=True)
+        else:
+            raise ValueError(f"Invalid FA version: {fa_version}")
+
+        if is_available != expected:
+            raise RuntimeError(
+                f"Expected is_flash_attn_{fa_version}_available() to be {expected} but got {is_available}"
+            )
+
+        # Check the number of calls to get_kernel
+        if kernels_available:
+            key = f"flash_attention_{fa_version}"
+            get_kernel.assert_called_once_with(FLASH_ATTN_KERNEL_FALLBACK[key], version=1)
+        else:
+            get_kernel.assert_not_called()
+
+
+def test_flash_attn_2_fallback_rescues_non_cuda_platform():
+    # Package installed but no CUDA/MLU device (e.g. XPU): the kernels fallback should still kick in
+    with mock_flash_attn_env(installed_packages={"flash_attn": "2.6.0"}, cuda_available=False, kernels_available=True):
+        assert not is_flash_attn_2_available()
+        assert is_flash_attn_2_available(kernels_fallback_ok=True)
+
+
+def test_require_flash_attn_decorators_accept_kernels_fallback():
+    # Smoke test: these decorators call is_flash_attn_2_available(kernels_fallback_ok=True) and must not raise
+    from transformers.testing_utils import require_all_flash_attn, require_flash_attn
+
+    class DummyTest:
+        pass
+
+    with mock_flash_attn_env(kernels_available=True):
+        assert require_flash_attn(DummyTest) is not None
+        assert require_all_flash_attn(DummyTest) is not None


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47318)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47318)
<!-- ci-dashboard-badge:end -->

This PR adds the kwarg `kernels_fallback_ok` to the `is_flash_attn_2_available` and `is_flash_attn_3_available` functions. The kwarg has the default value `False`, so the behavior of the function does not change. But it allows an user to check if `flash` would be available at runtime, either through the official package or through `kernels`. 

This is quite practical because in CB, we want to be able to check if we can `flash` instead of the original or default `attn_implementation`, and adding a new function to do this seemed bad design. Plus, it means we can simplify `require_flash_attn` because this is the exact check it performs.