### PR TITLE
ci: Handle missing summaries in collated reports

### DIFF
--- a/utils/collated_reports.py
+++ b/utils/collated_reports.py
@@ -46,6 +46,14 @@ def parse_short_summary_line(line: str) -> tuple[str | None, int]:
     return None, 0
 
 
+def get_missing_summary_result(model_dir: Path) -> dict:
+    return {
+        "status": "error",
+        "test": f"Missing summary_short.txt in artifact {model_dir.name}",
+        "count": 1,
+    }
+
+
 def validate_path(p: str) -> Path:
     # Validate path and apply glob pattern if provided
     path = Path(p)
@@ -176,8 +184,15 @@ if __name__ == "__main__":
         report = {"model": model_name, "results": []}
         results = []
 
+        summary_short_path = model_dir / "summary_short.txt"
+        if not summary_short_path.is_file():
+            total_status_count["error"] += 1
+            report["results"] = [get_missing_summary_result(model_dir)]
+            collated_report_buffer.append(report)
+            continue
+
         # Read short summary
-        with open(model_dir / "summary_short.txt", "r") as f:
+        with open(summary_short_path, "r") as f:
             short_summary_lines = f.readlines()
 
         # Parse short summary


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47368)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47368)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Make sure we always produce a summary short. 

So the missing report artifact directory is:

  single-gpu_run_models_gpu_utils_test_reports

A July 13 example is:

Run: https://github.com/huggingface/transformers/actions/runs/29221731474

The codegen model did not produce the summary_short.txt file

  https://github.com/huggingface/transformers/actions/runs/29221731474/job/86728608989

Failing collated job:
https://github.com/huggingface/transformers/actions/runs/29221731474/job/86746888790

Missing file:

single-gpu_run_models_gpu_models_codegen_test_reports/summary_short.txt

CodeGen did not produce summary_short.txt because pytest never reached pytest_terminal_summary.

Evidence from the job log:

- The job was still running tests:

    tests/models/codegen/
    test_tokenization_codegen.py::CodeGenTokenizationTest::test_internal_consistency

- Immediately after that, GitHub moved to:

    Run cp /transformers/test_outputs.txt ...

- There is no pytest final summary, no short test summary, no stats footer, and no  COMMAND_EXIT_CODE.

- The artifact upload says only 3 files existed:
- 
    captured_info.txt
    dummy.txt
    test_outputs.txt

  summary_short.txt is only written at the end of pytest, via conftest.py ->
  pytest_terminal_summary_main() -> tr.short_test_summary(). Since the pytest process was
  interrupted/stopped before terminal summary, that file was never created.

  The weird part is the wrapper step was marked success. The workflow expects script -q -c "...
  pytest ..." to append a COMMAND_EXIT_CODE, then it extracts that and exits. In this job that tail
  logic apparently never ran, yet the step concluded success. So the likely root is not a normal
  CodeGen test failure; it is the custom runner/container wrapper interrupting or ending the pytest
  command mid-run in a way GitHub treated as success.

  There was a real CodeGen failure earlier in the partial output (test_codegen_sample), but a normal
  pytest failure would still run terminal summary and create summary_short.txt. Here pytest did not
  finish.