### PR TITLE
Fix PPFormulaNet training loss: prevent incorrect label shift in ForCausalLMLoss

### DIFF
--- a/src/transformers/models/pp_formulanet/modeling_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/modeling_pp_formulanet.py
@@ -1104,7 +1104,8 @@ class PPFormulaNetForConditionalGeneration(PPFormulaNetPreTrainedModel, Generati
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size,
+                shift_labels=labels, **kwargs
             )
 
         return Seq2SeqLMOutput(

--- a/src/transformers/models/pp_formulanet/modular_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/modular_pp_formulanet.py
@@ -489,7 +489,8 @@ class PPFormulaNetForConditionalGeneration(Florence2ForConditionalGeneration):
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size,
+                shift_labels=labels, **kwargs
             )
 
         return Seq2SeqLMOutput(


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47319)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47319)
<!-- ci-dashboard-badge:end -->

ForCausalLMLoss internally shifts labels left by 1 (labels[..., 1:]) when shift_labels is not provided. However, PPFormulaNet is an encoder-decoder model where logits are already aligned with labels — no shift is needed. This causes the model to train against misaligned labels, losing the last target token.

This fix passes shift_labels=labels to ForCausalLMLoss, telling it to skip the internal shift. This matches the same pattern used by Florence2 (fixed in #46898), which PPFormulaNet inherits from but overrides orward().

Fixes #47317.