### PR TITLE
Add GGUF loading support for Phi-2 (#33260)

### DIFF
--- a/docs/source/en/gguf.md
+++ b/docs/source/en/gguf.md
@@ -27,7 +27,7 @@ The GGUF format also supports many quantized data types (refer to [quantization 
 Transformers supports loading models stored in the GGUF format for further training or finetuning. The GGUF checkpoint is **dequantized to fp32** where the full model weights are available and compatible with PyTorch.
 
 > [!TIP]
-> Models that support GGUF include Llama, Mistral, Qwen2, Qwen2Moe, Phi3, Bloom, Falcon, StableLM, GPT2, Starcoder2, and [more](https://github.com/huggingface/transformers/blob/main/src/transformers/integrations/ggml.py)
+> Models that support GGUF include Llama, Mistral, Qwen2, Qwen2Moe, Phi3, Phi2, Bloom, Falcon, StableLM, GPT2, Starcoder2, and [more](https://github.com/huggingface/transformers/blob/main/src/transformers/integrations/ggml.py)
 
 Add the `gguf_file` parameter to [`~PreTrainedModel.from_pretrained`] to specify the GGUF file to load.
 

--- a/src/transformers/integrations/ggml.py
+++ b/src/transformers/integrations/ggml.py
@@ -174,6 +174,20 @@ GGUF_CONFIG_MAPPING = {
         "attention.layer_norm_rms_epsilon": "rms_norm_eps",
         "vocab_size": "vocab_size",
     },
+    "phi2": {
+        "context_length": "max_position_embeddings",
+        "block_count": "num_hidden_layers",
+        "feed_forward_length": "intermediate_size",
+        "embedding_length": "hidden_size",
+        # NOTE: rope.dimension_count is turned into partial_rotary_factor in `load_gguf_checkpoint`
+        # since Phi-2 uses partial rotary embeddings.
+        "rope.dimension_count": None,
+        "rope.freq_base": "rope_theta",
+        "attention.head_count": "num_attention_heads",
+        "attention.head_count_kv": "num_key_value_heads",
+        "attention.layer_norm_epsilon": "layer_norm_eps",
+        "vocab_size": "vocab_size",
+    },
     "bloom": {
         "block_count": "n_layer",
         "embedding_length": "hidden_size",
@@ -809,6 +823,7 @@ GGUF_TO_FAST_CONVERTERS = {
     "qwen3": GGUFQwen2Converter,
     "qwen3_moe": GGUFQwen2Converter,
     "phi3": GGUFPhi3Converter,
+    "phi": GGUFGPTConverter,
     "bloom": GGUFGPTConverter,
     "falcon": GGUFGPTConverter,
     "stablelm": GGUFGPTConverter,

--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -453,6 +453,29 @@ class MiniMaxM2TensorProcessor(TensorProcessor):
             out.copy_(torch_weights)
 
 
+class PhiTensorProcessor(TensorProcessor):
+    def __init__(self, config=None):
+        super().__init__(config=config)
+
+    def process(self, weights, name, **kwargs):
+        # Phi-2 GGUF checkpoints store a single fused QKV projection (`attn_qkv`), while
+        # transformers' Phi uses separate `q_proj`, `k_proj` and `v_proj`. Split the fused
+        # weight/bias (concatenated as [q, k, v] along dim 0) and write the three tensors
+        # directly, as there is no 1-to-1 GGUF <-> HF name for them.
+        if ".attn_qkv." in name:
+            tensor_key_mapping = kwargs.get("tensor_key_mapping")
+            parsed_parameters = kwargs.get("parsed_parameters")
+            if tensor_key_mapping is not None and parsed_parameters is not None:
+                prefix, suffix = name.split(".attn_qkv.")
+                q, k, v = np.array_split(weights, 3, axis=0)
+                for sub, part in (("attn_q", q), ("attn_k", k), ("attn_v", v)):
+                    hf_name = tensor_key_mapping.get(f"{prefix}.{sub}.{suffix}")
+                    if hf_name is not None:
+                        parsed_parameters["tensors"][hf_name] = torch.from_numpy(np.copy(part))
+                return GGUFTensor(weights, None, {})
+        return GGUFTensor(weights, name, {})
+
+
 TENSOR_PROCESSORS = {
     "llama": LlamaTensorProcessor,
     "qwen2moe": Qwen2MoeTensorProcessor,
@@ -468,6 +491,7 @@ TENSOR_PROCESSORS = {
     "gemma3": Gemma2TensorProcessor,
     "lfm2": Lfm2TensorProcessor,
     "minimax-m2": MiniMaxM2TensorProcessor,
+    "phi2": PhiTensorProcessor,
 }
 
 
@@ -522,6 +546,8 @@ def get_gguf_hf_weights_map(
         model_type = "minimax-m2"
     elif model_type == "gpt_oss":
         model_type = "gpt-oss"
+    elif model_type == "phi":
+        model_type = "phi2"
     arch = None
     for key, value in MODEL_ARCH_NAMES.items():
         if value == model_type:
@@ -704,6 +730,18 @@ def load_gguf_checkpoint(gguf_checkpoint_path, return_tensors=False, model_to_lo
         # EOG tokens to match generation_config.json: <eos>(1),
         # <|tool_response>(50), <turn|>(106).
         parsed_parameters["config"]["eos_token_id"] = [1, 106, 50]
+
+    # Phi-2 GGUF uses architecture name "phi2" while transformers' model_type is "phi".
+    if parsed_parameters["config"].get("model_type") == "phi2":
+        parsed_parameters["config"]["model_type"] = "phi"
+        # Phi-2 uses partial rotary embeddings. GGUF stores the number of rotary dimensions
+        # (`rope.dimension_count`); transformers expects `partial_rotary_factor = rotary_dim / head_dim`.
+        rope_dims = read_field(reader, "phi2.rope.dimension_count")
+        hidden_size = parsed_parameters["config"].get("hidden_size")
+        num_heads = parsed_parameters["config"].get("num_attention_heads")
+        if rope_dims and hidden_size and num_heads:
+            head_dim = hidden_size // num_heads
+            parsed_parameters["config"]["partial_rotary_factor"] = rope_dims[0] / head_dim
 
     # MiniMax-M2: convert expert_gating_func integer to scoring_func string
     if parsed_parameters["config"].get("model_type") == "minimax_m2":

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -353,8 +353,22 @@ class GgufModelTests(unittest.TestCase):
     q4_k_m_lfm2_model_id = "LFM2-1.2B-Q4_K_M.gguf"
     gpt_oss_model_id = "unsloth/gpt-oss-20b-GGUF"
     gpt_oss_gguf_file = "gpt-oss-20b-Q5_K_M.gguf"
+    phi2_model_id = "TheBloke/phi-2-GGUF"
+    q2_k_phi2_model_id = "phi-2.Q2_K.gguf"
 
     example_text = "Hello"
+
+    def test_phi2_q2_k(self):
+        tokenizer = AutoTokenizer.from_pretrained(self.phi2_model_id, gguf_file=self.q2_k_phi2_model_id)
+        model = AutoModelForCausalLM.from_pretrained(self.phi2_model_id, gguf_file=self.q2_k_phi2_model_id).to(
+            torch_device
+        )
+
+        text = tokenizer(self.example_text, return_tensors="pt").to(torch_device)
+        out = model.generate(**text, max_new_tokens=12, do_sample=False)
+
+        EXPECTED_TEXT = "Hello, my name is John. Nice to meet you.\n"
+        self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
 
     def test_mistral_q4_0(self):
         tokenizer = AutoTokenizer.from_pretrained(self.mistral_model_id, gguf_file=self.q4_0_mistral_model_id)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47400)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47400)
<!-- ci-dashboard-badge:end -->

## What this does

Adds Phi-2 to the architectures supported by GGUF checkpoint loading, following the
protocol in #31175. Addresses a checklist item in #33260 (claimed
[here](https://github.com/huggingface/transformers/issues/33260#issuecomment-5012418261)).

- Map the `phi2` config keys and register the GPT-2 BPE tokenizer converter
  (`integrations/ggml.py`)
- Add `PhiTensorProcessor` to split the fused `attn_qkv` projection into separate
  `q_proj` / `k_proj` / `v_proj` (weight and bias), since transformers' Phi uses
  separate projections
- Remap `phi` -> `phi2` for the gguf-py tensor name map, rename the loaded
  `model_type` `phi2` -> `phi`, and derive `partial_rotary_factor` from
  `rope.dimension_count` (Phi-2 uses partial rotary embeddings)
- Add a Phi-2 integration test and list Phi2 in the GGUF docs

## Testing

```
RUN_SLOW=1 pytest tests/quantization/ggml/test_ggml.py -k test_phi2
```

Verified locally on CPU with `TheBloke/phi-2-GGUF` (`phi-2.Q2_K.gguf`): the checkpoint
loads as `PhiForCausalLM` with `partial_rotary_factor=0.4`, the split q/k/v projections
have the expected shapes, and greedy decoding produces coherent text. The test's
`EXPECTED_TEXT` was generated on CPU (fp32) — please confirm it on a CUDA runner and let
me know if it needs adjusting.

## AI assistance

This change was written with AI assistance (Claude Code) and reviewed line-by-line by me.

cc @SunMarc @LysandreJik @ArthurZucker