### PR TITLE
Fix assisted decoding for models with EncoderDecoder cache & OlmoHybrid

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -2002,6 +2002,9 @@ class EncoderDecoderCache(Cache):
     def is_compileable(self) -> bool:
         return self.self_attention_cache.is_compileable
 
+    def activate_past_recording(self):
+        self.self_attention_cache.activate_past_recording()
+
     def get_max_cache_shape(self, layer_idx: int = 0) -> int:
         logger.warning_once(
             "`get_max_cache_shape` is deprecated, and will be removed in version 5.16. Please use `get_max_length` instead"

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1510,7 +1510,7 @@ class Cache:
 
         return self.layers[layer_idx].get_mask_sizes(query_length)
 
-    def get_query_offset(self, layer_idx: int) -> int:
+    def get_query_offset(self, layer_idx: int = 0) -> int:
         """Returns the current offset of the query for the given `layer_idx`. It's always equal to the cache length, i.e.
         `get_seq_length(layer_idx)`, except for MTP layers.
         """
@@ -2017,7 +2017,7 @@ SlidingWindowCache = StaticCache
 
 
 class MtpCache(DynamicCache):
-    def get_query_offset(self, layer_idx=0):
+    def get_query_offset(self, layer_idx: int = 0):
         # Queries of MTP depth k run k+1 tokens ahead of the main_model, i.e. they have an offset of k+1
         mtp_offset = layer_idx + 1
         return super().get_query_offset(layer_idx) + mtp_offset

--- a/src/transformers/models/lfm2_vl/modeling_lfm2_vl.py
+++ b/src/transformers/models/lfm2_vl/modeling_lfm2_vl.py
@@ -86,6 +86,7 @@ class Lfm2VlPreTrainedModel(PreTrainedModel):
     _can_compile_fullgraph = False
     _supports_flex_attn = True
     _supports_attention_backend = True
+    _is_stateful = True
 
 
 @auto_docstring(

--- a/src/transformers/models/lfm2_vl/modular_lfm2_vl.py
+++ b/src/transformers/models/lfm2_vl/modular_lfm2_vl.py
@@ -76,6 +76,7 @@ class Lfm2VlMultiModalProjector(nn.Module):
 class Lfm2VlPreTrainedModel(LlavaPreTrainedModel):
     _can_compile_fullgraph = False
     base_model_prefix = "model"
+    _is_stateful = True
 
 
 class Lfm2VlCausalLMOutputWithPast(LlavaCausalLMOutputWithPast):

--- a/src/transformers/models/minicpmv4_6/modeling_minicpmv4_6.py
+++ b/src/transformers/models/minicpmv4_6/modeling_minicpmv4_6.py
@@ -584,6 +584,7 @@ class MiniCPMV4_6PreTrainedModel(PreTrainedModel):
         "MiniCPMV4_6VisionEncoderLayer",
         "MiniCPMV4_6ViTWindowAttentionMerger",
     ]
+    _is_stateful = True
 
 
 @auto_docstring(

--- a/src/transformers/models/minicpmv4_6/modular_minicpmv4_6.py
+++ b/src/transformers/models/minicpmv4_6/modular_minicpmv4_6.py
@@ -536,6 +536,7 @@ class MiniCPMV4_6PreTrainedModel(PreTrainedModel):
         "MiniCPMV4_6VisionEncoderLayer",
         "MiniCPMV4_6ViTWindowAttentionMerger",
     ]
+    _is_stateful = True
 
 
 class MiniCPMV4_6Model(Lfm2VlModel):

--- a/src/transformers/models/olmo_hybrid/modeling_olmo_hybrid.py
+++ b/src/transformers/models/olmo_hybrid/modeling_olmo_hybrid.py
@@ -158,6 +158,9 @@ class OlmoHybridDynamicCache:
         """We have a previous state if the last linear (conv) layer was already updated."""
         return self.conv_states_q[self.last_linear_layer] is not None
 
+    def get_query_offset(self, layer_idx: int = 0) -> int:
+        return self.get_seq_length(layer_idx=layer_idx)
+
 
 class OlmoHybridRMSNormGated(nn.Module):
     def __init__(self, hidden_size, eps=1e-6, **kwargs):

--- a/src/transformers/models/olmo_hybrid/modular_olmo_hybrid.py
+++ b/src/transformers/models/olmo_hybrid/modular_olmo_hybrid.py
@@ -291,6 +291,9 @@ class OlmoHybridDynamicCache:
         """We have a previous state if the last linear (conv) layer was already updated."""
         return self.conv_states_q[self.last_linear_layer] is not None
 
+    def get_query_offset(self, layer_idx: int = 0) -> int:
+        return self.get_seq_length(layer_idx=layer_idx)
+
 
 class OlmoHybridRMSNormGated(Qwen3NextRMSNormGated):
     pass


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47361)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47361)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

As per the title. `_assisted_decoding` now calls `activate_past_recording`, which needs to be overwritten for `EncoderDecoderCache` as otherwise we hit an AttributeError
ALso fixes OlmoHybrid