### PR TITLE
Fix _is_packed_sequence for 1D and 3D position_ids

### DIFF
--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -535,9 +535,19 @@ def _is_packed_sequence(position_ids, batch_size):
         1. Position ids exist
         2. Flattened sequences only are supported
         3. Compile-friendly `not (torch.diff(position_ids, dim=-1) >= 0).all()`, i.e. we have multiple increasing sequences
+
+    `position_ids` is expected to be `[batch_size, seq_len]`, but a couple of shapes are normalized to that first:
+        - 1D `[seq_len]`, e.g. Pixtral's `position_ids_in_meshgrid`, which only makes sense for `batch_size == 1`.
+        - 3D `[num_position_axes, batch_size, seq_len]`, e.g. MRoPE. All axes share the same packing layout, so a
+          single axis is enough to judge packing without misclassifying an unpacked batch as packed.
     """
     if position_ids is None:
         return False
+
+    if position_ids.ndim == 1:
+        position_ids = position_ids.unsqueeze(0)
+    elif position_ids.ndim == 3:
+        position_ids = position_ids[0]
 
     increasing_position_sequences = (
         torch.arange(position_ids.shape[1], device=position_ids.device) + position_ids.min()

--- a/tests/utils/test_modeling_flash_attention_utils.py
+++ b/tests/utils/test_modeling_flash_attention_utils.py
@@ -1,0 +1,63 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers.testing_utils import is_torch_available, require_torch
+
+
+if is_torch_available():
+    import torch
+
+    from transformers.modeling_flash_attention_utils import _is_packed_sequence
+
+
+@require_torch
+class IsPackedSequenceTest(unittest.TestCase):
+    def test_none_position_ids(self):
+        self.assertFalse(_is_packed_sequence(None, batch_size=1))
+
+    def test_1d_packed(self):
+        # Pixtral-style `position_ids_in_meshgrid` output: flattened, multiple increasing runs.
+        position_ids = torch.tensor([0, 1, 2, 0, 1])
+        self.assertTrue(bool(_is_packed_sequence(position_ids, batch_size=1)))
+
+    def test_1d_unpacked(self):
+        position_ids = torch.arange(5)
+        self.assertFalse(bool(_is_packed_sequence(position_ids, batch_size=1)))
+
+    def test_2d_packed(self):
+        position_ids = torch.tensor([[0, 1, 2, 0, 1, 2, 3]])
+        self.assertTrue(bool(_is_packed_sequence(position_ids, batch_size=1)))
+
+    def test_2d_unpacked_batch_size_one(self):
+        position_ids = torch.tensor([[0, 1, 2, 3, 4]])
+        self.assertFalse(bool(_is_packed_sequence(position_ids, batch_size=1)))
+
+    def test_2d_unpacked_batch_size_greater_than_one(self):
+        # Regular padded batch: never treated as packed, regardless of batch_size passed in.
+        position_ids = torch.tensor([[0, 1, 2], [0, 1, 2]])
+        self.assertFalse(bool(_is_packed_sequence(position_ids, batch_size=2)))
+
+    def test_3d_mrope_packed(self):
+        # MRoPE-style [num_position_axes, batch_size, seq_len], all axes share the packing layout.
+        position_ids = torch.stack([torch.tensor([[0, 1, 2, 0, 1, 2, 3]])] * 3)
+        self.assertEqual(position_ids.ndim, 3)
+        self.assertTrue(bool(_is_packed_sequence(position_ids, batch_size=1)))
+
+    def test_3d_mrope_unpacked_not_misclassified(self):
+        # Regression test: an unpacked, multi-example MRoPE batch must not be sent down the varlen path.
+        position_ids = torch.stack([torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]])] * 3)
+        self.assertEqual(position_ids.ndim, 3)
+        self.assertFalse(bool(_is_packed_sequence(position_ids, batch_size=2)))


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47342)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47342)
<!-- ci-dashboard-badge:end -->

upstreaming fixes from https://github.com/axolotl-ai-cloud/axolotl/pull/3165 and https://github.com/axolotl-ai-cloud/axolotl/pull/3442

_is_packed_sequence assumed position_ids is always [batch_size, seq_len]. Pixtral's position_ids_in_meshgrid can produce a 1D [seq_len] tensor, raising IndexError. Qwen-VL-style MRoPE models pass a 3D [num_position_axes, batch_size, seq_len] tensor, which was misclassified as packed (shape[1] picked up the axis dim instead of seq_len), sending real unpacked batches down the varlen flash-attention path and causing CUDA errors at train time.

Normalize position_ids to 2D before the existing check: unsqueeze a leading batch dim for 1D (only valid for batch_size == 1), and take a single axis for 3D MRoPE inputs, since all axes share the same packing layout.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.

Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
for reviewers and other users and will almost certainly get you blocked.

For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->