### PR TITLE
Raise informative error when a converted checkpoint matches none of the loaded class's weights

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4629,6 +4629,25 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
             # Adjust missing and unexpected keys
             model._adjust_missing_and_unexpected_keys(loading_info)
+            # A checkpoint whose tensors matched (almost) nothing, while weight conversions were
+            # registered, means the checkpoint was loaded through a class its conversion mapping
+            # does not target (e.g. AutoModelForCausalLM on a multimodal layout). The resulting
+            # model is fully randomly initialized yet generates fluently -- fail loudly instead.
+            n_model_keys = len(model.state_dict())
+            if (
+                load_config.weight_mapping
+                and loading_info.unexpected_keys
+                and n_model_keys > 0
+                and len(loading_info.missing_keys) >= 0.99 * n_model_keys
+            ):
+                raise ValueError(
+                    f"None of the checkpoint tensors at '{load_config.pretrained_model_name_or_path}' "
+                    f"matched {model.__class__.__name__} ({len(loading_info.missing_keys)}/{n_model_keys} "
+                    f"model keys missing, {len(loading_info.unexpected_keys)} checkpoint keys unused) even "
+                    f"though weight conversions are registered for this architecture. You are most likely "
+                    f"loading this checkpoint through the wrong class -- load it via the Auto class "
+                    f"registered for its `model_type` instead."
+                )
         finally:
             log_state_dict_report(
                 model=model,

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -3875,4 +3875,55 @@ class RemoteAndCustomCodeModelTests(unittest.TestCase):
         model = MyNewModel(PreTrainedConfig())
 
         self.assertTrue(model.is_custom_code())
+
+
+class TotalMismatchWithConversionsTest(unittest.TestCase):
+    """A converted checkpoint matching ~none of the loaded class's weights must raise (#47405)."""
+
+    def _tiny(self):
+        from transformers import PretrainedConfig, PreTrainedModel  # local: this file lacks PretrainedConfig
+
+        class TinyMismatchConfig(PretrainedConfig):
+            model_type = "tiny_mismatch_test"
+
+        class TinyMismatchModel(PreTrainedModel):
+            config_class = TinyMismatchConfig
+
+            def __init__(self, config):
+                super().__init__(config)
+                self.lin = torch.nn.Linear(4, 4, bias=False)
+                self.post_init()
+
+        return TinyMismatchModel(TinyMismatchConfig())
+
+    def _info(self, model):
+        from transformers.utils.loading_report import LoadStateDictInfo
+
+        return LoadStateDictInfo(
+            missing_keys=set(model.state_dict()),
+            unexpected_keys={"model.llm.some.converted.weight"},
+            mismatched_keys=set(),
+            error_msgs=[],
+            conversion_errors={},
+        )
+
+    def test_total_mismatch_with_conversions_raises(self):
+        from transformers.core_model_loading import WeightRenaming
+        from transformers.modeling_utils import LoadStateDictConfig
+
+        model = self._tiny()
+        cfg = LoadStateDictConfig(
+            pretrained_model_name_or_path="dummy/path",
+            weight_mapping=[WeightRenaming("a", "b")],
+        )
+        with self.assertRaisesRegex(ValueError, "wrong class"):
+            model.__class__._finalize_model_loading(model, cfg, self._info(model))
+
+    def test_total_mismatch_without_conversions_does_not_raise(self):
+        from transformers.modeling_utils import LoadStateDictConfig
+
+        model = self._tiny()
+        cfg = LoadStateDictConfig(pretrained_model_name_or_path="dummy/path", weight_mapping=None)
+        out = model.__class__._finalize_model_loading(model, cfg, self._info(model))
+        self.assertEqual(out.unexpected_keys, {"model.llm.some.converted.weight"})
         self.assertFalse(model.is_remote_code())


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47408)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47408)
<!-- ci-dashboard-badge:end -->

Fixes #47405

**Failure mode:** loading a checkpoint whose architecture has registered weight conversions through a non-matching class (e.g. `AutoModelForCausalLM` on a multimodal layout) currently succeeds silently: zero tensors match, the model is fully randomly initialized, and it *generates fluently* -- sending users into weight-level debugging instead of a one-line class fix.

**Change:** in `_finalize_model_loading`, after `_adjust_missing_and_unexpected_keys`, raise a `ValueError` when weight conversions are registered (`load_config.weight_mapping`), there are unexpected checkpoint keys, and >=99% of the model's keys are missing. The error names both counts and points at the Auto-class fix.

Design notes:
- **Outcome-based predicate** (near-total mismatch + conversions present) rather than probing the checkpoint's `model_type` registry -- covers every route into the failure, and cannot fire on any sane partial load.
- **Raise inside the `try`** so the `finally` still emits the full loading report before the exception -- verified: the MISSING/UNEXPECTED table prints, then the error surfaces.
- **No bypass kwarg**: a ~100%-miss load has no legitimate use, and `ignore_mismatched_sizes` has different semantics (shape mismatches). Happy to add an escape hatch if preferred.

Tests: positive (raises with conversions + total mismatch) and negative control (identical mismatch without conversions does not raise) in `tests/utils/test_modeling_utils.py`.

cc @CyrilVallez @zucchini-nlp

---
_Local `make check-repo` note: the `types` check flags a pre-existing `torch.cat(..., axis=-1)` at `modeling_utils.py:985` on clean main; unrelated to this diff. All ruff/style/consistency checks pass._