### PR TITLE
[docs] Improve CLI copy

### DIFF
--- a/src/transformers/cli/add_new_model_like.py
+++ b/src/transformers/cli/add_new_model_like.py
@@ -97,11 +97,11 @@ _AUTO_MAPPING_NAMES = {
 
 def add_new_model_like(
     repo_path: Annotated[
-        str | None, typer.Argument(help="When not using an editable install, the path to the Transformers repo.")
+        str | None, typer.Argument(help="Path to the Transformers repo when not using an editable install")
     ] = None,
 ):
     """
-    Add a new model to the library, based on an existing one.
+    Add a new model to the library based on an existing one
     """
     (
         old_model_infos,
@@ -552,7 +552,7 @@ def _add_new_model_like_internal(
     """
     # As the import was protected, raise if not present (as it's actually a hard dependency for this command)
     if not is_libcst_available():
-        raise ValueError("You need to install `libcst` to run this command -> `pip install libcst`")
+        raise ValueError("This command requires `libcst`. Install it with `pip install libcst`.")
 
     old_lowercase_name = old_model_infos.lowercase_name
 
@@ -693,27 +693,25 @@ def get_user_input():
     # Get old model type
     valid_model_type = False
     while not valid_model_type:
-        old_model_type = input(
-            "What model would you like to duplicate? Please provide it as lowercase, e.g. `llama`): "
-        )
+        old_model_type = input("Which model should you duplicate? Enter its lowercase name, for example, `llama`: ")
         if old_model_type in model_types:
             valid_model_type = True
         else:
-            print(f"{old_model_type} is not a valid model type.")
+            print(f"Couldn't find a model type named `{old_model_type}`.")
             near_choices = difflib.get_close_matches(old_model_type, model_types)
             if len(near_choices) >= 1:
                 if len(near_choices) > 1:
                     near_choices = " or ".join(near_choices)
-                print(f"Did you mean {near_choices}?")
+                print(f"Did you mean `{near_choices}`?")
 
     old_model_infos = ModelInfos(old_model_type)
 
     # Ask for the new model name
     new_lowercase_name = get_user_field(
-        "What is the new model name? Please provide it as snake lowercase, e.g. `new_model`?"
+        "What should the new model be called? Enter a lowercase snake_case name, for example, `new_model`:"
     )
     new_model_paper_name = get_user_field(
-        "What is the fully cased name you would like to appear in the doc (e.g. `NeW ModEl`)? ",
+        "What display name should appear in the docs? For example, `New Model`: ",
         default_value="".join(x.title() for x in new_lowercase_name.split("_")),
     )
 
@@ -726,39 +724,39 @@ def get_user_input():
     add_processor = False
     if old_model_infos.tokenizer_class is not None:
         add_tokenizer = get_user_field(
-            f"Do you want to create a new tokenizer? If `no`, it will use the same as {old_model_type} (y/n)?",
+            f"Create a new tokenizer? Enter `y` to create one or `n` to reuse `{old_model_type}`: ",
             convert_to=convert_to_bool,
-            fallback_message="Please answer yes/no, y/n, true/false or 1/0. ",
+            fallback_message="Enter yes/no, y/n, true/false, or 1/0.",
         )
     if old_model_infos.fast_tokenizer_class is not None:
         add_fast_tokenizer = get_user_field(
-            f"Do you want to create a new fast tokenizer? If `no`, it will use the same as {old_model_type} (y/n)?",
+            f"Create a new fast tokenizer? Enter `y` to create one or `n` to reuse `{old_model_type}`: ",
             convert_to=convert_to_bool,
-            fallback_message="Please answer yes/no, y/n, true/false or 1/0. ",
+            fallback_message="Enter yes/no, y/n, true/false, or 1/0.",
         )
     if old_model_infos.image_processor_classes is not None:
         add_image_processor = get_user_field(
-            f"Do you want to create a new image processor? If `no`, it will use the same as {old_model_type} (y/n)?",
+            f"Create a new image processor? Enter `y` to create one or `n` to reuse `{old_model_type}`: ",
             convert_to=convert_to_bool,
-            fallback_message="Please answer yes/no, y/n, true/false or 1/0. ",
+            fallback_message="Enter yes/no, y/n, true/false, or 1/0.",
         )
     if old_model_infos.video_processor_class is not None:
         add_video_processor = get_user_field(
-            f"Do you want to create a new video processor? If `no`, it will use the same as {old_model_type} (y/n)?",
+            f"Create a new video processor? Enter `y` to create one or `n` to reuse `{old_model_type}`: ",
             convert_to=convert_to_bool,
-            fallback_message="Please answer yes/no, y/n, true/false or 1/0. ",
+            fallback_message="Enter yes/no, y/n, true/false, or 1/0.",
         )
     if old_model_infos.feature_extractor_class is not None:
         add_feature_extractor = get_user_field(
-            f"Do you want to create a new feature extractor? If `no`, it will use the same as {old_model_type} (y/n)?",
+            f"Create a new feature extractor? Enter `y` to create one or `n` to reuse `{old_model_type}`: ",
             convert_to=convert_to_bool,
-            fallback_message="Please answer yes/no, y/n, true/false or 1/0. ",
+            fallback_message="Enter yes/no, y/n, true/false, or 1/0.",
         )
     if old_model_infos.processor_class is not None:
         add_processor = get_user_field(
-            f"Do you want to create a new processor? If `no`, it will use the same as {old_model_type} (y/n)?",
+            f"Create a new processor? Enter `y` to create one or `n` to reuse `{old_model_type}`: ",
             convert_to=convert_to_bool,
-            fallback_message="Please answer yes/no, y/n, true/false or 1/0. ",
+            fallback_message="Enter yes/no, y/n, true/false, or 1/0.",
         )
 
     old_lowercase_name = old_model_infos.lowercase_name

--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -75,11 +75,11 @@ HELP_STRING_MINIMAL = """
 
 **TRANSFORMERS CHAT INTERFACE**
 
-Chat interface to try out a model. Besides chatting with the model, here are some basic commands:
-- **!help**: shows all available commands (set generation settings, save chat, etc.)
-- **!status**: shows the current status of the model and generation settings
-- **!clear**: clears the current conversation and starts a new one
-- **!exit**: closes the interface
+Chat with a model and use these commands:
+- **!help**: Show all available commands
+- **!status**: Show the model and generation settings
+- **!clear**: Clear the conversation and start a new one
+- **!exit**: Exit the chat interface
 """
 
 
@@ -89,17 +89,15 @@ HELP_STRING = f"""
 **TRANSFORMERS CHAT INTERFACE HELP**
 
 Full command list:
-- **!help**: shows this help message
-- **!clear**: clears the current conversation and starts a new one
-- **!status**: shows the current status of the model and generation settings
-- **!example {{NAME}}**: loads example named `{{NAME}}` from the config and uses it as the user input.
+- **!help**: Show this help message
+- **!clear**: Clear the conversation and start a new one
+- **!status**: Show the model and generation settings
+- **!example {{NAME}}**: Load the `{{NAME}}` example and send it as your message.
 Available example names: `{"`, `".join(DEFAULT_EXAMPLES.keys())}`
-- **!set {{ARG_1}}={{VALUE_1}} {{ARG_2}}={{VALUE_2}}** ...: changes the system prompt or generation settings (multiple
-settings are separated by a space). Accepts the same flags and format as the `generate_flags` CLI argument.
-If you're a new user, check this basic flag guide: https://huggingface.co/docs/transformers/llm_tutorial#common-options
-- **!save {{SAVE_NAME}} (optional)**: saves the current chat and settings to file by default to
-`./chat_history/{{MODEL_ID}}/chat_{{DATETIME}}.yaml` or `{{SAVE_NAME}}` if provided
-- **!exit**: closes the interface
+- **!set {{ARG_1}}={{VALUE_1}} {{ARG_2}}={{VALUE_2}}**: Update the system prompt or generation settings. Separate multiple settings with spaces. Use the same format as the `generate_flags` argument.
+For a flag guide, see https://huggingface.co/docs/transformers/llm_tutorial#common-options
+- **!save {{SAVE_NAME}} (optional)**: Save the chat and settings to `./chat_history/{{MODEL_ID}}/chat_{{DATETIME}}.yaml`, or to `{{SAVE_NAME}}` when provided.
+- **!exit**: Exit the chat interface
 """
 
 
@@ -298,24 +296,24 @@ class RichInterface:
 
 
 class Chat:
-    """Chat with a model from the command line."""
+    """Chat with a model from the command line"""
 
     # Defining a class to help with internal state but in practice it's just a method to call
     # TODO: refactor into a proper module with helpers + 1 main method
     def __init__(
         self,
-        model_id: Annotated[str, typer.Argument(help="ID of the model to use (e.g. 'HuggingFaceTB/SmolLM3-3B').")],
+        model_id: Annotated[str, typer.Argument(help="Model ID to use, for example, `HuggingFaceTB/SmolLM3-3B`")],
         base_url: Annotated[
-            str | None, typer.Argument(help="Base url to connect to (e.g. http://localhost:8000/v1).")
+            str | None, typer.Argument(help="Server URL to connect to, for example, `http://localhost:8000/v1`")
         ] = f"http://{DEFAULT_HTTP_ENDPOINT['hostname']}:{DEFAULT_HTTP_ENDPOINT['port']}",
         generate_flags: Annotated[
             list[str] | None,
             typer.Argument(
                 help=(
-                    "Flags to pass to `generate`, using a space as a separator between flags. Accepts booleans, numbers, "
-                    "and lists of integers, more advanced parameterization should be set through --generation-config. "
+                    "Generation settings as space-separated `key=value` pairs. Accepts booleans, numbers, and lists of "
+                    "integers. Use `--generation-config` for more advanced settings. "
                     "Example: `transformers chat <base_url> <model_id> max_new_tokens=100 do_sample=False eos_token_id=[1,2]`. "
-                    "If you're a new user, check this basic flag guide: "
+                    "For a flag guide, see "
                     "https://huggingface.co/docs/transformers/llm_tutorial#common-options"
                 )
             ),
@@ -323,20 +321,20 @@ class Chat:
         # General settings
         user: Annotated[
             str | None,
-            typer.Option(help="Username to display in chat interface. Defaults to the current user's name."),
+            typer.Option(help="Name to show in the chat interface; defaults to your OS username"),
         ] = None,
-        system_prompt: Annotated[str | None, typer.Option(help="System prompt.")] = None,
-        save_folder: Annotated[str, typer.Option(help="Folder to save chat history.")] = "./chat_history/",
-        examples_path: Annotated[str | None, typer.Option(help="Path to a yaml file with examples.")] = None,
+        system_prompt: Annotated[str | None, typer.Option(help="System prompt for the conversation")] = None,
+        save_folder: Annotated[str, typer.Option(help="Directory for chat history")] = "./chat_history/",
+        examples_path: Annotated[str | None, typer.Option(help="Path to a YAML file with examples")] = None,
         # Generation settings
         generation_config: Annotated[
             str | None,
             typer.Option(
-                help="Path to a local generation config file or to a HuggingFace repo containing a `generation_config.json` file. Other generation settings passed as CLI arguments will be applied on top of this generation config."
+                help="Local path or Hub repo containing `generation_config.json`; CLI generation settings override it"
             ),
         ] = None,
     ) -> None:
-        """Chat with a model from the command line."""
+        """Chat with a model from the command line"""
         self.base_url = base_url
 
         parsed = urlparse(self.base_url)
@@ -367,7 +365,7 @@ class Chat:
 
         # Check requirements
         if not is_rich_available():
-            raise ImportError("You need to install rich to use the chat interface. (`pip install rich`)")
+            raise ImportError("The chat interface requires `rich`. Install it with `pip install rich`.")
 
         # Run chat session
         asyncio.run(self._inner_run())
@@ -379,12 +377,12 @@ class Chat:
             output = httpx.get(health_url)
             if output.status_code != 200:
                 raise ValueError(
-                    f"The server running on {url} returned status code {output.status_code} on health check (/health)."
+                    f"The server at {url} returned status code {output.status_code} while checking `/health`."
                 )
         except httpx.ConnectError:
             raise ValueError(
-                f"No server currently running on {url}. To run a local server, please run `transformers serve` in a"
-                f"separate shell. Find more information here: https://huggingface.co/docs/transformers/serving"
+                f"No server is running at {url}. Start one in another shell with `transformers serve`. "
+                f"See https://huggingface.co/docs/transformers/serving for details."
             )
 
         return True
@@ -418,7 +416,7 @@ class Chat:
                 else os.path.join(self.save_folder, self.model_id, f"chat_{time.strftime('%Y-%m-%d_%H-%M-%S')}.json")
             )
             save_chat(filename=filename, chat=chat, settings=self.settings)
-            interface.print_color(text=f"Chat saved to {filename}!", color="green")
+            interface.print_color(text=f"Saved chat to {filename}", color="green")
 
         elif user_input.startswith("!set"):
             # splits the new args into a list of strings, each string being a `flag=value` pair (same format as
@@ -429,10 +427,7 @@ class Chat:
             for flag in new_generate_flags:
                 if "=" not in flag:
                     interface.print_color(
-                        text=(
-                            f"Invalid flag format, missing `=` after `{flag}`. Please use the format "
-                            "`arg_1=value_1 arg_2=value_2 ...`."
-                        ),
+                        text=(f"Invalid flag format: `{flag}` has no `=`. Use `arg_1=value_1 arg_2=value_2 …`."),
                         color="red",
                     )
                     break
@@ -448,9 +443,7 @@ class Chat:
                 interface.print_user_message(examples[example_name]["text"])
                 chat.append({"role": "user", "content": examples[example_name]["text"]})
             else:
-                example_error = (
-                    f"Example {example_name} not found in list of available examples: {list(examples.keys())}."
-                )
+                example_error = f"Unknown example `{example_name}`. Available examples: {list(examples.keys())}."
                 interface.print_color(text=example_error, color="red")
 
         elif user_input == "!status":
@@ -458,7 +451,7 @@ class Chat:
 
         else:
             valid_command = False
-            interface.print_color(text=f"'{user_input}' is not a valid command. Showing help message.", color="red")
+            interface.print_color(text="Unknown command. Showing help.", color="red")
             interface.print_help()
 
         return chat, valid_command, config
@@ -508,7 +501,7 @@ class Chat:
                             )
                         )
                         save_chat(filename=filename, chat=chat, settings=self.settings)
-                        interface.print_color(text=f"Chat saved to {filename}!", color="green")
+                        interface.print_color(text=f"Saved chat to {filename}", color="green")
                         continue
 
                     elif user_input.startswith("!set"):
@@ -521,8 +514,7 @@ class Chat:
                             if "=" not in flag:
                                 interface.print_color(
                                     text=(
-                                        f"Invalid flag format, missing `=` after `{flag}`. Please use the format "
-                                        "`arg_1=value_1 arg_2=value_2 ...`."
+                                        f"Invalid flag format: `{flag}` has no `=`. Use `arg_1=value_1 arg_2=value_2 …`."
                                     ),
                                     color="red",
                                 )
@@ -540,7 +532,9 @@ class Chat:
                             interface.print_user_message(self.examples[example_name]["text"])
                             chat.append({"role": "user", "content": self.examples[example_name]["text"]})
                         else:
-                            example_error = f"Example {example_name} not found in list of available examples: {list(self.examples.keys())}."
+                            example_error = (
+                                f"Unknown example `{example_name}`. Available examples: {list(self.examples.keys())}."
+                            )
                             interface.print_color(text=example_error, color="red")
 
                     elif user_input == "!status":
@@ -548,9 +542,7 @@ class Chat:
                         continue
 
                     elif user_input.startswith("!"):
-                        interface.print_color(
-                            text=f"'{user_input}' is not a valid command. Showing help message.", color="red"
-                        )
+                        interface.print_color(text="Unknown command. Showing help.", color="red")
                         interface.print_help()
                         continue
 
@@ -641,9 +633,8 @@ def parse_generate_flags(generate_flags: list[str] | None) -> dict:
         processed_generate_flags = json.loads(generate_flags_string)
     except json.JSONDecodeError:
         raise ValueError(
-            "Failed to convert `generate_flags` into a valid JSON object."
-            "\n`generate_flags` = {generate_flags}"
-            "\nConverted JSON string = {generate_flags_string}"
+            "Couldn't parse the generation settings. Use space-separated `key=value` pairs, "
+            "for example, `temperature=0.7 max_new_tokens=100`."
         )
     return processed_generate_flags
 

--- a/src/transformers/cli/download.py
+++ b/src/transformers/cli/download.py
@@ -17,19 +17,15 @@ import typer
 
 
 def download(
-    model_id: Annotated[str, typer.Argument(help="The model ID to download")],
-    cache_dir: Annotated[str | None, typer.Option(help="Directory where to save files.")] = None,
-    force_download: Annotated[
-        bool, typer.Option(help="If set, the files will be downloaded even if they are already cached locally.")
-    ] = False,
+    model_id: Annotated[str, typer.Argument(help="Model ID to download")],
+    cache_dir: Annotated[str | None, typer.Option(help="Directory to store files")] = None,
+    force_download: Annotated[bool, typer.Option(help="Download files even if they're already cached")] = False,
     trust_remote_code: Annotated[
         bool,
-        typer.Option(
-            help="Whether or not to allow for custom models defined on the Hub in their own modeling files. Use only if you've reviewed the code as it will execute on your local machine"
-        ),
+        typer.Option(help="Allow custom model code from the Hub to run locally after you've reviewed it"),
     ] = False,
 ):
-    """Download a model and its tokenizer from the Hub."""
+    """Download a model and tokenizer from the Hugging Face Hub"""
     from ..models.auto import AutoModel, AutoTokenizer
 
     AutoModel.from_pretrained(

--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -41,26 +41,27 @@ class ReasoningMode(str, enum.Enum):
 class Serve:
     def __init__(
         self,
-        force_model: Annotated[str | None, typer.Argument(help="Model to preload and use for all requests.")] = None,
+        force_model: Annotated[
+            str | None, typer.Argument(help="Load this model first and use it for every request")
+        ] = None,
         # Model options
         continuous_batching: Annotated[
             bool,
-            typer.Option(help="Enable continuous batching with paged attention. Configure with --cb-* flags."),
+            typer.Option(help="Enable continuous batching with paged attention; configure it with --cb-* options"),
         ] = False,
         attn_implementation: Annotated[
-            str | None, typer.Option(help="Attention implementation (e.g. flash_attention_2).")
+            str | None, typer.Option(help="Set the attention implementation, for example, `flash_attention_2`")
         ] = None,
-        compile: Annotated[bool, typer.Option(help="Enable torch.compile for faster inference.")] = False,
+        compile: Annotated[bool, typer.Option(help="Compile with `torch.compile` for faster inference")] = False,
         quantization: Annotated[
-            str | None, typer.Option(help="Quantization method: 'bnb-4bit' or 'bnb-8bit'.")
+            str | None, typer.Option(help="Set the quantization method: `bnb-4bit` or `bnb-8bit`")
         ] = None,
         reasoning: Annotated[
             ReasoningMode,
             typer.Option(
                 help=(
-                    "Reasoning mode. 'auto' uses the chat template default. Only applies to models that "
-                    "support reasoning via their chat template (e.g. Qwen3, Gemma 4) — for other models "
-                    "this flag has no effect."
+                    "Set the reasoning mode: `auto` uses the chat template default. This only applies to models "
+                    "whose chat template supports reasoning."
                 )
             ),
         ] = ReasoningMode.AUTO.value,  # type: ignore[invalid-parameter-default]
@@ -68,45 +69,50 @@ class Serve:
             str | None,
             typer.Option(
                 help=(
-                    "Default JSON kwargs forwarded to apply_chat_template "
-                    "(e.g. '{\"enable_thinking\": true}'); per-request chat_template_kwargs override these."
+                    "Default JSON arguments for `apply_chat_template`; per-request `chat_template_kwargs` override these"
                 )
             ),
         ] = None,
-        device: Annotated[str, typer.Option(help="Device for inference (e.g. 'auto', 'cuda:0', 'cpu').")] = "auto",
-        dtype: Annotated[str | None, typer.Option(help="Override model dtype. 'auto' derives from weights.")] = "auto",
-        trust_remote_code: Annotated[bool, typer.Option(help="Trust remote code when loading.")] = False,
+        device: Annotated[
+            str, typer.Option(help="Device for inference, for example, `auto`, `cuda:0`, or `cpu`")
+        ] = "auto",
+        dtype: Annotated[
+            str | None, typer.Option(help="Override model dtype; `auto` derives it from the weights")
+        ] = "auto",
+        trust_remote_code: Annotated[bool, typer.Option(help="Allow custom model code to run locally")] = False,
         model_timeout: Annotated[
-            int, typer.Option(help="Seconds before idle model is unloaded. Ignored when force_model is set.")
+            int, typer.Option(help="Unload idle models after this many seconds; ignored with a fixed model")
         ] = 300,
         # Continuous batching tuning
         cb_block_size: Annotated[
-            int | None, typer.Option(help="KV cache block size in tokens for continuous batching.")
+            int | None, typer.Option(help="KV-cache block size in tokens for continuous batching")
         ] = None,
         cb_num_blocks: Annotated[
-            int | None, typer.Option(help="Number of KV cache blocks for continuous batching.")
+            int | None, typer.Option(help="Number of KV-cache blocks for continuous batching")
         ] = None,
         cb_max_batch_tokens: Annotated[
-            int | None, typer.Option(help="Maximum tokens per batch for continuous batching.")
+            int | None, typer.Option(help="Maximum tokens per batch for continuous batching")
         ] = None,
         cb_max_memory_percent: Annotated[
-            float | None, typer.Option(help="Max GPU memory fraction for KV cache (0.0-1.0).")
+            float | None, typer.Option(help="Maximum GPU-memory fraction for KV cache, from `0.0` to `1.0`")
         ] = None,
         cb_use_cuda_graph: Annotated[
-            bool | None, typer.Option(help="Enable CUDA graphs for continuous batching.")
+            bool | None, typer.Option(help="Enable CUDA graphs for continuous batching")
         ] = None,
         # Server options
-        host: Annotated[str, typer.Option(help="Server listen address.")] = "localhost",
-        port: Annotated[int, typer.Option(help="Server listen port.")] = 8000,
-        enable_cors: Annotated[bool, typer.Option(help="Enable permissive CORS.")] = False,
-        log_level: Annotated[str, typer.Option(help="Logging level (e.g. 'info', 'warning').")] = "warning",
-        default_seed: Annotated[int | None, typer.Option(help="Default torch seed.")] = None,
+        host: Annotated[str, typer.Option(help="Host address to listen on")] = "localhost",
+        port: Annotated[int, typer.Option(help="Port to listen on")] = 8000,
+        enable_cors: Annotated[bool, typer.Option(help="Allow cross-origin requests from any origin")] = False,
+        log_level: Annotated[str, typer.Option(help="Logging level, for example, `info` or `warning`")] = "warning",
+        default_seed: Annotated[int | None, typer.Option(help="Default PyTorch seed")] = None,
         non_blocking: Annotated[
             bool, typer.Option(hidden=True, help="Run server in a background thread. Used by tests.")
         ] = False,
     ) -> None:
         if not is_serve_available():
-            raise ImportError("Missing dependencies for serving. Install with `pip install transformers[serving]`")
+            raise ImportError(
+                "Serving dependencies are missing. Install them with `pip install transformers[serving]`."
+            )
 
         import uvicorn
 
@@ -158,7 +164,7 @@ class Serve:
         if chat_template_kwargs:
             chat_template_kwargs = json.loads(chat_template_kwargs)
             if not isinstance(chat_template_kwargs, dict):
-                raise typer.BadParameter("--chat-template-kwargs must be a JSON object")
+                raise typer.BadParameter("Expected a JSON object for `--chat-template-kwargs`")
         else:
             chat_template_kwargs = {}
 
@@ -227,15 +233,14 @@ class Serve:
 
 
 Serve.__doc__ = """
-Run a FastAPI server to serve models on-demand with an OpenAI compatible API.
-Models will be loaded and unloaded automatically based on usage and a timeout.
+Run a FastAPI server with an OpenAI-compatible API; models load on demand and unload after a timeout
 
 \b
 Endpoints:
-    POST /v1/chat/completions — Chat completions (streaming + non-streaming).
-    POST /v1/completions      — Legacy text completions from a prompt.
-    GET  /v1/models           — Lists available models.
-    GET  /health              — Health check.
+    POST /v1/chat/completions — Chat completions, streaming or non-streaming
+    POST /v1/completions      — Legacy text completions from a prompt
+    GET  /v1/models           — List available models
+    GET  /health              — Check server health
 
-Requires FastAPI and Uvicorn: pip install transformers[serving]
+Install FastAPI and Uvicorn with `pip install transformers[serving]`
 """

--- a/src/transformers/cli/system.py
+++ b/src/transformers/cli/system.py
@@ -41,10 +41,10 @@ from ..utils import (
 def env(
     accelerate_config_file: Annotated[
         str | None,
-        typer.Argument(help="The accelerate config file to use for the default values in the launching script."),
+        typer.Argument(help="Accelerate config file for launcher defaults"),
     ] = None,
 ) -> None:
-    """Print information about the environment."""
+    """Print environment details for a Transformers bug report"""
     import safetensors
 
     # TODO: remove hasattr guard once safetensors >= 0.8.0 is released (adds __version__)
@@ -131,7 +131,7 @@ def env(
 
 
 def version() -> None:
-    """Print CLI version."""
+    """Print the Transformers version"""
     print(__version__)
 
 

--- a/src/transformers/cli/transformers.py
+++ b/src/transformers/cli/transformers.py
@@ -22,7 +22,7 @@ from transformers.cli.serve import Serve
 from transformers.cli.system import env, version
 
 
-app = typer_factory(help="Transformers CLI")
+app = typer_factory(help="Run Transformers commands")
 
 app.command()(add_new_model_like)
 app.command(name="chat")(Chat)

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -21,7 +21,7 @@ from transformers.cli.chat import new_chat_history, parse_generate_flags, save_c
 def test_help(cli):
     output = cli("chat", "--help")
     assert output.exit_code == 0
-    assert "Chat with a model from the command line." in output.output
+    assert "Chat with a model from the command line" in output.output
 
 
 def test_save_and_clear_chat():


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47327)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47327)
<!-- ci-dashboard-badge:end -->

Improves CLI copy to be more clear, consistent, brief, and actionable (adapted from https://github.com/vercel/vercel/blob/main/packages/cli/.agents/skills/cli-ux/references/copy.md). See some selected examples below:

| Before | After |
|---|---|
| When not using an editable install, the path to the Transformers repo. | Path to the Transformers repo when not using an editable install |
| Enable permissive CORS. | Allow cross-origin requests from any origin |
| Seconds before idle model is unloaded. Ignored when force_model is set. | Unload idle models after this many seconds; ignored with a fixed model |
| Whether or not to allow for custom models defined on the Hub in their own modeling files. Use only if you've reviewed the code as it will execute on your local machine | Allow custom model code from the Hub to run locally after you've reviewed it |
| Path to a local generation config file or to a HuggingFace repo containing a `generation_config.json` file. Other generation settings passed as CLI arguments will be applied on top of this generation config. | Local path or Hub repo containing `generation_config.json`; CLI generation settings override it |
| When not using an editable install, the path to the Transformers repo. | Path to the Transformers repo when not using an editable install |