### PR TITLE
Fix assistant tokens mask when a generation span ends at token index 0 or on stripped whitespace

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3153,11 +3153,22 @@ class PreTrainedTokenizerBase(PushToHubMixin):
                         current_mask = [0] * len(input_ids[i])
                         for assistant_start_char, assistant_end_char in generation_indices[i]:
                             start_token = out.char_to_token(i, assistant_start_char)
-                            end_token = out.char_to_token(i, assistant_end_char - 1)
                             if start_token is None:
                                 # start_token is out of bounds maybe due to truncation.
                                 break
-                            for token_id in range(start_token, end_token + 1 if end_token else len(input_ids[i])):
+                            # char_to_token can return None when a char has no aligned token (e.g. a
+                            # trailing space stripped by the pre-tokenizer), so scan backwards for the
+                            # last char in the span that does map to a token. We cannot rely on the
+                            # truthiness of end_token because index 0 is a valid token.
+                            end_token = None
+                            for char_idx in range(assistant_end_char - 1, assistant_start_char - 1, -1):
+                                end_token = out.char_to_token(i, char_idx)
+                                if end_token is not None:
+                                    break
+                            if end_token is None:
+                                # No token in the span is in bounds, the span was truncated: mask to the end.
+                                end_token = len(input_ids[i]) - 1
+                            for token_id in range(start_token, end_token + 1):
                                 current_mask[token_id] = 1
                         assistant_masks.append(current_mask)
 

--- a/tests/models/layoutlmv2/test_tokenization_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_tokenization_layoutlmv2.py
@@ -2088,6 +2088,10 @@ class LayoutLMv2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def test_chat_template_return_assistant_tokens_mask_truncated(self):
         pass
 
+    @unittest.skip("Chat is not supported")
+    def test_chat_template_return_assistant_tokens_mask_edge_cases(self):
+        pass
+
     def test_empty_input_string(self):
         tokenizer_return_type = []
         output_tensor_type = []

--- a/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
+++ b/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
@@ -2151,6 +2151,10 @@ class LayoutLMv3TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def test_chat_template_return_assistant_tokens_mask_truncated(self):
         pass
 
+    @unittest.skip("Chat is not supported")
+    def test_chat_template_return_assistant_tokens_mask_edge_cases(self):
+        pass
+
     def test_empty_input_string(self):
         tokenizer_return_type = []
         output_tensor_type = []

--- a/tests/models/layoutxlm/test_tokenization_layoutxlm.py
+++ b/tests/models/layoutxlm/test_tokenization_layoutxlm.py
@@ -1742,6 +1742,10 @@ class LayoutXLMTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def test_chat_template_return_assistant_tokens_mask_truncated(self):
         pass
 
+    @unittest.skip("Chat is not supported")
+    def test_chat_template_return_assistant_tokens_mask_edge_cases(self):
+        pass
+
     def test_empty_input_string(self):
         tokenizer_return_type = []
         output_tensor_type = []

--- a/tests/models/markuplm/test_tokenization_markuplm.py
+++ b/tests/models/markuplm/test_tokenization_markuplm.py
@@ -2052,6 +2052,10 @@ class MarkupLMTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def test_chat_template_return_assistant_tokens_mask_truncated(self):
         pass
 
+    @unittest.skip("Chat is not supported")
+    def test_chat_template_return_assistant_tokens_mask_edge_cases(self):
+        pass
+
     def test_empty_input_string(self):
         tokenizer_return_type = []
         output_tensor_type = []

--- a/tests/models/tapas/test_tokenization_tapas.py
+++ b/tests/models/tapas/test_tokenization_tapas.py
@@ -1068,6 +1068,10 @@ class TapasTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def test_chat_template_return_assistant_tokens_mask_truncated(self):
         pass
 
+    @unittest.skip("Chat is not supported")
+    def test_chat_template_return_assistant_tokens_mask_edge_cases(self):
+        pass
+
     def test_empty_input_string(self):
         sequences = [
             "Testing batch encode plus",

--- a/tests/models/udop/test_tokenization_udop.py
+++ b/tests/models/udop/test_tokenization_udop.py
@@ -1084,6 +1084,10 @@ class UdopTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def test_chat_template_return_assistant_tokens_mask_truncated(self):
         pass
 
+    @unittest.skip("Chat is not supported")
+    def test_chat_template_return_assistant_tokens_mask_edge_cases(self):
+        pass
+
     @unittest.skip(reason="Chat template tests don't play well with table/layout models.")
     def test_chat_template_batched(self):
         pass

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1438,6 +1438,85 @@ Hey how are you doing"""  # noqa: W293
                 )
 
     @require_jinja
+    def test_chat_template_return_assistant_tokens_mask_edge_cases(self):
+        # Regression tests for cases where char_to_token(assistant_end_char - 1) is falsy without
+        # the assistant span being truncated: the last assistant token is at index 0, or the span
+        # ends on a char with no aligned token (e.g. whitespace stripped by the pre-tokenizer). In
+        # both cases the mask must stop at the last real assistant token, not run to the end of the
+        # sequence and wrongly cover the following user turn.
+
+        # Case A: the assistant turn is the first content, so its last token is at index 0.
+        assistant_first_template = (
+            "{% for message in messages %}"
+            "{% if message['role'] == 'assistant' %}"
+            "{% generation %}{{ message['content'] }}{% endgeneration %}"
+            "{% else %}{{ '<|user|>' + message['content'] }}{% endif %}"
+            "{% endfor %}"
+        )
+        conversation_a = [
+            {"role": "assistant", "content": "A"},
+            {"role": "user", "content": "user message"},
+        ]
+
+        # Case B: the assistant generation block ends with a trailing space.
+        trailing_space_template = (
+            "{% for message in messages %}"
+            "{% if message['role'] == 'assistant' %}"
+            "{% generation %}{{ message['content'] + ' ' }}{% endgeneration %}"
+            "{% else %}{{ message['content'] }}{% endif %}"
+            "{% endfor %}"
+        )
+        conversation_b = [
+            {"role": "assistant", "content": "hello world"},
+            {"role": "user", "content": "followup question here"},
+        ]
+
+        for tokenizer, pretrained_name, _ in self.tokenizers_list:
+            with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
+                tokenizer_r = self.get_tokenizer(pretrained_name)
+                if tokenizer_r.backend != "tokenizers":
+                    self.skipTest(reason="Custom backend tokenizer")
+
+                # `assistant_content` is the assistant text that must be masked, and `user_content` is a
+                # slice of the following user turn that must not be masked. For the trailing-space case
+                # we deliberately pick a user slice past the first user word: byte-level BPE tokenizers
+                # merge the stripped trailing space into the first user token, so that boundary token is
+                # legitimately ambiguous, but everything after it must stay unmasked.
+                for template, conversation, assistant_content, user_content in (
+                    (assistant_first_template, conversation_a, "A", "user message"),
+                    (trailing_space_template, conversation_b, "hello world", "question here"),
+                ):
+                    output = tokenizer_r.apply_chat_template(
+                        conversation,
+                        chat_template=template,
+                        tokenize=True,
+                        return_assistant_tokens_mask=True,
+                        return_dict=True,
+                    )
+                    chat_string = tokenizer_r.apply_chat_template(conversation, tokenize=False, chat_template=template)
+                    assistant_masks = output["assistant_masks"]
+
+                    assistant_start = output.char_to_token(chat_string.index(assistant_content))
+                    assistant_end = output.char_to_token(
+                        chat_string.index(assistant_content) + len(assistant_content) - 1
+                    )
+                    user_start = output.char_to_token(chat_string.index(user_content))
+                    user_end = output.char_to_token(chat_string.index(user_content) + len(user_content) - 1)
+                    if None in (assistant_start, assistant_end, user_start, user_end):
+                        continue
+
+                    # The assistant content is masked ...
+                    self.assertEqual(
+                        assistant_masks[assistant_start : assistant_end + 1],
+                        [1] * (assistant_end - assistant_start + 1),
+                    )
+                    # ... and the following user turn is not.
+                    self.assertEqual(
+                        assistant_masks[user_start : user_end + 1],
+                        [0] * (user_end - user_start + 1),
+                    )
+
+    @require_jinja
     def test_continue_final_message(self):
         dummy_template = """
         {%- for message in messages %}


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47326)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47326)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47325.

`apply_chat_template(..., return_assistant_tokens_mask=True)` masks every token from the start of a `{% generation %}` span to the end of the sequence whenever `char_to_token(assistant_end_char - 1)` is falsy without the span being truncated, wrongly labelling later user/system turns as assistant tokens. This PR replaces the truthiness check with an explicit `is None` walk-back so the mask stops at the last real assistant token, while keeping the existing mask-to-end behavior for genuinely truncated spans.

## Problem

The end of each generation span is computed as:

```python
end_token = out.char_to_token(i, assistant_end_char - 1)
...
for token_id in range(start_token, end_token + 1 if end_token else len(input_ids[i])):
```

The ternary tests the truthiness of `end_token`, but `end_token` is legitimately falsy in two non-truncation cases:

1. **`end_token == 0`** — the span's last char maps to token index 0 because the assistant turn is the first content in the sequence. `0` is a valid token index.
2. **`end_token is None`** — the span's last char has no aligned token, e.g. a trailing space inside `{% generation %}` that a WordPiece pre-tokenizer strips.

In both cases the loop falls through to `len(input_ids[i])` and masks the rest of the sequence. Since `assistant_masks` is typically used to build SFT/RLHF loss masks, this silently trains on user/system text.

Minimal repro for case 1 (gpt2):

```python
from transformers import AutoTokenizer

tok = AutoTokenizer.from_pretrained("gpt2")
template = (
    "{% for message in messages %}"
    "{% if message['role'] == 'assistant' %}"
    "{% generation %}{{ message['content'] }}{% endgeneration %}"
    "{% else %}{{ '<|user|>' + message['content'] }}{% endif %}"
    "{% endfor %}"
)
conversation = [
    {"role": "assistant", "content": "A"},
    {"role": "user", "content": "user message"},
]
out = tok.apply_chat_template(
    conversation, chat_template=template, tokenize=True,
    return_assistant_tokens_mask=True, return_dict=True,
)
print(tok.convert_ids_to_tokens(out["input_ids"]))
# ['A', '<', '|', 'user', '|', '>', 'user', 'Ġmessage']
print(out["assistant_masks"])
# main:      [1, 1, 1, 1, 1, 1, 1, 1]  <- whole user turn masked as assistant
# this PR:   [1, 0, 0, 0, 0, 0, 0, 0]
```

Case 2 with `bert-base-uncased` and a generation block rendering `message['content'] + ' '` goes from `[1, 1, 1, 1, 1, 1]` (everything masked) to `[1, 1, 0, 0, 0, 0]`. Full repro for both cases is in #47325.

## Fix

Instead of testing truthiness, scan backwards from `assistant_end_char - 1` towards `assistant_start_char` and take the first char that maps to a token as `end_token`. Only when no char in the span maps to a token (the span was truncated away entirely) fall back to masking to the end of the sequence — preserving the truncation semantics covered by the existing `test_chat_template_return_assistant_tokens_mask_truncated`.

## Tests

Added `test_chat_template_return_assistant_tokens_mask_edge_cases` to `tests/test_tokenization_common.py` with two subcases: an assistant-first span whose last token is index 0, and a generation block ending in a trailing space (with a comment on why byte-level BPE tokenizers make the boundary token ambiguous in the second case).

Running the new test plus the existing truncation test against `main`'s source (new test, pre-fix library):

```
$ pytest tests/models/gpt2/test_tokenization_gpt2.py -k "edge_cases or assistant_tokens_mask_truncated" -q
SUBFAILED[type (openai-community/gpt2)] tests/models/gpt2/test_tokenization_gpt2.py::GPT2TokenizationTest::test_chat_template_return_assistant_tokens_mask_edge_cases
1 failed, 2 passed, 61 deselected
```

On this branch:

```
$ pytest tests/models/gpt2/test_tokenization_gpt2.py -k "edge_cases or assistant_tokens_mask_truncated" -q
2 passed, 61 deselected, 2 subtests passed
```

The truncation test passes before and after, confirming the fallback semantics are unchanged.

## Differentiation from existing PRs

- #34531 (merged) fixed the **start** token being out of bounds under truncation; the falsy **end** token cases fixed here occur without truncation.
- huggingface/tokenizers#1640 fixed a start-token `None` case inside `tokenizers`; it does not touch this end-token truthiness check in `transformers`.
- #44543 (open) fixes all-zero masks on the multimodal **processor** path (`processing_utils.py`); no open PR addresses this tokenizer-path (`tokenization_utils_base.py`) bug.

## Note on AI assistance

Disclosure: this change was developed with AI assistance. I reviewed every changed line, reproduced the bug, and validated the fix and its tests locally, and I stand by the change. Coordination issue: #47325.

## Who can review?

@ArthurZucker @itazap