### PR TITLE
fix: serialize ContinuousBatchingConfig properly instead of null (#47039)

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -468,6 +468,8 @@ class GenerationConfig(PushToHubMixin):
         self.disable_compile = kwargs.pop("disable_compile", None)
 
         self.continuous_batching_config = kwargs.pop("continuous_batching_config", None)
+        if isinstance(self.continuous_batching_config, dict):
+            self.continuous_batching_config = ContinuousBatchingConfig(**self.continuous_batching_config)
 
         # Deprecated (moved to the Hub). TODO remove for v5
         self.low_memory = kwargs.pop("low_memory", None)
@@ -1814,6 +1816,11 @@ class ContinuousBatchingConfig:
     max_cached_graphs: int | None = None
 
     def __post_init__(self):
+        # Rehydrate nested compile configs from dict (round-trip after JSON serialization)
+        if isinstance(self.varlen_compile_config, dict):
+            self.varlen_compile_config = CompileConfig(**self.varlen_compile_config)
+        if isinstance(self.decode_compile_config, dict):
+            self.decode_compile_config = CompileConfig(**self.decode_compile_config)
         # Only turn off graph mixing support if TP is on
         graph_mixing_supported = os.environ.get("NCCL_GRAPH_MIXING_SUPPORT", "1") == "1"
         distributed = int(os.environ.get("WORLD_SIZE", "1")) > 1
@@ -1852,3 +1859,13 @@ class ContinuousBatchingConfig:
     def fallback_max_blocks_per_request(self) -> int:
         """Fallback if no user-hint is given and decode path is available."""
         return 32
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serializes this instance to a Python dictionary."""
+        output = copy.deepcopy(self.__dict__)
+        # If nested compile configs are present, serialize them with their own to_dict()
+        if isinstance(output.get("varlen_compile_config"), CompileConfig):
+            output["varlen_compile_config"] = output["varlen_compile_config"].to_dict()
+        if isinstance(output.get("decode_compile_config"), CompileConfig):
+            output["decode_compile_config"] = output["decode_compile_config"].to_dict()
+        return output

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -22,7 +22,14 @@ import warnings
 from huggingface_hub import create_pull_request
 from parameterized import parameterized
 
-from transformers import AutoConfig, GenerationConfig, WatermarkingConfig, is_torch_available
+from transformers import (
+    AutoConfig,
+    CompileConfig,
+    ContinuousBatchingConfig,
+    GenerationConfig,
+    WatermarkingConfig,
+    is_torch_available,
+)
 from transformers import logging as transformers_logging
 
 
@@ -776,6 +783,41 @@ class GenerationConfigSerializationTest(unittest.TestCase):
         self.assertEqual(watermark.hash_key, hashing_key)
         self.assertEqual(watermark.seeding_scheme, seeding_scheme)
         self.assertEqual(watermark.context_width, context_width)
+
+    def test_serialize_generation_continuous_batching_config(self):
+        """Tests that ContinuousBatchingConfig is properly serialized and rehydrated in GenerationConfig."""
+        continuous_batching_config = ContinuousBatchingConfig(
+            block_size=128,
+            default_compile_level=2,
+            varlen_compile_config=CompileConfig(dynamic=True),
+            decode_compile_config=CompileConfig(mode="default"),
+        )
+        generation_config = GenerationConfig(continuous_batching_config=continuous_batching_config)
+
+        with tempfile.TemporaryDirectory("test-generation-config") as tmp_dir:
+            generation_config.save_pretrained(tmp_dir)
+            new_config = GenerationConfig.from_pretrained(tmp_dir)
+
+        # Verify round-trip: ContinuousBatchingConfig is restored as proper type
+        self.assertIsInstance(new_config.continuous_batching_config, ContinuousBatchingConfig)
+        self.assertEqual(new_config.continuous_batching_config.block_size, 128)
+        self.assertEqual(new_config.continuous_batching_config.default_compile_level, 2)
+
+        # Verify nested CompileConfig rehydration
+        self.assertIsInstance(new_config.continuous_batching_config.varlen_compile_config, CompileConfig)
+        self.assertTrue(new_config.continuous_batching_config.varlen_compile_config.dynamic)
+        self.assertIsInstance(new_config.continuous_batching_config.decode_compile_config, CompileConfig)
+        self.assertEqual(new_config.continuous_batching_config.decode_compile_config.mode, "default")
+
+        # Verify that JSON does not contain null for continuous_batching_config
+        json_str = generation_config.to_json_string(use_diff=False)
+        self.assertNotIn("continuous_batching_config: null", json_str)
+        self.assertIn("continuous_batching_config", json_str)
+        self.assertIn("block_size", json_str)
+
+        # Verify _compile_all_devices is NOT leaked through CompileConfig serialization
+        varlen_dict = new_config.continuous_batching_config.varlen_compile_config.to_dict()
+        self.assertNotIn("_compile_all_devices", varlen_dict)
 
 
 @is_staging_test


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47415)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47415)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47039 — `ContinuousBatchingConfig` was serializing as `null` in `GenerationConfig.to_json_string()` because it lacked a `to_dict()` method and its nested `CompileConfig` fields weren't being rehydrated after JSON round-trip.

## Changes

### `src/transformers/generation/configuration_utils.py`

1. **`ContinuousBatchingConfig.to_dict()`** — New method that serializes the instance to a dict, properly calling `to_dict()` on nested `CompileConfig` fields (`varlen_compile_config`, `decode_compile_config`).

2. **`ContinuousBatchingConfig.__post_init__()`** — Added rehydration of nested `CompileConfig` from dicts (handles the deserialization path after JSON round-trip).

3. **`GenerationConfig.__init__()`** — Added rehydration of `ContinuousBatchingConfig` from dict when a plain dict is passed (e.g., from `from_pretrained` after JSON deserialization).

### `tests/generation/test_configuration_utils.py`

- Added `test_serialize_generation_continuous_batching_config` — Verifies:
  - Round-trip save/load preserves `ContinuousBatchingConfig` type and values
  - Nested `CompileConfig` fields are properly rehydrated
  - JSON output does not contain `continuous_batching_config: null`
  - `_compile_all_devices` is not leaked through `CompileConfig` serialization

## Who can review?

@Rocketknight1 @remi-or