### PR TITLE
Make non-blocking serve uvicorn thread a daemon with force_exit

### DIFF
--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -210,7 +210,9 @@ class Serve:
             asyncio.set_event_loop(loop)
             loop.run_until_complete(self.server.serve())
 
-        self._thread = threading.Thread(target=_run, name="uvicorn-thread", daemon=False)
+        # Daemon so a stuck uvicorn cannot keep the Python process alive after
+        # kill_server()'s join timeout (tests use non_blocking=True).
+        self._thread = threading.Thread(target=_run, name="uvicorn-thread", daemon=True)
         self._thread.start()
 
     def reset_loaded_models(self):
@@ -223,6 +225,8 @@ class Serve:
         if not self._thread or not self._thread.is_alive():
             return
         self.server.should_exit = True
+        # force_exit asks uvicorn to abandon a stuck graceful shutdown.
+        self.server.force_exit = True
         self._thread.join(timeout=2)
 
 

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -105,6 +105,56 @@ def test_host_port_blocking(cli):
         server_instance.run.assert_called_once()
 
 
+class TestServeThreadLifecycle(unittest.TestCase):
+    """Unit tests for background uvicorn thread lifecycle (no network)."""
+
+    def test_start_server_uses_daemon_thread(self):
+        serve = object.__new__(Serve)
+        serve.server = MagicMock()
+
+        async def immediate_serve():
+            return None
+
+        serve.server.serve = immediate_serve
+        serve.start_server()
+        try:
+            self.assertTrue(
+                serve._thread.daemon,
+                "non-blocking uvicorn thread must be daemon so process exit cannot hang forever",
+            )
+            serve._thread.join(timeout=2)
+            self.assertFalse(serve._thread.is_alive())
+        finally:
+            if serve._thread.is_alive():
+                serve.server.should_exit = True
+                serve.server.force_exit = True
+                serve._thread.join(timeout=2)
+
+    def test_kill_server_sets_force_exit(self):
+        serve = object.__new__(Serve)
+        serve._generation_state = MagicMock()
+        serve._model_manager = MagicMock()
+        serve.server = MagicMock()
+        serve.server.should_exit = False
+        serve.server.force_exit = False
+
+        # Pretend a live non-daemon-ish thread that finishes quickly
+        import threading
+
+        done = threading.Event()
+
+        def worker():
+            done.wait(timeout=1)
+
+        serve._thread = threading.Thread(target=worker, name="uvicorn-thread", daemon=True)
+        serve._thread.start()
+        serve.kill_server()
+        self.assertTrue(serve.server.should_exit)
+        self.assertTrue(serve.server.force_exit)
+        done.set()
+        serve._thread.join(timeout=2)
+
+
 class TestProcessorInputsFromMessages(unittest.TestCase):
     def test_llm_string_content(self):
         get_processor_inputs_from_messages = BaseHandler.get_processor_inputs_from_messages


### PR DESCRIPTION
## What does this PR do?

Prevents the Python process from hanging when the non-blocking `transformers serve` uvicorn thread does not exit within `kill_server()`'s 2s join timeout.

### Problem

`start_server()` creates a **non-daemon** background thread for uvicorn (`daemon=False`). `kill_server()` sets `server.should_exit = True` and joins with `timeout=2`. If uvicorn does not leave `serve()` within 2 seconds:

1. `join` returns while the thread is still alive
2. Because the thread is non-daemon, interpreter shutdown waits forever for it
3. Tests and other non-blocking callers hang after teardown

This path is used heavily by the serve test suite (`non_blocking=True` + `kill_server()` in `tearDownClass`).

### Fix

1. Mark the uvicorn thread as `daemon=True` so a stuck serve cannot block process exit after the join timeout.
2. Set `server.force_exit = True` in addition to `should_exit` so uvicorn abandons a stuck graceful shutdown when possible.

The default CLI path (`non_blocking=False`) still runs uvicorn on the main thread via `server.run()` and is unchanged.

**Origin:** Background thread introduced in [#41487](https://github.com/huggingface/transformers/pull/41487) (2025-10-16) with `daemon=False`.

**Test:**
```
Red:  daemon=False and missing force_exit fail new unit tests
Green: pytest tests/cli/test_serve.py::TestServeThreadLifecycle  # 2 passed
```

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Did you write any new necessary tests?

## Who can review?

@LysandreJik @SunMarc (serve)
