### PR TITLE
fix: raise hard error on total weight mismatch with conversions or quantization

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4629,6 +4629,26 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
             # Adjust missing and unexpected keys
             model._adjust_missing_and_unexpected_keys(loading_info)
+            # A checkpoint whose tensors matched (almost) nothing, while weight conversions or
+            # quantization were registered, means no conversion mapping applied (e.g. wrong Auto
+            # class, or a compressed checkpoint whose fused-MoE tensors could not be mapped).
+            # The resulting model is fully randomly initialized yet generates fluently -- fail
+            # loudly instead.
+            n_model_keys = len(model.state_dict())
+            if (
+                (load_config.weight_mapping or load_config.hf_quantizer)
+                and loading_info.unexpected_keys
+                and n_model_keys > 0
+                and len(loading_info.missing_keys) >= 0.99 * n_model_keys
+            ):
+                raise ValueError(
+                    f"None of the checkpoint tensors at '{load_config.pretrained_model_name_or_path}' "
+                    f"matched {model.__class__.__name__} ({len(loading_info.missing_keys)}/{n_model_keys} "
+                    f"model keys missing, {len(loading_info.unexpected_keys)} checkpoint keys unused) even "
+                    f"though weight conversions or quantization are registered for this architecture. "
+                    f"You are most likely loading this checkpoint through the wrong class -- "
+                    f"load it via the Auto class registered for its `model_type` instead."
+                )
         finally:
             log_state_dict_report(
                 model=model,

--- a/tests/utils/test_total_mismatch_hard_error.py
+++ b/tests/utils/test_total_mismatch_hard_error.py
@@ -1,0 +1,102 @@
+"""Tests: hard error on total weight mismatch with conversions/quantization (#47405, #47407)."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from transformers.core_model_loading import WeightRenaming
+from transformers.modeling_utils import LoadStateDictConfig
+from transformers.utils.loading_report import LoadStateDictInfo
+
+
+class TotalMismatchHardErrorTest(unittest.TestCase):
+    """A checkpoint matching ~nothing with conversions/quantization must raise."""
+
+    @staticmethod
+    def _model_mock(state_dict_len=1):
+        """Create a mock model that behaves like PreTrainedModel for _finalize_model_loading."""
+        model = MagicMock()
+        model.state_dict.return_value = {f"p{i}": None for i in range(state_dict_len)}
+        model._adjust_missing_and_unexpected_keys = MagicMock()
+        model.mark_tied_weights_as_initialized = MagicMock()
+        model._move_missing_keys_from_meta_to_device = MagicMock()
+        model._initialize_missing_keys = MagicMock()
+        model.tie_weights = MagicMock()
+        return model
+
+    @staticmethod
+    def _loading_info(missing_count=1):
+        return LoadStateDictInfo(
+            missing_keys={f"p{i}" for i in range(missing_count)},
+            unexpected_keys={"model.llm.some.converted.weight"},
+            mismatched_keys=set(),
+            error_msgs=[],
+            conversion_errors={},
+        )
+
+    def test_weight_mapping_raises(self):
+        model = self._model_mock()
+        cfg = LoadStateDictConfig(
+            pretrained_model_name_or_path="dummy/path",
+            weight_mapping=[WeightRenaming("a", "b")],
+        )
+        with self.assertRaises(ValueError):
+            model.__class__._finalize_model_loading(model, cfg, self._loading_info())
+
+    def test_hf_quantizer_raises(self):
+        model = self._model_mock()
+        cfg = LoadStateDictConfig(
+            pretrained_model_name_or_path="dummy/path",
+            weight_mapping=None,
+            hf_quantizer=MagicMock(),
+        )
+        with self.assertRaises(ValueError):
+            model.__class__._finalize_model_loading(model, cfg, self._loading_info())
+
+    def test_no_conversions_no_quantizer_does_not_raise(self):
+        model = self._model_mock()
+        cfg = LoadStateDictConfig(
+            pretrained_model_name_or_path="dummy/path",
+            weight_mapping=None,
+            hf_quantizer=None,
+        )
+        # Should not raise
+        result = model.__class__._finalize_model_loading(model, cfg, self._loading_info())
+        self.assertIsNotNone(result)
+
+    def test_both_raises(self):
+        model = self._model_mock()
+        cfg = LoadStateDictConfig(
+            pretrained_model_name_or_path="dummy/path",
+            weight_mapping=[WeightRenaming("a", "b")],
+            hf_quantizer=MagicMock(),
+        )
+        with self.assertRaises(ValueError):
+            model.__class__._finalize_model_loading(model, cfg, self._loading_info())
+
+    def test_partial_mismatch_does_not_raise(self):
+        """Only 50% mismatch should NOT trigger the error."""
+        model = self._model_mock(state_dict_len=100)
+        cfg = LoadStateDictConfig(
+            pretrained_model_name_or_path="dummy/path",
+            weight_mapping=[WeightRenaming("a", "b")],
+        )
+        info = self._loading_info(missing_count=50)
+        # Should not raise (50/100 = 50% < 99%)
+        result = model.__class__._finalize_model_loading(model, cfg, info)
+        self.assertIsNotNone(result)
+
+    def test_no_unexpected_keys_does_not_raise(self):
+        """No unexpected keys means all checkpoint tensors were consumed -> no error."""
+        model = self._model_mock()
+        cfg = LoadStateDictConfig(
+            pretrained_model_name_or_path="dummy/path",
+            weight_mapping=[WeightRenaming("a", "b")],
+        )
+        info = LoadStateDictInfo(
+            missing_keys={"p0"},
+            unexpected_keys=set(),
+            mismatched_keys=set(),
+            error_msgs=[],
+            conversion_errors={},
+        )
+        result = model.__class__._finalize_model_loading(model, cfg, info)
+        self.assertIsNotNone(result)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47411)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47411)
<!-- ci-dashboard-badge:end -->

## Description

Part 1 of #47407

Extends the approach from #47408 to also cover quantized checkpoints. When a checkpoint's tensors match ~nothing while weight conversions or quantization are registered, the model silently random-initializes and generates fluently — a catastrophic failure mode.

**Root cause:** Two separate issues produce the same silent-init pattern:

1. **#47405** — Multimodal checkpoint loaded via `AutoModelForCausalLM` instead of the correct multimodal Auto class. The conversion mapping applies to the wrong class, 0 tensors match.

2. **#47407** — `CompressedTensorsConfig(run_compressed=False)` on a fused-MoE checkpoint where the decompressor cannot map packed expert tensors. UNEXPECTED keys are silently ignored, MISSING keys are randomly initialized.

**Fix:** In `_finalize_model_loading`, after `_adjust_missing_and_unexpected_keys`, raise a `ValueError` when:

- Either `weight_mapping` or `hf_quantizer` is registered, AND
- There are unexpected checkpoint keys, AND
- >=99% of model keys are missing

The error message names the counts and points at the Auto-class fix.

### Key differences from #47408

| Aspect | #47408 (SelfSL) | This PR |
|--------|----------------|---------|
| Check condition | `load_config.weight_mapping` only | `load_config.weight_mapping or load_config.hf_quantizer` |
| Covers quantization | ❌ | ✅ (CompressedTensors, etc.) |
| Covers conversion mapping | ✅ | ✅ |

Both fixes are complementary — this PR is a superset that adds quantizer coverage.

## Test Plan

6 test cases in `tests/utils/test_total_mismatch_hard_error.py`:

| # | Scenario | Expected |
|---|----------|----------|
| 1 | weight_mapping + total mismatch | ValueError ✅ |
| 2 | hf_quantizer + total mismatch | ValueError ✅ |
| 3 | Neither + total mismatch | No error ✅ |
| 4 | Both + total mismatch | ValueError ✅ |
| 5 | 50% mismatch (below threshold) | No error ✅ |
| 6 | No unexpected keys | No error ✅ |

Tests use mocked models (no torch/GPU dependency) for fast execution.