### PR TITLE
Fix IndexError in SequenceFeatureExtractor.pad on all-empty batch

### DIFF
--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -150,7 +150,7 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
         if isinstance(first_element, (list, tuple)):
             # first_element might be an empty list/tuple in some edge cases so we grab the first non empty element.
             index = 0
-            while len(required_input[index]) == 0:
+            while index < len(required_input) and len(required_input[index]) == 0:
                 index += 1
             if index < len(required_input):
                 first_element = required_input[index][0]

--- a/tests/utils/test_feature_extraction_utils.py
+++ b/tests/utils/test_feature_extraction_utils.py
@@ -213,6 +213,25 @@ class BatchFeatureTester(unittest.TestCase):
         self.assertEqual(batch_fp16["tuple_tensors"][0].dtype, torch.float16)
 
 
+class SequenceFeatureExtractorPadTester(unittest.TestCase):
+    """Tests for SequenceFeatureExtractor.pad edge cases."""
+
+    def test_pad_all_empty_batch_does_not_raise(self):
+        # Regression test: when scanning for the first non-empty element, `pad` used an
+        # unbounded `while len(required_input[index]) == 0: index += 1` loop. If *every*
+        # element in the batch was an empty list, the index walked past the end and raised
+        # `IndexError` before the following `if index < len(required_input):` guard could run.
+        feature_extractor = Wav2Vec2FeatureExtractor(
+            feature_size=1, sampling_rate=16000, padding_value=0.0, return_attention_mask=False
+        )
+        input_name = feature_extractor.model_input_names[0]
+        processed_features = BatchFeature({input_name: [[], []]})
+
+        # Previously raised "IndexError: list index out of range".
+        padded = feature_extractor.pad(processed_features, padding="longest")
+        self.assertEqual(len(padded[input_name]), 2)
+
+
 class FeatureExtractorUtilTester(unittest.TestCase):
     def test_cached_files_are_used_when_internet_is_down(self):
         # A mock response for an HTTP head request to emulate server down


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47389)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47389)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`SequenceFeatureExtractor.pad` (`src/transformers/feature_extraction_sequence_utils.py`) — the padding entry point for every audio feature extractor (Wav2Vec2, Whisper, CLAP, EnCodec, Gemma3n, … 30 subclasses) — crashes with `IndexError` when the whole batch is empty.

When the first element of the batch is an empty list/tuple, `pad` scans for the first non-empty element to infer the input type:

```python
first_element = required_input[0]
if isinstance(first_element, (list, tuple)):
    # first_element might be an empty list/tuple in some edge cases so we grab the first non empty element.
    index = 0
    while len(required_input[index]) == 0:   # unbounded
        index += 1
    if index < len(required_input):
        first_element = required_input[index][0]
```

The `while` loop has no upper bound, so if **every** element in the batch is empty it increments `index` past the end and raises `IndexError: list index out of range` — before the following `if index < len(required_input):` guard (which was clearly meant to handle exactly this case) can ever run.

## Evidence this is unintended

The analogous code in `PreTrainedTokenizerBase.pad` (`tokenization_utils_base.py`) does the same "grab the first non-empty element" with a **bounded** loop, and its comment explicitly notes that an all-empty batch should just be left alone:

```python
first_element = required_input[0]
if isinstance(first_element, (list, tuple)):
    # first_element might be an empty list/tuple in some edge cases so we grab the first non empty element.
    for item in required_input:
        if len(item) > 0:
            first_element = item[0]
            break
    # At this state, if `first_element` is still a list/tuple, it's an empty one so there is nothing to do.
```

## Fix

Bound the loop so the existing guard is reached and an all-empty batch is handled gracefully instead of crashing:

```python
while index < len(required_input) and len(required_input[index]) == 0:
    index += 1
```

## Reproduction

```python
from transformers import Wav2Vec2FeatureExtractor
from transformers.feature_extraction_utils import BatchFeature

fe = Wav2Vec2FeatureExtractor(feature_size=1, sampling_rate=16000, padding_value=0.0, return_attention_mask=False)
fe.pad(BatchFeature({"input_values": [[], []]}), padding="longest")
```

| | result |
|---|---|
| before | `IndexError: list index out of range` ❌ |
| after | returns a `BatchFeature` with 2 (empty) rows ✅ |

A regression test is added in `tests/utils/test_feature_extraction_utils.py`.

## Before submitting
- [x] This PR fixes a bug.
- [x] Added a regression test (`SequenceFeatureExtractorPadTester.test_pad_all_empty_batch_does_not_raise`).