### PR TITLE
ci: cover xet as well (runtime error)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -41,10 +41,37 @@ from transformers.utils.network_logging import register_network_debug_plugin
 
 
 _ci_fallback_cache_dir = None
-# Records the repo/file id for every call that was retried through the read-only cache
-# fallback. Surfaced in the pytest terminal summary so CI logs show whether (and how
-# often) the fallback actually fired during a run.
-_ci_fallback_events = []
+# Directory holding one append-only file per process recording the repo/file id for every
+# call retried through the read-only cache fallback. A directory (rather than an in-memory
+# list) is used so the count survives `pytest-xdist`: tests run in worker subprocesses, but
+# `pytest_terminal_summary` runs on the controller, which aggregates all the files. The path
+# is shared with workers via an env var (they inherit it at spawn, like DISABLE_SAFETENSORS_CONVERSION).
+_ci_fallback_events_dir = None
+
+
+def _record_fallback_event(repo_id):
+    """Append `repo_id` to this process's fallback-event file (xdist-safe, best-effort)."""
+    if not _ci_fallback_events_dir:
+        return
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    try:
+        with open(os.path.join(_ci_fallback_events_dir, f"{worker}-{os.getpid()}.log"), "a", encoding="utf-8") as fh:
+            fh.write(f"{repo_id}\n")
+    except OSError:
+        pass
+
+
+def _collect_fallback_events():
+    """Aggregate fallback events recorded by every process (controller + xdist workers)."""
+    events = []
+    if _ci_fallback_events_dir and os.path.isdir(_ci_fallback_events_dir):
+        for name in sorted(os.listdir(_ci_fallback_events_dir)):
+            try:
+                with open(os.path.join(_ci_fallback_events_dir, name), encoding="utf-8") as fh:
+                    events.extend(line.strip() for line in fh if line.strip())
+            except OSError:
+                pass
+    return events
 
 
 # Rust's `std::io::Error` renders OS-level failures as ``"<strerror> (os error <N>)"``
@@ -102,8 +129,9 @@ def _with_tmpdir_cache_fallback(fn):
             global _ci_fallback_cache_dir
             if _ci_fallback_cache_dir is None:
                 _ci_fallback_cache_dir = tempfile.mkdtemp(prefix="ci_fallback_tmpdir_cache_dir_")
-            repo_id = kwargs.get("path_or_repo_id") or (args[0] if args else "?")
-            _ci_fallback_events.append(str(repo_id))
+            # `cached_files` names it `path_or_repo_id`; `hf_hub_download` names it `repo_id`.
+            repo_id = kwargs.get("path_or_repo_id") or kwargs.get("repo_id") or (args[0] if args else "?")
+            _record_fallback_event(str(repo_id))
             # Emit a marker as well; captured per-test by pytest, but the guaranteed-visible
             # count is reported in `pytest_terminal_summary` at the end of the run.
             print(
@@ -174,9 +202,44 @@ warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
 def pytest_configure(config):
+    # Shared directory for the read-only cache fallback events. The controller creates it and
+    # exports the path; xdist workers (spawned later) inherit the env var and write into the
+    # same directory, so `pytest_terminal_summary` on the controller can aggregate all of them.
+    global _ci_fallback_events_dir
+    _ci_fallback_events_dir = os.environ.get("CI_FALLBACK_EVENTS_DIR")
+    if _ci_fallback_events_dir is None:
+        _ci_fallback_events_dir = tempfile.mkdtemp(prefix="ci_fallback_events_")
+        os.environ["CI_FALLBACK_EVENTS_DIR"] = _ci_fallback_events_dir
+
     import transformers.utils.hub as _hub
 
     _hub.cached_files = _with_tmpdir_cache_fallback(_hub.cached_files)
+
+    # `cached_files` is transformers' entry point, but libraries such as PEFT call
+    # `huggingface_hub.hf_hub_download` directly (e.g. PeftConfig.from_pretrained fetching
+    # adapter_config.json), bypassing it. Wrap that too and re-bind it wherever it has already
+    # been imported via `from huggingface_hub import hf_hub_download`; modules imported later
+    # (peft.config is loaded lazily during the test) pick up the wrapped version automatically.
+    import huggingface_hub
+
+    _original_hf_hub_download = huggingface_hub.hf_hub_download
+    if not getattr(_original_hf_hub_download, "_ci_fallback_wrapped", False):
+        _wrapped_hf_hub_download = _with_tmpdir_cache_fallback(_original_hf_hub_download)
+        _wrapped_hf_hub_download._ci_fallback_wrapped = True
+        huggingface_hub.hf_hub_download = _wrapped_hf_hub_download
+        # Re-bind already-imported *third-party* consumers (e.g. peft). Skip transformers and
+        # huggingface_hub themselves: transformers funnels downloads through the already-wrapped
+        # `cached_files`, and huggingface_hub's own `snapshot_download` calls `hf_hub_download`
+        # internally -- wrapping either inner call would redirect only the download to the tmp dir
+        # while the caller still resolves the file against the original (read-only) cache_dir,
+        # producing a spurious "missing file". Consumers imported later (peft.config is loaded
+        # lazily during the test) pick up the wrapped function via the package attribute above.
+        for _mod in list(sys.modules.values()):
+            _name = getattr(_mod, "__name__", "") or ""
+            if _name.split(".", 1)[0] in ("transformers", "huggingface_hub"):
+                continue
+            if getattr(_mod, "hf_hub_download", None) is _original_hf_hub_download:
+                _mod.hf_hub_download = _wrapped_hf_hub_download
 
     config.addinivalue_line("markers", "is_pipeline_test: mark test to run only when pipelines are tested")
     config.addinivalue_line("markers", "is_staging_test: mark test to run only in the staging environment")
@@ -218,15 +281,14 @@ def pytest_runtest_logreport(report):
 def pytest_terminal_summary(terminalreporter):
     # Always report whether the read-only cache fallback fired, so CI logs give an
     # unambiguous signal that the fallback path was (or was not) exercised this run.
-    if _ci_fallback_events:
+    # Events are aggregated across processes (xdist workers write to a shared directory).
+    events = _collect_fallback_events()
+    if events:
         from collections import Counter
 
         terminalreporter.write_sep("=", "CI READ-ONLY CACHE FALLBACK", yellow=True, bold=True)
-        terminalreporter.write_line(
-            f"Read-only cache fallback fired {len(_ci_fallback_events)} time(s); "
-            f"tmp cache_dir={_ci_fallback_cache_dir}"
-        )
-        for repo_id, count in sorted(Counter(_ci_fallback_events).items()):
+        terminalreporter.write_line(f"Read-only cache fallback fired {len(events)} time(s):")
+        for repo_id, count in sorted(Counter(events).items()):
             terminalreporter.write_line(f"  - {repo_id} (x{count})")
     else:
         terminalreporter.write_sep("=", "CI READ-ONLY CACHE FALLBACK: not triggered", bold=True)

--- a/conftest.py
+++ b/conftest.py
@@ -19,6 +19,7 @@ import doctest
 import errno
 import functools
 import os
+import re
 import sys
 import tempfile
 import warnings
@@ -42,20 +43,32 @@ from transformers.utils.network_logging import register_network_debug_plugin
 _ci_fallback_cache_dir = None
 
 
+# Rust's `std::io::Error` renders OS-level failures as ``"<strerror> (os error <N>)"``
+# where ``<N>`` is the raw platform errno. The trailing ``(os error N)`` fragment is
+# emitted by Rust in English regardless of locale, so the numeric code -- not the
+# human-readable ``<strerror>`` text -- is the stable signal to key off.
+_OS_ERROR_CODE_RE = re.compile(r"os error (\d+)", re.IGNORECASE)
+
+
 def _is_readonly_fs_error(e):
     """Return True if `e` signals a read-only filesystem (EROFS).
 
     The plain download path raises `OSError` with `errno == EROFS`. The Xet path
-    (`hf_xet` Rust library) instead raises a bare `RuntimeError` whose message contains
-    "os error 30" (EROFS) with no `.errno` set, so it must be matched on the message.
+    (`hf_xet` Rust library) instead raises a bare `RuntimeError` with no `.errno` set,
+    carrying a Rust-rendered message that ends with ``(os error <N>)``. We extract that
+    numeric code and compare it to `errno.EROFS` rather than matching the locale-dependent
+    strerror text, which is far more robust. The cause/context chain is followed so a
+    wrapped error is still recognised.
     """
-    if isinstance(e, OSError) and e.errno == errno.EROFS:
-        return True
-    # hf_xet surfaces the read-only failure as a RuntimeError with no `.errno`, e.g.
-    # "Previous task error: I/O error: I/O error: Read-only file system (os error 30)"
-    if isinstance(e, RuntimeError):
-        msg = str(e).lower()
-        return "read-only file system" in msg or f"os error {errno.EROFS}" in msg
+    # Follow the cause/context chain so a wrapped error is still recognised.
+    while e is not None:
+        # Standard path: an OSError carrying the EROFS errno.
+        if isinstance(e, OSError) and e.errno == errno.EROFS:
+            return True
+        # hf_xet path: a bare RuntimeError with the raw OS errno rendered as "(os error N)".
+        if isinstance(e, RuntimeError) and any(int(c) == errno.EROFS for c in _OS_ERROR_CODE_RE.findall(str(e))):
+            return True
+        e = e.__cause__ or e.__context__
     return False
 
 
@@ -133,6 +146,7 @@ NOT_DEVICE_TESTS = {
     "ModelTester::test_pipeline_",
     "/repo_utils/",
     "/utils/",
+    "/conftest_tests/",
 }
 
 # allow having multiple repository checkouts and not needing to remember to rerun

--- a/conftest.py
+++ b/conftest.py
@@ -51,9 +51,12 @@ def _is_readonly_fs_error(e):
     """
     if isinstance(e, OSError) and e.errno == errno.EROFS:
         return True
-    # hf_xet surfaces the read-only failure as a RuntimeError, e.g.
+    # hf_xet surfaces the read-only failure as a RuntimeError with no `.errno`, e.g.
     # "Previous task error: I/O error: I/O error: Read-only file system (os error 30)"
-    return isinstance(e, RuntimeError) and "os error 30" in str(e)
+    if isinstance(e, RuntimeError):
+        msg = str(e).lower()
+        return "read-only file system" in msg or f"os error {errno.EROFS}" in msg
+    return False
 
 
 def _with_tmpdir_cache_fallback(fn):
@@ -63,8 +66,13 @@ def _with_tmpdir_cache_fallback(fn):
     work fine. Only downloads of new or updated files fail with EROFS. On such failure,
     a session-scoped tmp dir is created once (via `tempfile.mkdtemp`, which is atomic
     and process-safe) and the call is retried with `cache_dir` set to the tmp dir.
-    `HF_XET_CACHE` is also redirected (via both the Python constant and `os.environ`) to
-    cover the Xet storage path used by the `hf_xet` Rust library.
+
+    The retry also disables Xet (``HF_HUB_DISABLE_XET``) so the download takes the plain
+    HTTP path, which writes into the redirected `cache_dir`. This is required because the
+    Xet path (`hf_xet` Rust library) uses a process-wide session singleton that binds to
+    the original read-only `HF_XET_CACHE` the first time it runs; redirecting `HF_XET_CACHE`
+    on retry has no effect on that already-created session, so the write keeps failing.
+    `HF_XET_CACHE` is still redirected too, as a belt-and-suspenders measure.
     """
 
     @functools.wraps(fn)
@@ -80,6 +88,8 @@ def _with_tmpdir_cache_fallback(fn):
             import huggingface_hub.constants as hf_constants
 
             with (
+                mock.patch.object(hf_constants, "HF_HUB_DISABLE_XET", True),
+                mock.patch.dict(os.environ, {"HF_HUB_DISABLE_XET": "1"}),
                 mock.patch.object(hf_constants, "HF_XET_CACHE", _ci_fallback_cache_dir),
                 mock.patch.dict(os.environ, {"HF_XET_CACHE": _ci_fallback_cache_dir}),
             ):

--- a/conftest.py
+++ b/conftest.py
@@ -42,6 +42,20 @@ from transformers.utils.network_logging import register_network_debug_plugin
 _ci_fallback_cache_dir = None
 
 
+def _is_readonly_fs_error(e):
+    """Return True if `e` signals a read-only filesystem (EROFS).
+
+    The plain download path raises `OSError` with `errno == EROFS`. The Xet path
+    (`hf_xet` Rust library) instead raises a bare `RuntimeError` whose message contains
+    "os error 30" (EROFS) with no `.errno` set, so it must be matched on the message.
+    """
+    if isinstance(e, OSError) and e.errno == errno.EROFS:
+        return True
+    # hf_xet surfaces the read-only failure as a RuntimeError, e.g.
+    # "Previous task error: I/O error: I/O error: Read-only file system (os error 30)"
+    return isinstance(e, RuntimeError) and "os error 30" in str(e)
+
+
 def _with_tmpdir_cache_fallback(fn):
     """Decorator that retries `fn` with a writable tmp cache dir if it raises EROFS.
 
@@ -57,8 +71,8 @@ def _with_tmpdir_cache_fallback(fn):
     def wrapper(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except OSError as e:
-            if e.errno != errno.EROFS:
+        except (OSError, RuntimeError) as e:
+            if not _is_readonly_fs_error(e):
                 raise
             global _ci_fallback_cache_dir
             if _ci_fallback_cache_dir is None:

--- a/conftest.py
+++ b/conftest.py
@@ -41,6 +41,10 @@ from transformers.utils.network_logging import register_network_debug_plugin
 
 
 _ci_fallback_cache_dir = None
+# Records the repo/file id for every call that was retried through the read-only cache
+# fallback. Surfaced in the pytest terminal summary so CI logs show whether (and how
+# often) the fallback actually fired during a run.
+_ci_fallback_events = []
 
 
 # Rust's `std::io::Error` renders OS-level failures as ``"<strerror> (os error <N>)"``
@@ -98,6 +102,16 @@ def _with_tmpdir_cache_fallback(fn):
             global _ci_fallback_cache_dir
             if _ci_fallback_cache_dir is None:
                 _ci_fallback_cache_dir = tempfile.mkdtemp(prefix="ci_fallback_tmpdir_cache_dir_")
+            repo_id = kwargs.get("path_or_repo_id") or (args[0] if args else "?")
+            _ci_fallback_events.append(str(repo_id))
+            # Emit a marker as well; captured per-test by pytest, but the guaranteed-visible
+            # count is reported in `pytest_terminal_summary` at the end of the run.
+            print(
+                f"[CI_CACHE_FALLBACK] read-only cache hit for {repo_id!r} ({type(e).__name__}); "
+                "retrying via writable tmp cache_dir with Xet disabled",
+                file=sys.stderr,
+                flush=True,
+            )
             import huggingface_hub.constants as hf_constants
 
             with (
@@ -202,6 +216,21 @@ def pytest_runtest_logreport(report):
 
 
 def pytest_terminal_summary(terminalreporter):
+    # Always report whether the read-only cache fallback fired, so CI logs give an
+    # unambiguous signal that the fallback path was (or was not) exercised this run.
+    if _ci_fallback_events:
+        from collections import Counter
+
+        terminalreporter.write_sep("=", "CI READ-ONLY CACHE FALLBACK", yellow=True, bold=True)
+        terminalreporter.write_line(
+            f"Read-only cache fallback fired {len(_ci_fallback_events)} time(s); "
+            f"tmp cache_dir={_ci_fallback_cache_dir}"
+        )
+        for repo_id, count in sorted(Counter(_ci_fallback_events).items()):
+            terminalreporter.write_line(f"  - {repo_id} (x{count})")
+    else:
+        terminalreporter.write_sep("=", "CI READ-ONLY CACHE FALLBACK: not triggered", bold=True)
+
     from transformers.testing_utils import pytest_terminal_summary_main
 
     make_reports = terminalreporter.config.getoption("--make-reports")

--- a/tests/conftest_tests/test_cache_fallback.py
+++ b/tests/conftest_tests/test_cache_fallback.py
@@ -1,0 +1,117 @@
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the read-only cache fallback defined in the repo-root ``conftest.py``.
+
+These exercise the *test runner* itself rather than the ``transformers`` library, so they
+live in their own directory and are scheduled by the tests fetcher whenever ``conftest.py``
+is modified (see ``utils/tests_fetcher.py``).
+"""
+
+import errno
+import os
+import unittest
+import unittest.mock as mock
+
+
+class ReadOnlyCacheFallbackTest(unittest.TestCase):
+    """Guards the read-only cache fallback defined in the repo-root ``conftest.py``.
+
+    In CI the shared HF cache is read-only, so downloads of models not already present
+    fail with EROFS. ``conftest._with_tmpdir_cache_fallback`` wraps ``cached_files`` to
+    retry such failures against a writable tmp dir with Xet disabled. Both the plain
+    ``OSError``/EROFS path and the ``hf_xet`` ``RuntimeError`` path must be handled --
+    the latter was the regression that slipped past the original errno-only check.
+    """
+
+    def setUp(self):
+        import conftest
+
+        self.conftest = conftest
+        # Reset the module-level session cache dir so each test starts from a clean slate;
+        # the patcher restores whatever value was there before on cleanup.
+        patcher = mock.patch.object(conftest, "_ci_fallback_cache_dir", None)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_is_readonly_fs_error_classification(self):
+        is_ro = self.conftest._is_readonly_fs_error
+        # Plain download path: OSError with EROFS errno.
+        self.assertTrue(is_ro(OSError(errno.EROFS, "Read-only file system")))
+        # A wrapped OSError is detected through the exception chain.
+        wrapped_erofs = RuntimeError("wrapped")
+        wrapped_erofs.__cause__ = OSError(errno.EROFS, "Read-only file system")
+        self.assertTrue(is_ro(wrapped_erofs))
+        # hf_xet path: bare RuntimeError carrying the raw OS errno as "(os error N)".
+        self.assertTrue(is_ro(RuntimeError("I/O error: Read-only file system (os error 30)")))
+        self.assertTrue(is_ro(RuntimeError("Data processing error: I/O error: OS ERROR 30")))
+        # Negatives: unrelated errors must propagate untouched.
+        self.assertFalse(is_ro(OSError(errno.EACCES, "Permission denied")))
+        self.assertFalse(is_ro(RuntimeError("some unrelated runtime error")))
+        self.assertFalse(is_ro(RuntimeError("I/O error (os error 13)")))  # EACCES, not EROFS
+        self.assertFalse(is_ro(ValueError("nope")))
+
+    def test_passthrough_on_success(self):
+        fn = mock.Mock(return_value="resolved")
+        wrapped = self.conftest._with_tmpdir_cache_fallback(fn)
+        self.assertEqual(wrapped("repo", filenames=["f"]), "resolved")
+        fn.assert_called_once_with("repo", filenames=["f"])
+
+    def test_reraises_non_readonly_error(self):
+        fn = mock.Mock(side_effect=OSError(errno.EACCES, "Permission denied"))
+        wrapped = self.conftest._with_tmpdir_cache_fallback(fn)
+        with self.assertRaises(OSError):
+            wrapped()
+        fn.assert_called_once()
+
+    def _assert_recovers(self, first_error):
+        """The first call raises ``first_error``; the retry must be given a writable
+        ``cache_dir`` with Xet disabled, and its result returned."""
+        import huggingface_hub.constants as hf_constants
+
+        original_disable_xet = hf_constants.HF_HUB_DISABLE_XET
+        calls = []
+
+        def side_effect(*args, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise first_error
+            # On the retry Xet must be disabled and a writable cache_dir supplied.
+            self.assertTrue(hf_constants.HF_HUB_DISABLE_XET)
+            self.assertEqual(os.environ.get("HF_HUB_DISABLE_XET"), "1")
+            return "recovered"
+
+        fn = mock.Mock(side_effect=side_effect)
+        wrapped = self.conftest._with_tmpdir_cache_fallback(fn)
+
+        self.assertEqual(wrapped(path_or_repo_id="repo"), "recovered")
+        self.assertEqual(len(calls), 2)
+        # The first attempt is untouched; the retry gets the fallback cache dir.
+        self.assertNotIn("cache_dir", calls[0])
+        retry_cache_dir = calls[1]["cache_dir"]
+        self.assertEqual(retry_cache_dir, self.conftest._ci_fallback_cache_dir)
+        self.assertTrue(os.path.isdir(retry_cache_dir))
+        # Xet-disable patch is scoped to the retry and restored afterwards.
+        self.assertEqual(hf_constants.HF_HUB_DISABLE_XET, original_disable_xet)
+
+    def test_retry_on_xet_runtime_error(self):
+        # The exact error raised by the hf_xet Rust layer against a read-only cache.
+        self._assert_recovers(RuntimeError("Data processing error: I/O error: Read-only file system (os error 30)"))
+
+    def test_retry_on_oserror_erofs(self):
+        # The plain (non-Xet) download path raises this.
+        self._assert_recovers(OSError(errno.EROFS, "Read-only file system"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/repo_utils/test_tests_fetcher.py
+++ b/tests/repo_utils/test_tests_fetcher.py
@@ -39,6 +39,7 @@ from tests_fetcher import (  # noqa: E402
     diff_is_docstring_only,
     extract_imports,
     get_all_tests,
+    get_conftest_tests,
     get_diff,
     get_module_dependencies,
     get_repo_utils_tests,
@@ -47,6 +48,7 @@ from tests_fetcher import (  # noqa: E402
     init_test_examples_dependencies,
     parse_commit_message,
     print_tree_deps_of,
+    should_run_conftest_tests,
     should_run_repo_utils_tests,
 )
 
@@ -263,6 +265,39 @@ class TestFetcherTester(unittest.TestCase):
     def test_should_run_repo_utils_tests(self):
         assert should_run_repo_utils_tests(["utils/check_modeling_structure.py"])
         assert not should_run_repo_utils_tests(["src/transformers/modeling_utils.py"])
+
+    def test_get_conftest_tests_on_full_repo(self):
+        conftest_tests = get_conftest_tests()
+        assert "tests/conftest_tests/test_cache_fallback.py" in conftest_tests
+
+    def test_should_run_conftest_tests(self):
+        # Triggered by the repo-root conftest.py as well as any nested conftest.py.
+        assert should_run_conftest_tests(["conftest.py"])
+        assert should_run_conftest_tests(["tests/models/bert/conftest.py"])
+        # But not by a change to conftest tooling that is not a conftest.py file.
+        assert not should_run_conftest_tests(["utils/check_modeling_structure.py"])
+        assert not should_run_conftest_tests(["src/transformers/modeling_utils.py"])
+
+    def test_create_test_list_from_filter_routes_conftest_tests(self):
+        with tempfile.TemporaryDirectory() as tmp_folder:
+            create_test_list_from_filter(
+                [
+                    "tests/conftest_tests/test_cache_fallback.py",
+                    "tests/trainer/test_trainer.py",
+                ],
+                out_path=tmp_folder,
+            )
+
+            with open(Path(tmp_folder) / "tests_repo_utils_test_list.txt", encoding="utf-8") as f:
+                repo_utils_tests = f.read().splitlines()
+
+            # Conftest tests ride along in the repo_utils job and must not leak into non_model.
+            assert repo_utils_tests == ["tests/conftest_tests/test_cache_fallback.py"]
+            assert not (Path(tmp_folder) / "tests_conftest_test_list.txt").exists()
+
+            with open(Path(tmp_folder) / "tests_non_model_test_list.txt", encoding="utf-8") as f:
+                non_model_tests = f.read().splitlines()
+            assert "tests/conftest_tests/test_cache_fallback.py" not in non_model_tests
 
     def test_create_test_list_from_filter_routes_repo_utils_tests(self):
         with tempfile.TemporaryDirectory() as tmp_folder:

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import errno
 import json
 import os
 import tempfile
@@ -195,6 +196,91 @@ class GetFromCacheTests(unittest.TestCase):
             with self.assertRaises(ModuleNotFoundError):
                 # The error should be re-raised by cached_files, not caught in the exception handling block
                 cached_file(RANDOM_BERT, "nonexistent.json")
+
+
+class ReadOnlyCacheFallbackTest(unittest.TestCase):
+    """Guards the read-only cache fallback defined in the repo-root ``conftest.py``.
+
+    In CI the shared HF cache is read-only, so downloads of models not already present
+    fail with EROFS. ``conftest._with_tmpdir_cache_fallback`` wraps ``cached_files`` to
+    retry such failures against a writable tmp dir with Xet disabled. Both the plain
+    ``OSError``/EROFS path and the ``hf_xet`` ``RuntimeError`` path must be handled --
+    the latter was the regression that slipped past the original errno-only check.
+    """
+
+    def setUp(self):
+        import conftest
+
+        self.conftest = conftest
+        # Reset the module-level session cache dir so each test starts from a clean slate.
+        self._saved_cache_dir = conftest._ci_fallback_cache_dir
+        conftest._ci_fallback_cache_dir = None
+
+    def tearDown(self):
+        self.conftest._ci_fallback_cache_dir = self._saved_cache_dir
+
+    def test_is_readonly_fs_error_classification(self):
+        is_ro = self.conftest._is_readonly_fs_error
+        # Plain download path: OSError with EROFS errno.
+        self.assertTrue(is_ro(OSError(errno.EROFS, "Read-only file system")))
+        # hf_xet path: bare RuntimeError, matched on message (no .errno set).
+        self.assertTrue(is_ro(RuntimeError("I/O error: Read-only file system (os error 30)")))
+        self.assertTrue(is_ro(RuntimeError("Data processing error: I/O error: OS ERROR 30")))
+        # Negatives: unrelated errors must propagate untouched.
+        self.assertFalse(is_ro(OSError(errno.EACCES, "Permission denied")))
+        self.assertFalse(is_ro(RuntimeError("some unrelated runtime error")))
+        self.assertFalse(is_ro(ValueError("nope")))
+
+    def test_passthrough_on_success(self):
+        fn = mock.Mock(return_value="resolved")
+        wrapped = self.conftest._with_tmpdir_cache_fallback(fn)
+        self.assertEqual(wrapped("repo", filenames=["f"]), "resolved")
+        fn.assert_called_once_with("repo", filenames=["f"])
+
+    def test_reraises_non_readonly_error(self):
+        fn = mock.Mock(side_effect=OSError(errno.EACCES, "Permission denied"))
+        wrapped = self.conftest._with_tmpdir_cache_fallback(fn)
+        with self.assertRaises(OSError):
+            wrapped()
+        fn.assert_called_once()
+
+    def _assert_recovers(self, first_error):
+        """The first call raises ``first_error``; the retry must be given a writable
+        ``cache_dir`` with Xet disabled, and its result returned."""
+        import huggingface_hub.constants as hf_constants
+
+        original_disable_xet = hf_constants.HF_HUB_DISABLE_XET
+        calls = []
+
+        def side_effect(*args, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise first_error
+            # On the retry Xet must be disabled and a writable cache_dir supplied.
+            self.assertTrue(hf_constants.HF_HUB_DISABLE_XET)
+            self.assertEqual(os.environ.get("HF_HUB_DISABLE_XET"), "1")
+            return "recovered"
+
+        fn = mock.Mock(side_effect=side_effect)
+        wrapped = self.conftest._with_tmpdir_cache_fallback(fn)
+
+        self.assertEqual(wrapped(path_or_repo_id="repo"), "recovered")
+        self.assertEqual(len(calls), 2)
+        # The first attempt is untouched; the retry gets the fallback cache dir.
+        self.assertNotIn("cache_dir", calls[0])
+        retry_cache_dir = calls[1]["cache_dir"]
+        self.assertEqual(retry_cache_dir, self.conftest._ci_fallback_cache_dir)
+        self.assertTrue(os.path.isdir(retry_cache_dir))
+        # Xet-disable patch is scoped to the retry and restored afterwards.
+        self.assertEqual(hf_constants.HF_HUB_DISABLE_XET, original_disable_xet)
+
+    def test_retry_on_xet_runtime_error(self):
+        # The exact error raised by the hf_xet Rust layer against a read-only cache.
+        self._assert_recovers(RuntimeError("Data processing error: I/O error: Read-only file system (os error 30)"))
+
+    def test_retry_on_oserror_erofs(self):
+        # The plain (non-Xet) download path raises this.
+        self._assert_recovers(OSError(errno.EROFS, "Read-only file system"))
 
 
 class OfflineModeTests(unittest.TestCase):

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import errno
 import json
 import os
 import tempfile
@@ -196,91 +195,6 @@ class GetFromCacheTests(unittest.TestCase):
             with self.assertRaises(ModuleNotFoundError):
                 # The error should be re-raised by cached_files, not caught in the exception handling block
                 cached_file(RANDOM_BERT, "nonexistent.json")
-
-
-class ReadOnlyCacheFallbackTest(unittest.TestCase):
-    """Guards the read-only cache fallback defined in the repo-root ``conftest.py``.
-
-    In CI the shared HF cache is read-only, so downloads of models not already present
-    fail with EROFS. ``conftest._with_tmpdir_cache_fallback`` wraps ``cached_files`` to
-    retry such failures against a writable tmp dir with Xet disabled. Both the plain
-    ``OSError``/EROFS path and the ``hf_xet`` ``RuntimeError`` path must be handled --
-    the latter was the regression that slipped past the original errno-only check.
-    """
-
-    def setUp(self):
-        import conftest
-
-        self.conftest = conftest
-        # Reset the module-level session cache dir so each test starts from a clean slate.
-        self._saved_cache_dir = conftest._ci_fallback_cache_dir
-        conftest._ci_fallback_cache_dir = None
-
-    def tearDown(self):
-        self.conftest._ci_fallback_cache_dir = self._saved_cache_dir
-
-    def test_is_readonly_fs_error_classification(self):
-        is_ro = self.conftest._is_readonly_fs_error
-        # Plain download path: OSError with EROFS errno.
-        self.assertTrue(is_ro(OSError(errno.EROFS, "Read-only file system")))
-        # hf_xet path: bare RuntimeError, matched on message (no .errno set).
-        self.assertTrue(is_ro(RuntimeError("I/O error: Read-only file system (os error 30)")))
-        self.assertTrue(is_ro(RuntimeError("Data processing error: I/O error: OS ERROR 30")))
-        # Negatives: unrelated errors must propagate untouched.
-        self.assertFalse(is_ro(OSError(errno.EACCES, "Permission denied")))
-        self.assertFalse(is_ro(RuntimeError("some unrelated runtime error")))
-        self.assertFalse(is_ro(ValueError("nope")))
-
-    def test_passthrough_on_success(self):
-        fn = mock.Mock(return_value="resolved")
-        wrapped = self.conftest._with_tmpdir_cache_fallback(fn)
-        self.assertEqual(wrapped("repo", filenames=["f"]), "resolved")
-        fn.assert_called_once_with("repo", filenames=["f"])
-
-    def test_reraises_non_readonly_error(self):
-        fn = mock.Mock(side_effect=OSError(errno.EACCES, "Permission denied"))
-        wrapped = self.conftest._with_tmpdir_cache_fallback(fn)
-        with self.assertRaises(OSError):
-            wrapped()
-        fn.assert_called_once()
-
-    def _assert_recovers(self, first_error):
-        """The first call raises ``first_error``; the retry must be given a writable
-        ``cache_dir`` with Xet disabled, and its result returned."""
-        import huggingface_hub.constants as hf_constants
-
-        original_disable_xet = hf_constants.HF_HUB_DISABLE_XET
-        calls = []
-
-        def side_effect(*args, **kwargs):
-            calls.append(kwargs)
-            if len(calls) == 1:
-                raise first_error
-            # On the retry Xet must be disabled and a writable cache_dir supplied.
-            self.assertTrue(hf_constants.HF_HUB_DISABLE_XET)
-            self.assertEqual(os.environ.get("HF_HUB_DISABLE_XET"), "1")
-            return "recovered"
-
-        fn = mock.Mock(side_effect=side_effect)
-        wrapped = self.conftest._with_tmpdir_cache_fallback(fn)
-
-        self.assertEqual(wrapped(path_or_repo_id="repo"), "recovered")
-        self.assertEqual(len(calls), 2)
-        # The first attempt is untouched; the retry gets the fallback cache dir.
-        self.assertNotIn("cache_dir", calls[0])
-        retry_cache_dir = calls[1]["cache_dir"]
-        self.assertEqual(retry_cache_dir, self.conftest._ci_fallback_cache_dir)
-        self.assertTrue(os.path.isdir(retry_cache_dir))
-        # Xet-disable patch is scoped to the retry and restored afterwards.
-        self.assertEqual(hf_constants.HF_HUB_DISABLE_XET, original_disable_xet)
-
-    def test_retry_on_xet_runtime_error(self):
-        # The exact error raised by the hf_xet Rust layer against a read-only cache.
-        self._assert_recovers(RuntimeError("Data processing error: I/O error: Read-only file system (os error 30)"))
-
-    def test_retry_on_oserror_erofs(self):
-        # The plain (non-Xet) download path raises this.
-        self._assert_recovers(OSError(errno.EROFS, "Read-only file system"))
 
 
 class OfflineModeTests(unittest.TestCase):

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -943,6 +943,36 @@ def should_run_repo_utils_tests(modified_files: list[str]) -> bool:
     return any(path.startswith("utils/") for path in modified_files)
 
 
+def get_conftest_tests() -> list[str]:
+    """
+    Return the list of tests guarding the pytest ``conftest.py`` machinery itself.
+
+    Returns:
+        `List[str]`: The conftest test files.
+    """
+    conftest_dir = PATH_TO_TESTS / "conftest_tests"
+    if not conftest_dir.is_dir():
+        return []
+    return sorted(str(path.relative_to(PATH_TO_REPO)) for path in conftest_dir.glob("test_*.py"))
+
+
+def should_run_conftest_tests(modified_files: list[str]) -> bool:
+    """
+    Return whether the ``conftest.py`` tests should be scheduled based on the modified files.
+
+    These tests exercise the test runner (the repo-root ``conftest.py``) rather than the
+    library, so they only need to run when a ``conftest.py`` is touched.
+
+    Args:
+        modified_files (`List[str]`):
+            The list of modified files relative to the repo root.
+
+    Returns:
+        `bool`: Whether the conftest tests should run.
+    """
+    return any(os.path.basename(path) == "conftest.py" for path in modified_files)
+
+
 def _print_list(l) -> str:
     """
     Pretty print a list of elements with one line per element and a - starting each line.
@@ -1011,6 +1041,9 @@ def infer_tests_to_run(output_file: str, diff_with_last_commit: bool = False, te
 
     if should_run_repo_utils_tests(modified_files):
         test_files_to_run.extend(get_repo_utils_tests())
+
+    if should_run_conftest_tests(modified_files):
+        test_files_to_run.extend(get_conftest_tests())
 
     test_files_to_run = sorted(set(test_files_to_run))
     # Remove SageMaker tests
@@ -1094,10 +1127,12 @@ JOB_TO_TEST_FILE = {
     "examples_torch": r"examples/pytorch/.*test_.*",
     "tests_exotic_models": r"tests/models/.*(?=layoutlmv|nat|deta|udop|nougat).*",
     "tests_custom_tokenizers": r"tests/models/.*/test_tokenization_(?=bert_japanese|openai|clip).*",
-    "tests_repo_utils": r"tests/repo_utils/test_.*\.py",
+    # conftest tests exercise the test runner (repo-root conftest.py); they share the
+    # consistency image and run alongside the repo utils tests in the same CI job.
+    "tests_repo_utils": r"tests/(?:repo_utils|conftest_tests)/test_.*\.py",
     "pipelines_torch": r"tests/models/.*/test_modeling_.*",
-    # don't include peft tests for non_model
-    "tests_non_model": r"tests/(?!peft_integration/)[^/]*?/test_.*\.py",
+    # don't include peft or conftest tests for non_model (conftest tests run in the repo_utils job)
+    "tests_non_model": r"tests/(?!peft_integration/|conftest_tests/)[^/]*?/test_.*\.py",
     "tests_training_ci": r"tests/models/.*/test_modeling_.*",
     "tests_tensor_parallel_ci": r"(tests/models/.*/test_modeling_.*|tests/tensor_parallel(?:/test_tensor_parallel\.py)?)",
     "tests_peft_integration": r"tests/peft_integration/test_.*\.py",


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47338)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47338)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

The fallback to use a tempdir on read only cache needs to be extended for XET that produces Runtime errors not OS Errors