### PR TITLE
Accept legacy list special_tokens in _set_model_specific_special_tokens

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1409,7 +1409,9 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         """
         return self.convert_tokens_to_ids(self.all_special_tokens)
 
-    def _set_model_specific_special_tokens(self, special_tokens: dict[str, str | AddedToken]):
+    def _set_model_specific_special_tokens(
+        self, special_tokens: dict[str, str | AddedToken] | list[str | AddedToken] | tuple[str | AddedToken, ...]
+    ):
         """
         Adds new model-specific special tokens (e.g., for multimodal models).
 
@@ -1417,8 +1419,24 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         For example: if the model tokenizer is multimodal, we can support special image or audio tokens.
 
         Args:
-            special_tokens: Dictionary of {token_name: token_value}
+            special_tokens: Dictionary of {token_name: token_value}. A legacy list/tuple of token
+                strings is also accepted and routed to `extra_special_tokens` (unnamed specials).
         """
+        # Legacy configs / callers sometimes pass a bare list of special token strings. Lists have no
+        # `.keys()`, which used to raise AttributeError (see #47110). Unnamed tokens belong on
+        # `extra_special_tokens`.
+        if isinstance(special_tokens, (list, tuple)):
+            existing = {str(t) for t in self._extra_special_tokens}
+            for token in special_tokens:
+                if str(token) not in existing:
+                    self._extra_special_tokens.append(token)
+                    existing.add(str(token))
+            return
+        if not isinstance(special_tokens, dict):
+            raise TypeError(
+                "`special_tokens` must be a dict of attribute names to token values, "
+                f"or a list/tuple of tokens, got {type(special_tokens).__name__}."
+            )
         self.SPECIAL_TOKENS_ATTRIBUTES = self.SPECIAL_TOKENS_ATTRIBUTES + list(special_tokens.keys())
         for key, value in special_tokens.items():
             if isinstance(value, (str, AddedToken)):

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -394,3 +394,37 @@ class TokenizerUtilsTest(unittest.TestCase):
                     raise ValueError("real error")
                 except import_protobuf_decode_error():
                     pass
+
+    def test_set_model_specific_special_tokens_accepts_legacy_list(self):
+        """Legacy list payloads must not crash on .keys() (issue #47110)."""
+        from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+        class _Stub:
+            SPECIAL_TOKENS_ATTRIBUTES = ["bos_token", "eos_token", "unk_token"]
+
+            def __init__(self):
+                self._special_tokens_map = {}
+                self._extra_special_tokens = []
+
+        stub = _Stub()
+        legacy = ["<s>NOTUSED", "</s>NOTUSED", "<unk>NOTUSED"]
+        PreTrainedTokenizerBase._set_model_specific_special_tokens(stub, legacy)
+        self.assertEqual(stub._extra_special_tokens, legacy)
+        # Named dict path still works
+        PreTrainedTokenizerBase._set_model_specific_special_tokens(stub, {"image_token": "<image>"})
+        self.assertIn("image_token", stub.SPECIAL_TOKENS_ATTRIBUTES)
+        self.assertEqual(stub._special_tokens_map["image_token"], "<image>")
+
+    def test_set_model_specific_special_tokens_rejects_invalid_type(self):
+        from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+        class _Stub:
+            SPECIAL_TOKENS_ATTRIBUTES = ["bos_token"]
+
+            def __init__(self):
+                self._special_tokens_map = {}
+                self._extra_special_tokens = []
+
+        stub = _Stub()
+        with self.assertRaises(TypeError):
+            PreTrainedTokenizerBase._set_model_specific_special_tokens(stub, "not-a-mapping")


### PR DESCRIPTION
## What does this PR do?

Fixes #47110: `_set_model_specific_special_tokens` crashed with `'list' object has no attribute 'keys'` when given a legacy list of special token strings.

### Problem

```python
self.SPECIAL_TOKENS_ATTRIBUTES = self.SPECIAL_TOKENS_ATTRIBUTES + list(special_tokens.keys())
```

assumes `special_tokens` is always a dict of `{name: value}`. Legacy payloads (and some callers) pass a bare list such as `['<s>NOTUSED', '</s>NOTUSED', '<unk>NOTUSED']`, which has no `.keys()`.

Prior attempt [#47132](https://github.com/huggingface/transformers/pull/47132) only raised a clearer `TypeError` for non-dicts (still fails to load) and was closed after CI failures. This PR makes list payloads work by routing them to `extra_special_tokens` (unnamed specials), which is the V5 home for list-shaped special token data.

### Fix

- `list` / `tuple`: append tokens to `_extra_special_tokens` (deduped by string form) and return
- `dict`: existing named-token behavior
- anything else: clear `TypeError`

### Test

```
Red:  AttributeError: 'list' object has no attribute 'keys'
Green: pytest tests/tokenization/test_tokenization_utils.py::TokenizerUtilsTest::test_set_model_specific_special_tokens_accepts_legacy_list
       pytest tests/tokenization/test_tokenization_utils.py::TokenizerUtilsTest::test_set_model_specific_special_tokens_rejects_invalid_type
```

**Origin:** Named model-specific specials API from [#34461](https://github.com/huggingface/transformers/pull/34461) (2024-11-04).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue? [#47110](https://github.com/huggingface/transformers/issues/47110)
- [x] Did you write any new necessary tests?

## Who can review?

@ArthurZucker @itazap (tokenizers)
