### PR TITLE
Wire DistributedConfig through from_pretrained and save_pretrained (FSDP orchestration 2/3)

### DIFF
--- a/docs/source/en/expert_parallelism.md
+++ b/docs/source/en/expert_parallelism.md
@@ -22,11 +22,16 @@ rendered properly in your Markdown viewer.
 Enable expert parallelism with the [`DistributedConfig`] class and the `enable_expert_parallel` argument.
 
 ```py
+import os
+
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers.distributed.configuration_utils import DistributedConfig
 
-distributed_config = DistributedConfig(enable_expert_parallel=True)
+distributed_config = DistributedConfig(
+    tp_size=int(os.environ["WORLD_SIZE"]),
+    enable_expert_parallel=True,
+)
 
 model = AutoModelForCausalLM.from_pretrained(
     "openai/gpt-oss-120b",

--- a/docs/source/en/model_doc/minimax_m3_vl.md
+++ b/docs/source/en/model_doc/minimax_m3_vl.md
@@ -165,8 +165,10 @@ model = AutoModelForImageTextToText.from_pretrained(
     dtype=torch.bfloat16,
     # Dequantize the native MXFP8 weights to bf16 at load (the speed win); needs even TP/EP sharding.
     quantization_config=FineGrainedFP8Config(dequantize=True),
-    tp_plan="auto",
-    distributed_config=DistributedConfig(enable_expert_parallel=True),
+    distributed_config=DistributedConfig(
+        tp_size=int(os.environ["WORLD_SIZE"]),
+        enable_expert_parallel=True,
+    ),
     attn_implementation="kernels-staging/msa@v0",  # MSA block-sparse attention kernel
 )
 model.eval()

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -16,7 +16,6 @@ import collections
 import copy
 import functools
 import inspect
-import json
 import os
 import re
 import sys
@@ -52,8 +51,10 @@ from .core_model_loading import (
     revert_weight_conversion,
 )
 from .distributed import DistributedConfig
+from .distributed.fsdp import is_fsdp_managed_module
 from .distributed.mixin import DistributedMixin
 from .distributed.utils import (
+    _distributed_barrier,
     _get_torch_distributed_world_size,
     _is_torch_distributed_initialized,
     is_local_dist_rank_0,
@@ -83,9 +84,6 @@ from .integrations.sdpa_attention import sdpa_attention_forward
 from .integrations.sdpa_paged import sdpa_attention_paged_forward
 from .integrations.tensor_parallel import (
     _get_parameter_tp_plan,
-    apply_tensor_parallelism,
-    gather_state_dict_for_save,
-    initialize_tensor_parallelism,
     shard_and_distribute_module,
     verify_tp_plan,
 )
@@ -1388,18 +1386,15 @@ class PreTrainedModel(
         """
         # Attach the different parallel plans and tied weight keys to the top-most model, so that everything is
         # easily available.
-        # Start from the class-level plans (e.g. `{"lm_head": "colwise_rep"}` on `...ForCausalLM` classes), copying
-        # them as they are mutated below and would otherwise contaminate the class attribute shared by all instances
-        self._tp_plan = dict(self._tp_plan or {})
-        self._ep_plan = dict(self._ep_plan or {})
-        self._pp_plan = dict(self._pp_plan or {})
-        self._fsdp_plan = dict(self._fsdp_plan or {})
+        self._tp_plan, self._ep_plan, self._pp_plan, self._fsdp_plan = {}, {}, {}, {}
         # If current model is a base model, attach `base_model_tp_plan` and `base_model_pp_plan` from config
         if self.base_model is self:
-            self._pp_plan.update(self.config.base_model_pp_plan or {})
-            self._tp_plan.update(self.config.base_model_tp_plan or {})
-            self._ep_plan.update(self.config.base_model_ep_plan or {})
-            self._fsdp_plan.update(self.config.base_model_fsdp_plan or {})
+            self._pp_plan = self.config.base_model_pp_plan.copy() if self.config.base_model_pp_plan is not None else {}
+            self._tp_plan = self.config.base_model_tp_plan.copy() if self.config.base_model_tp_plan is not None else {}
+            self._ep_plan = self.config.base_model_ep_plan.copy() if self.config.base_model_ep_plan is not None else {}
+            self._fsdp_plan = (
+                self.config.base_model_fsdp_plan.copy() if self.config.base_model_fsdp_plan is not None else {}
+            )
         # Current submodel should register its tied weights
         self.all_tied_weights_keys = self.get_expanded_tied_weights_keys(all_submodels=False)
         # Current submodel should register its `_keep_in_fp32_modules`
@@ -3321,6 +3316,7 @@ class PreTrainedModel(
         token: str | bool | None = None,
         save_peft_format: bool = True,
         save_original_format: bool = True,
+        distributed_checkpoint: bool = False,
         **kwargs,
     ):
         """
@@ -3344,7 +3340,7 @@ class PreTrainedModel(
                 namespace).
             max_shard_size (`int` or `str`, *optional*, defaults to `"50GB"`):
                 The maximum size for a checkpoint before being sharded. Checkpoints shard will then be each of size
-                lower than this size. If expressed as a string, needs to be digits followed by a unit (like `"5MB"`).
+                lower than this size. If expressed as a string, needs be digits followed by a unit (like `"5MB"`).
 
                 <Tip warning={true}>
 
@@ -3366,6 +3362,11 @@ class PreTrainedModel(
                 For backward compatibility with the previous versions of `transformers` you can save the checkpoint with
                 its reverse mapping. The reverse mapping needs to exists even if the model was loaded from a None legacy
                 checkpoint.
+            distributed_checkpoint (`bool`, *optional*, defaults to `False`):
+                When saving an FSDP-wrapped model, use the distributed checkpoint (DCP) path instead of gathering weights
+                to CPU first. Every rank must call this method; rank 0 writes the consolidated Hugging Face safetensors.
+                When `False`, FSDP weights are gathered to CPU on rank 0 via `gather_full_state_dict` before writing.
+                Native FSDP requires `torch>=2.7`.
             kwargs (`dict[str, Any]`, *optional*):
                 Additional key word arguments passed along to the [`~utils.PushToHubMixin.push_to_hub`] method.
         """
@@ -3412,6 +3413,8 @@ class PreTrainedModel(
 
         # Only save the model itself if we are using distributed training
         model_to_save = unwrap_model(self)
+        save_on_this_rank = self.should_save_on_this_rank(is_main_process)
+
         # save the string version of dtype to the config, e.g. convert torch.float32 => "float32"
         # we currently don't use this setting automatically, but may start to use with v5
         dtype = model_to_save.dtype
@@ -3423,11 +3426,11 @@ class PreTrainedModel(
 
         # If we have a custom model, we copy the file defining it in the folder and set the attributes so it can be
         # loaded from the Hub.
-        if self.is_remote_code():
+        if save_on_this_rank and self.is_remote_code():
             custom_object_save(self, save_directory, config=self.config)
 
         # Save the config
-        if is_main_process:
+        if save_on_this_rank:
             if not _hf_peft_config_loaded:
                 model_to_save.config.save_pretrained(save_directory)
             if self.can_generate():
@@ -3460,9 +3463,35 @@ class PreTrainedModel(
                 current_peft_config = self.peft_config[active_adapter]
                 current_peft_config.save_pretrained(save_directory)
 
-        # Get the model state_dict
+        if distributed_checkpoint:
+            hub_kwargs = {}
+            if push_to_hub:
+                hub_kwargs = {
+                    "repo_id": repo_id,
+                    "files_timestamps": files_timestamps,
+                    "commit_message": commit_message,
+                    "create_pr": create_pr,
+                }
+            self.save_distributed_checkpoint(
+                model_to_save,
+                save_directory,
+                push_to_hub=push_to_hub,
+                save_on_this_rank=save_on_this_rank,
+                token=token,
+                **hub_kwargs,
+            )
+            return
+
+        needs_dist_barrier = False
         if state_dict is None:
             state_dict = model_to_save.state_dict()
+
+        if self._tp_size is not None:
+            state_dict, needs_dist_barrier = self._gather_tp_state_dict_for_save(
+                state_dict, is_checkpoint_writer=save_on_this_rank
+            )
+        elif is_fsdp_managed_module(model_to_save):
+            state_dict, needs_dist_barrier = self._gather_fsdp_state_dict_for_save(model_to_save)
 
         # if any model parameters are offloaded, we need to know it for later
         is_offloaded = False
@@ -3487,10 +3516,6 @@ class PreTrainedModel(
             for ignore_key in self._keys_to_ignore_on_save:
                 if ignore_key in state_dict:
                     del state_dict[ignore_key]
-
-        # If model was sharded with TP, gather full tensors for saving
-        if self._tp_size is not None:
-            state_dict = gather_state_dict_for_save(state_dict, self._tp_plan, self._device_mesh, self._tp_size)
 
         # Remove tied weights as safetensors do not handle them
         state_dict = remove_tied_weights_from_state_dict(state_dict, model_to_save)
@@ -3529,7 +3554,7 @@ class PreTrainedModel(
                 filename.startswith(weights_no_suffix)
                 and os.path.isfile(full_filename)
                 and filename not in state_dict_split.filename_to_tensors
-                and is_main_process
+                and save_on_this_rank
                 and reg.fullmatch(filename_no_suffix) is not None
             ):
                 os.remove(full_filename)
@@ -3546,73 +3571,59 @@ class PreTrainedModel(
             )
 
         # Save the model
-        for shard_file, tensor_names in logging.tqdm(
-            state_dict_split.filename_to_tensors.items(), desc="Writing model shards"
-        ):
-            filename = os.path.join(save_directory, shard_file)
-            shard_state_dict = {}
-            for tensor_name in tensor_names:
-                # Get the tensor, and remove it from state_dict to avoid keeping the ref
-                tensor = state_dict.pop(tensor_name)
+        if save_on_this_rank:
+            for shard_file, tensor_names in logging.tqdm(
+                state_dict_split.filename_to_tensors.items(), desc="Writing model shards"
+            ):
+                filename = os.path.join(save_directory, shard_file)
+                shard_state_dict = {}
+                for tensor_name in tensor_names:
+                    # Get the tensor, and remove it from state_dict to avoid keeping the ref
+                    tensor = state_dict.pop(tensor_name)
 
-                # If the param was offloaded, we need to load it back from disk to resave it. It's a strange pattern,
-                # but it would otherwise not be contained in the saved shard if we were to simply move the file
-                # or something
-                if is_offloaded and tensor.device.type == "meta":
-                    tensor = load_offloaded_parameter(model_to_save, tensor_name)
+                    # If the param was offloaded, we need to load it back from disk to resave it. It's a strange pattern,
+                    # but it would otherwise not be contained in the saved shard if we were to simply move the file
+                    # or something
+                    if is_offloaded and tensor.device.type == "meta":
+                        tensor = load_offloaded_parameter(model_to_save, tensor_name)
 
-                # only do contiguous after it's permuted correctly in case of TP
-                shard_state_dict[tensor_name] = tensor.contiguous()
+                    # only do contiguous after it's permuted correctly in case of TP
+                    shard_state_dict[tensor_name] = tensor.contiguous()
 
-            # As explained above, for offloaded scenarios, weight format could not be reverted before due to meta weights,
-            # so do it now after they were loaded onto cpu. For one-weight-to-many operations, it may be an issue, but usually the shards
-            # contain all the necessary params, except if we are quite unlucky on the sharding. The failure surface is (very few models
-            # with one-weight-to-many + offloading to disk + unlucky sharding), so it will almost never happen
-            if is_offloaded and save_original_format and not _hf_peft_config_loaded:
-                try:
-                    shard_state_dict = revert_weight_conversion(model_to_save, shard_state_dict)
-                    # Save the weight_map, since some names etc may have changed due to conversion compared to initial `state_dict_split`
-                    if state_dict_split.is_sharded:
-                        weight_map.update({k: os.path.basename(shard_file)} for k in shard_state_dict.keys())  # ty: ignore[unresolved-attribute]
-                except Exception:
-                    raise RuntimeError(
-                        "We could not revert some weight conversions because of offlading, and several weights needed for a single "
-                        "conversion operation living in different shard files. Try reducing `max_shard_size` a bit, or worst case "
-                        "set `save_original_format=False`."
-                    )
+                # As explained above, for offloaded scenarios, weight format could not be reverted before due to meta weights,
+                # so do it now after they were loaded onto cpu. For one-weight-to-many operations, it may be an issue, but usually the shards
+                # contain all the necessary params, except if we are quite unlucky on the sharding. The failure surface is (very few models
+                # with one-weight-to-many + offloading to disk + unlucky sharding), so it will almost never happen
+                if is_offloaded and save_original_format and not _hf_peft_config_loaded:
+                    try:
+                        shard_state_dict = revert_weight_conversion(model_to_save, shard_state_dict)
+                        # Save the weight_map, since some names etc may have changed due to conversion compared to initial `state_dict_split`
+                        if state_dict_split.is_sharded:
+                            weight_map.update({k: os.path.basename(shard_file)} for k in shard_state_dict.keys())  # ty: ignore[unresolved-attribute]
+                    except Exception:
+                        raise RuntimeError(
+                            "We could not revert some weight conversions because of offlading, and several weights needed for a single "
+                            "conversion operation living in different shard files. Try reducing `max_shard_size` a bit, or worst case "
+                            "set `save_original_format=False`."
+                        )
 
-            # TODO: it would be very nice to do the writing concurrently, but safetensors never releases the GIL,
-            # so it's not possible for now....
-            # Write the shard to disk
-            safe_save_file(shard_state_dict, filename, metadata=metadata)
-            # Cleanup the data before next loop (important with offloading, so we don't blowup cpu RAM)
-            del shard_state_dict
+                # TODO: it would be very nice to do the writing concurrently, but safetensors never releases the GIL,
+                # so it's not possible for now....
+                # Write the shard to disk
+                safe_save_file(shard_state_dict, filename, metadata=metadata)
+                # Cleanup the data before next loop (important with offloading, so we don't blowup cpu RAM)
+                del shard_state_dict
 
-        # Save index if sharded
-        index = None
-        if state_dict_split.is_sharded:
-            index = {
-                "metadata": {"total_parameters": self.num_parameters(), **state_dict_split.metadata},
-                "weight_map": weight_map,
-            }
-
-        if index is None:
-            path_to_weights = os.path.join(save_directory, weights_name)
-            logger.info(f"Model weights saved in {path_to_weights}")
-        else:
-            save_index_file = SAFE_WEIGHTS_INDEX_NAME
-            save_index_file = os.path.join(save_directory, _add_variant(save_index_file, variant))
-            # Save the index as well
-            with open(save_index_file, "w", encoding="utf-8") as f:
-                content = json.dumps(index, indent=2, sort_keys=True) + "\n"
-                f.write(content)
-            logger.info(
-                f"The model is bigger than the maximum size per checkpoint ({max_shard_size}) and is going to be "
-                f"split in {len(state_dict_split.filename_to_tensors)} checkpoint shards. You can find where each parameters has been saved in the "
-                f"index located at {save_index_file}."
+            self.save_gathered_checkpoint_index(
+                save_directory,
+                state_dict_split=state_dict_split,
+                weight_map=weight_map,
+                weights_name=weights_name,
+                variant=variant,
+                max_shard_size=max_shard_size,
             )
 
-        if push_to_hub:
+        if push_to_hub and save_on_this_rank:
             # Eventually create an empty model card
             model_card = create_and_tag_model_card(repo_id, self.model_tags, token=token)
 
@@ -3627,6 +3638,13 @@ class PreTrainedModel(
                 token=token,
                 create_pr=create_pr,
             )
+
+        # `gather_full_state_dict` concentrates the full state on rank 0 only;
+        # other ranks then loop over an empty shard list and would race ahead
+        # of rank 0's safetensors writes. Barrier so any subsequent
+        # `from_pretrained` on this path sees the consolidated files.
+        if needs_dist_barrier:
+            _distributed_barrier()
 
     @wraps(PushToHubMixin.push_to_hub)
     def push_to_hub(self, *args, **kwargs):
@@ -4024,6 +4042,11 @@ class PreTrainedModel(
             max_memory (`Dict`, *optional*):
                 A dictionary device identifier to maximum memory if using `device_map`. Will default to the maximum memory available for each
                 GPU and the available CPU RAM if unset.
+            distributed_config ([`~transformers.distributed.configuration_utils.DistributedConfig`], *optional*):
+                Configuration for native distributed loading with tensor parallelism or FSDP2. Pass
+                `DistributedConfig(tp_size=N)` for tensor parallelism, or
+                `DistributedConfig(fsdp_size=N)` for FSDP2. Requires `torchrun` and an initialized
+                process group when `tp_size > 1` or `fsdp_size > 1`. Mutually exclusive with `device_map`.
             tp_plan (`Optional[Union[dict, str]]`, *optional*):
                 A torch tensor parallel plan, see [here](https://pytorch.org/tutorials/intermediate/TP_tutorial.html). Use `tp_plan="auto"` to
                 use the predefined plan based on the model. If it's a dict, then it should match between module names and desired layout.
@@ -4124,8 +4147,6 @@ class PreTrainedModel(
         adapter_name = kwargs.pop("adapter_name", "default")
         generation_config = kwargs.pop("generation_config", None)
         gguf_file = kwargs.pop("gguf_file", None)
-        tp_plan = kwargs.pop("tp_plan", None)
-        tp_size = kwargs.pop("tp_size", None)
         distributed_config: DistributedConfig = kwargs.pop("distributed_config", None)
         device_mesh = kwargs.pop("device_mesh", None)
         trust_remote_code = kwargs.pop("trust_remote_code", None)
@@ -4133,9 +4154,6 @@ class PreTrainedModel(
         use_kernels = kwargs.pop("use_kernels", False)
         kernel_config = kwargs.pop("kernel_config", None)
         key_mapping = kwargs.pop("key_mapping", None)
-
-        if distributed_config is not None and tp_plan is None:
-            tp_plan = "auto"
 
         # Not used anymore -- remove them from the kwargs
         for name in ["mirror", "_fast_init", "low_cpu_mem_usage", "from_tf", "from_flax", "offload_state_dict"]:
@@ -4173,11 +4191,9 @@ class PreTrainedModel(
                 ": PartialState().process_index} where PartialState comes from accelerate library"
             )
 
-        if tp_plan is not None or tp_size is not None:  # TP warnings, and setup
-            if tp_size is None:
-                tp_size = torch.distributed.get_world_size()
-            device_map, device_mesh = initialize_tensor_parallelism(
-                tp_plan, tp_size=tp_size, device_mesh=device_mesh, device_map=device_map
+        if distributed_config is not None:
+            distributed_config, device_map, device_mesh = cls.prepare_distribute_model(
+                distributed_config, device_mesh=device_mesh, device_map=device_map
             )
 
         if gguf_file is not None and not is_accelerate_available():
@@ -4221,6 +4237,9 @@ class PreTrainedModel(
             config = copy.deepcopy(config)
             model_kwargs = kwargs
             commit_hash = getattr(config, "_commit_hash", commit_hash)
+
+        if distributed_config is not None:
+            config.distributed_config = distributed_config
 
         download_kwargs_with_commit["commit_hash"] = commit_hash
 
@@ -4331,10 +4350,7 @@ class PreTrainedModel(
         # Obtain the weight conversion mapping for this model if any are registered and apply to all submodels recursively
         weight_conversions = get_model_conversion_mapping(model, key_mapping, hf_quantizer)
 
-        if _torch_distributed_available and device_mesh is not None:  # add hooks to nn.Modules: no weights
-            if distributed_config is None:
-                distributed_config = DistributedConfig(tp_size=tp_size)
-            model = apply_tensor_parallelism(model, tp_plan, distributed_config, device_mesh)
+        model = cls.maybe_distribute_model(model, distributed_config, device_mesh)
 
         # Prepare the full device map
         if device_map is not None:

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -1746,13 +1746,14 @@ def _tp_continuous_batching_worker(
     use_cuda_graph: bool,
     use_async_batching: bool,
 ) -> None:
-    """Loads `model_id` with `tp_plan="auto"`, checks three TP-specific paths in the same process: (a) direct
+    """Loads `model_id` with `DistributedConfig(tp_size=...)`, checks three TP-specific paths in the same process: (a) direct
     broadcasts via `DistributedHelper`, (b) per-rank parity of CB-generated tokens via `dist.all_gather_object`, and
     (c) reproducibility across two CB runs sharing the same seed. Rank 0 owns all the assertions; the other ranks
     only need to participate in the collectives."""
     import torch
     import torch.distributed as dist
 
+    from transformers.distributed import DistributedConfig
     from transformers.generation.continuous_batching.distributed import DistributedHelper
 
     tokenizer = AutoTokenizer.from_pretrained(model_id, padding_side="left")
@@ -1760,7 +1761,10 @@ def _tp_continuous_batching_worker(
         tokenizer.pad_token = tokenizer.eos_token
 
     model = AutoModelForCausalLM.from_pretrained(
-        model_id, attn_implementation=attn_implementation, tp_plan="auto", dtype=torch.float32
+        model_id,
+        attn_implementation=attn_implementation,
+        distributed_config=DistributedConfig(tp_size=int(os.environ["WORLD_SIZE"])),
+        dtype=torch.float32,
     ).eval()
 
     # Direct broadcast tests: only rank 0's value should propagate to every TP rank
@@ -1838,6 +1842,8 @@ def _tp_cancellation_worker(
 
     import torch
 
+    from transformers.distributed import DistributedConfig
+
     cb_config = ContinuousBatchingConfig(use_cuda_graph=use_cuda_graph, use_async_batching=use_async_batching)
 
     tokenizer = AutoTokenizer.from_pretrained(model_id, padding_side="left")
@@ -1845,7 +1851,10 @@ def _tp_cancellation_worker(
         tokenizer.pad_token = tokenizer.eos_token
 
     model = AutoModelForCausalLM.from_pretrained(
-        model_id, attn_implementation=attn_implementation, tp_plan="auto", dtype=torch.float32
+        model_id,
+        attn_implementation=attn_implementation,
+        distributed_config=DistributedConfig(tp_size=int(os.environ["WORLD_SIZE"])),
+        dtype=torch.float32,
     ).eval()
 
     chat = [{"role": "user", "content": "Tell me a long story about a robot exploring the galaxy."}]

--- a/tests/models/deepseek_v4/test_modeling_deepseek_v4.py
+++ b/tests/models/deepseek_v4/test_modeling_deepseek_v4.py
@@ -468,7 +468,9 @@ def main() -> int:
         dtype="auto",
         attn_implementation="eager",
         experts_implementation=LOADTIME_DISPATCH,
-        distributed_config=DistributedConfig(enable_expert_parallel=True),
+        distributed_config=DistributedConfig(
+            tp_size=int(os.environ["WORLD_SIZE"]), enable_expert_parallel=True
+        ),
     )
     model.eval()
     tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
@@ -545,7 +547,9 @@ def main() -> int:
         dtype="auto",
         attn_implementation="eager",
         experts_implementation=LOADTIME_DISPATCH,
-        distributed_config=DistributedConfig(enable_expert_parallel=True),
+        distributed_config=DistributedConfig(
+            tp_size=int(os.environ["WORLD_SIZE"]), enable_expert_parallel=True
+        ),
     )
     model.eval()
     tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)

--- a/tests/models/glm_moe_dsa/test_modeling_glm_moe_dsa.py
+++ b/tests/models/glm_moe_dsa/test_modeling_glm_moe_dsa.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Testing suite for the PyTorch GlmMoeDsa model."""
 
+import os
 import unittest
 
 import torch
@@ -27,6 +28,7 @@ from transformers import (
     is_torch_available,
     set_seed,
 )
+from transformers.distributed import DistributedConfig
 from transformers.testing_utils import (
     require_torch,
     require_torch_accelerator,
@@ -204,7 +206,7 @@ class GlmMoeDsaIntegrationTest(unittest.TestCase):
         model = AutoModelForCausalLM.from_pretrained(
             model_id,
             quantization_config=quantization_config,
-            tp_plan="auto",
+            distributed_config=DistributedConfig(tp_size=int(os.environ["WORLD_SIZE"])),
             attn_implementation="eager",
         )
 

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -159,6 +159,7 @@ def distributed_worker(quantized, model_size, kernels, attn_impl, mode):
     import os
 
     from transformers import AutoModelForCausalLM, AutoTokenizer
+    from transformers.distributed import DistributedConfig
     from transformers.testing_utils import torch_device
 
     def generate_config_key(quantized, model, kernels, attn_impl, mode):
@@ -179,7 +180,7 @@ def distributed_worker(quantized, model_size, kernels, attn_impl, mode):
     model = AutoModelForCausalLM.from_pretrained(
         model_id,
         dtype="auto",
-        tp_plan="auto",  # distributed inference
+        distributed_config=DistributedConfig(tp_size=int(os.environ["WORLD_SIZE"])),
         use_kernels=kernels,
     ).to(torch_device)
     model.set_attn_implementation(attn_impl)

--- a/tests/test_tensor_parallel_mixin.py
+++ b/tests/test_tensor_parallel_mixin.py
@@ -145,7 +145,10 @@ def _load_tp_and_reference_models(model_path, model_class):
     Returns:
         tuple: (model_tp, model_ref, device)
     """
-    model_tp = model_class.from_pretrained(model_path, tp_plan="auto")
+    model_tp = model_class.from_pretrained(
+        model_path,
+        distributed_config=DistributedConfig(tp_size=dist.get_world_size()),
+    )
     dist.barrier()
 
     device = model_tp.device
@@ -173,7 +176,7 @@ def _verify_tp_sharding(rank, model_tp, model_ref):
             # Verify sharding is correct
             for dim in range(param.ndim):
                 if param.size(dim) != param_full.size(dim):
-                    param_plan = _get_parameter_tp_plan(name, model_tp.tp_plan, is_weight=True)
+                    param_plan = _get_parameter_tp_plan(name, model_tp._tp_plan, is_weight=True)
                     if param_plan in ("packed_colwise",):
                         expected_size = param_full.size(dim) // world_size
                         assert param.size(dim) == expected_size, (
@@ -254,7 +257,7 @@ def _test_tp_backward_impl(rank, model_path, model_class, atol, rtol):
             if grad.shape != grad_tp.shape:
                 for dim in range(grad.ndim):
                     if grad.size(dim) != grad_tp.size(dim):
-                        param_plan = _get_parameter_tp_plan(name, model_tp.tp_plan, is_weight=True)
+                        param_plan = _get_parameter_tp_plan(name, model_tp._tp_plan, is_weight=True)
                         if param_plan in ("packed_colwise",):
                             # interleaved slicing
                             grad = get_packed_grad_shard(grad, world_size, rank, dim)
@@ -324,7 +327,11 @@ def _test_tp_generation_quantized_impl(_rank, model_path, model_class, max_new_t
 
     quantization_config = TorchAoConfig(Float8WeightOnlyConfig())
 
-    model_tp = model_class.from_pretrained(model_path, tp_plan="auto", quantization_config=quantization_config)
+    model_tp = model_class.from_pretrained(
+        model_path,
+        distributed_config=DistributedConfig(tp_size=dist.get_world_size()),
+        quantization_config=quantization_config,
+    )
     dist.barrier()
 
     device = model_tp.device
@@ -376,7 +383,7 @@ def _load_ep_and_reference_models(model_path, model_class):
     """Load EP model and non-EP reference model for comparison."""
     model_ep = model_class.from_pretrained(
         model_path,
-        distributed_config=DistributedConfig(enable_expert_parallel=True),
+        distributed_config=DistributedConfig(tp_size=dist.get_world_size(), enable_expert_parallel=True),
     )
     dist.barrier()
 
@@ -491,15 +498,6 @@ class TensorParallelTesterMixin(ABC):
             return self.model_tester.causal_lm_class
         return self.all_model_classes[0]
 
-    def _get_tp_config(self):
-        """Tiny config with `vocab_size` rounded up to a multiple of the world size, as sharded dims (typically `lm_head`) have to be split across ranks."""
-        config = self.model_tester.get_config()
-        text_config = config.get_text_config()
-        remainder = text_config.vocab_size % self.tensor_parallel_size
-        if remainder:
-            text_config.vocab_size += self.tensor_parallel_size - remainder
-        return config
-
     def _skip_if_not_supported(self, expert_parallel: bool = False):
         """Check and skip the test if tensor/expert parallel is not supported for this model/environment."""
         parallelism = "Expert" if expert_parallel else "Tensor"
@@ -548,7 +546,7 @@ class TensorParallelTesterMixin(ABC):
     def test_tp_forward(self):
         self._skip_if_not_supported()
 
-        config = self._get_tp_config()
+        config = self.model_tester.get_config()
         model_class = self._get_tp_model_class()
         atol = self.tensor_parallel_atol
         rtol = self.tensor_parallel_rtol
@@ -564,7 +562,7 @@ class TensorParallelTesterMixin(ABC):
     def test_tp_backward(self):
         self._skip_if_not_supported()
 
-        config = self._get_tp_config()
+        config = self.model_tester.get_config()
         model_class = self._get_tp_model_class()
         atol = self.tensor_parallel_atol
         rtol = self.tensor_parallel_rtol
@@ -581,7 +579,7 @@ class TensorParallelTesterMixin(ABC):
         # Test TP generation: unfused checkpoint → conversion mapping (if needed) → TP sharding → model → generate
         self._skip_if_not_supported()
 
-        config = self._get_tp_config()
+        config = self.model_tester.get_config()
 
         model_class = self._get_tp_model_class()
         atol = self.tensor_parallel_atol
@@ -603,7 +601,7 @@ class TensorParallelTesterMixin(ABC):
         if not is_torchao_available():
             self.skipTest("Test requires torchao")
 
-        config = self._get_tp_config()
+        config = self.model_tester.get_config()
         model_class = self._get_tp_model_class()
         max_new_tokens = 25
 
@@ -620,7 +618,7 @@ class TensorParallelTesterMixin(ABC):
     def test_ep_forward(self):
         self._skip_if_not_supported(expert_parallel=True)
 
-        config = self._get_tp_config()
+        config = self.model_tester.get_config()
         model_class = self._get_tp_model_class()
         atol = self.tensor_parallel_atol
         rtol = self.tensor_parallel_rtol
@@ -636,7 +634,7 @@ class TensorParallelTesterMixin(ABC):
     def test_ep_backward(self):
         self._skip_if_not_supported(expert_parallel=True)
 
-        config = self._get_tp_config()
+        config = self.model_tester.get_config()
         model_class = self._get_tp_model_class()
         atol = self.tensor_parallel_atol
         rtol = self.tensor_parallel_rtol

--- a/tests/trainer/distributed/test_trainer_distributed_fsdp.py
+++ b/tests/trainer/distributed/test_trainer_distributed_fsdp.py
@@ -144,7 +144,7 @@ class InitializeMissingKeysTest(unittest.TestCase):
 
         with (
             patch("transformers.modeling_utils.is_fsdp_enabled", return_value=True),
-            patch("transformers.modeling_utils.is_local_dist_rank_0", return_value=False),
+            patch("transformers.distributed.utils.is_local_dist_rank_0", return_value=False),
         ):
             model._move_missing_keys_from_meta_to_device(
                 missing_keys=set(), device_map=None, device_mesh=None, hf_quantizer=None
@@ -161,7 +161,7 @@ class InitializeMissingKeysTest(unittest.TestCase):
 
         with (
             patch("transformers.modeling_utils.is_fsdp_enabled", return_value=True),
-            patch("transformers.modeling_utils.is_local_dist_rank_0", return_value=False),
+            patch("transformers.distributed.utils.is_local_dist_rank_0", return_value=False),
         ):
             model._move_missing_keys_from_meta_to_device(
                 missing_keys=set(), device_map=None, device_mesh=None, hf_quantizer=None


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47353)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47353)
<!-- ci-dashboard-badge:end -->

## Summary

Part of FSDP orchestration stack (2/3). Replaces #46990. Depends on #47352.

- Wire `prepare_distribute_model` / `maybe_distribute_model` into `from_pretrained`
- Add FSDP gather and DCP (`distributed_checkpoint=True`) paths in `save_pretrained`
- **Breaking:** remove `tp_plan` / `tp_size` kwargs from `from_pretrained`; use `distributed_config=DistributedConfig(tp_size=N)` instead
- Migrate TP tests and docs to explicit `DistributedConfig`

## Stack

#47352 (1/3) → this PR (2/3) → 3/3