### PR TITLE
[docs] Exporters

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -126,6 +126,8 @@
       title: torch.compile
     - local: exporters
       title: Exporters
+    - local: exporters_extend
+      title: Extending the exporters
     - local: perf_infer_gpu_multi
       title: Tensor parallelism
     - local: expert_parallelism

--- a/docs/source/en/exporters.md
+++ b/docs/source/en/exporters.md
@@ -354,13 +354,13 @@ multi-modal). That's why it works for any architecture, including decoder-only, 
 encoder-decoder, and multi-modal models, without per-model glue. `export_for_generation` is a
 one-liner over it.
 
-The capture runs the model eagerly on `inputs`, so pass small but representative values: one
+The capture runs the model eagerly on `inputs`, so pass small but representative values like a
 short prompt, a single small image, a few audio frames. The exported program isn't tied to
 those sizes (dynamic shapes still flow through), but smaller capture inputs make
 `decompose_for_generation` cheaper and keep symbolic-shape inference tractable.
 
 Call `decompose_for_generation` directly when you want to do something between decomposing and
-exporting: run an eager forward for verification, swap a submodule's inputs, or skip a stage.
+exporting like running an eager forward for verification, swapping a submodule's inputs, or skipping a stage.
 
 ```python
 from transformers.exporters.utils import decompose_for_generation
@@ -381,7 +381,7 @@ for name, (submodel, subinputs) in components.items():
 `torch.export`, `torch.onnx.export`, and ExecuTorch each have rough edges around specific
 PyTorch patterns. The exporters work around these with a small set of reversible patches
 and FX-level fixes applied at well-defined points in the export flow. None of this is
-visible from the public `export()` API, but the most common things to know:
+visible from the public `export` API, but the most common things to know:
 
 - Flash-attention and flex-attention are not exportable on any backend; `sdpa` is the preferred
   setting and `eager` also works (slower). Set one of them on the model before calling `export()`
@@ -393,95 +393,7 @@ visible from the public `export()` API, but the most common things to know:
   the model itself is fundamentally non-exportable; each entry carries a TODO with the
   model-side change needed.
 
-<details>
-<summary>Export pipeline internals (per-backend stages and how to extend)</summary>
+## Next steps
 
-Each exporter's source file labels its stages as `# ── Stage N: … ─────` blocks; the
-tables below mirror that layout 1:1, so the file you read and the doc you read are the
-same map.
-
-Two lifecycles are used consistently:
-
-| Lifecycle | Registered via | Applied via | Behavior |
-| --------- | --------------- | ----------- | -------- |
-| Patches | `@register_patch(backend, *dotted_paths)` | `apply_patches(backend)` | Reversibly swaps an attribute (a `torch` op, an ExecuTorch internal, a model class method) for the duration of the export. Pass multiple paths to a single decorator to share the same factory across targets, useful when the same method shape needs to be patched on several classes (for example `_update_mamba_mask` on Jamba, Bamba, and others). Originals are restored on exit, even if the body raises. |
-| Fixes | `@register_fx_node_fix(backend)` / `@register_fx_program_fix(backend)` | `apply_fx_node_fixes(backend, gm)` / `apply_fx_program_fixes(backend, ep)`; ONNX-IR fixes are listed in `_IR_FIXES` and applied via `apply_onnx_ir_fixes` | Mutates the in-progress graph or program in place. There's no revert: fixes permanently repair the artifact before the next pipeline step. |
-
-Every patch / fix sits in a backend-keyed registry (`_PATCHES`, `_FX_NODE_FIXES`,
-`_FX_PROGRAM_FIXES` in [exporters/utils.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/utils.py)).
-Adding a new one is *write a function and decorate it*, nothing else.
-
-### `DynamoExporter`
-
-The base exporter has one patch stage and four structural helpers. They run in this order
-inside `DynamoExporter.export`, against the original `nn.Module`:
-
-| # | Stage | Section in [exporter_dynamo.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_dynamo.py) | What it does | How to extend |
-| - | ----- | --------------------------------------------------------------------------------------------------------------------------------- | ------------- | -------------- |
-| 1 | Forward-signature patch (`patch_forward_signature`) | `# ── Stage 1: Model signature patch ──` | Replaces `model.forward` with an explicit flat-arg signature derived from the inputs dict, so `torch.export` doesn't bundle `**kwargs` into a single tuple. This is the entry contract `torch.export` reads before tracing. | Internal, no extension knob. |
-| 2 | Model patches (`_PATCHES["dynamo"]` via `apply_patches("dynamo")`) | `# ── Stage 2: Model patches ──` | Reversible class-attribute swaps applied during tracing. Each `_patch_*(original) → replacement` factory targets one or more `Class.method` paths and replaces a non-exportable model pattern (data-dependent loops, in-place ops, mask checks, chunked-attention `split → zip → cat`) with an export-safe equivalent. | Define `_patch_*(original)` and decorate with `@register_patch("dynamo", *dotted_paths)`. Pass multiple paths to share the same factory across classes (for example `_update_mamba_mask` on Jamba, Bamba, and others). Examples: mamba/linear-attn mask, NLLB classifier cast, chunked-vision attention. |
-| 3 | Pytree registration (`register_cache_pytrees_for_model`) | `# ── Stage 3: Pytree registration ──` | Registers flatten/unflatten via `torch.utils._pytree.register_pytree_node` for every captured `Cache` / `ModelOutput`. Reflection-driven, tuned for tensor containers (not a general serializer). | Usually automatic. If a type isn't reflectable, add a branch to `_flatten_to_context` / `_unflatten_from_context`. |
-| 4 | Dynamic shapes (`get_auto_dynamic_shapes`) | `# ── Stage 4: Dynamic shapes ──` | Auto-assigns `Dim.AUTO` to every tensor and cache leaf when `DynamoConfig.dynamic=True` and the user did not pass `dynamic_shapes` explicitly. | Override per-export via `DynamoConfig.dynamic_shapes`. |
-| 5 | State cleanup (`reset_model_state` / `_STATEFUL_CACHE_ATTRS`) | `# ── Stage 5: Model state cleanup ──` | Resets non-`Cache` tensor attributes set inside `forward` (for example glm_moe_dsa `_cached_keys`, wav2vec2_bert `cached_rotary_positional_embedding`) that `torch.export` leaves as FakeTensors, so a follow-up eager forward is safe. | Append the attribute name to `_STATEFUL_CACHE_ATTRS`. |
-
-### `OnnxExporter`
-
-`OnnxExporter` extends `DynamoExporter` with five numbered stages applied around
-`torch.onnx.export`. The labels match the `# ── Stage N: … ──` headers in the source:
-
-| # | Stage | Section in [exporter_onnx.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_onnx.py) | When it runs | Lifecycle | What it does | How to extend |
-| - | ----- | --------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------- | ------------- | -------------- |
-| 1 | Torch patches (`_PATCHES["onnx"]`) | `# ── Stage 1: Torch patches ──` | During `torch.export` / `torch.onnx.export` | Reversible (`apply_patches("onnx")`) | Reversible swaps of `torch` ops (`where`, `unsqueeze`, `scaled_dot_product_attention`, `searchsorted`, …) that the ONNX decomposer can't lower as-is. Each `_patch_*(original)` closes over the original. | Define `_patch_*(original)` and decorate with `@register_patch("onnx", "dotted.path")`. |
-| 2 | ONNX patches (`_PATCHES["onnx"]`) | `# ── Stage 2: ONNX patches ──` | During `torch.onnx.export` | Reversible (`apply_patches("onnx")`) | Hooks the private `_prepare_exported_program_for_export` step so the FX node fixes (stage 3) run again right after `run_decompositions`. Any new symbolic-guard nodes the ONNX decomposition introduces get repaired before the FX → ONNX lowering picks them up. | Same registry as stage 1. Define `_patch_*(original)` and decorate with `@register_patch("onnx", "dotted.path")`. |
-| 3 | FX node fixes (`_FX_NODE_FIXES["onnx"]`) | `# ── Stage 3: FX node fixes ──` | After `torch.export`, again after `run_decompositions` | In-place (`apply_fx_node_fixes("onnx", gm)`) | Per-node rewrites on the `GraphModule` to drop or replace nodes the ONNX decomposer can't lower (alias ops, in-place views, `_assert_*`, dead comparisons, in-place `triu_`, `fill_diagonal_`, `sort(stable=True)`). DCE runs automatically at the end of the walk. | Define `_fix_*(gm, node) → bool` (return `True` to consume) and decorate with `@register_fx_node_fix("onnx")`. |
-| 4 | ONNX translations (`_ONNX_TRANSLATION_TABLE`) | `# ── Stage 4: ONNX translations ──` | During FX → ONNX lowering | n/a (translation table) | Overrides `torchlib`'s default lowering for specific aten ops where the default is buggy or missing. Currently `aten.index_put` (bool-mask path), `aten.bincount` (`OneHot + ReduceSum`), and `aten._grouped_mm` / `transformers.grouped_mm_fallback` (MoE grouped-matmul → unrolled `Slice + MatMul + Concat`). | Implement an `_aten_*` onnxscript function and add it to `_ONNX_TRANSLATION_TABLE`. |
-| 5 | ONNX IR fixes (`_IR_FIXES` / `apply_onnx_ir_fixes`) | `# ── Stage 5: ONNX IR fixes ──` | After `torch.onnx.export` returns | In-place (`apply_onnx_ir_fixes`) | Post-export rewrites on the `ONNXProgram` IR to work around ORT validation/runtime bugs (for example forcing `TopK(sorted=True)`). Applied to both the top-level graph and every function. | Implement `_fix_ir_*(graph_like)` and append to `_IR_FIXES`. |
-
-A complete inventory of patches in the file is one grep away:
-
-```bash
-grep -nE "^def (_patch_|_fix_|_aten_)" src/transformers/exporters/exporter_onnx.py
-```
-
-### `ExecutorchExporter`
-
-`ExecutorchExporter` extends `DynamoExporter` with four numbered stages applied around
-`to_edge_transform_and_lower` and `to_executorch`:
-
-| # | Stage | Section in [exporter_executorch.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_executorch.py) | When it runs | Lifecycle | What it does | How to extend |
-| - | ----- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------- | ------------- | -------------- |
-| 1 | Backend preparation (`_BACKEND_PREPARE`) | `# ── Stage 1: Backend preparation ──` | Before `torch.export` | n/a (one-shot) | `prepare_for_xnnpack` moves the model to CPU/fp32 and selects `XnnpackPartitioner`; `prepare_for_cuda` moves to CUDA/bf16 and selects `CudaPartitioner`. Returns `(model, sample_inputs, partitioner)`. | Implement `prepare_for_<name>` and register it in `_BACKEND_PREPARE`. |
-| 2 | Torch patches (`_PATCHES["executorch"]`) | `# ── Stage 2: Torch patches ──` | During `torch.export` tracing | Reversible (`apply_patches("executorch")`) | Replaces `torch` ops the ExecuTorch backends can't accept (`split_copy`, `chunk`, `topk(k>dim)`, non-divisible `avg_pool2d`, `dropout`, in-place `view`, GQA-shaped SDPA) with decomposed equivalents. | Define `_patch_*(original)` and decorate with `@register_patch("executorch", "dotted.path")`. |
-| 3 | ExecuTorch patches (`_PATCHES["executorch"]`) | `# ── Stage 3: ExecuTorch patches ──` | During `to_edge_transform_and_lower` / `to_executorch` | Reversible (`apply_patches("executorch")`) | Reversibly swaps ExecuTorch internals that crash on legitimate dynamic-shape patterns: `SpecPropPass.update_placeholder_tensor_specs`, `PruneEmptyTensorsPass.remove_empty_tensors_from_cat`, `eval_upper_bound`, `dim_order_from_stride` (rebound on every importer), XNNPACK squeeze/unsqueeze define-node, complex-dtype validator, edge-dialect sym-op allowlist. | Same registry as stage 2. Define `_patch_*(original)` and decorate with `@register_patch("executorch", "dotted.path")`. |
-| 4 | FX program fixes (`_FX_PROGRAM_FIXES["executorch"]`) | `# ── Stage 4: FX program fixes ──` | After `torch.export`, before `to_edge_transform_and_lower` | In-place (`apply_fx_program_fixes("executorch", ep)`) | Repair the `ExportedProgram` where the fix needs program-level context: widen `int_oo` upper bounds in `range_constraints`, fill missing placeholder `meta["val"]` from `state_dict`. | Define `_fix_*(exported_program) → None` and decorate with `@register_fx_program_fix("executorch")`. |
-| 5 | FX node fixes (`_FX_NODE_FIXES["executorch"]`) | `# ── Stage 5: FX node fixes ──` | After stage 4, before `to_edge_transform_and_lower` | In-place (`apply_fx_node_fixes("executorch", gm)`) | Per-node rewrites: swap Python sym ops for `executorch_prim.*` equivalents, rewrite `pow` as `mul` chain, normalize amax/max negative dim, force contiguous clone. DCE runs automatically at the end of the walk. | Define `_fix_*(gm, node) → bool` (return `True` to consume) and decorate with `@register_fx_node_fix("executorch")`. |
-
-### When to patch the exporter vs. fix the model
-
-The split is intentional:
-
-| Fix location | Use when |
-| ------------ | -------- |
-| Modeling change | The pattern blocks export across multiple backends: data-dependent loops, stateful caches outside `Cache`, hand-written split-loop attention. Fix it once in the model, and every exporter benefits. |
-| Exporter patch | The issue is a single backend's lowering bug: a missing ONNX translation, an ORT validation quirk, an FX decomposition that emits a dead op. Keep the workaround in the exporter, and the modeling code stays clean. |
-
-### Known upstream workarounds
-
-A small number of model classes hit confirmed bugs in `onnxscript`'s graph optimizer
-(constant folding crashing on `SplitToSequence`, FPN initializers being dropped). For those,
-ONNX optimization is selectively disabled via
-[`ONNX_DISABLE_OPTIMIZE_MODEL_CLASSES`](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py)
-in the test suite, and each entry is annotated with the upstream issue it works around. This
-list is expected to shrink as upstream bugs land; it is not an extension point for
-arbitrary skipping, and new entries must reference a specific upstream bug.
-
-A second list, [`EXPORT_SKIP_MODEL_CLASSES`](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py),
-opts a handful of model classes out of the entire export sweep when the model itself is
-fundamentally non-exportable as-is (data-dependent control flow that can't be vectorized,
-modules treated as forward arguments, …). Same expectations: every entry carries a TODO
-naming the underlying model change needed, and the list is expected to shrink, not grow.
-
-</details>
-
-See the [Exporters](./main_classes/exporters) main classes page for the complete API reference:
-every exporter class, config field, and utility function.
+- Add export support for a new architecture or backend with the patch and fix registries in
+  [Extending the exporters](./exporters_extend).

--- a/docs/source/en/exporters.md
+++ b/docs/source/en/exporters.md
@@ -16,40 +16,54 @@ rendered properly in your Markdown viewer.
 
 # Exporters
 
-Export any [`PreTrainedModel`] to ONNX, ExecuTorch, or a standalone PyTorch program — same model,
-same two lines of code, any runtime.
+Export any [`PreTrainedModel`] to ONNX, ExecuTorch, or a standalone PyTorch program with the
+same two lines of code, regardless of the target runtime.
 
 ```python
-exporter = DynamoExporter()
-config = DynamoConfig(dynamic=True)  # or OnnxExporter, ExecutorchExporter
+exporter = DynamoExporter()  # or OnnxExporter, ExecutorchExporter
+config = DynamoConfig(dynamic=True)
 exported = exporter.export(model, inputs, config=config)
 ```
 
-Because the exporters live inside Transformers, they evolve with the models. Every architecture
-change, new attention pattern, or custom cache type is supported at export time from day one —
-no waiting for a downstream library to catch up.
+The exporters live inside Transformers instead of a downstream library, so architecture changes,
+new attention patterns, and custom cache types are supported at export time as soon as they land
+in the modeling code.
 
-<Tip warning={true}>
-
-The exporters are **experimental**. Many of the patches in this module work around specific
-upstream bugs (torch, onnxscript, onnxruntime, executorch) and will be removed as soon as the
-fix lands upstream. Until the API stabilises, treat the patches as tied to the versions used in
-the test suite — pin those versions in production tooling, and expect both new patches and
-removals as we follow upstream.
-
-</Tip>
+> [!WARNING]
+> The exporters are experimental. Many of the patches in this module work around specific
+> upstream bugs (Torch, ONNX Script, ONNX Runtime, ExecuTorch) and will be removed as soon as the
+> fix lands upstream. Until the API stabilizes, treat the patches as tied to the versions used in
+> the test suite. Pin those versions in production tooling, and expect new patches to appear and
+> old ones to disappear as upstream changes land.
 
 | Exporter               | Output                     | Runtime                                       |
 | ---------------------- | -------------------------- | --------------------------------------------- |
 | [`DynamoExporter`]     | `ExportedProgram`          | Any PyTorch runtime, AOT compilation          |
-| [`OnnxExporter`]       | `ONNXProgram`              | Any ONNX runtime (ORT, TensorRT, OpenVINO, …) |
+| [`OnnxExporter`]       | `ONNXProgram`              | Any ONNX runtime (ORT, TensorRT, OpenVINO) |
 | [`ExecutorchExporter`] | `ExecutorchProgramManager` | Mobile and edge devices (ExecuTorch)          |
 
-[`AutoHfExporter`] picks the right exporter from a config and [`AutoExportConfig`] picks the right
-config class from a dict — the same auto-class idiom the rest of `transformers` uses, useful when
-the backend is selected at runtime rather than hard-coded in the call site.
+[`AutoHfExporter`] picks the right exporter from a config, and [`AutoExportConfig`] picks the
+right config class from a dict. Both follow the same auto-class pattern in Transformers, which
+is useful when the backend is selected at runtime instead of hardcoded at the call site.
+
+```python
+from transformers.exporters import AutoExportConfig, AutoHfExporter
+
+export_config_dict = {"export_format": "onnx", "dynamic": True}
+config = AutoExportConfig.from_dict(export_config_dict)
+exporter = AutoHfExporter.from_config(config)
+
+onnx_program = exporter.export(model, inputs, config=config)
+```
 
 ## Installation
+
+Install the dependencies for the backend you plan to export to.
+
+> [!TIP]
+> The versions below are the ones the exporter test suite is pinned against. Newer or older
+> releases often work, but the exporter patches target a specific API surface, so for production
+> tooling pin these and expect [`HfExporter`] to log a warning when it detects drift.
 
 <hfoptions id="exporters-install">
 <hfoption id="Dynamo">
@@ -75,16 +89,10 @@ pip install transformers "torch==2.12.0" "executorch==1.3.1"
 </hfoption>
 </hfoptions>
 
-<Tip>
-The versions above are the ones the exporter test suite is pinned against — newer / older releases
-often work but the exporter patches target a specific API surface, so for production tooling pin
-these and expect [`HfExporter`] to log a warning when it detects drift.
-</Tip>
+## Export a model
 
-## Quick start
-
-All exporters share the same interface: create an exporter with a config, call `.export(model, inputs)`.
-Switch between runtimes by swapping the exporter class — nothing else changes.
+All exporters share the same interface. Create an exporter with a config, and call [`~exporters.HfExporter.export`].
+Switch between runtimes by swapping the exporter class.
 
 <hfoptions id="exporters-quickstart">
 <hfoption id="Dynamo">
@@ -161,13 +169,12 @@ outputs = method.execute(list(inputs.values()))
 
 ## Dynamic shapes
 
-The quick-start examples above already pass `dynamic=True`, which marks every tensor
+The examples above pass `dynamic=True`, which marks every tensor
 dimension as dynamic so the exported graph accepts inputs of any size at runtime without
 retracing.
 
 For fine-grained control over which dimensions are dynamic, pass explicit `dynamic_shapes`
-instead. This is forwarded directly to `torch.export.export` — see the
-[torch.export documentation](https://pytorch.org/docs/stable/export.html) for the expected format.
+instead. This is forwarded directly to [torch.export.export](https://pytorch.org/docs/stable/export.html).
 
 <hfoptions id="explicit-dynamic-shapes">
 <hfoption id="Dynamo">
@@ -188,7 +195,7 @@ exporter = DynamoExporter()
 config = DynamoConfig(
     dynamic_shapes={"input_ids": {0: batch, 1: seq}, "attention_mask": {0: batch, 1: seq}},
     # Emit data-dependent shape guards as runtime asserts instead of failing the export when a
-    # guard wouldn't hold across the explicit symbolic range — most LLMs need this under fine-grained
+    # guard wouldn't hold across the explicit symbolic range. Most LLMs need this under fine-grained
     # ``Dim(min=, max=)`` bounds. Not needed with ``dynamic=True`` / ``Dim.AUTO``, where torch.export
     # infers shape relations instead of verifying them against user-stated bounds.
     prefer_deferred_runtime_asserts_over_guards=True,
@@ -215,7 +222,7 @@ exporter = OnnxExporter()
 config = OnnxConfig(
     dynamic_shapes={"input_ids": {0: batch, 1: seq}, "attention_mask": {0: batch, 1: seq}},
     # Emit data-dependent shape guards as runtime asserts instead of failing the export when a
-    # guard wouldn't hold across the explicit symbolic range — most LLMs need this under fine-grained
+    # guard wouldn't hold across the explicit symbolic range. Most LLMs need this under fine-grained
     # ``Dim(min=, max=)`` bounds. Not needed with ``dynamic=True`` / ``Dim.AUTO``, where torch.export
     # infers shape relations instead of verifying them against user-stated bounds.
     prefer_deferred_runtime_asserts_over_guards=True,
@@ -243,7 +250,7 @@ config = ExecutorchConfig(
     backend="xnnpack",
     dynamic_shapes={"input_ids": {0: batch, 1: seq}, "attention_mask": {0: batch, 1: seq}},
     # Emit data-dependent shape guards as runtime asserts instead of failing the export when a
-    # guard wouldn't hold across the explicit symbolic range — most LLMs need this under fine-grained
+    # guard wouldn't hold across the explicit symbolic range. Most LLMs need this under fine-grained
     # ``Dim(min=, max=)`` bounds. Not needed with ``dynamic=True`` / ``Dim.AUTO``, where torch.export
     # infers shape relations instead of verifying them against user-stated bounds.
     prefer_deferred_runtime_asserts_over_guards=True,
@@ -258,15 +265,19 @@ et_program = exporter.export(model, inputs, config=config)
 
 For autoregressive generation, the model's `forward` has different shapes at the prefill step
 (full prompt, no KV cache) versus the decode step (single token, populated KV cache). Exporters
-expose [`~HfExporter.export_for_generation`] which splits both stages and exports each.
-For multi-modal generative models it additionally splits the prefill into vision/audio encoder,
-projector, language model, and `lm_head`. Encoder and language-model discovery uses the canonical
-[`~PreTrainedModel.get_encoder`] (`modality="image"` / `"audio"`) and
-[`~PreTrainedModel.get_decoder`] accessors, so any new architecture that wires those up
-correctly works out of the box. Projector lookup falls back to a heuristic name list
-(`multi_modal_projector`, `connector`, `embed_vision`, `embed_audio`); new architectures
-should align their projector attribute to one of these canonical names rather than growing
-the list.
+expose [`~HfExporter.export_for_generation`], which splits both stages and exports each.
+
+For multi-modal generative models, the prefill additionally splits into an image or audio
+encoder, the language model, and `lm_head`. Encoder and language-model discovery uses the
+canonical [`~PreTrainedModel.get_encoder`] (`modality="image"` / `"audio"`) and
+[`~PreTrainedModel.get_decoder`] accessors, so any new architecture using these
+works out of the box.
+
+A projector component appears only when the model exposes one
+under a canonical attribute name (`multi_modal_projector`, `connector`, `embed_vision`,
+`embed_audio`). Qwen2-VL below folds its projector into the vision tower, so its component dict
+has no separate `multi_modal_projector` key. New architectures must align their projector
+attribute to one of these canonical names instead of growing the list.
 
 <hfoptions id="generate">
 <hfoption id="Dynamo">
@@ -328,13 +339,10 @@ components = exporter.export_for_generation(model, inputs, config=config)
 </hfoption>
 </hfoptions>
 
-<Tip warning={true}>
-
-The exported components are **independent graphs**, not a turnkey inference pipeline.
-The caller is responsible for running each encoder, projecting embeddings, and orchestrating
-the generation loop. We are actively working to reduce the glue required between components.
-
-</Tip>
+> [!WARNING]
+> The exported components are independent graphs, not a ready-to-run inference pipeline. The
+> caller is responsible for running each encoder, projecting embeddings, and orchestrating the
+> generation loop.
 
 <details>
 <summary>What <code>export_for_generation</code> does under the hood</summary>
@@ -342,16 +350,17 @@ the generation loop. We are actively working to reduce the glue required between
 [`~exporters.utils.decompose_for_generation`] runs `model.generate(**inputs, max_new_tokens=2)`
 once and hooks `model.forward` to capture the real prefill and decode kwargs (and the
 per-submodule kwargs via hooks on each encoder / projector / language model if the model is
-multi-modal). That's why it works for any architecture — decoder-only, SSM, encoder-decoder,
-multi-modal — without per-model glue. `export_for_generation` is a one-liner over it.
+multi-modal). That's why it works for any architecture, including decoder-only, SSM,
+encoder-decoder, and multi-modal models, without per-model glue. `export_for_generation` is a
+one-liner over it.
 
-The capture runs the model eagerly on `inputs`, so pass **small but representative** values —
-one short prompt, a single small image, a few audio frames. The exported program isn't tied
-to those sizes (dynamic shapes still flow through), but smaller capture inputs make
+The capture runs the model eagerly on `inputs`, so pass small but representative values: one
+short prompt, a single small image, a few audio frames. The exported program isn't tied to
+those sizes (dynamic shapes still flow through), but smaller capture inputs make
 `decompose_for_generation` cheaper and keep symbolic-shape inference tractable.
 
-Call `decompose_for_generation` directly when you want to do something between decomposing
-and exporting — run an eager forward for verification, swap a submodule's inputs, skip a stage:
+Call `decompose_for_generation` directly when you want to do something between decomposing and
+exporting: run an eager forward for verification, swap a submodule's inputs, or skip a stage.
 
 ```python
 from transformers.exporters.utils import decompose_for_generation
@@ -361,8 +370,8 @@ components = decompose_for_generation(model, inputs)
 
 exported = {}
 for name, (submodel, subinputs) in components.items():
-    eager_outputs = submodel(**subinputs)
-    exported[name] = exporter.export(submodel,subinputs, config=config)
+    eager_outputs = submodel(**subinputs)  # sanity-check the eager forward before exporting
+    exported[name] = exporter.export(submodel, subinputs, config=config)
 ```
 
 </details>
@@ -385,7 +394,7 @@ visible from the public `export()` API, but the most common things to know:
   model-side change needed.
 
 <details>
-<summary>Export pipeline — internals (per-backend stages and how to extend)</summary>
+<summary>Export pipeline internals (per-backend stages and how to extend)</summary>
 
 Each exporter's source file labels its stages as `# ── Stage N: … ─────` blocks; the
 tables below mirror that layout 1:1, so the file you read and the doc you read are the
@@ -393,48 +402,40 @@ same map.
 
 Two lifecycles are used consistently:
 
-- **Patches** (registered via `@register_patch(backend, *dotted_paths)`, installed via
-  `apply_patches(backend)`) reversibly swap an attribute (a `torch` op, an ExecuTorch
-  internal, a model class method) for the duration of the export. Pass multiple paths
-  to a single decorator to share the same factory across targets — useful when the
-  same method shape needs to be patched on several classes (e.g. `_update_mamba_mask`
-  on Jamba/Bamba/…). Originals are restored on exit, even if the body raises.
-- **Fixes** (registered via `@register_fx_node_fix(backend)` /
-  `@register_fx_program_fix(backend)`, applied via `apply_fx_node_fixes(backend, gm)` /
-  `apply_fx_program_fixes(backend, ep)`; ONNX-IR fixes still listed in `_IR_FIXES` and
-  applied via `apply_onnx_ir_fixes`) mutate the in-progress graph or program in place.
-  There's no revert — they're meant to permanently repair the artifact before the next
-  pipeline step.
+| Lifecycle | Registered via | Applied via | Behavior |
+| --------- | --------------- | ----------- | -------- |
+| Patches | `@register_patch(backend, *dotted_paths)` | `apply_patches(backend)` | Reversibly swaps an attribute (a `torch` op, an ExecuTorch internal, a model class method) for the duration of the export. Pass multiple paths to a single decorator to share the same factory across targets, useful when the same method shape needs to be patched on several classes (for example `_update_mamba_mask` on Jamba, Bamba, and others). Originals are restored on exit, even if the body raises. |
+| Fixes | `@register_fx_node_fix(backend)` / `@register_fx_program_fix(backend)` | `apply_fx_node_fixes(backend, gm)` / `apply_fx_program_fixes(backend, ep)`; ONNX-IR fixes are listed in `_IR_FIXES` and applied via `apply_onnx_ir_fixes` | Mutates the in-progress graph or program in place. There's no revert: fixes permanently repair the artifact before the next pipeline step. |
 
 Every patch / fix sits in a backend-keyed registry (`_PATCHES`, `_FX_NODE_FIXES`,
 `_FX_PROGRAM_FIXES` in [exporters/utils.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/utils.py)).
-Adding a new one is *write a function and decorate it* — nothing else.
+Adding a new one is *write a function and decorate it*, nothing else.
 
 ### `DynamoExporter`
 
 The base exporter has one patch stage and four structural helpers. They run in this order
 inside `DynamoExporter.export`, against the original `nn.Module`:
 
-| #     | Stage                                                                | Section in [exporter_dynamo.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_dynamo.py) | What it does                                                                                                                                                                                                                                                                                                | How to extend                                                                                                                                                                                                                                                                |
-| ----- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **1** | **Forward-signature patch** (`patch_forward_signature`)              | `# ── Stage 1: Model signature patch ──`                                                                                             | Replaces `model.forward` with an explicit flat-arg signature derived from the inputs dict, so `torch.export` doesn't bundle `**kwargs` into a single tuple. This is the entry contract `torch.export` reads before tracing.                                                                                | Internal — no extension knob.                                                                                                                                                                                                                                                |
-| **2** | **Model patches** (`_PATCHES["dynamo"]` via `apply_patches("dynamo")`) | `# ── Stage 2: Model patches ──`                                                                                                     | Reversible class-attribute swaps applied during tracing. Each `_patch_*(original) → replacement` factory targets one or more `Class.method` paths and replaces a non-exportable model pattern (data-dependent loops, in-place ops, mask checks, chunked-attention `split → zip → cat`) with an export-safe equivalent. | Define `_patch_*(original)` and decorate with `@register_patch("dynamo", *dotted_paths)`. Pass multiple paths to share the same factory across classes (e.g. `_update_mamba_mask` on Jamba/Bamba/…). Examples: mamba/linear-attn mask, NLLB classifier cast, chunked-vision attention. |
-| **3** | **Pytree registration** (`register_cache_pytrees_for_model`)         | `# ── Stage 3: Pytree registration ──`                                                                                               | Registers flatten/unflatten via `torch.utils._pytree.register_pytree_node` for every captured `Cache` / `ModelOutput`. Reflection-driven, tuned for tensor containers (not a general serialiser).                                                                                                          | Usually automatic. If a type isn't reflectable, add a branch to `_flatten_to_context` / `_unflatten_from_context`.                                                                                                                                                            |
-| **4** | **Dynamic shapes** (`get_auto_dynamic_shapes`)                       | `# ── Stage 4: Dynamic shapes ──`                                                                                                    | Auto-assigns `Dim.AUTO` to every tensor and cache leaf when `DynamoConfig.dynamic=True` and the user did not pass `dynamic_shapes` explicitly.                                                                                                                                                              | Override per-export via `DynamoConfig.dynamic_shapes`.                                                                                                                                                                                                                       |
-| **5** | **State cleanup** (`reset_model_state` / `_STATEFUL_CACHE_ATTRS`)    | `# ── Stage 5: Model state cleanup ──`                                                                                               | Resets non-`Cache` tensor attributes set inside `forward` (e.g. glm_moe_dsa `_cached_keys`, wav2vec2_bert `cached_rotary_positional_embedding`) that `torch.export` leaves as FakeTensors, so a follow-up eager forward is safe.                                                                            | Append the attribute name to `_STATEFUL_CACHE_ATTRS`.                                                                                                                                                                                                                        |
+| # | Stage | Section in [exporter_dynamo.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_dynamo.py) | What it does | How to extend |
+| - | ----- | --------------------------------------------------------------------------------------------------------------------------------- | ------------- | -------------- |
+| 1 | Forward-signature patch (`patch_forward_signature`) | `# ── Stage 1: Model signature patch ──` | Replaces `model.forward` with an explicit flat-arg signature derived from the inputs dict, so `torch.export` doesn't bundle `**kwargs` into a single tuple. This is the entry contract `torch.export` reads before tracing. | Internal, no extension knob. |
+| 2 | Model patches (`_PATCHES["dynamo"]` via `apply_patches("dynamo")`) | `# ── Stage 2: Model patches ──` | Reversible class-attribute swaps applied during tracing. Each `_patch_*(original) → replacement` factory targets one or more `Class.method` paths and replaces a non-exportable model pattern (data-dependent loops, in-place ops, mask checks, chunked-attention `split → zip → cat`) with an export-safe equivalent. | Define `_patch_*(original)` and decorate with `@register_patch("dynamo", *dotted_paths)`. Pass multiple paths to share the same factory across classes (for example `_update_mamba_mask` on Jamba, Bamba, and others). Examples: mamba/linear-attn mask, NLLB classifier cast, chunked-vision attention. |
+| 3 | Pytree registration (`register_cache_pytrees_for_model`) | `# ── Stage 3: Pytree registration ──` | Registers flatten/unflatten via `torch.utils._pytree.register_pytree_node` for every captured `Cache` / `ModelOutput`. Reflection-driven, tuned for tensor containers (not a general serializer). | Usually automatic. If a type isn't reflectable, add a branch to `_flatten_to_context` / `_unflatten_from_context`. |
+| 4 | Dynamic shapes (`get_auto_dynamic_shapes`) | `# ── Stage 4: Dynamic shapes ──` | Auto-assigns `Dim.AUTO` to every tensor and cache leaf when `DynamoConfig.dynamic=True` and the user did not pass `dynamic_shapes` explicitly. | Override per-export via `DynamoConfig.dynamic_shapes`. |
+| 5 | State cleanup (`reset_model_state` / `_STATEFUL_CACHE_ATTRS`) | `# ── Stage 5: Model state cleanup ──` | Resets non-`Cache` tensor attributes set inside `forward` (for example glm_moe_dsa `_cached_keys`, wav2vec2_bert `cached_rotary_positional_embedding`) that `torch.export` leaves as FakeTensors, so a follow-up eager forward is safe. | Append the attribute name to `_STATEFUL_CACHE_ATTRS`. |
 
 ### `OnnxExporter`
 
 `OnnxExporter` extends `DynamoExporter` with five numbered stages applied around
 `torch.onnx.export`. The labels match the `# ── Stage N: … ──` headers in the source:
 
-| #     | Stage                                                       | Section in [exporter_onnx.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_onnx.py) | When it runs                                     | Lifecycle                            | What it does                                                                                                                                                                                                                                                                | How to extend                                                                                |
-| ----- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| **1** | **Torch patches** (`_PATCHES["onnx"]`)                      | `# ── Stage 1: Torch patches ──`                                                                                                 | During `torch.export` / `torch.onnx.export`      | Reversible (`apply_patches("onnx")`) | Reversible swaps of `torch` ops (`where`, `unsqueeze`, `scaled_dot_product_attention`, `searchsorted`, …) that the ONNX decomposer can't lower as-is. Each `_patch_*(original)` closes over the original.                                                                   | Define `_patch_*(original)` and decorate with `@register_patch("onnx", "dotted.path")`.       |
-| **2** | **ONNX patches** (`_PATCHES["onnx"]`)                       | `# ── Stage 2: ONNX patches ──`                                                                                                  | During `torch.onnx.export`                       | Reversible (`apply_patches("onnx")`) | Hooks the private `_prepare_exported_program_for_export` step so the FX node fixes (stage 3) run again right after `run_decompositions` — any new symbolic-guard nodes the ONNX decomposition introduces get repaired before the FX → ONNX lowering picks them up.          | Same registry as stage 1 — define `_patch_*(original)` and decorate with `@register_patch("onnx", "dotted.path")`. |
-| **3** | **FX node fixes** (`_FX_NODE_FIXES["onnx"]`)                | `# ── Stage 3: FX node fixes ──`                                                                                                 | After `torch.export`, again after `run_decompositions` | In-place (`apply_fx_node_fixes("onnx", gm)`) | Per-node rewrites on the `GraphModule` to drop or replace nodes the ONNX decomposer can't lower (alias ops, in-place views, `_assert_*`, dead comparisons, in-place `triu_`, `fill_diagonal_`, `sort(stable=True)`). DCE runs automatically at the end of the walk.   | Define `_fix_*(gm, node) → bool` (return `True` to consume) and decorate with `@register_fx_node_fix("onnx")`. |
-| **4** | **ONNX translations** (`_ONNX_TRANSLATION_TABLE`)           | `# ── Stage 4: ONNX translations ──`                                                                                             | During FX → ONNX lowering                        | n/a (translation table)              | Overrides `torchlib`'s default lowering for specific aten ops where the default is buggy or missing. Currently `aten.index_put` (bool-mask path), `aten.bincount` (`OneHot + ReduceSum`), and `aten._grouped_mm` / `transformers.grouped_mm_fallback` (MoE grouped-matmul → unrolled `Slice + MatMul + Concat`). | Implement an `_aten_*` onnxscript function and add it to `_ONNX_TRANSLATION_TABLE`.          |
-| **5** | **ONNX IR fixes** (`_IR_FIXES` / `apply_onnx_ir_fixes`)     | `# ── Stage 5: ONNX IR fixes ──`                                                                                                 | After `torch.onnx.export` returns                | In-place (`apply_onnx_ir_fixes`)     | Post-export rewrites on the `ONNXProgram` IR to work around ORT validation/runtime bugs (e.g. forcing `TopK(sorted=True)`). Applied to both the top-level graph and every function.                                                                                         | Implement `_fix_ir_*(graph_like)` and append to `_IR_FIXES`.                                 |
+| # | Stage | Section in [exporter_onnx.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_onnx.py) | When it runs | Lifecycle | What it does | How to extend |
+| - | ----- | --------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------- | ------------- | -------------- |
+| 1 | Torch patches (`_PATCHES["onnx"]`) | `# ── Stage 1: Torch patches ──` | During `torch.export` / `torch.onnx.export` | Reversible (`apply_patches("onnx")`) | Reversible swaps of `torch` ops (`where`, `unsqueeze`, `scaled_dot_product_attention`, `searchsorted`, …) that the ONNX decomposer can't lower as-is. Each `_patch_*(original)` closes over the original. | Define `_patch_*(original)` and decorate with `@register_patch("onnx", "dotted.path")`. |
+| 2 | ONNX patches (`_PATCHES["onnx"]`) | `# ── Stage 2: ONNX patches ──` | During `torch.onnx.export` | Reversible (`apply_patches("onnx")`) | Hooks the private `_prepare_exported_program_for_export` step so the FX node fixes (stage 3) run again right after `run_decompositions`. Any new symbolic-guard nodes the ONNX decomposition introduces get repaired before the FX → ONNX lowering picks them up. | Same registry as stage 1. Define `_patch_*(original)` and decorate with `@register_patch("onnx", "dotted.path")`. |
+| 3 | FX node fixes (`_FX_NODE_FIXES["onnx"]`) | `# ── Stage 3: FX node fixes ──` | After `torch.export`, again after `run_decompositions` | In-place (`apply_fx_node_fixes("onnx", gm)`) | Per-node rewrites on the `GraphModule` to drop or replace nodes the ONNX decomposer can't lower (alias ops, in-place views, `_assert_*`, dead comparisons, in-place `triu_`, `fill_diagonal_`, `sort(stable=True)`). DCE runs automatically at the end of the walk. | Define `_fix_*(gm, node) → bool` (return `True` to consume) and decorate with `@register_fx_node_fix("onnx")`. |
+| 4 | ONNX translations (`_ONNX_TRANSLATION_TABLE`) | `# ── Stage 4: ONNX translations ──` | During FX → ONNX lowering | n/a (translation table) | Overrides `torchlib`'s default lowering for specific aten ops where the default is buggy or missing. Currently `aten.index_put` (bool-mask path), `aten.bincount` (`OneHot + ReduceSum`), and `aten._grouped_mm` / `transformers.grouped_mm_fallback` (MoE grouped-matmul → unrolled `Slice + MatMul + Concat`). | Implement an `_aten_*` onnxscript function and add it to `_ONNX_TRANSLATION_TABLE`. |
+| 5 | ONNX IR fixes (`_IR_FIXES` / `apply_onnx_ir_fixes`) | `# ── Stage 5: ONNX IR fixes ──` | After `torch.onnx.export` returns | In-place (`apply_onnx_ir_fixes`) | Post-export rewrites on the `ONNXProgram` IR to work around ORT validation/runtime bugs (for example forcing `TopK(sorted=True)`). Applied to both the top-level graph and every function. | Implement `_fix_ir_*(graph_like)` and append to `_IR_FIXES`. |
 
 A complete inventory of patches in the file is one grep away:
 
@@ -447,74 +448,40 @@ grep -nE "^def (_patch_|_fix_|_aten_)" src/transformers/exporters/exporter_onnx.
 `ExecutorchExporter` extends `DynamoExporter` with four numbered stages applied around
 `to_edge_transform_and_lower` and `to_executorch`:
 
-| #     | Stage                                                              | Section in [exporter_executorch.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_executorch.py) | When it runs                                            | Lifecycle                            | What it does                                                                                                                                                                                                                                                                                              | How to extend                                                                                                                |
-| ----- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| **1** | **Backend preparation** (`_BACKEND_PREPARE`)                       | `# ── Stage 1: Backend preparation ──`                                                                                                       | Before `torch.export`                                   | n/a (one-shot)                       | `prepare_for_xnnpack` moves the model to CPU/fp32 and selects `XnnpackPartitioner`; `prepare_for_cuda` moves to CUDA/bf16 and selects `CudaPartitioner`. Returns `(model, sample_inputs, partitioner)`.                                                                                                   | Implement `prepare_for_<name>` and register it in `_BACKEND_PREPARE`.                                                        |
-| **2** | **Torch patches** (`_PATCHES["executorch"]`)                       | `# ── Stage 2: Torch patches ──`                                                                                                             | During `torch.export` tracing                           | Reversible (`apply_patches("executorch")`) | Replaces `torch` ops the ExecuTorch backends can't accept (`split_copy`, `chunk`, `topk(k>dim)`, non-divisible `avg_pool2d`, `dropout`, in-place `view`, GQA-shaped SDPA) with decomposed equivalents.                                                                                              | Define `_patch_*(original)` and decorate with `@register_patch("executorch", "dotted.path")`.                                |
-| **3** | **ExecuTorch patches** (`_PATCHES["executorch"]`)                  | `# ── Stage 3: ExecuTorch patches ──`                                                                                                        | During `to_edge_transform_and_lower` / `to_executorch`  | Reversible (`apply_patches("executorch")`) | Reversibly swaps ExecuTorch internals that crash on legitimate dynamic-shape patterns: `SpecPropPass.update_placeholder_tensor_specs`, `PruneEmptyTensorsPass.remove_empty_tensors_from_cat`, `eval_upper_bound`, `dim_order_from_stride` (rebound on every importer), XNNPACK squeeze/unsqueeze define-node, complex-dtype validator, edge-dialect sym-op allowlist. | Same registry as stage 2 — define `_patch_*(original)` and decorate with `@register_patch("executorch", "dotted.path")`.     |
-| **4** | **FX program fixes** (`_FX_PROGRAM_FIXES["executorch"]`)           | `# ── Stage 4: FX program fixes ──`                                                                                                          | After `torch.export`, before `to_edge_transform_and_lower` | In-place (`apply_fx_program_fixes("executorch", ep)`) | Repair the `ExportedProgram` where the fix needs program-level context: widen `int_oo` upper bounds in `range_constraints`, fill missing placeholder `meta["val"]` from `state_dict`.                                                                                                          | Define `_fix_*(exported_program) → None` and decorate with `@register_fx_program_fix("executorch")`. |
-| **5** | **FX node fixes** (`_FX_NODE_FIXES["executorch"]`)                 | `# ── Stage 5: FX node fixes ──`                                                                                                             | After stage 4, before `to_edge_transform_and_lower`     | In-place (`apply_fx_node_fixes("executorch", gm)`) | Per-node rewrites: swap Python sym ops for `executorch_prim.*` equivalents, rewrite `pow` as `mul` chain, normalize amax/max negative dim, force contiguous clone. DCE runs automatically at the end of the walk.                                                                                | Define `_fix_*(gm, node) → bool` (return `True` to consume) and decorate with `@register_fx_node_fix("executorch")`. |
+| # | Stage | Section in [exporter_executorch.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_executorch.py) | When it runs | Lifecycle | What it does | How to extend |
+| - | ----- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------- | ------------- | -------------- |
+| 1 | Backend preparation (`_BACKEND_PREPARE`) | `# ── Stage 1: Backend preparation ──` | Before `torch.export` | n/a (one-shot) | `prepare_for_xnnpack` moves the model to CPU/fp32 and selects `XnnpackPartitioner`; `prepare_for_cuda` moves to CUDA/bf16 and selects `CudaPartitioner`. Returns `(model, sample_inputs, partitioner)`. | Implement `prepare_for_<name>` and register it in `_BACKEND_PREPARE`. |
+| 2 | Torch patches (`_PATCHES["executorch"]`) | `# ── Stage 2: Torch patches ──` | During `torch.export` tracing | Reversible (`apply_patches("executorch")`) | Replaces `torch` ops the ExecuTorch backends can't accept (`split_copy`, `chunk`, `topk(k>dim)`, non-divisible `avg_pool2d`, `dropout`, in-place `view`, GQA-shaped SDPA) with decomposed equivalents. | Define `_patch_*(original)` and decorate with `@register_patch("executorch", "dotted.path")`. |
+| 3 | ExecuTorch patches (`_PATCHES["executorch"]`) | `# ── Stage 3: ExecuTorch patches ──` | During `to_edge_transform_and_lower` / `to_executorch` | Reversible (`apply_patches("executorch")`) | Reversibly swaps ExecuTorch internals that crash on legitimate dynamic-shape patterns: `SpecPropPass.update_placeholder_tensor_specs`, `PruneEmptyTensorsPass.remove_empty_tensors_from_cat`, `eval_upper_bound`, `dim_order_from_stride` (rebound on every importer), XNNPACK squeeze/unsqueeze define-node, complex-dtype validator, edge-dialect sym-op allowlist. | Same registry as stage 2. Define `_patch_*(original)` and decorate with `@register_patch("executorch", "dotted.path")`. |
+| 4 | FX program fixes (`_FX_PROGRAM_FIXES["executorch"]`) | `# ── Stage 4: FX program fixes ──` | After `torch.export`, before `to_edge_transform_and_lower` | In-place (`apply_fx_program_fixes("executorch", ep)`) | Repair the `ExportedProgram` where the fix needs program-level context: widen `int_oo` upper bounds in `range_constraints`, fill missing placeholder `meta["val"]` from `state_dict`. | Define `_fix_*(exported_program) → None` and decorate with `@register_fx_program_fix("executorch")`. |
+| 5 | FX node fixes (`_FX_NODE_FIXES["executorch"]`) | `# ── Stage 5: FX node fixes ──` | After stage 4, before `to_edge_transform_and_lower` | In-place (`apply_fx_node_fixes("executorch", gm)`) | Per-node rewrites: swap Python sym ops for `executorch_prim.*` equivalents, rewrite `pow` as `mul` chain, normalize amax/max negative dim, force contiguous clone. DCE runs automatically at the end of the walk. | Define `_fix_*(gm, node) → bool` (return `True` to consume) and decorate with `@register_fx_node_fix("executorch")`. |
 
 ### When to patch the exporter vs. fix the model
 
 The split is intentional:
 
-- **Modeling change** if the pattern blocks export across multiple backends — data-dependent
-  loops, stateful caches outside `Cache`, hand-written split-loop attention. Fix it once in
-  the model and every exporter benefits.
-- **Exporter patch** if the issue is a single backend's lowering bug — a missing ONNX
-  translation, an ORT validation quirk, an FX decomposition that emits a dead op. Keep the
-  workaround in the exporter and the modeling code stays clean.
+| Fix location | Use when |
+| ------------ | -------- |
+| Modeling change | The pattern blocks export across multiple backends: data-dependent loops, stateful caches outside `Cache`, hand-written split-loop attention. Fix it once in the model, and every exporter benefits. |
+| Exporter patch | The issue is a single backend's lowering bug: a missing ONNX translation, an ORT validation quirk, an FX decomposition that emits a dead op. Keep the workaround in the exporter, and the modeling code stays clean. |
 
 ### Known upstream workarounds
 
 A small number of model classes hit confirmed bugs in `onnxscript`'s graph optimizer
-(constant folding crashing on `SplitToSequence`, FPN initialisers being dropped). For those,
-ONNX optimisation is selectively disabled via
+(constant folding crashing on `SplitToSequence`, FPN initializers being dropped). For those,
+ONNX optimization is selectively disabled via
 [`ONNX_DISABLE_OPTIMIZE_MODEL_CLASSES`](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py)
-in the test suite — each entry is annotated with the upstream issue it works around. This
-list is **expected to shrink** as upstream bugs land; it is not an extension point for
-arbitrary skipping, and new entries should reference a specific upstream bug.
+in the test suite, and each entry is annotated with the upstream issue it works around. This
+list is expected to shrink as upstream bugs land; it is not an extension point for
+arbitrary skipping, and new entries must reference a specific upstream bug.
 
 A second list, [`EXPORT_SKIP_MODEL_CLASSES`](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py),
 opts a handful of model classes out of the entire export sweep when the model itself is
-fundamentally non-exportable as-is (data-dependent control flow that can't be vectorised,
+fundamentally non-exportable as-is (data-dependent control flow that can't be vectorized,
 modules treated as forward arguments, …). Same expectations: every entry carries a TODO
-naming the underlying model change needed; the list should shrink, not grow.
+naming the underlying model change needed, and the list is expected to shrink, not grow.
 
 </details>
 
-## API reference
-
-### Exporter classes
-
-[[autodoc]] transformers.exporters.exporter_dynamo.DynamoExporter
-    - export
-
-[[autodoc]] transformers.exporters.exporter_onnx.OnnxExporter
-    - export
-
-[[autodoc]] transformers.exporters.exporter_executorch.ExecutorchExporter
-    - export
-
-### Configuration
-
-[[autodoc]] transformers.exporters.configs.DynamoConfig
-
-[[autodoc]] transformers.exporters.configs.OnnxConfig
-
-[[autodoc]] transformers.exporters.configs.ExecutorchConfig
-
-### Utilities
-
-[[autodoc]] transformers.exporters.utils.get_leaf_tensors
-
-[[autodoc]] transformers.exporters.utils.prepare_for_export
-
-[[autodoc]] transformers.exporters.utils.decompose_prefill_decode
-
-[[autodoc]] transformers.exporters.utils.decompose_multimodal
-
-[[autodoc]] transformers.exporters.utils.decompose_for_generation
-
-[[autodoc]] transformers.exporters.utils.is_multimodal
+See the [Exporters](./main_classes/exporters) main classes page for the complete API reference:
+every exporter class, config field, and utility function.

--- a/docs/source/en/exporters.md
+++ b/docs/source/en/exporters.md
@@ -16,8 +16,7 @@ rendered properly in your Markdown viewer.
 
 # Exporters
 
-Export any [`PreTrainedModel`] to ONNX, ExecuTorch, or a standalone PyTorch program with the
-same two lines of code, regardless of the target runtime.
+Export any [`PreTrainedModel`] to ONNX, ExecuTorch, or a standalone PyTorch program, regardless of the target runtime.
 
 ```python
 exporter = DynamoExporter()  # or OnnxExporter, ExecutorchExporter
@@ -30,17 +29,13 @@ new attention patterns, and custom cache types are supported at export time as s
 in the modeling code.
 
 > [!WARNING]
-> The exporters are experimental. Many of the patches in this module work around specific
-> upstream bugs (Torch, ONNX Script, ONNX Runtime, ExecuTorch) and will be removed as soon as the
-> fix lands upstream. Until the API stabilizes, treat the patches as tied to the versions used in
-> the test suite. Pin those versions in production tooling, and expect new patches to appear and
-> old ones to disappear as upstream changes land.
+> The exporters are experimental. Many of the patches in this module work around specific upstream bugs (Torch, ONNX Script, ONNX Runtime, ExecuTorch) and will be removed as soon as the fix lands upstream. Until the API stabilizes, treat the patches as tied to the versions used in the test suite. Pin those versions in production tooling, and expect new patches to appear and old ones to disappear as upstream changes land.
 
-| Exporter               | Output                     | Runtime                                       |
-| ---------------------- | -------------------------- | --------------------------------------------- |
-| [`DynamoExporter`]     | `ExportedProgram`          | Any PyTorch runtime, AOT compilation          |
+| Exporter               | Output                     | Runtime                                    |
+| ---------------------- | -------------------------- | ------------------------------------------ |
+| [`DynamoExporter`]     | `ExportedProgram`          | Any PyTorch runtime, AOT compilation       |
 | [`OnnxExporter`]       | `ONNXProgram`              | Any ONNX runtime (ORT, TensorRT, OpenVINO) |
-| [`ExecutorchExporter`] | `ExecutorchProgramManager` | Mobile and edge devices (ExecuTorch)          |
+| [`ExecutorchExporter`] | `ExecutorchProgramManager` | Mobile and edge devices (ExecuTorch)       |
 
 [`AutoHfExporter`] picks the right exporter from a config, and [`AutoExportConfig`] picks the
 right config class from a dict. Both follow the same auto-class pattern in Transformers, which
@@ -92,6 +87,7 @@ pip install transformers "torch==2.12.0" "executorch==1.3.1"
 ## Export a model
 
 All exporters share the same interface. Create an exporter with a config, and call [`~exporters.HfExporter.export`].
+
 Switch between runtimes by swapping the exporter class.
 
 <hfoptions id="exporters-quickstart">
@@ -141,6 +137,8 @@ outputs = session.run(None, ort_inputs)
 </hfoption>
 <hfoption id="ExecuTorch">
 
+[`~exporters.ExecutorchConfig#backend`] defaults to `xnnpack` which targets the CPU and works on CPU-only installations. `cuda` targets the GPU and requires a CUDA-enabled environment. Requesting it without CUDA raises a `RuntimeError`.
+
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers.exporters import ExecutorchExporter, ExecutorchConfig
@@ -169,12 +167,12 @@ outputs = method.execute(list(inputs.values()))
 
 ## Dynamic shapes
 
-The examples above pass `dynamic=True`, which marks every tensor
+Passing `dynamic=True` marks every tensor
 dimension as dynamic so the exported graph accepts inputs of any size at runtime without
 retracing.
 
 For fine-grained control over which dimensions are dynamic, pass explicit `dynamic_shapes`
-instead. This is forwarded directly to [torch.export.export](https://pytorch.org/docs/stable/export.html).
+instead, which is forwarded directly to [torch.export.export](https://pytorch.org/docs/stable/export.html).
 
 <hfoptions id="explicit-dynamic-shapes">
 <hfoption id="Dynamo">
@@ -268,16 +266,16 @@ For autoregressive generation, the model's `forward` has different shapes at the
 expose [`~HfExporter.export_for_generation`], which splits both stages and exports each.
 
 For multi-modal generative models, the prefill additionally splits into an image or audio
-encoder, the language model, and `lm_head`. Encoder and language-model discovery uses the
-canonical [`~PreTrainedModel.get_encoder`] (`modality="image"` / `"audio"`) and
+encoder, the language model, and `lm_head`. Encoder and language-model discovery uses
+[`~PreTrainedModel.get_encoder`] (`modality="image"` or `"audio"`) and
 [`~PreTrainedModel.get_decoder`] accessors, so any new architecture using these
-works out of the box.
+work out of the box.
 
 A projector component appears only when the model exposes one
-under a canonical attribute name (`multi_modal_projector`, `connector`, `embed_vision`,
+under an attribute name (`multi_modal_projector`, `connector`, `embed_vision`,
 `embed_audio`). Qwen2-VL below folds its projector into the vision tower, so its component dict
 has no separate `multi_modal_projector` key. New architectures must align their projector
-attribute to one of these canonical names instead of growing the list.
+attribute to one of these names instead of growing the list.
 
 <hfoptions id="generate">
 <hfoption id="Dynamo">
@@ -344,23 +342,22 @@ components = exporter.export_for_generation(model, inputs, config=config)
 > caller is responsible for running each encoder, projecting embeddings, and orchestrating the
 > generation loop.
 
-<details>
-<summary>What <code>export_for_generation</code> does under the hood</summary>
+### How `export_for_generation` works
 
 [`~exporters.utils.decompose_for_generation`] runs `model.generate(**inputs, max_new_tokens=2)`
 once and hooks `model.forward` to capture the real prefill and decode kwargs (and the
-per-submodule kwargs via hooks on each encoder / projector / language model if the model is
+per-submodule kwargs via hooks on each encoder/projector/language model if the model is
 multi-modal). That's why it works for any architecture, including decoder-only, SSM,
 encoder-decoder, and multi-modal models, without per-model glue. `export_for_generation` is a
 one-liner over it.
 
-The capture runs the model eagerly on `inputs`, so pass small but representative values like a
-short prompt, a single small image, a few audio frames. The exported program isn't tied to
+The capture runs the model eagerly on `inputs`, so pass small but representative values, such as a
+short prompt, a single small image, or a few audio frames. The exported program isn't tied to
 those sizes (dynamic shapes still flow through), but smaller capture inputs make
 `decompose_for_generation` cheaper and keep symbolic-shape inference tractable.
 
-Call `decompose_for_generation` directly when you want to do something between decomposing and
-exporting like running an eager forward for verification, swapping a submodule's inputs, or skipping a stage.
+Call `decompose_for_generation` directly to act between decomposing and exporting, such as
+running an eager forward for verification, swapping a submodule's inputs, or skipping a stage.
 
 ```python
 from transformers.exporters.utils import decompose_for_generation
@@ -374,8 +371,6 @@ for name, (submodel, subinputs) in components.items():
     exported[name] = exporter.export(submodel, subinputs, config=config)
 ```
 
-</details>
-
 ## Limitations and workarounds
 
 `torch.export`, `torch.onnx.export`, and ExecuTorch each have rough edges around specific
@@ -383,17 +378,17 @@ PyTorch patterns. The exporters work around these with a small set of reversible
 and FX-level fixes applied at well-defined points in the export flow. None of this is
 visible from the public `export` API, but the most common things to know:
 
-- Flash-attention and flex-attention are not exportable on any backend; `sdpa` is the preferred
-  setting and `eager` also works (slower). Set one of them on the model before calling `export()`
-  if it's using something else.
-- `grouped_mm` traces fine through `DynamoExporter` and is auto-translated for `OnnxExporter`;
-  for `ExecutorchExporter` with the XNNPACK backend, the exporter swaps MoE experts to
-  `batched_mm` because XNNPACK has no `_grouped_mm.out` kernel.
+- FlashAttention and FlexAttention are not exportable on any backend. `sdpa` is the preferred
+setting and `eager` also works (slower). Set one of them on the model before calling `export`
+if it's using something else.
+- `grouped_mm` traces fine through `DynamoExporter` and is auto-translated for `OnnxExporter`.
+For `ExecutorchExporter` with the XNNPACK backend, the exporter swaps MoE experts to
+`batched_mm` because XNNPACK has no `_grouped_mm.out` kernel.
 - A short list of models (`EXPORT_SKIP_MODEL_CLASSES`) is skipped from the export sweep when
-  the model itself is fundamentally non-exportable; each entry carries a TODO with the
-  model-side change needed.
+the model itself is fundamentally non-exportable. Each entry carries a `TODO` with the
+model-side change needed.
 
 ## Next steps
 
 - Add export support for a new architecture or backend with the patch and fix registries in
-  [Extending the exporters](./exporters_extend).
+[Extending the exporters](./exporters_extend).

--- a/docs/source/en/exporters.md
+++ b/docs/source/en/exporters.md
@@ -384,9 +384,6 @@ if it's using something else.
 - `grouped_mm` traces fine through `DynamoExporter` and is auto-translated for `OnnxExporter`.
 For `ExecutorchExporter` with the XNNPACK backend, the exporter swaps MoE experts to
 `batched_mm` because XNNPACK has no `_grouped_mm.out` kernel.
-- A short list of models (`EXPORT_SKIP_MODEL_CLASSES`) is skipped from the export sweep when
-the model itself is fundamentally non-exportable. Each entry carries a `TODO` with the
-model-side change needed.
 
 ## Next steps
 

--- a/docs/source/en/exporters_extend.md
+++ b/docs/source/en/exporters_extend.md
@@ -26,16 +26,16 @@ below follow that same layout 1:1, so the file you read and the doc you read are
 
 ## Patches and fixes
 
-The exporters use two lifecycles consistently.
+Patches and fixes differ in whether they can be reverted.
 
-Patches are registered with `@register_patch(backend, *dotted_paths)` and installed with
+- Patches are registered with `@register_patch(backend, *dotted_paths)` and installed with
 `apply_patches(backend)`. A patch reversibly swaps an attribute (a `torch` op, an ExecuTorch
 internal, or a model class method) for the duration of the export. Pass multiple paths to a single
 decorator to share one factory across targets, which is useful when the same method shape needs
 patching on several classes (for example `_update_mamba_mask` on Jamba, Bamba, and others).
 Originals are restored on exit, even if the export raises.
 
-Fixes are registered with `@register_fx_node_fix(backend)` or `@register_fx_program_fix(backend)`
+- Fixes are registered with `@register_fx_node_fix(backend)` or `@register_fx_program_fix(backend)`
 and applied with `apply_fx_node_fixes(backend, gm)` or `apply_fx_program_fixes(backend, ep)`.
 ONNX-IR fixes are listed in `_IR_FIXES` and applied with `apply_onnx_ir_fixes`. A fix mutates the
 in-progress graph or program in place. There's no revert, since fixes permanently repair the
@@ -43,13 +43,14 @@ artifact before the next pipeline step.
 
 Every patch and fix sits in a backend-keyed registry (`_PATCHES`, `_FX_NODE_FIXES`,
 `_FX_PROGRAM_FIXES` in [exporters/utils.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/utils.py)).
-Adding a new one is *write a function and decorate it*, nothing else.
+
+Adding a new one is *writing a function and decorating it*, nothing else.
 
 ## DynamoExporter
 
 The base exporter has one patch stage and four structural helpers. They run in this order inside
-`DynamoExporter.export`, against the original `nn.Module`. Source:
-[exporter_dynamo.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_dynamo.py).
+`DynamoExporter.export`, against the original `nn.Module` (see
+[exporter_dynamo.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_dynamo.py)).
 
 ### Stage 1: Forward-signature patch
 
@@ -59,7 +60,7 @@ Replaces `model.forward` with an explicit flat-arg signature derived from the in
 `torch.export` doesn't bundle `**kwargs` into a single tuple. This is the entry contract
 `torch.export` reads before tracing.
 
-This stage is internal and has no extension knob.
+This stage is internal and isn't an extension point.
 
 ### Stage 2: Model patches
 
@@ -79,11 +80,11 @@ mamba/linear-attn mask, the NLLB classifier cast, and chunked-vision attention.
 `register_cache_pytrees_for_model`, under the `# ── Stage 3: Pytree registration ──` marker.
 
 Registers flatten/unflatten via `torch.utils._pytree.register_pytree_node` for every captured
-`Cache` and `ModelOutput`. It's reflection-driven and tuned for tensor containers, not a general
-serializer.
+`Cache` and `ModelOutput`. It discovers each type's structure by walking its attributes at
+runtime, tuned for tensor containers rather than acting as a general serializer.
 
-This is usually automatic. If a type isn't reflectable, add a branch to `_flatten_to_context` or
-`_unflatten_from_context`.
+This is usually automatic. If a type keeps its tensors somewhere the attribute walk can't reach,
+add a branch to `_flatten_to_context` or `_unflatten_from_context`.
 
 ### Stage 4: Dynamic shapes
 
@@ -107,10 +108,10 @@ To extend, append the attribute name to `_STATEFUL_CACHE_ATTRS`.
 ## OnnxExporter
 
 `OnnxExporter` extends `DynamoExporter` with five numbered stages applied around
-`torch.onnx.export`. Source:
-[exporter_onnx.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_onnx.py).
+`torch.onnx.export`. (see
+[exporter_onnx.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_onnx.py)).
 
-A complete inventory of patches in the file is one grep away:
+Grep a complete inventory of patches in the file:
 
 ```bash
 grep -nE "^def (_patch_|_fix_|_aten_)" src/transformers/exporters/exporter_onnx.py
@@ -136,7 +137,7 @@ Hooks the private `_prepare_exported_program_for_export` step so the FX node fix
 again right after `run_decompositions`. Any new symbolic-guard nodes the ONNX decomposition
 introduces get repaired before the FX to ONNX lowering picks them up.
 
-Uses the same registry as stage 1: define `_patch_*(original)` and decorate it with
+Uses the same registry as stage 1. Define `_patch_*(original)` and decorate it with
 `@register_patch("onnx", "dotted.path")`.
 
 ### Stage 3: FX node fixes
@@ -176,17 +177,17 @@ To add one, implement `_fix_ir_*(graph_like)` and append it to `_IR_FIXES`.
 
 ## ExecutorchExporter
 
-`ExecutorchExporter` extends `DynamoExporter` with four stages applied around
-`to_edge_transform_and_lower` and `to_executorch`, plus a backend-preparation step that runs first.
-Source:
-[exporter_executorch.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_executorch.py).
+`ExecutorchExporter` extends `DynamoExporter` with five stages applied around
+`to_edge_transform_and_lower` and `to_executorch`, starting with a backend-preparation step
+(see
+[exporter_executorch.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_executorch.py)).
 
 ### Stage 1: Backend preparation
 
 `_BACKEND_PREPARE`, under the `# ── Stage 1: Backend preparation ──` marker. Runs before
 `torch.export` and is a one-shot step, not a reversible patch.
 
-`prepare_for_xnnpack` moves the model to CPU/fp32 and selects `XnnpackPartitioner`;
+`prepare_for_xnnpack` moves the model to CPU/fp32 and selects `XnnpackPartitioner`.
 `prepare_for_cuda` moves it to CUDA/bf16 and selects `CudaPartitioner`. Each returns
 `(model, sample_inputs, partitioner)`.
 
@@ -222,7 +223,7 @@ Uses the same registry as stage 2: define `_patch_*(original)` and decorate it w
 the `# ── Stage 4: FX program fixes ──` marker. Runs after `torch.export`, before
 `to_edge_transform_and_lower`.
 
-Repairs the `ExportedProgram` where the fix needs program-level context: widen `int_oo` upper
+Repairs the `ExportedProgram` where the fix needs program-level context. Widen `int_oo` upper
 bounds in `range_constraints`, and fill missing placeholder `meta["val"]` from `state_dict`.
 
 To add one, define `_fix_*(exported_program) → None` and decorate it with
@@ -233,7 +234,7 @@ To add one, define `_fix_*(exported_program) → None` and decorate it with
 `_FX_NODE_FIXES["executorch"]`, in-place via `apply_fx_node_fixes("executorch", gm)`, under the
 `# ── Stage 5: FX node fixes ──` marker. Runs after stage 4, before `to_edge_transform_and_lower`.
 
-Per-node rewrites: swap Python sym ops for `executorch_prim.*` equivalents, rewrite `pow` as a
+Per-node rewrites swap Python sym ops for `executorch_prim.*` equivalents. Rewrite `pow` as a
 `mul` chain, normalize amax/max negative dim, and force a contiguous clone. DCE runs automatically
 at the end of the walk.
 
@@ -266,5 +267,5 @@ A second list,
 [`EXPORT_SKIP_MODEL_CLASSES`](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py),
 opts a handful of model classes out of the entire export sweep when the model itself is
 fundamentally non-exportable as-is (data-dependent control flow that can't be vectorized, or
-modules treated as forward arguments). Same expectations: every entry carries a TODO naming the
+modules treated as forward arguments). Same expectations: every entry carries a `TODO` naming the
 underlying model change needed, and the list is expected to shrink, not grow.

--- a/docs/source/en/exporters_extend.md
+++ b/docs/source/en/exporters_extend.md
@@ -1,0 +1,270 @@
+<!--Copyright 2026 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Extending the exporters
+
+The exporters keep their workarounds as reversible patches and FX-level fixes applied at
+well-defined points in the export flow, out of the modeling code wherever possible. Adding
+export support for a new architecture or backend means registering one of these, and each fix
+belongs at the lowest stage that can express it cleanly.
+
+Each exporter's source file labels its stages as `# ── Stage N: … ──` comment blocks. The sections
+below follow that same layout 1:1, so the file you read and the doc you read are the same map.
+
+## Patches and fixes
+
+The exporters use two lifecycles consistently.
+
+Patches are registered with `@register_patch(backend, *dotted_paths)` and installed with
+`apply_patches(backend)`. A patch reversibly swaps an attribute (a `torch` op, an ExecuTorch
+internal, or a model class method) for the duration of the export. Pass multiple paths to a single
+decorator to share one factory across targets, which is useful when the same method shape needs
+patching on several classes (for example `_update_mamba_mask` on Jamba, Bamba, and others).
+Originals are restored on exit, even if the export raises.
+
+Fixes are registered with `@register_fx_node_fix(backend)` or `@register_fx_program_fix(backend)`
+and applied with `apply_fx_node_fixes(backend, gm)` or `apply_fx_program_fixes(backend, ep)`.
+ONNX-IR fixes are listed in `_IR_FIXES` and applied with `apply_onnx_ir_fixes`. A fix mutates the
+in-progress graph or program in place. There's no revert, since fixes permanently repair the
+artifact before the next pipeline step.
+
+Every patch and fix sits in a backend-keyed registry (`_PATCHES`, `_FX_NODE_FIXES`,
+`_FX_PROGRAM_FIXES` in [exporters/utils.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/utils.py)).
+Adding a new one is *write a function and decorate it*, nothing else.
+
+## DynamoExporter
+
+The base exporter has one patch stage and four structural helpers. They run in this order inside
+`DynamoExporter.export`, against the original `nn.Module`. Source:
+[exporter_dynamo.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_dynamo.py).
+
+### Stage 1: Forward-signature patch
+
+`patch_forward_signature`, under the `# ── Stage 1: Model signature patch ──` marker.
+
+Replaces `model.forward` with an explicit flat-arg signature derived from the inputs dict, so
+`torch.export` doesn't bundle `**kwargs` into a single tuple. This is the entry contract
+`torch.export` reads before tracing.
+
+This stage is internal and has no extension knob.
+
+### Stage 2: Model patches
+
+`_PATCHES["dynamo"]` via `apply_patches("dynamo")`, under the `# ── Stage 2: Model patches ──` marker.
+
+Reversible class-attribute swaps applied during tracing. Each `_patch_*(original) → replacement`
+factory targets one or more `Class.method` paths and replaces a non-exportable model pattern
+(data-dependent loops, in-place ops, mask checks, chunked-attention `split → zip → cat`) with an
+export-safe equivalent.
+
+To add one, define `_patch_*(original)` and decorate it with `@register_patch("dynamo", *dotted_paths)`.
+Pass multiple paths to share the factory across classes. Existing examples cover the
+mamba/linear-attn mask, the NLLB classifier cast, and chunked-vision attention.
+
+### Stage 3: Pytree registration
+
+`register_cache_pytrees_for_model`, under the `# ── Stage 3: Pytree registration ──` marker.
+
+Registers flatten/unflatten via `torch.utils._pytree.register_pytree_node` for every captured
+`Cache` and `ModelOutput`. It's reflection-driven and tuned for tensor containers, not a general
+serializer.
+
+This is usually automatic. If a type isn't reflectable, add a branch to `_flatten_to_context` or
+`_unflatten_from_context`.
+
+### Stage 4: Dynamic shapes
+
+`get_auto_dynamic_shapes`, under the `# ── Stage 4: Dynamic shapes ──` marker.
+
+Auto-assigns `Dim.AUTO` to every tensor and cache leaf when `DynamoConfig.dynamic=True` and the
+user did not pass `dynamic_shapes` explicitly.
+
+Override per-export via `DynamoConfig.dynamic_shapes`.
+
+### Stage 5: State cleanup
+
+`reset_model_state` and `_STATEFUL_CACHE_ATTRS`, under the `# ── Stage 5: Model state cleanup ──` marker.
+
+Resets non-`Cache` tensor attributes set inside `forward` (for example glm_moe_dsa `_cached_keys`
+and wav2vec2_bert `cached_rotary_positional_embedding`) that `torch.export` leaves as FakeTensors,
+so a follow-up eager forward is safe.
+
+To extend, append the attribute name to `_STATEFUL_CACHE_ATTRS`.
+
+## OnnxExporter
+
+`OnnxExporter` extends `DynamoExporter` with five numbered stages applied around
+`torch.onnx.export`. Source:
+[exporter_onnx.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_onnx.py).
+
+A complete inventory of patches in the file is one grep away:
+
+```bash
+grep -nE "^def (_patch_|_fix_|_aten_)" src/transformers/exporters/exporter_onnx.py
+```
+
+### Stage 1: Torch patches
+
+`_PATCHES["onnx"]`, reversible via `apply_patches("onnx")`, under the `# ── Stage 1: Torch patches ──`
+marker. Runs during `torch.export` and `torch.onnx.export`.
+
+Reversible swaps of `torch` ops (`where`, `unsqueeze`, `scaled_dot_product_attention`,
+`searchsorted`, and others) that the ONNX decomposer can't lower as-is. Each `_patch_*(original)`
+closes over the original.
+
+To add one, define `_patch_*(original)` and decorate it with `@register_patch("onnx", "dotted.path")`.
+
+### Stage 2: ONNX patches
+
+`_PATCHES["onnx"]`, reversible via `apply_patches("onnx")`, under the `# ── Stage 2: ONNX patches ──`
+marker. Runs during `torch.onnx.export`.
+
+Hooks the private `_prepare_exported_program_for_export` step so the FX node fixes (stage 3) run
+again right after `run_decompositions`. Any new symbolic-guard nodes the ONNX decomposition
+introduces get repaired before the FX to ONNX lowering picks them up.
+
+Uses the same registry as stage 1: define `_patch_*(original)` and decorate it with
+`@register_patch("onnx", "dotted.path")`.
+
+### Stage 3: FX node fixes
+
+`_FX_NODE_FIXES["onnx"]`, in-place via `apply_fx_node_fixes("onnx", gm)`, under the
+`# ── Stage 3: FX node fixes ──` marker. Runs after `torch.export`, then again after
+`run_decompositions`.
+
+Per-node rewrites on the `GraphModule` to drop or replace nodes the ONNX decomposer can't lower
+(alias ops, in-place views, `_assert_*`, dead comparisons, in-place `triu_`, `fill_diagonal_`,
+`sort(stable=True)`). DCE runs automatically at the end of the walk.
+
+To add one, define `_fix_*(gm, node) → bool` (return `True` to consume the node) and decorate it
+with `@register_fx_node_fix("onnx")`.
+
+### Stage 4: ONNX translations
+
+`_ONNX_TRANSLATION_TABLE`, under the `# ── Stage 4: ONNX translations ──` marker. Runs during the
+FX to ONNX lowering.
+
+Overrides `torchlib`'s default lowering for specific aten ops where the default is buggy or missing.
+Currently `aten.index_put` (bool-mask path), `aten.bincount` (`OneHot + ReduceSum`), and
+`aten._grouped_mm` / `transformers.grouped_mm_fallback` (MoE grouped-matmul lowered to an unrolled
+`Slice + MatMul + Concat`).
+
+To add one, implement an `_aten_*` onnxscript function and add it to `_ONNX_TRANSLATION_TABLE`.
+
+### Stage 5: ONNX IR fixes
+
+`_IR_FIXES` applied via `apply_onnx_ir_fixes`, under the `# ── Stage 5: ONNX IR fixes ──` marker.
+Runs after `torch.onnx.export` returns.
+
+Post-export rewrites on the `ONNXProgram` IR to work around ORT validation and runtime bugs (for
+example forcing `TopK(sorted=True)`). Applied to both the top-level graph and every function.
+
+To add one, implement `_fix_ir_*(graph_like)` and append it to `_IR_FIXES`.
+
+## ExecutorchExporter
+
+`ExecutorchExporter` extends `DynamoExporter` with four stages applied around
+`to_edge_transform_and_lower` and `to_executorch`, plus a backend-preparation step that runs first.
+Source:
+[exporter_executorch.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_executorch.py).
+
+### Stage 1: Backend preparation
+
+`_BACKEND_PREPARE`, under the `# ── Stage 1: Backend preparation ──` marker. Runs before
+`torch.export` and is a one-shot step, not a reversible patch.
+
+`prepare_for_xnnpack` moves the model to CPU/fp32 and selects `XnnpackPartitioner`;
+`prepare_for_cuda` moves it to CUDA/bf16 and selects `CudaPartitioner`. Each returns
+`(model, sample_inputs, partitioner)`.
+
+To add a backend, implement `prepare_for_<name>` and register it in `_BACKEND_PREPARE`.
+
+### Stage 2: Torch patches
+
+`_PATCHES["executorch"]`, reversible via `apply_patches("executorch")`, under the
+`# ── Stage 2: Torch patches ──` marker. Runs during `torch.export` tracing.
+
+Replaces `torch` ops the ExecuTorch backends can't accept (`split_copy`, `chunk`, `topk(k>dim)`,
+non-divisible `avg_pool2d`, `dropout`, in-place `view`, GQA-shaped SDPA) with decomposed equivalents.
+
+To add one, define `_patch_*(original)` and decorate it with `@register_patch("executorch", "dotted.path")`.
+
+### Stage 3: ExecuTorch patches
+
+`_PATCHES["executorch"]`, reversible via `apply_patches("executorch")`, under the
+`# ── Stage 3: ExecuTorch patches ──` marker. Runs during `to_edge_transform_and_lower` and
+`to_executorch`.
+
+Reversibly swaps ExecuTorch internals that crash on legitimate dynamic-shape patterns:
+`SpecPropPass.update_placeholder_tensor_specs`, `PruneEmptyTensorsPass.remove_empty_tensors_from_cat`,
+`eval_upper_bound`, `dim_order_from_stride` (rebound on every importer), the XNNPACK
+squeeze/unsqueeze define-node, the complex-dtype validator, and the edge-dialect sym-op allowlist.
+
+Uses the same registry as stage 2: define `_patch_*(original)` and decorate it with
+`@register_patch("executorch", "dotted.path")`.
+
+### Stage 4: FX program fixes
+
+`_FX_PROGRAM_FIXES["executorch"]`, in-place via `apply_fx_program_fixes("executorch", ep)`, under
+the `# ── Stage 4: FX program fixes ──` marker. Runs after `torch.export`, before
+`to_edge_transform_and_lower`.
+
+Repairs the `ExportedProgram` where the fix needs program-level context: widen `int_oo` upper
+bounds in `range_constraints`, and fill missing placeholder `meta["val"]` from `state_dict`.
+
+To add one, define `_fix_*(exported_program) → None` and decorate it with
+`@register_fx_program_fix("executorch")`.
+
+### Stage 5: FX node fixes
+
+`_FX_NODE_FIXES["executorch"]`, in-place via `apply_fx_node_fixes("executorch", gm)`, under the
+`# ── Stage 5: FX node fixes ──` marker. Runs after stage 4, before `to_edge_transform_and_lower`.
+
+Per-node rewrites: swap Python sym ops for `executorch_prim.*` equivalents, rewrite `pow` as a
+`mul` chain, normalize amax/max negative dim, and force a contiguous clone. DCE runs automatically
+at the end of the walk.
+
+To add one, define `_fix_*(gm, node) → bool` (return `True` to consume the node) and decorate it
+with `@register_fx_node_fix("executorch")`.
+
+## When to patch the exporter vs. fix the model
+
+The split is intentional.
+
+Make a modeling change when the pattern blocks export across multiple backends: data-dependent
+loops, stateful caches outside `Cache`, or hand-written split-loop attention. Fix it once in the
+model, and every exporter benefits.
+
+Write an exporter patch when the issue is a single backend's lowering bug: a missing ONNX
+translation, an ORT validation quirk, or an FX decomposition that emits a dead op. Keep the
+workaround in the exporter, and the modeling code stays clean.
+
+## Known upstream workarounds
+
+A small number of model classes hit confirmed bugs in `onnxscript`'s graph optimizer (constant
+folding crashing on `SplitToSequence`, FPN initializers being dropped). For those, ONNX
+optimization is selectively disabled via
+[`ONNX_DISABLE_OPTIMIZE_MODEL_CLASSES`](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py)
+in the test suite, and each entry is annotated with the upstream issue it works around. This list
+is expected to shrink as upstream bugs land. It is not an extension point for arbitrary skipping,
+and new entries must reference a specific upstream bug.
+
+A second list,
+[`EXPORT_SKIP_MODEL_CLASSES`](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py),
+opts a handful of model classes out of the entire export sweep when the model itself is
+fundamentally non-exportable as-is (data-dependent control flow that can't be vectorized, or
+modules treated as forward arguments). Same expectations: every entry carries a TODO naming the
+underlying model change needed, and the list is expected to shrink, not grow.

--- a/docs/source/en/exporters_extend.md
+++ b/docs/source/en/exporters_extend.md
@@ -16,256 +16,139 @@ rendered properly in your Markdown viewer.
 
 # Extending the exporters
 
-The exporters keep their workarounds as reversible patches and FX-level fixes applied at
-well-defined points in the export flow, out of the modeling code wherever possible. Adding
-export support for a new architecture or backend means registering one of these, and each fix
-belongs at the lowest stage that can express it cleanly.
+`torch.export` traces the model into a graph, later stages transform
+that graph, and a final stage lowers or emits it for the target runtime. Most models pass through
+untouched. When there's a PyTorch pattern the backend can't handle, the exporter applies a
+small workaround at that stage rather than editing the model.
 
-Each exporter's source file labels its stages as `# ── Stage N: … ──` comment blocks. The sections
-below follow that same layout 1:1, so the file you read and the doc you read are the same map.
+Add a workaround by writing one function and registering it with a decorator. Each workaround belongs at the lowest stage that can express it cleanly.
 
 ## Patches and fixes
 
-Patches and fixes differ in whether they can be reverted.
+A workaround is either a patch or a fix. The two differ in whether they can be reverted.
 
-- Patches are registered with `@register_patch(backend, *dotted_paths)` and installed with
-`apply_patches(backend)`. A patch reversibly swaps an attribute (a `torch` op, an ExecuTorch
-internal, or a model class method) for the duration of the export. Pass multiple paths to a single
-decorator to share one factory across targets, which is useful when the same method shape needs
-patching on several classes (for example `_update_mamba_mask` on Jamba, Bamba, and others).
-Originals are restored on exit, even if the export raises.
+|              | Patch                                                                          | Fix                                                                                   |
+| ------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| What it does | Swaps out an attribute (a `torch` op, an ExecuTorch internal, or a model method) for the duration of the export | Rewrites the traced graph or program                                                  |
+| Reverted     | Yes, the original is restored afterward                                        | No, it repairs the artifact before the next stage runs                                |
+| Register with | `@register_patch(backend, *paths)`                                            | `@register_fx_node_fix(backend)` or `@register_fx_program_fix(backend)`               |
 
-- Fixes are registered with `@register_fx_node_fix(backend)` or `@register_fx_program_fix(backend)`
-and applied with `apply_fx_node_fixes(backend, gm)` or `apply_fx_program_fixes(backend, ep)`.
-ONNX-IR fixes are listed in `_IR_FIXES` and applied with `apply_onnx_ir_fixes`. A fix mutates the
-in-progress graph or program in place. There's no revert, since fixes permanently repair the
-artifact before the next pipeline step.
+Both live in a registry in
+[exporters/utils.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/utils.py),
+and the exporter installs everything registered for its backend at the right stage.
 
-Every patch and fix sits in a backend-keyed registry (`_PATCHES`, `_FX_NODE_FIXES`,
-`_FX_PROGRAM_FIXES` in [exporters/utils.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/utils.py)).
+Reach for a patch when the issue is a single backend's lowering bug: a missing ONNX
+translation, an ORT validation quirk, or an FX decomposition that emits a dead op. The workaround
+stays in the exporter, and the modeling code stays clean.
 
-Adding a new one is *writing a function and decorating it*, nothing else.
+When the pattern blocks export across multiple backends, such as data-dependent loops, stateful
+caches outside `Cache`, or hand-written split-loop attention, fix the model instead. Fixing it
+once in the model helps every exporter.
 
-## DynamoExporter
+## Add a patch
 
-The base exporter has one patch stage and four structural helpers. They run in this order inside
-`DynamoExporter.export`, against the original `nn.Module` (see
-[exporter_dynamo.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_dynamo.py)).
+Suppose a model method does something `torch.export` can't trace. NLLB-MoE's
+`NllbMoeTop2Router._cast_classifier` casts the classifier weights to another dtype,
+which isn't traceable. Replace it with a no-op for the duration of the export.
 
-### Stage 1: Forward-signature patch
+Write a factory that takes the original method and returns its replacement, then register the
+factory against the method's dotted path:
 
-`patch_forward_signature`, under the `# ── Stage 1: Model signature patch ──` marker.
+```python
+from transformers.exporters.utils import register_patch
 
-Replaces `model.forward` with an explicit flat-arg signature derived from the inputs dict, so
-`torch.export` doesn't bundle `**kwargs` into a single tuple. This is the entry contract
-`torch.export` reads before tracing.
+@register_patch("dynamo", "transformers.models.nllb_moe.modeling_nllb_moe.NllbMoeTop2Router._cast_classifier")
+def _patch_classifier_cast(_original):
+    # Replace the untraceable dtype cast with a no-op during export.
+    return lambda self, *args, **kwargs: None
+```
 
-This stage is internal and isn't an extension point.
+The exporter swaps the method in before tracing and restores it afterward,
+so the patch only affects export. A few variations:
 
-### Stage 2: Model patches
+- Pass extra paths to share one factory across call sites, for example
+  `@register_patch("dynamo", path_a, path_b)`.
+- Patch a `torch` op by pointing the path at it, for example `@register_patch("onnx", "torch.where")`.
+  The factory receives the real op as its argument, so the replacement can call through to it.
+- Write a fix instead of a patch when you need to rewrite the graph after tracing. The mechanism is
+  the same, a decorated function in the matching registry.
 
-`_PATCHES["dynamo"]` via `apply_patches("dynamo")`, under the `# ── Stage 2: Model patches ──` marker.
+## Stage reference
 
-Reversible class-attribute swaps applied during tracing. Each `_patch_*(original) → replacement`
-factory targets one or more `Class.method` paths and replaces a non-exportable model pattern
-(data-dependent loops, in-place ops, mask checks, chunked-attention `split → zip → cat`) with an
-export-safe equivalent.
+Each exporter's source labels its stages as `# ── Stage N: … ──` comment blocks, so the file and
+this reference line up. Look there for the exact ops and classes each stage handles.
 
-To add one, define `_patch_*(original)` and decorate it with `@register_patch("dynamo", *dotted_paths)`.
-Pass multiple paths to share the factory across classes. Existing examples cover the
-mamba/linear-attn mask, the NLLB classifier cast, and chunked-vision attention.
+### DynamoExporter
 
-### Stage 3: Pytree registration
+The base exporter runs one patch stage and four helpers, in order, inside `DynamoExporter.export`
+(see [exporter_dynamo.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_dynamo.py)).
 
-`register_cache_pytrees_for_model`, under the `# ── Stage 3: Pytree registration ──` marker.
+1. Forward-signature patch: gives `model.forward` a flat argument signature so `torch.export`
+   doesn't bundle inputs into one `**kwargs` tuple. This is internal and not an extension point.
+2. Model patches: swap untraceable model methods for export-safe equivalents during tracing. Extend
+   with `@register_patch("dynamo", ...)`.
+3. Pytree registration: register each `Cache` and `ModelOutput` so `torch.export` can flatten and
+   rebuild it (usually happens automatically). Add a branch to `_flatten_to_context` / `_unflatten_from_context`
+   for a type the attribute walk can't reach.
+4. Dynamic shapes: assign `Dim.AUTO` to every tensor and cache leaf when `dynamic=True`. Override
+   with `DynamoConfig.dynamic_shapes`.
+5. State cleanup: reset tensor attributes a model sets inside `forward` that `torch.export` leaves
+   as fake tensors. Extend by adding the attribute name to `_STATEFUL_CACHE_ATTRS`.
 
-Registers flatten/unflatten via `torch.utils._pytree.register_pytree_node` for every captured
-`Cache` and `ModelOutput`. It discovers each type's structure by walking its attributes at
-runtime, tuned for tensor containers rather than acting as a general serializer.
+### OnnxExporter
 
-This is usually automatic. If a type keeps its tensors somewhere the attribute walk can't reach,
-add a branch to `_flatten_to_context` or `_unflatten_from_context`.
-
-### Stage 4: Dynamic shapes
-
-`get_auto_dynamic_shapes`, under the `# ── Stage 4: Dynamic shapes ──` marker.
-
-Auto-assigns `Dim.AUTO` to every tensor and cache leaf when `DynamoConfig.dynamic=True` and the
-user did not pass `dynamic_shapes` explicitly.
-
-Override per-export via `DynamoConfig.dynamic_shapes`.
-
-### Stage 5: State cleanup
-
-`reset_model_state` and `_STATEFUL_CACHE_ATTRS`, under the `# ── Stage 5: Model state cleanup ──` marker.
-
-Resets non-`Cache` tensor attributes set inside `forward` (for example glm_moe_dsa `_cached_keys`
-and wav2vec2_bert `cached_rotary_positional_embedding`) that `torch.export` leaves as FakeTensors,
-so a follow-up eager forward is safe.
-
-To extend, append the attribute name to `_STATEFUL_CACHE_ATTRS`.
-
-## OnnxExporter
-
-`OnnxExporter` extends `DynamoExporter` with five numbered stages applied around
-`torch.onnx.export`. (see
+`OnnxExporter` adds five stages around `torch.onnx.export` (see
 [exporter_onnx.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_onnx.py)).
-
-Grep a complete inventory of patches in the file:
+Grep the file for the full list of patches:
 
 ```bash
 grep -nE "^def (_patch_|_fix_|_aten_)" src/transformers/exporters/exporter_onnx.py
 ```
 
-### Stage 1: Torch patches
+1. Torch patches: swap `torch` ops the ONNX exporter can't translate as-is. Extend with
+   `@register_patch("onnx", ...)`.
+2. ONNX patches: re-run the node fixes after `run_decompositions` so newly introduced shape-guard
+   nodes get repaired before lowering. Uses the same `@register_patch("onnx", ...)` registry.
+3. FX node fixes: rewrite graph nodes the ONNX exporter can't lower, such as alias ops, in-place
+   views, and dead asserts. Extend with `@register_fx_node_fix("onnx")`.
+4. ONNX translations: supply a custom lowering for an aten op where the default is missing or buggy
+   (for example `aten.index_put` or `aten._grouped_mm`). Add an `_aten_*` function to
+   `_ONNX_TRANSLATION_TABLE`.
+5. ONNX IR fixes: rewrite the finished ONNX program to work around ONNX Runtime bugs (for example
+   forcing `TopK(sorted=True)`). Add a `_fix_ir_*` function to `_IR_FIXES`.
 
-`_PATCHES["onnx"]`, reversible via `apply_patches("onnx")`, under the `# ── Stage 1: Torch patches ──`
-marker. Runs during `torch.export` and `torch.onnx.export`.
+### ExecutorchExporter
 
-Reversible swaps of `torch` ops (`where`, `unsqueeze`, `scaled_dot_product_attention`,
-`searchsorted`, and others) that the ONNX decomposer can't lower as-is. Each `_patch_*(original)`
-closes over the original.
-
-To add one, define `_patch_*(original)` and decorate it with `@register_patch("onnx", "dotted.path")`.
-
-### Stage 2: ONNX patches
-
-`_PATCHES["onnx"]`, reversible via `apply_patches("onnx")`, under the `# ── Stage 2: ONNX patches ──`
-marker. Runs during `torch.onnx.export`.
-
-Hooks the private `_prepare_exported_program_for_export` step so the FX node fixes (stage 3) run
-again right after `run_decompositions`. Any new symbolic-guard nodes the ONNX decomposition
-introduces get repaired before the FX to ONNX lowering picks them up.
-
-Uses the same registry as stage 1. Define `_patch_*(original)` and decorate it with
-`@register_patch("onnx", "dotted.path")`.
-
-### Stage 3: FX node fixes
-
-`_FX_NODE_FIXES["onnx"]`, in-place via `apply_fx_node_fixes("onnx", gm)`, under the
-`# ── Stage 3: FX node fixes ──` marker. Runs after `torch.export`, then again after
-`run_decompositions`.
-
-Per-node rewrites on the `GraphModule` to drop or replace nodes the ONNX decomposer can't lower
-(alias ops, in-place views, `_assert_*`, dead comparisons, in-place `triu_`, `fill_diagonal_`,
-`sort(stable=True)`). DCE runs automatically at the end of the walk.
-
-To add one, define `_fix_*(gm, node) → bool` (return `True` to consume the node) and decorate it
-with `@register_fx_node_fix("onnx")`.
-
-### Stage 4: ONNX translations
-
-`_ONNX_TRANSLATION_TABLE`, under the `# ── Stage 4: ONNX translations ──` marker. Runs during the
-FX to ONNX lowering.
-
-Overrides `torchlib`'s default lowering for specific aten ops where the default is buggy or missing.
-Currently `aten.index_put` (bool-mask path), `aten.bincount` (`OneHot + ReduceSum`), and
-`aten._grouped_mm` / `transformers.grouped_mm_fallback` (MoE grouped-matmul lowered to an unrolled
-`Slice + MatMul + Concat`).
-
-To add one, implement an `_aten_*` onnxscript function and add it to `_ONNX_TRANSLATION_TABLE`.
-
-### Stage 5: ONNX IR fixes
-
-`_IR_FIXES` applied via `apply_onnx_ir_fixes`, under the `# ── Stage 5: ONNX IR fixes ──` marker.
-Runs after `torch.onnx.export` returns.
-
-Post-export rewrites on the `ONNXProgram` IR to work around ORT validation and runtime bugs (for
-example forcing `TopK(sorted=True)`). Applied to both the top-level graph and every function.
-
-To add one, implement `_fix_ir_*(graph_like)` and append it to `_IR_FIXES`.
-
-## ExecutorchExporter
-
-`ExecutorchExporter` extends `DynamoExporter` with five stages applied around
-`to_edge_transform_and_lower` and `to_executorch`, starting with a backend-preparation step
-(see
+`ExecutorchExporter` adds five stages around `to_edge_transform_and_lower` and `to_executorch`,
+starting with backend preparation (see
 [exporter_executorch.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_executorch.py)).
 
-### Stage 1: Backend preparation
-
-`_BACKEND_PREPARE`, under the `# ── Stage 1: Backend preparation ──` marker. Runs before
-`torch.export` and is a one-shot step, not a reversible patch.
-
-`prepare_for_xnnpack` moves the model to CPU/fp32 and selects `XnnpackPartitioner`.
-`prepare_for_cuda` moves it to CUDA/bf16 and selects `CudaPartitioner`. Each returns
-`(model, sample_inputs, partitioner)`.
-
-To add a backend, implement `prepare_for_<name>` and register it in `_BACKEND_PREPARE`.
-
-### Stage 2: Torch patches
-
-`_PATCHES["executorch"]`, reversible via `apply_patches("executorch")`, under the
-`# ── Stage 2: Torch patches ──` marker. Runs during `torch.export` tracing.
-
-Replaces `torch` ops the ExecuTorch backends can't accept (`split_copy`, `chunk`, `topk(k>dim)`,
-non-divisible `avg_pool2d`, `dropout`, in-place `view`, GQA-shaped SDPA) with decomposed equivalents.
-
-To add one, define `_patch_*(original)` and decorate it with `@register_patch("executorch", "dotted.path")`.
-
-### Stage 3: ExecuTorch patches
-
-`_PATCHES["executorch"]`, reversible via `apply_patches("executorch")`, under the
-`# ── Stage 3: ExecuTorch patches ──` marker. Runs during `to_edge_transform_and_lower` and
-`to_executorch`.
-
-Reversibly swaps ExecuTorch internals that crash on legitimate dynamic-shape patterns:
-`SpecPropPass.update_placeholder_tensor_specs`, `PruneEmptyTensorsPass.remove_empty_tensors_from_cat`,
-`eval_upper_bound`, `dim_order_from_stride` (rebound on every importer), the XNNPACK
-squeeze/unsqueeze define-node, the complex-dtype validator, and the edge-dialect sym-op allowlist.
-
-Uses the same registry as stage 2: define `_patch_*(original)` and decorate it with
-`@register_patch("executorch", "dotted.path")`.
-
-### Stage 4: FX program fixes
-
-`_FX_PROGRAM_FIXES["executorch"]`, in-place via `apply_fx_program_fixes("executorch", ep)`, under
-the `# ── Stage 4: FX program fixes ──` marker. Runs after `torch.export`, before
-`to_edge_transform_and_lower`.
-
-Repairs the `ExportedProgram` where the fix needs program-level context. Widen `int_oo` upper
-bounds in `range_constraints`, and fill missing placeholder `meta["val"]` from `state_dict`.
-
-To add one, define `_fix_*(exported_program) → None` and decorate it with
-`@register_fx_program_fix("executorch")`.
-
-### Stage 5: FX node fixes
-
-`_FX_NODE_FIXES["executorch"]`, in-place via `apply_fx_node_fixes("executorch", gm)`, under the
-`# ── Stage 5: FX node fixes ──` marker. Runs after stage 4, before `to_edge_transform_and_lower`.
-
-Per-node rewrites swap Python sym ops for `executorch_prim.*` equivalents. Rewrite `pow` as a
-`mul` chain, normalize amax/max negative dim, and force a contiguous clone. DCE runs automatically
-at the end of the walk.
-
-To add one, define `_fix_*(gm, node) → bool` (return `True` to consume the node) and decorate it
-with `@register_fx_node_fix("executorch")`.
-
-## When to patch the exporter vs. fix the model
-
-The split is intentional.
-
-Make a modeling change when the pattern blocks export across multiple backends: data-dependent
-loops, stateful caches outside `Cache`, or hand-written split-loop attention. Fix it once in the
-model, and every exporter benefits.
-
-Write an exporter patch when the issue is a single backend's lowering bug: a missing ONNX
-translation, an ORT validation quirk, or an FX decomposition that emits a dead op. Keep the
-workaround in the exporter, and the modeling code stays clean.
+1. Backend preparation: move the model to the target device and dtype and pick its partitioner
+   (`prepare_for_xnnpack`, `prepare_for_cuda`). Add a backend by registering `prepare_for_<name>` in
+   `_BACKEND_PREPARE`.
+2. Torch patches: replace `torch` ops the ExecuTorch backends can't accept, such as `split_copy`,
+   `chunk`, and `topk(k>dim)`. Extend with `@register_patch("executorch", ...)`.
+3. ExecuTorch patches: swap ExecuTorch internals that crash on valid dynamic-shape graphs. Uses the
+   same `@register_patch("executorch", ...)` registry.
+4. FX program fixes: repair the exported program where the fix needs whole-program context, such as
+   widening range constraints or filling missing placeholder metadata. Extend with
+   `@register_fx_program_fix("executorch")`.
+5. FX node fixes: rewrite individual nodes, such as mapping Python sym ops to `executorch_prim.*` or
+   rewriting `pow` as a `mul` chain. Extend with `@register_fx_node_fix("executorch")`.
 
 ## Known upstream workarounds
 
 A small number of model classes hit confirmed bugs in `onnxscript`'s graph optimizer (constant
-folding crashing on `SplitToSequence`, FPN initializers being dropped). For those, ONNX
-optimization is selectively disabled via
-[`ONNX_DISABLE_OPTIMIZE_MODEL_CLASSES`](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py)
-in the test suite, and each entry is annotated with the upstream issue it works around. This list
-is expected to shrink as upstream bugs land. It is not an extension point for arbitrary skipping,
-and new entries must reference a specific upstream bug.
+folding crashing on `SplitToSequence`, FPN initializers being dropped). For those, ONNX optimization
+is selectively disabled via
+[ONNX_DISABLE_OPTIMIZE_MODEL_CLASSES](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py)
+in the test suite, and each entry is annotated with the upstream issue it works around. This list is
+expected to shrink as upstream bugs land. It is not an extension point for arbitrary skipping, and
+new entries must reference a specific upstream bug.
 
 A second list,
-[`EXPORT_SKIP_MODEL_CLASSES`](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py),
-opts a handful of model classes out of the entire export sweep when the model itself is
-fundamentally non-exportable as-is (data-dependent control flow that can't be vectorized, or
-modules treated as forward arguments). Same expectations: every entry carries a `TODO` naming the
-underlying model change needed, and the list is expected to shrink, not grow.
+[EXPORT_SKIP_MODEL_CLASSES](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py),
+opts a handful of model classes out of the entire export sweep when the model itself is fundamentally
+non-exportable as-is (data-dependent control flow that can't be vectorized, or modules treated as
+forward arguments). Every entry carries a `TODO` naming the underlying model
+change needed, and the list is expected to shrink, not grow.

--- a/docs/source/en/exporters_extend.md
+++ b/docs/source/en/exporters_extend.md
@@ -138,17 +138,14 @@ starting with backend preparation (see
 
 ## Known upstream workarounds
 
-A small number of model classes hit confirmed bugs in `onnxscript`'s graph optimizer (constant
-folding crashing on `SplitToSequence`, FPN initializers being dropped). For those, ONNX optimization
-is selectively disabled via
-[ONNX_DISABLE_OPTIMIZE_MODEL_CLASSES](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py)
-in the test suite, and each entry is annotated with the upstream issue it works around. This list is
-expected to shrink as upstream bugs land. It is not an extension point for arbitrary skipping, and
-new entries must reference a specific upstream bug.
+A few model classes hit confirmed bugs in the `onnxscript` graph optimizer (constant folding crashing
+on `SplitToSequence`, FPN initializers being dropped). [ONNX_DISABLE_OPTIMIZE](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_export.py) 
+disables `onnxscript` optimization for those models. Each entry records the
+upstream issue next to the model name. The list is expected to shrink as upstream bugs land, so a
+new entry must reference a specific upstream bug rather than disable optimization arbitrarily.
 
-A second list,
-[EXPORT_SKIP_MODEL_CLASSES](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_utils.py),
-opts a handful of model classes out of the entire export sweep when the model itself is fundamentally
-non-exportable as-is (data-dependent control flow that can't be vectorized, or modules treated as
-forward arguments). Every entry carries a `TODO` naming the underlying model
-change needed, and the list is expected to shrink, not grow.
+[EXPORT_SKIPS](https://github.com/huggingface/transformers/blob/main/tests/exporters/test_export.py),
+opts a handful of model classes out of the export sweep entirely when the model is
+fundamentally non-exportable as-is (data-dependent control flow that can't be vectorized, or modules
+treated as forward arguments). Each entry carries a reason naming the model-side change needed. This
+list is also expected to shrink, not grow.

--- a/docs/source/en/main_classes/exporters.md
+++ b/docs/source/en/main_classes/exporters.md
@@ -36,6 +36,21 @@ Learn how to use the built-in exporters in the [Exporters](../exporters) guide.
 
 [[autodoc]] exporters.base.HfExporter
 
+## DynamoExporter
+
+[[autodoc]] exporters.exporter_dynamo.DynamoExporter
+    - export
+
+## OnnxExporter
+
+[[autodoc]] exporters.exporter_onnx.OnnxExporter
+    - export
+
+## ExecutorchExporter
+
+[[autodoc]] exporters.exporter_executorch.ExecutorchExporter
+    - export
+
 ## DynamoConfig
 
 [[autodoc]] exporters.configs.DynamoConfig
@@ -47,3 +62,20 @@ Learn how to use the built-in exporters in the [Exporters](../exporters) guide.
 ## ExecutorchConfig
 
 [[autodoc]] exporters.configs.ExecutorchConfig
+
+## Utilities
+
+Lower-level functions that power `export_for_generation`, useful when you need to intervene
+between decomposing a model and exporting each component.
+
+[[autodoc]] exporters.utils.get_leaf_tensors
+
+[[autodoc]] exporters.utils.prepare_for_export
+
+[[autodoc]] exporters.utils.decompose_prefill_decode
+
+[[autodoc]] exporters.utils.decompose_multimodal
+
+[[autodoc]] exporters.utils.decompose_for_generation
+
+[[autodoc]] exporters.utils.is_multimodal


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47374)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47374)
<!-- ci-dashboard-badge:end -->

Refactors the exporters docs a bit by user intent (using exporters vs extending exporters) and make it shorter and more scannable.

- Split the doc by audience so the user guide is focused on using an exporter and a separate guide for contributors who want to patch/fix.
- Replace dense stages for every exporter with one concrete worked example and then a more compact stage reference for each exporter.
- Clearer distinction when to reach for patch vs fix and fold into one section instead of two separate ones.
- Add code snippet for `AutoHfExporter` and `AutoExportConfig`.
- Add ExecuTorch `cuda` backend requires CUDA and `xnnpack` works for CPU-only (#47201).