### PR TITLE
Fix torch_float casting to int instead of float

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -711,11 +711,11 @@ def torch_float(x):
     Casts an input to a torch float32 tensor if we are in a tracing context, otherwise to a Python float.
     """
     if not _is_torch_available:
-        return int(x)
+        return float(x)
 
     import torch
 
-    return x.to(torch.float32) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else int(x)
+    return x.to(torch.float32) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else float(x)
 
 
 def filter_out_non_signature_kwargs(extra: list | None = None):


### PR DESCRIPTION
# What does this PR do?

`torch_float` (`src/transformers/utils/generic.py`) is documented to cast its input *"to a Python float"* (and, in a tracing context, to a `torch.float32` tensor). But both of its non-tracing return paths call `int(x)` instead of `float(x)`:

```python
def torch_float(x):
    """
    Casts an input to a torch float32 tensor if we are in a tracing context, otherwise to a Python float.
    """
    if not _is_torch_available:
        return int(x)                                                                              # truncates

    import torch

    return x.to(torch.float32) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else int(x)  # truncates
```

This is a copy-paste leftover from the sibling `torch_int` immediately above, which correctly uses `int(x)` in both branches. Because the value is truncated, the function named `torch_float` returns an **int** on the normal eager path, contradicting both its name and its docstring (and inconsistent with the `torch.float32` cast it does under tracing).

## Impact

The in-tree caller is ImageGPT attention scaling (`models/imagegpt/modeling_imagegpt.py:106`):

```python
attn_weights = attn_weights / torch_float(value.size(-1) ** 0.5)
```

`value.size(-1) ** 0.5` is the (float) square root of the attention head dimension. Truncating it corrupts the scaling denominator for any non-perfect-square head dim:

| checkpoint | head_dim | `sqrt(head_dim)` | current (int) | correct (float) |
|---|---|---|---|---|
| imagegpt-small | 64 | 8.0000 | 8 | 8.0 (unaffected) |
| imagegpt-medium | 128 | 11.3137 | **11** | 11.3137 |
| imagegpt-large | 96 | 9.7980 | **9** | 9.7980 |

The default small config has a perfect-square head dim, which is why this slipped through.

## Fix

Return a `float` from both branches, matching the docstring and the tracing-path `float32` cast:

```python
    if not _is_torch_available:
        return float(x)
    ...
    return x.to(torch.float32) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else float(x)
```

## Reproduction (no torch required)

The `not _is_torch_available` branch is identical to the non-tracing `else` branch (both `int(x)`), so the bug is observable with plain Python:

```
current torch_float(sqrt(128)) = 11                  -> attn 100.0 / 11        = 9.090909  (wrong)
fixed   torch_float(sqrt(128)) = 11.313708498984761  -> attn 100.0 / 11.3137   = 8.838835  (correct)
```

## Before submitting
- [x] This PR fixes a bug (behavior + docstring mismatch), minimal 2-line change.
- [x] Did you make sure to update the documentation? (no doc changes needed; the docstring already describes the correct behavior.)
