### PR TITLE
fix: raise hard error when compressed-tensors packed weights cannot be mapped

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4629,6 +4629,25 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
             # Adjust missing and unexpected keys
             model._adjust_missing_and_unexpected_keys(loading_info)
+            # Raise a hard error when compressed-tensors (or similar) packed weights cannot be mapped
+            if load_config.weight_mapping:
+                packed_unexpected = sorted(k for k in loading_info.unexpected_keys if "_packed" in k)
+                if packed_unexpected:
+                    missing_counterparts = sorted(
+                        k for k in packed_unexpected if k.replace("_packed", "") in loading_info.missing_keys
+                    )
+                    if missing_counterparts:
+                        raise ValueError(
+                            "Found unexpected packed weight keys in the checkpoint that could not be mapped to "
+                            "their unpacked counterparts via registered weight conversions. This means the model "
+                            "was silently loaded with randomly initialized weights for the corresponding layers, "
+                            "which produces incorrect outputs. "
+                            f"Unexpected packed keys: {packed_unexpected}. "
+                            f"Missing unpacked keys: {missing_counterparts}. "
+                            "Please ensure the quantizer's weight conversions are properly registered for this "
+                            "model architecture, or load the model with the appropriate quantization "
+                            "configuration (e.g., run_compressed=True if you intend to use compressed-tensors)."
+                        )
         finally:
             log_state_dict_report(
                 model=model,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47410)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47410)
<!-- ci-dashboard-badge:end -->

Closes #47407

When loading a compressed-tensors checkpoint with `run_compressed=False`, packed fused-MoE expert tensors (like `gate_up_proj_packed`) can be UNEXPECTED while their unpacked counterparts (`gate_up_proj`, `down_proj`) are MISSING. On older versions of transformers (e.g., 5.10.x), this causes `from_pretrained` to succeed silently with randomly initialized weights — producing garbage outputs.

This PR adds a check in `_finalize_model_loading` after `_adjust_missing_and_unexpected_keys`: if there are unexpected keys containing `_packed` that have corresponding missing unpacked keys, and weight conversions are registered, we now raise a `ValueError` instead of silently random-initializing the weights.

This prevents the worst failure mode — silent weight corruption behind a "successful" `from_pretrained` — for QAT/recovery-training workflows.