### PR TITLE
Preserve exception cause when hub kernel loading fails

### DIFF
--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -506,7 +506,7 @@ def load_and_register_attn_kernel(
     except ValueError:
         raise
     except Exception as e:
-        raise ValueError(f"An error occurred while trying to load from '{repo_id}': {e}.")
+        raise ValueError(f"An error occurred while trying to load from '{repo_id}': {e}.") from e
 
     # correctly wrap the kernel
     mask_implementation = "flash_attention_2"

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -644,7 +644,7 @@ def load_and_register_attn_kernel(
     except ValueError:
         raise
     except Exception as e:
-        raise ValueError(f"An error occurred while trying to load from '{repo_id}': {e}.")
+        raise ValueError(f"An error occurred while trying to load from '{repo_id}': {e}.") from e
 
     # correctly wrap the kernel
     mask_implementation = "flash_attention_2"

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -589,6 +589,20 @@ class TestAttentionKernelRegistration(TestCasePlus):
             except Exception as e:
                 print(f"Could not clean up `ALL_MASK_ATTENTION_FUNCTIONS`: {e}")
 
+    def test_load_and_register_preserves_exception_cause(self):
+        """Non-ValueError failures from get_kernel must keep the original exception as __cause__."""
+        original = RuntimeError("hub fetch failed: network down")
+
+        def boom(*args, **kwargs):
+            raise original
+
+        with patch("transformers.integrations.hub_kernels.get_kernel", side_effect=boom):
+            with self.assertRaises(ValueError) as ctx:
+                load_and_register_attn_kernel("kernels-community/broken-kernel")
+        self.assertIs(ctx.exception.__cause__, original)
+        self.assertIn("broken-kernel", str(ctx.exception))
+        self.assertIn("hub fetch failed", str(ctx.exception))
+
     def test_add_to_mapping_local(self):
         repo_path = "/abs/path/kernel"
         compatible_mapping = {}

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -589,6 +589,32 @@ class TestAttentionKernelRegistration(TestCasePlus):
             except Exception as e:
                 print(f"Could not clean up `ALL_MASK_ATTENTION_FUNCTIONS`: {e}")
 
+    def test_load_and_register_preserves_exception_cause(self):
+        """Non-ValueError failures from get_kernel must keep the original exception as __cause__."""
+        original = RuntimeError("hub fetch failed: network down")
+
+        def boom(*args, **kwargs):
+            raise original
+
+        with patch("transformers.integrations.hub_kernels.get_kernel", side_effect=boom):
+            with self.assertRaises(ValueError) as ctx:
+                load_and_register_attn_kernel("kernels-community/broken-kernel")
+        self.assertIs(ctx.exception.__cause__, original)
+        self.assertIn("broken-kernel", str(ctx.exception))
+        self.assertIn("hub fetch failed", str(ctx.exception))
+
+    def test_load_and_register_reraises_valueerror_unchanged(self):
+        """ValueError from get_kernel is re-raised as-is (no double-wrap)."""
+        original = ValueError("invalid repo revision")
+
+        def boom(*args, **kwargs):
+            raise original
+
+        with patch("transformers.integrations.hub_kernels.get_kernel", side_effect=boom):
+            with self.assertRaises(ValueError) as ctx:
+                load_and_register_attn_kernel("kernels-community/broken-kernel")
+        self.assertIs(ctx.exception, original)
+
     def test_add_to_mapping_local(self):
         repo_path = "/abs/path/kernel"
         compatible_mapping = {}


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47370)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47370)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Preserves the original exception cause when hub kernel loading fails.

When `get_kernel(...)` raises a non-`ValueError` exception, `load_and_register_attn_kernel` wraps it in a `ValueError` with a message that includes `str(e)`. Without `from e`, Python discards the original traceback (`__cause__` is `None`), so debugging a failed kernel download only shows the wrapper string and not the hub/network stack.

```python
try:
    kernel = get_kernel(...)
except ValueError:
    raise
except Exception as e:
    raise ValueError(f"An error occurred while trying to load from '{repo_id}': {e}.")  # no from e
```

**After:** `raise ValueError(...) from e` so `exc.__cause__` is the original error.

This matches the chaining pattern used elsewhere in integrations (`deepspeed.py`, `tiktoken.py`, `metal_quantization.py`).

**Origin:** Introduced in [#40542](https://github.com/huggingface/transformers/pull/40542) (2025-08-29).

**Rebased** onto current `main` (2026-08-06). Line still present and still missing `from e`.

**Tests:**
- `test_load_and_register_preserves_exception_cause`: RuntimeError from `get_kernel` becomes ValueError with original as `__cause__`
- `test_load_and_register_reraises_valueerror_unchanged`: ValueError from `get_kernel` is re-raised as-is (no double-wrap)

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Did you write any new necessary tests?

## Who can review?

@drbh (kernels)