### PR TITLE
Fix double-shifted training loss in GitForCausalLM

### DIFF
--- a/src/transformers/models/git/modeling_git.py
+++ b/src/transformers/models/git/modeling_git.py
@@ -1083,11 +1083,12 @@ class GitForCausalLM(GitPreTrainedModel, GenerationMixin):
             # we are doing next-token prediction; shift prediction scores and input ids by one
             num_image_tokens = self.git.encoder.layer[0].attention.self.image_patch_tokens
             shifted_logits = logits[:, num_image_tokens:-1, :].contiguous()
-            labels = labels[:, 1:].contiguous()
+            shift_labels = labels[:, 1:].contiguous()
             loss = self.loss_function(
-                shifted_logits.view(-1, self.config.vocab_size),
-                labels.view(-1),
+                logits=shifted_logits,
+                labels=None,
                 vocab_size=self.config.vocab_size,
+                shift_labels=shift_labels,
                 **kwargs,
             )
 


### PR DESCRIPTION

[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47395)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47395)


# What does this PR do?

`GitForCausalLM.forward` shifts the labels manually and then passes them positionally to `self.loss_function`, so they bind to `labels` and `shift_labels` stays `None`. `ForCausalLMLoss` (`loss_utils.py:61-64`) then shifts a second time, and position `t` is trained to predict token `t + 2`.

Because the manual shift flattens the labels to 1-D before the call, the internal pad-and-slice keeps the shape consistent (`N → N+1 → N`), so nothing raises — and each batch row's final target is silently pulled in from the next row.

This regressed in #35875, which swapped `CrossEntropyLoss` (no shift) for `self.loss_function` (shifts) while leaving the manual shift in place. First released in v4.49.0. Same mechanism as the Moonshine fix in #46784.

Unlike Moonshine, GIT cannot just drop the manual shift: `logits` carries `num_image_tokens` leading image positions that must be sliced off regardless. So this PR passes `shift_labels` explicitly to suppress the internal shift, following the convention already used by `csm` (`modeling_csm.py:619-621`), and keeps the tensors 2-D since `ForCausalLMLoss` flattens them itself — which also removes the cross-row leak.

Verified with the repro from the issue (CPU, no pretrained weights). Before:

```
model loss            : 4.584834575653076
aligned CE (expected) : 4.646134853363037
matches aligned       : False
matches double-shift  : True
row 0 correct targets : [28, 71, 8, 58, 61, 15]
row 0 actual targets  : [71, 8, 58, 61, 15, 19]
row 1 labels          : [19, 42, 30, 58, 94, 67]
```

After:

```
model loss            : 4.646134853363037
aligned CE (expected) : 4.646134853363037
matches aligned       : True
matches double-shift  : False
```

Also checked that the `num_items_in_batch` path used by `Trainer` under gradient accumulation still matches the mean reduction when all targets are valid.

Per review, no model-level regression test is added here — the common test coming from #46903 is expected to cover this. The change is source-only.

```
$ pytest tests/models/git/
189 passed, 297 skipped, 2208 subtests passed
```

`ruff check` and `ruff format --check` (pinned 0.14.10) are clean. No `# Copied from` blocks reference this code and GIT has no modular file, so nothing needs regenerating.

Fixes #47394

Disclosure: this fix was implemented with the assistance of a code agent, per my proposal in the linked issue, and reviewed and validated by me.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue? https://github.com/huggingface/transformers/issues/47394
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@zucchini-nlp