### PR TITLE
fix: correct dict comprehension syntax in save_pretrained to prevent ValueError

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3666,7 +3666,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                     shard_state_dict = revert_weight_conversion(model_to_save, shard_state_dict)
                     # Save the weight_map, since some names etc may have changed due to conversion compared to initial `state_dict_split`
                     if state_dict_split.is_sharded:
-                        weight_map.update({k: os.path.basename(shard_file)} for k in shard_state_dict.keys())  # ty: ignore[unresolved-attribute]
+                        weight_map.update({k: os.path.basename(shard_file) for k in shard_state_dict.keys()})  # ty: ignore[unresolved-attribute]
                 except Exception:
                     raise RuntimeError(
                         "We could not revert some weight conversions because of offlading, and several weights needed for a single "


### PR DESCRIPTION
# What does this PR do?

Fixes #47333 

There is a small syntax error in `modeling_utils.py` that crashes the `save_pretrained` process for models with offloaded modules.

Currently, `weight_map.update()` is being passed a generator yielding single-key dictionaries, which throws a `ValueError` because `update()` expects a sequence of 2-item tuples. 

Before:
`weight_map.update({k: os.path.basename(shard_file)} for k in shard_state_dict.keys())`

After (moved the closing brace to make it a standard dict comprehension):
`weight_map.update({k: os.path.basename(shard_file) for k in shard_state_dict.keys()})`

## Code Agent Policy

- [x] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.

## Who can review?

@Cyrilvallez @SunMarc (Tagging you as you were mentioned in the original issue!)