### PR TITLE
[Inkling] Fix float64 MPS crash in InklingProcessor dMel bin extraction

### DIFF
--- a/src/transformers/models/inkling/feature_extraction_inkling.py
+++ b/src/transformers/models/inkling/feature_extraction_inkling.py
@@ -111,7 +111,7 @@ class InklingFeatureExtractor(SequenceFeatureExtractor):
     def _torch_extract_fbank_features(self, waveform: torch.Tensor, device: str = "cpu") -> torch.Tensor:
         right_pad = math.ceil(waveform.shape[-1] / self.hop_length) * self.hop_length - waveform.shape[-1]
         left_pad = max(self.n_fft - self.hop_length, 0)
-        waveform = F.pad(waveform, (left_pad, right_pad))
+        waveform = F.pad(waveform.to(device), (left_pad, right_pad))
 
         stft = torch.stft(
             waveform,
@@ -233,7 +233,7 @@ class InklingFeatureExtractor(SequenceFeatureExtractor):
         # padding, which we zero out so it carries `padding_value`.
         num_frames = torch.div(
             padded_inputs.audio_lengths + self.hop_length - 1, self.hop_length, rounding_mode="floor"
-        )
+        ).to(device)
         input_features_mask = torch.arange(input_features.shape[1], device=device)[None, :] < num_frames[:, None]
         input_features = input_features * input_features_mask.unsqueeze(-1)
 

--- a/src/transformers/models/inkling/processing_inkling.py
+++ b/src/transformers/models/inkling/processing_inkling.py
@@ -83,8 +83,9 @@ class InklingProcessor(ProcessorMixin):
         super().__init__(feature_extractor, image_processor, tokenizer, chat_template=chat_template)
 
     def _extract_dmel_bins(self, input_features: "torch.Tensor") -> "torch.Tensor":
-        bin_centers = self.bin_centers.to(input_features.device)
-        mel = input_features.to(torch.float64).clamp(min=self.dmel_min_value, max=self.dmel_max_value)
+        compute_dtype = torch.float32 if input_features.device.type == "mps" else torch.float64
+        bin_centers = self.bin_centers.to(device=input_features.device, dtype=compute_dtype)
+        mel = input_features.to(compute_dtype).clamp(min=self.dmel_min_value, max=self.dmel_max_value)
         return (mel.unsqueeze(-1) - bin_centers).abs().argmin(dim=-1).to(torch.int32)
 
     def _process_audio(self, audio, **kwargs):

--- a/tests/models/inkling/test_processing_inkling.py
+++ b/tests/models/inkling/test_processing_inkling.py
@@ -23,7 +23,14 @@ from parameterized import parameterized
 from safetensors.torch import load_file
 
 from transformers import AutoProcessor, InklingProcessor, is_torch_available
-from transformers.testing_utils import get_tests_dir, require_librosa, require_vision, slow
+from transformers.testing_utils import (
+    get_tests_dir,
+    require_librosa,
+    require_torch_accelerator,
+    require_vision,
+    slow,
+    torch_device,
+)
 from transformers.utils import is_vision_available
 
 from ...test_processing_common import MODALITY_INPUT_DATA, ProcessorTesterMixin
@@ -209,6 +216,7 @@ class InklingProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
 
 @slow
+@require_torch_accelerator
 class InklingProcessingIntegrationTest(unittest.TestCase):
     """
     Check against sglang reference..
@@ -262,22 +270,27 @@ class InklingProcessingIntegrationTest(unittest.TestCase):
         return torch.cat(per_audio, dim=0)
 
     def _assert_matches_sglang(self, case: str, messages: list, has_audio: bool = False):
-        inputs = self.processor.apply_chat_template(
-            messages,
-            add_generation_prompt=True,
-            tokenize=True,
-            return_dict=True,
-            return_tensors="pt",
-        )
         expected = self._load_expected(case)
+        for device in ["cpu", torch_device]:
+            processor_kwargs = {} if device == "cpu" else {"audio_kwargs": {"device": device}}
+            inputs = self.processor.apply_chat_template(
+                messages,
+                add_generation_prompt=True,
+                tokenize=True,
+                return_dict=True,
+                return_tensors="pt",
+                processor_kwargs=processor_kwargs,
+            ).to(device)
 
-        input_ids = inputs["input_ids"][0]
-        expected_input_ids = self._remap_sentinels(expected["input_ids"].to(torch.int64))
-        torch.testing.assert_close(input_ids, expected_input_ids, rtol=0, atol=0)
+            input_ids = inputs["input_ids"][0]
+            expected_input_ids = self._remap_sentinels(expected["input_ids"].to(torch.int64)).to(device)
+            torch.testing.assert_close(input_ids, expected_input_ids, rtol=0, atol=0)
 
-        if has_audio:
-            dmel = self._expected_dmel_from_inputs(inputs)
-            torch.testing.assert_close(dmel, expected["audio_dmel"].to(torch.int32), rtol=0, atol=0)
+            if has_audio:
+                dmel = self._expected_dmel_from_inputs(inputs)
+                torch.testing.assert_close(
+                    dmel, expected["audio_dmel"].to(dtype=torch.int32, device=device), rtol=0, atol=0
+                )
 
     def test_apply_chat_template_text(self):
         messages = [{"role": "user", "content": [{"type": "text", "text": "What is the capital of France?"}]}]


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47392)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47392)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

`InklingProcessor._extract_dmel_bins` (src/transformers/models/inkling/processing_inkling.py) hardcodes `torch.float64` when upcasting `input_features` and creating `bin_centers`. The MPS backend on Apple Silicon does not support float64, so any Inkling audio processing on an MPS device raises:

```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework does not support float64
```

## Fix

Fall back to `float32` on MPS and keep `float64` elsewhere, matching the existing precedent in `whisper/generation_whisper.py:801`:

```python
compute_dtype = torch.float32 if input_features.device.type == "mps" else torch.float64
```

The dMel binning uses 16 bins over the range `[-7.0, 2.0]` — float32 precision is more than sufficient, and the int32 bin indices are identical between the two dtypes (verified on CPU).

## Before submitting

- [x] Did you read the contributor guideline?
- [x] Did you run `make style`?
- [x] Did you run `make typing`?
- [x] Did you run `make fix-repo`?
- [x] Did you run `make check-repo`?
- [x] Did you test your changes locally with `RUN_SLOW=1 pytest tests/models/inkling/test_processing_inkling.py`?

## AI assistance disclosure

The bug diagnosis was AI-assisted; the fix was written, verified, and submitted by me.