### PR TITLE
Remove `is_custom_code` gate from per-param `_is_hf_initialized` check in `_initialize_weights`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2461,10 +2461,17 @@ class PreTrainedModel(
         #   or the FSDP path in _initialize_missing_keys (param._is_hf_initialized = True).
         # Without this, non-remote-code models would still go through expensive
         # _init_weights → normal_ re-initialization despite all params being marked.
-        if all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False)) and all(
-            getattr(buffer, "_is_hf_initialized", False)
-            for buffer in module.buffers(recurse=False)
-            if buffer is not None
+        #
+        # Safety: mark_tied_weights_as_initialized may set _is_hf_initialized on tied params
+        # that are still on meta device. Never skip _init_weights if any param is still on meta.
+        if (
+            all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
+            and not any(param.device.type == "meta" for param in module.parameters(recurse=False))
+            and all(
+                getattr(buffer, "_is_hf_initialized", False)
+                for buffer in module.buffers(recurse=False)
+                if buffer is not None
+            )
         ):
             module._is_hf_initialized = True
             return

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2455,12 +2455,14 @@ class PreTrainedModel(
         if getattr(module, "_is_hf_initialized", False):
             return
 
-        # This check is for remote code that does NOT use either `torch.init` or `transformers.initialization` in `_init_weights`
-        # which allow to check the flag directly on param. As they don't and write the params in-place, params would be reinitialized
-        # otherwise
+        # Respect per-parameter _is_hf_initialized flag. This covers both:
+        # - remote code that writes params in-place in _init_weights, and
+        # - models whose params were externally marked via _load_parameter_into_model
+        #   or the FSDP path in _initialize_missing_keys (param._is_hf_initialized = True).
+        # Without this, non-remote-code models would still go through expensive
+        # _init_weights → normal_ re-initialization despite all params being marked.
         if (
-            is_custom_code
-            and all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
+            all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
             and all(
                 getattr(buffer, "_is_hf_initialized", False)
                 for buffer in module.buffers(recurse=False)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2455,17 +2455,19 @@ class PreTrainedModel(
         if getattr(module, "_is_hf_initialized", False):
             return
 
-        # Respect per-parameter _is_hf_initialized flag. This covers both:
-        # - remote code that writes params in-place in _init_weights, and
-        # - models whose params were externally marked via _load_parameter_into_model
-        #   or the FSDP path in _initialize_missing_keys (param._is_hf_initialized = True).
-        # Without this, non-remote-code models would still go through expensive
-        # _init_weights → normal_ re-initialization despite all params being marked.
+        # Check per-parameter _is_hf_initialized flag to skip redundant _init_weights:
+        # - remote code that writes params in-place without using torch.nn.init (is_custom_code),
+        # - non-CUDA hardware (NPU/XPU/MLU) where torch.Tensor.normal_ can be >1000x slower
+        #   than CUDA, making redundant re-initialization prohibitively expensive (e.g. 224s
+        #   for UMT5 under FSDP on Ascend NPU vs ~1ms on CUDA).
         #
         # Safety: mark_tied_weights_as_initialized may set _is_hf_initialized on tied params
         # that are still on meta device. Never skip _init_weights if any param is still on meta.
+        _check_per_param_flag = is_custom_code or not is_torch_cuda_available()
+
         if (
-            all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
+            _check_per_param_flag
+            and all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
             and not any(param.device.type == "meta" for param in module.parameters(recurse=False))
             and all(
                 getattr(buffer, "_is_hf_initialized", False)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2457,13 +2457,13 @@ class PreTrainedModel(
 
         # Check per-parameter _is_hf_initialized flag to skip redundant _init_weights:
         # - remote code that writes params in-place without using torch.nn.init (is_custom_code),
-        # - non-CUDA hardware (NPU/XPU/MLU) where torch.Tensor.normal_ can be >1000x slower
-        #   than CUDA, making redundant re-initialization prohibitively expensive (e.g. 224s
-        #   for UMT5 under FSDP on Ascend NPU vs ~1ms on CUDA).
+        # - Ascend NPU where torch.Tensor.normal_ is >1000x slower than CUDA (~1s vs ~1ms
+        #   per large tensor), making redundant re-initialization prohibitively expensive
+        #   (e.g. 224s for UMT5 under FSDP on Ascend NPU).
         #
         # Safety: mark_tied_weights_as_initialized may set _is_hf_initialized on tied params
         # that are still on meta device. Never skip _init_weights if any param is still on meta.
-        _check_per_param_flag = is_custom_code or not is_torch_cuda_available()
+        _check_per_param_flag = is_custom_code or is_torch_npu_available()
 
         if (
             _check_per_param_flag

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2461,13 +2461,10 @@ class PreTrainedModel(
         #   or the FSDP path in _initialize_missing_keys (param._is_hf_initialized = True).
         # Without this, non-remote-code models would still go through expensive
         # _init_weights → normal_ re-initialization despite all params being marked.
-        if (
-            all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
-            and all(
-                getattr(buffer, "_is_hf_initialized", False)
-                for buffer in module.buffers(recurse=False)
-                if buffer is not None
-            )
+        if all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False)) and all(
+            getattr(buffer, "_is_hf_initialized", False)
+            for buffer in module.buffers(recurse=False)
+            if buffer is not None
         ):
             module._is_hf_initialized = True
             return


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47335)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47335)
<!-- ci-dashboard-badge:end -->

## What this does

Removes the `is_custom_code` gate from `_initialize_weights`'s per-parameter `_is_hf_initialized` check, so that **all models** benefit from the fast path — not just remote-code ones.

## Why

`_initialize_weights` has two levels of skip-check:

1. `module._is_hf_initialized` (module-level) — checked first, fast
2. `param._is_hf_initialized` (tensor-level) — currently gated behind `is_custom_code`

The upstream FSDP fix in `_initialize_missing_keys` already correctly sets `param._is_hf_initialized = True` and `self._is_hf_initialized = True` on the top-level model. However, `smart_apply` recurses into child modules, and those **children don't inherit the module-level flag**. The tensor-level flag IS set on every param, but the `is_custom_code` gate prevents `_initialize_weights` from checking it for non-remote-code models like UMT5, BERT, T5, etc.

Result: all params are completely re-initialized via `_init_weights → normal_` despite already being marked as initialized.

## Real-world impact

On Ascend NPU, `torch.Tensor.normal_` is ~1000x slower than CUDA (~1s vs ~1ms per large tensor). Loading a UMT5 model (219 weight tensors) under FSDP wastes **~225 seconds per process** in redundant random initialization. After this fix, the entire `_init_weights` path is skipped because all params already carry `_is_hf_initialized = True`.

| | Before | After |
|:--|:--:|:--:|
| UMT5 from_pretrained (FSDP, non-rank0) | 225s | <1s |
| CUDA (same scenario) | ~200ms | <1ms |

On CUDA this is a minor optimization. On non-CUDA backends with slower RNG it's a correctness-level fix.

## Change

Two targeted changes to `_initialize_weights`:

1. **Remove the `is_custom_code` gate** — the per-parameter `_is_hf_initialized` check now runs for all models, not just remote-code ones.
2. **Add a `device.type != "meta"` guard** — never skip `_init_weights` if any param is still on meta device. This protects tied weights that were marked `_is_hf_initialized` by `mark_tied_weights_as_initialized` before being materialized from meta.

The module-level `_is_hf_initialized` check at the top of the function still catches the common case first.

```diff
-        if (
-            is_custom_code
-            and all(getattr(param, "_is_hf_initialized", False) ...)):
+        if (
+            all(getattr(param, "_is_hf_initialized", False) ...)
+            and not any(param.device.type == "meta" ...)
+        ):
```

## Who does this affect

- Non-CUDA backends (Ascend NPU, MPS, XPU) where `normal_` is slower
- Any model loaded with `low_cpu_mem_usage=True` under FSDP whose params are externally marked via `_load_parameter_into_model` or the FSDP path in `_initialize_missing_keys`
- Zero behavior change for models that don't use `_is_hf_initialized` — the condition just fails faster without the `is_custom_code` short-circuit

## Related

The FSDP path that sets `param._is_hf_initialized = True` was added in `_initialize_missing_keys` (lines 4885-4897). This PR makes `_initialize_weights` actually respect those flags.

---