### PR TITLE
Fix sdpa prefill with position_bias

### DIFF
--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -141,6 +141,8 @@ def sdpa_attention_forward(
     if is_causal and attention_mask is None and q_length > 1 and kv_length > q_length:
         key = key[:, :, :q_length, :]
         value = value[:, :, :q_length, :]
+        if position_bias is not None:
+            position_bias = position_bias[:, :, :q_length, :]
 
     # If we have a position_bias, create the correct floating-point mask by combining it with the existing mask, or a causal mask
     # if `is_causal=True`

--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -141,8 +141,9 @@ def sdpa_attention_forward(
     if is_causal and attention_mask is None and q_length > 1 and kv_length > q_length:
         key = key[:, :, :q_length, :]
         value = value[:, :, :q_length, :]
+        # If we have a position_bias, we need to crop it as well (on last dim, which is the kv seq_len dim)
         if position_bias is not None:
-            position_bias = position_bias[:, :, :q_length, :]
+            position_bias = position_bias[:, :, :, :q_length]
 
     # If we have a position_bias, create the correct floating-point mask by combining it with the existing mask, or a causal mask
     # if `is_causal=True`


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47359)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47359)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

In some rare cases, sdpa can crop k/v (during prefill with StaticCache under some other conditions). In those cases, we need to crop position_bias as well