### PR TITLE
Fix Daily CI reporting issues

### DIFF
--- a/.github/workflows/model_jobs.yml
+++ b/.github/workflows/model_jobs.yml
@@ -49,6 +49,32 @@ permissions:
   contents: read
 
 jobs:
+  report_metadata:
+    name: Report metadata
+    if: ${{ inputs.runner_type != '' }}
+    runs-on: ubuntu-latest
+    outputs:
+      machine_type: ${{ steps.set_machine_type.outputs.machine_type }}
+    steps:
+      - name: Set `machine_type` for report and artifact names
+        id: set_machine_type
+        shell: bash
+        env:
+          input_machine_type: ${{ inputs.machine_type }}
+        run: |
+          echo "$input_machine_type"
+
+          if [ "$input_machine_type" = "aws-g5-4xlarge-cache" ]; then
+            machine_type=single-gpu
+          elif [ "$input_machine_type" = "aws-g5-12xlarge-cache" ]; then
+            machine_type=multi-gpu
+          else
+            machine_type="$input_machine_type"
+          fi
+
+          echo "$machine_type"
+          echo "machine_type=$machine_type" >> $GITHUB_OUTPUT
+
   run_models_gpu:
     name: " "
     strategy:
@@ -61,8 +87,6 @@ jobs:
     container:
       image: ${{ inputs.docker }}
       options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
-    outputs:
-      machine_type: ${{ steps.set_machine_type.outputs.machine_type }}
     steps:
       - name: Echo input and matrix info
         shell: bash
@@ -142,7 +166,6 @@ jobs:
 
           echo "$machine_type"
           echo "machine_type=$machine_type" >> $GITHUB_ENV
-          echo "machine_type=$machine_type" >> $GITHUB_OUTPUT
 
       - name: Create report directory if it doesn't exist
         shell: bash
@@ -210,11 +233,11 @@ jobs:
   collated_reports:
     name: Collated Reports
     if: ${{ always() && inputs.runner_type != '' }}
-    needs: run_models_gpu
+    needs: [run_models_gpu, report_metadata]
     uses: huggingface/transformers/.github/workflows/collated-reports.yml@6abd9725ee7d809dc974991f8ff6c958afb63a3a  # main
     with:
       job: run_models_gpu
       report_repo_id: ${{ inputs.report_repo_id }}
       gpu_name: ${{ inputs.runner_type }}
-      machine_type: ${{ needs.run_models_gpu.outputs.machine_type }}
+      machine_type: ${{ needs.report_metadata.outputs.machine_type }}
     secrets: inherit

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -108,7 +108,7 @@ jobs:
         env:
           job: ${{ inputs.job }}
           subdirs: ${{ inputs.subdirs }}
-          NUM_SLICES: 2
+          NUM_SLICES: 3
         run: |
           if [ "$job" = "run_models_gpu" ]; then
             python3 ../utils/split_model_tests.py --subdirs "$subdirs" --num_splits "$NUM_SLICES" > folder_slices.txt

--- a/utils/collated_reports.py
+++ b/utils/collated_reports.py
@@ -46,6 +46,14 @@ def parse_short_summary_line(line: str) -> tuple[str | None, int]:
     return None, 0
 
 
+def get_missing_summary_result(model_dir: Path) -> dict:
+    return {
+        "status": "error",
+        "test": f"Missing summary_short.txt in artifact {model_dir.name}",
+        "count": 1,
+    }
+
+
 def validate_path(p: str) -> Path:
     # Validate path and apply glob pattern if provided
     path = Path(p)
@@ -176,8 +184,15 @@ if __name__ == "__main__":
         report = {"model": model_name, "results": []}
         results = []
 
+        summary_short_path = model_dir / "summary_short.txt"
+        if not summary_short_path.is_file():
+            total_status_count["error"] += 1
+            report["results"] = [get_missing_summary_result(model_dir)]
+            collated_report_buffer.append(report)
+            continue
+
         # Read short summary
-        with open(model_dir / "summary_short.txt", "r") as f:
+        with open(summary_short_path, "r") as f:
             short_summary_lines = f.readlines()
 
         # Parse short summary


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47364)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47364)
<!-- ci-dashboard-badge:end -->

# What this PR does

## Fix 1

The scheduled model CI collated report can fail before uploading reports with:

```
collated_reports.py: error: argument --machine-type/-m: expected one argument
```

`.github/workflows/model_jobs.yml` was passing `machine_type` to the reusable collated report workflow from `needs.run_models_gpu.outputs.machine_type`. 

That job is matrixed, so relying on a matrix job output here can produce an empty value for the downstream reusable workflow.

This moves the normalized report machine type into a small non-matrix `report_metadata` job and passes `needs.report_metadata.outputs.machine_type` to `collated-reports.yml`. The per-matrix test job still sets `machine_type` in `GITHUB_ENV` for artifact names exactly as before.

## Fix 2

The generated folder matrix crossed GitHub’s 256-job limit:

- July 15: 512 dirs -> [256, 256]
- July 16: 514 dirs -> [257, 257]

Added a slice

## Fix 3

  Some model CI jobs can upload a partial report artifact without summary_short.txt when pytest does
  not reach its terminal summary hook. The collated report job then fails with:

  FileNotFoundError: [Errno 2] No such file or directory:
    '<artifact>/summary_short.txt'

  This makes utils/collated_reports.py tolerate missing summary_short.txt files. Instead of crashing
  the entire collated report job, it records that artifact as an error entry and continues processing
  the remaining reports.

  This preserves the useful collated report output while still surfacing the malformed/incomplete
  artifact as a failure signal.