### PR TITLE
Warn when `group_by_length` is silently ignored for iterable datasets

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1018,6 +1018,12 @@ class Trainer:
         if train_dataset is None:
             train_dataset = self.train_dataset
         if train_dataset is None or not has_length(train_dataset):
+            if train_dataset is not None and self.args.train_sampling_strategy == "group_by_length":
+                logger.warning(
+                    "`train_sampling_strategy='group_by_length'` is ignored because the training dataset does not "
+                    "implement `__len__` (e.g. an `IterableDataset`). Examples will be consumed in the dataset's own "
+                    "order."
+                )
             return None
 
         # Build the sampler.


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47379)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47379)
<!-- ci-dashboard-badge:end -->

`train_sampling_strategy="group_by_length"` has no effect on datasets without `__len__` (e.g. `IterableDataset`): `_get_train_sampler` returns `None` early, and examples are consumed in the dataset's own order. This used to raise a `ValueError` (#15437), but the check was dropped in the sampler unification refactor (#43138), so it now fails silently.

This adds a warning on that path. No behavior change otherwise; a warning rather than restoring the error, since users relying on the current no-op shouldn't break.

Fixes the silent-no-op part of #32326; the feature request itself (buffer-based length grouping for streaming datasets) is out of scope here.