### PR TITLE
fix: Wav2Vec2PhonemeCTCTokenizer.phonemize stale phonemizer_lang

### DIFF
--- a/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
+++ b/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
@@ -256,6 +256,7 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
         word_delimiter = self.word_delimiter_token + " " if self.word_delimiter_token is not None else ""
         if phonemizer_lang is not None and phonemizer_lang != self.phonemizer_lang:
             self.init_backend(phonemizer_lang)
+            self.phonemizer_lang = phonemizer_lang
         else:
             phonemizer_lang = self.phonemizer_lang
 

--- a/tests/models/wav2vec2_phoneme/test_tokenization_wav2vec2_phoneme_fix.py
+++ b/tests/models/wav2vec2_phoneme/test_tokenization_wav2vec2_phoneme_fix.py
@@ -1,0 +1,96 @@
+"""Tests for Wav2Vec2PhonemeCTCTokenizer stale phonemizer_lang bug (#46614)."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from transformers.models.wav2vec2_phoneme.tokenization_wav2vec2_phoneme import (
+    Wav2Vec2PhonemeCTCTokenizer,
+)
+
+
+class Wav2Vec2PhonemeTokenizerTest(unittest.TestCase):
+    """The phonemize() method must update self.phonemizer_lang when switching backends.
+
+    Regression test for #46614: phonemize() re-creates the espeak backend when the
+    requested language differs from self.phonemizer_lang, but never updates
+    self.phonemizer_lang. A subsequent call with the ORIGINAL language skips the
+    backend re-init and uses the wrong (cached) backend.
+    """
+
+    def test_phonemize_updates_phonemizer_lang(self):
+        """After phonemize() switches to a different language, self.phonemizer_lang
+        must reflect the new language so the next switch-back is detected."""
+        tokenizer = Wav2Vec2PhonemeCTCTokenizer.__new__(Wav2Vec2PhonemeCTCTokenizer)
+        # Set minimal required attrs that phonemize reads
+        tokenizer.phonemizer_lang = "en-us"
+        tokenizer._phonemizer_backend = MagicMock()
+        tokenizer._phonemizer_backend.phonemize.return_value = ["dummy"]
+        tokenizer.word_delimiter_token = None
+        tokenizer.phone_delimiter_token = ""
+        tokenizer.do_phonemize = True
+
+        # Mock init_backend so it doesn't actually import phonemizer
+        tokenizer.init_backend = MagicMock()
+
+        # Call phonemize with a different language
+        tokenizer.phonemize("hello", phonemizer_lang="es")
+
+        # self.phonemizer_lang must be updated
+        self.assertEqual(
+            tokenizer.phonemizer_lang, "es",
+            "phonemizer_lang must be updated after switching backends",
+        )
+
+    def test_phonemize_same_language_skips_backend_init(self):
+        """Calling phonemize with the same language must NOT re-init the backend."""
+        tokenizer = Wav2Vec2PhonemeCTCTokenizer.__new__(Wav2Vec2PhonemeCTCTokenizer)
+        tokenizer.phonemizer_lang = "en-us"
+        tokenizer._phonemizer_backend = MagicMock()
+        tokenizer._phonemizer_backend.phonemize.return_value = ["dummy"]
+        tokenizer.word_delimiter_token = None
+        tokenizer.phone_delimiter_token = ""
+        tokenizer.do_phonemize = True
+
+        tokenizer.init_backend = MagicMock()
+
+        # Call with same language
+        tokenizer.phonemize("hello", phonemizer_lang="en-us")
+
+        tokenizer.init_backend.assert_not_called()
+
+    def test_phonemize_different_language_inits_backend(self):
+        """Calling phonemize with a different language MUST re-init the backend."""
+        tokenizer = Wav2Vec2PhonemeCTCTokenizer.__new__(Wav2Vec2PhonemeCTCTokenizer)
+        tokenizer.phonemizer_lang = "en-us"
+        tokenizer._phonemizer_backend = MagicMock()
+        tokenizer._phonemizer_backend.phonemize.return_value = ["dummy"]
+        tokenizer.word_delimiter_token = None
+        tokenizer.phone_delimiter_token = ""
+        tokenizer.do_phonemize = True
+
+        tokenizer.init_backend = MagicMock()
+
+        tokenizer.phonemize("hello", phonemizer_lang="es")
+
+        tokenizer.init_backend.assert_called_once_with("es")
+
+    def test_phonemize_switch_back_and_forth(self):
+        """Switching languages repeatedly must work correctly (#46614 regression)."""
+        tokenizer = Wav2Vec2PhonemeCTCTokenizer.__new__(Wav2Vec2PhonemeCTCTokenizer)
+        tokenizer.phonemizer_lang = "en-us"
+        tokenizer._phonemizer_backend = MagicMock()
+        tokenizer._phonemizer_backend.phonemize.return_value = ["dummy"]
+        tokenizer.word_delimiter_token = None
+        tokenizer.phone_delimiter_token = ""
+        tokenizer.do_phonemize = True
+
+        tokenizer.init_backend = MagicMock()
+
+        # Switch to Spanish
+        tokenizer.phonemize("hola", phonemizer_lang="es")
+        self.assertEqual(tokenizer.phonemizer_lang, "es")
+
+        # Switch back to English - would fail without the fix
+        tokenizer.init_backend.reset_mock()
+        tokenizer.phonemize("hello", phonemizer_lang="en-us")
+        self.assertEqual(tokenizer.phonemizer_lang, "en-us")
+        tokenizer.init_backend.assert_called_once_with("en-us")


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47412)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47412)
<!-- ci-dashboard-badge:end -->

Fixes #46614

## Root cause

`Wav2Vec2PhonemeCTCTokenizer.phonemize()` re-creates the espeak backend when a different language is requested, but **never updates `self.phonemizer_lang`**. On the next call with the ORIGINAL language, the stale comparison sees `"en-us" != "es"` as True (both differ from the stored `self.phonemizer_lang`), so the backend is NOT re-created and the cached Spanish backend phonemizes the English text.

## Fix

One line: `self.phonemizer_lang = phonemizer_lang` after `self.init_backend(phonemizer_lang)`.

`prepare_for_tokenization()` already sets `self.phonemizer_lang` before `init_backend()` and is not affected.

## Tests

4 new test cases in `tests/models/wav2vec2_phoneme/test_tokenization_wav2vec2_phoneme_fix.py`:

| Test | What it checks |
|------|---------------|
| `test_phonemize_updates_phonemizer_lang` | After switching language, `self.phonemizer_lang` reflects the new value |
| `test_phonemize_same_language_skips_backend_init` | Same language does not re-init backend |
| `test_phonemize_different_language_inits_backend` | Different language does re-init backend |
| `test_phonemize_switch_back_and_forth` | Full regression: en → es → en works correctly |

All tests use mocked backends (no phonemizer/espeak dependency).