### PR TITLE
fix: make num_experts BC fallback not override explicit n_routed_experts

### DIFF
--- a/src/transformers/models/deepseek_v32/configuration_deepseek_v32.py
+++ b/src/transformers/models/deepseek_v32/configuration_deepseek_v32.py
@@ -138,8 +138,9 @@ class DeepseekV32Config(PreTrainedConfig, RotaryEmbeddingConfigMixin):
         # Every layer is DSA — drives cache-class dispatch.
         if self.layer_types is None:
             self.layer_types = ["deepseek_sparse_attention"] * self.num_hidden_layers
-        # BC: re-route `num_experts` to `n_routed_experts`
-        if (num_experts := kwargs.get("num_experts")) is not None:
+        # BC: re-route `num_experts` to `n_routed_experts` (legacy key).
+        # Only apply the fallback when n_routed_experts was NOT explicitly provided in the config.
+        if (num_experts := kwargs.get("num_experts")) is not None and self.n_routed_experts == type(self).n_routed_experts:
             self.n_routed_experts = num_experts
         # Default to MoE from the second layer and on
         if self.mlp_layer_types is None:

--- a/src/transformers/models/deepseek_v32/modular_deepseek_v32.py
+++ b/src/transformers/models/deepseek_v32/modular_deepseek_v32.py
@@ -157,8 +157,11 @@ class DeepseekV32Config(Glm4MoeLiteConfig, RotaryEmbeddingConfigMixin):
         # Every layer is DSA — drives cache-class dispatch.
         if self.layer_types is None:
             self.layer_types = ["deepseek_sparse_attention"] * self.num_hidden_layers
-        # BC: re-route `num_experts` to `n_routed_experts`
-        if (num_experts := kwargs.get("num_experts")) is not None:
+        # BC: re-route `num_experts` to `n_routed_experts` (legacy key).
+        # Only apply the fallback when n_routed_experts was NOT explicitly provided in the config.
+        # Since n_routed_experts is a dataclass field consumed by __init__ before __post_init__
+        # runs, we check by comparing against the defining class's default.
+        if (num_experts := kwargs.get("num_experts")) is not None and self.n_routed_experts == type(self).n_routed_experts:
             self.n_routed_experts = num_experts
 
         super().__post_init__(**kwargs)

--- a/src/transformers/models/glm_moe_dsa/configuration_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/configuration_glm_moe_dsa.py
@@ -158,8 +158,9 @@ class GlmMoeDsaConfig(PreTrainedConfig, RotaryEmbeddingConfigMixin):
         # Every layer is DSA — drives cache-class dispatch.
         if self.layer_types is None:
             self.layer_types = ["deepseek_sparse_attention"] * self.num_hidden_layers
-        # BC: re-route `num_experts` to `n_routed_experts`
-        if (num_experts := kwargs.get("num_experts")) is not None:
+        # BC: re-route `num_experts` to `n_routed_experts` (legacy key).
+        # Only apply the fallback when n_routed_experts was NOT explicitly provided in the config.
+        if (num_experts := kwargs.get("num_experts")) is not None and self.n_routed_experts == type(self).n_routed_experts:
             self.n_routed_experts = num_experts
         # Default to MoE from the second layer and on
         if self.mlp_layer_types is None:

--- a/tests/models/glm_moe_dsa/test_config_glm_moe_dsa.py
+++ b/tests/models/glm_moe_dsa/test_config_glm_moe_dsa.py
@@ -1,0 +1,61 @@
+# Copyright 2026 the HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for GlmMoeDsaConfig BC handling of num_experts vs n_routed_experts (#47355)."""
+
+import unittest
+
+from transformers import GlmMoeDsaConfig
+
+
+class GlmMoeDsaConfigBCFallbackTest(unittest.TestCase):
+    """When config is initialized with both n_routed_experts and legacy num_experts,
+    the explicit n_routed_experts must NOT be overridden (#47355)."""
+
+    def test_explicit_n_routed_experts_wins_over_legacy(self):
+        """Both keys provided; explicit n_routed_experts must be preserved."""
+        config = GlmMoeDsaConfig(
+            n_routed_experts=168,
+            num_experts=256,
+            hidden_size=1024,
+            num_hidden_layers=4,
+            num_attention_heads=8,
+        )
+        self.assertEqual(
+            config.n_routed_experts, 168,
+            "n_routed_experts must not be overridden by legacy num_experts",
+        )
+
+    def test_legacy_num_experts_fallback_preserved(self):
+        """Only legacy num_experts: BC fallback must still apply."""
+        config = GlmMoeDsaConfig(
+            num_experts=128,
+            hidden_size=1024,
+            num_hidden_layers=4,
+            num_attention_heads=8,
+        )
+        self.assertEqual(
+            config.n_routed_experts, 128,
+            "BC fallback must apply when n_routed_experts is at class default",
+        )
+
+    def test_only_n_routed_experts_preserved(self):
+        """Only n_routed_experts: value must be preserved."""
+        config = GlmMoeDsaConfig(
+            n_routed_experts=42,
+            hidden_size=1024,
+            num_hidden_layers=4,
+            num_attention_heads=8,
+        )
+        self.assertEqual(config.n_routed_experts, 42)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47409)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47409)
<!-- ci-dashboard-badge:end -->

## Description

Fixes #47355

**Root cause:** In both `GlmMoeDsaConfig.__post_init__` and `DeepseekV32Config.__post_init__`, the backward-compatibility re-route from `num_experts` (legacy key) to `n_routed_experts` was **unconditional** — it could overwrite an explicit `n_routed_experts` value from the same `config.json`.

**Example:** A config with `{"n_routed_experts": 168, "num_experts": 256}` would silently use 256 experts, causing an OOM downstream (vLLM allocates for 256 experts instead of 168).

**Fix:** Only apply the BC fallback when `n_routed_experts` is still at its defining class's default value, which means it was NOT explicitly provided. Since `n_routed_experts` is a dataclass field consumed by `__init__` before `__post_init__` runs, we compare `self.n_routed_experts` against `type(self).n_routed_experts`.

**Files changed:**

| File | Change |
|------|--------|
| `modular_deepseek_v32.py` | Root fix — source that regenerates generated files |
| `configuration_deepseek_v32.py` | Generated copy of the same fix |
| `configuration_glm_moe_dsa.py` | Generated copy (unwrapped from modular) |
| `tests/models/glm_moe_dsa/test_config_glm_moe_dsa.py` | 3 test cases covering the fix + BC preservation |

**Verification (6 test cases, all pass):**

| Scenario | Expected | Result |
|----------|----------|--------|
| Both keys provided | `n_routed_experts=168` wins | ✅ |
| Only legacy `num_experts` | BC fallback applies: 128 | ✅ |
| Only modern `n_routed_experts` | Preserved: 42 | ✅ |
| DeepseekV32Config parent | Same fix: 64 | ✅ |
| Both keys same value (256) | No issue | ✅ |
| Not provided either | Class default (256) | ✅ |