### PR TITLE
Pin kernels to compatible version in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,10 +41,10 @@ jobs:
           persist-credentials: false
 
       - name: Install benchmark script dependencies
-        run: python3 -m pip install -r benchmark_v2/requirements.txt kernels
+        run: python3 -m pip install -r benchmark_v2/requirements.txt
 
       - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
-        run: python3 -m pip uninstall -y transformers && python3 -m pip install -e ".[torch]"
+        run: python3 -m pip uninstall -y transformers && python3 -m pip install -e ".[torch,kernels]"
 
       - name: Run benchmark
         run: |


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47339)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47339)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

The benchmark workflow installed `kernels` unpinned, pulling the latest version (>=0.16) which is outside transformers' required range [0.15.2, 0.16.0). The subsequent `.[torch]` reinstall does not include kernels, so the stale version was never corrected. At runtime the benchmark runner enables kernels whenever the import succeeds, but transformers' `is_kernels_available()` enforces the version range and rejects it, raising `ValueError: Kernels are not available`.

Install kernels via the pinned `.[kernels]` extra so setup.py's `kernels>=0.15.2,<0.16` constraint governs the installed version.

https://github.com/huggingface/transformers/actions/runs/29391269980/job/87275127776