### PR TITLE
fix: handle list input for special_tokens (#47110)

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1173,6 +1173,13 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         if not special_tokens_dict:
             return 0
 
+        if not isinstance(special_tokens_dict, dict):
+            raise TypeError(
+                f"special_tokens_dict must be a dict, got {type(special_tokens_dict).__name__}. "
+                "Expected a dict with keys from SPECIAL_TOKENS_ATTRIBUTES (e.g., 'cls_token', 'sep_token', etc.) "
+                "or 'extra_special_tokens'."
+            )
+
         # V5: Allowed keys are SPECIAL_TOKENS_ATTRIBUTES + "extra_special_tokens"
         # Backward compatibility: convert "additional_special_tokens" to "extra_special_tokens"
         special_tokens_dict = dict(special_tokens_dict)

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1426,6 +1426,12 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         Args:
             special_tokens: Dictionary of {token_name: token_value}
         """
+        if not isinstance(special_tokens, dict):
+            raise TypeError(
+                f"special_tokens must be a dict, got {type(special_tokens).__name__}. "
+                "Expected a dict with keys as token attribute names (e.g., 'image_token') "
+                "and values as str or AddedToken."
+            )
         self.SPECIAL_TOKENS_ATTRIBUTES = self.SPECIAL_TOKENS_ATTRIBUTES + list(special_tokens.keys())
         for key, value in special_tokens.items():
             if isinstance(value, (str, AddedToken)):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47416)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47416)
<!-- ci-dashboard-badge:end -->

## What this PR does

Fixes #47110

Adds a TypeError guard in `add_special_tokens` to handle the case when a list is passed as `special_tokens_dict` instead of a dict. Previously, passing a list would raise a cryptic `'list' object has no attribute 'keys'` (or `ValueError: dictionary update sequence element has length...`). Now it raises a clear TypeError with guidance on the expected format.

## Who can review?

@ArthurZucker @itazap