### PR TITLE
fix: restore fast tokenizer thread-safety (#47085)

### DIFF
--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -19,6 +19,7 @@ see tokenization_utils.py
 import copy
 import json
 import os
+import threading
 from collections import defaultdict
 from collections.abc import Iterable
 from shutil import copyfile
@@ -390,6 +391,10 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         if self._tokenizer is None:
             raise ValueError("The backend tokenizer is not correctly initialized.")
 
+        # Per-instance lock for thread-safe access to the Rust-backed tokenizer.
+        # See https://github.com/huggingface/transformers/issues/47085
+        self._lock = threading.RLock()
+
         _truncation = kwargs.pop("tokenizer_truncation", None) or self._tokenizer.truncation or _json_truncation
         if _truncation is not None:
             self._tokenizer.enable_truncation(**_truncation)
@@ -486,6 +491,18 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         )
         if self._should_update_post_processor:
             self.update_post_processor()
+
+    def __getstate__(self):
+        # ``threading.RLock`` is not picklable, so drop it from the serialized state.
+        # It is reconstructed on unpickle via ``__setstate__``.
+        state = self.__dict__.copy()
+        state.pop("_lock", None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # Reconstruct the per-instance lock (same logic as ``__init__``).
+        self._lock = threading.RLock()
 
     @property
     def is_fast(self) -> bool:
@@ -938,28 +955,32 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 f"batch_text_or_text_pairs has to be a list or a tuple (got {type(batch_text_or_text_pairs)})"
             )
 
-        self.set_truncation_and_padding(
-            padding_strategy=padding_strategy,
-            truncation_strategy=truncation_strategy,
-            max_length=max_length,
-            stride=stride,
-            pad_to_multiple_of=pad_to_multiple_of,
-            padding_side=padding_side,
-        )
+        # Lock the critical section: set_truncation_and_padding (Rust &mut self) +
+        # encode_batch (Rust &self, releases GIL) must be atomic per instance to avoid
+        # ``RuntimeError: Already borrowed`` with concurrent threads (issue #47085).
+        with self._lock:
+            self.set_truncation_and_padding(
+                padding_strategy=padding_strategy,
+                truncation_strategy=truncation_strategy,
+                max_length=max_length,
+                stride=stride,
+                pad_to_multiple_of=pad_to_multiple_of,
+                padding_side=padding_side,
+            )
 
-        # Use self.split_special_tokens as default if not explicitly provided
-        if split_special_tokens is None:
-            split_special_tokens = self.split_special_tokens
+            # Use self.split_special_tokens as default if not explicitly provided
+            if split_special_tokens is None:
+                split_special_tokens = self.split_special_tokens
 
-        if self._tokenizer.encode_special_tokens != split_special_tokens:
-            self._tokenizer.encode_special_tokens = split_special_tokens
+            if self._tokenizer.encode_special_tokens != split_special_tokens:
+                self._tokenizer.encode_special_tokens = split_special_tokens
 
-        # Direct rust backend call
-        encodings = self._tokenizer.encode_batch(
-            batch_text_or_text_pairs,
-            add_special_tokens=add_special_tokens,
-            is_pretokenized=is_split_into_words,
-        )
+            # Direct rust backend call
+            encodings = self._tokenizer.encode_batch(
+                batch_text_or_text_pairs,
+                add_special_tokens=add_special_tokens,
+                is_pretokenized=is_split_into_words,
+            )
 
         # Convert encodings to BatchEncoding format
         tokens_and_encodings = [
@@ -1028,7 +1049,8 @@ class TokenizersBackend(PreTrainedTokenizerBase):
             token_ids = [token_ids]
         if isinstance(token_ids, dict):
             token_ids = token_ids["input_ids"]
-        text = self._tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
+        with self._lock:
+            text = self._tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
 
         clean_up_tokenization_spaces = (
             clean_up_tokenization_spaces

--- a/tests/tokenization/test_tokenization_fast.py
+++ b/tests/tokenization/test_tokenization_fast.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import concurrent.futures
+import copy
 import json
 import os
+import pickle
 import shutil
 import tempfile
 import unittest
@@ -333,19 +335,256 @@ class TokenizerVersioningTest(unittest.TestCase):
 
 @require_tokenizers
 class ReduceMutableBorrowTests(unittest.TestCase):
+    """Thread-safety tests for fast (Rust-backed) tokenizers.
+
+    These tests reproduce the ``RuntimeError: Already borrowed`` race described in
+    https://github.com/huggingface/transformers/issues/47085 and verify that the
+    per-instance ``threading.RLock`` serialises the critical section.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
+        # Build a small WordLevel tokenizer for offline use
+        wl_vocab = {"[UNK]": 0, "[PAD]": 1, "hello": 2, "world": 3, "test": 4, "tokenizer": 5, "thread": 6}
+        wl_dir = os.path.join(cls.tmpdirname, "wordlevel")
+        os.makedirs(wl_dir, exist_ok=True)
+        wl_tokenizer = Tokenizer(WordLevel(wl_vocab, unk_token="[UNK]"))
+        wl_tokenizer.pre_tokenizer = pre_tokenizers.Whitespace()
+        fast_wl = PreTrainedTokenizerFast(
+            tokenizer_object=wl_tokenizer,
+            unk_token="[UNK]",
+            pad_token="[PAD]",
+            cls_token="[CLS]",
+            sep_token="[SEP]",
+            mask_token="[MASK]",
+        )
+        fast_wl.save_pretrained(wl_dir)
+        cls.wordlevel_path = wl_dir
+
+        # Build a small BPE tokenizer for offline use
+        bpe_dir = os.path.join(cls.tmpdirname, "bpe")
+        os.makedirs(bpe_dir, exist_ok=True)
+        bpe = Tokenizer(BPE(unk_token="[UNK]"))
+        trainer = trainers.BpeTrainer(
+            special_tokens=["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"],
+            vocab_size=50,
+        )
+        corpus = [
+            "hello world",
+            "tokenizer thread safety",
+            "test the tokenizer",
+            "fast tokenization",
+            "concurrent encoding",
+        ]
+        bpe.pre_tokenizer = pre_tokenizers.ByteLevel()
+        bpe.train_from_iterator(corpus, trainer=trainer)
+        bpe.decoder = decoders.ByteLevel()
+        fast_bpe = PreTrainedTokenizerFast(
+            tokenizer_object=bpe,
+            unk_token="[UNK]",
+            pad_token="[PAD]",
+            cls_token="[CLS]",
+            sep_token="[SEP]",
+            mask_token="[MASK]",
+        )
+        fast_bpe.save_pretrained(bpe_dir)
+        cls.bpe_path = bpe_dir
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdirname, ignore_errors=True)
+
+    def _encode_with_varying_settings(self, tokenizer, text, seed):
+        """Encode with changing truncation/padding to maximise interleaving."""
+        settings = [
+            {"truncation": True, "padding": False, "max_length": 8},
+            {"truncation": True, "padding": True, "max_length": 16},
+            {"truncation": "longest_first", "padding": "longest", "max_length": 12},
+            {"truncation": False, "padding": "max_length", "max_length": 8},
+            {"truncation": "only_first", "padding": True, "max_length": 10},
+            {"truncation": True, "padding": False, "max_length": 6},
+        ]
+        setting = settings[seed % len(settings)]
+        return tokenizer.encode(text, **setting)
+
+    # ------------------------------------------------------------------
+    # Core race-condition reproduction
+    # ------------------------------------------------------------------
+
     def test_async_share_tokenizer(self):
         # See https://github.com/huggingface/transformers/pull/12550
         # and https://github.com/huggingface/tokenizers/issues/537
-        tokenizer = PreTrainedTokenizerFast.from_pretrained("robot-test/dummy-tokenizer-wordlevel")
-        text = "The Matrix is a 1999 science fiction action film."
+        # Extended for issue #47085: all threads use identical settings.
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(self.wordlevel_path)
+        text = "hello world test tokenizer thread"
+        expected = tokenizer.encode(text, truncation="longest_first", padding="longest")
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = [executor.submit(self.fetch, tokenizer, text) for i in range(10)]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(self.fetch, tokenizer, text) for _ in range(10)]
             return_value = [future.result() for future in futures]
-            self.assertEqual(return_value, [[1, 10, 0, 8, 0, 18, 0, 0, 0, 2] for i in range(10)])
+            self.assertEqual(return_value, [expected for _ in range(10)])
 
     def fetch(self, tokenizer, text):
         return tokenizer.encode(text, truncation="longest_first", padding="longest")
+
+    def test_concurrent_mixed_settings(self):
+        """16 threads, 50 iterations each, varying truncation/padding (original repro)."""
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(self.wordlevel_path)
+        text = "hello world test tokenizer thread safety"
+
+        def worker(tid):
+            for i in range(50):
+                self._encode_with_varying_settings(tokenizer, text, tid * 50 + i)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+            futures = [pool.submit(worker, i) for i in range(16)]
+            for f in concurrent.futures.as_completed(futures, timeout=60):
+                f.result()  # re-raise any exception
+
+    def test_concurrent_encode_with_decode(self):
+        """Interleave encoding and decoding on the same tokenizer."""
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(self.wordlevel_path)
+        texts = ["hello world", "test tokenizer", "thread safety"]
+        encoded = [tokenizer.encode(t) for t in texts]
+
+        def encode_worker():
+            for _ in range(30):
+                for t in texts:
+                    tokenizer.encode(t, truncation=True, padding=True, max_length=8)
+
+        def decode_worker():
+            for _ in range(30):
+                for e in encoded:
+                    tokenizer.decode(e)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            enc_futures = [pool.submit(encode_worker) for _ in range(4)]
+            dec_futures = [pool.submit(decode_worker) for _ in range(4)]
+            for f in concurrent.futures.as_completed(enc_futures + dec_futures, timeout=60):
+                f.result()
+
+    def test_batch_encode_concurrent(self):
+        """Concurrent batch-encoding with varying padding/truncation."""
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(self.wordlevel_path)
+        batch = ["hello world", "test tokenizer", "thread safety is important", "fast tokenization"]
+
+        def worker(tid):
+            for i in range(30):
+                pad = i % 2 == 0
+                trunc = i % 3 == 0
+                kwargs = {}
+                if pad:
+                    kwargs["padding"] = True
+                if trunc:
+                    kwargs["truncation"] = True
+                kwargs["max_length"] = 8 + (i % 4)
+                tokenizer(batch, **kwargs)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=12) as pool:
+            futures = [pool.submit(worker, i) for i in range(12)]
+            for f in concurrent.futures.as_completed(futures, timeout=60):
+                f.result()
+
+    def test_bpe_concurrent_mixed_settings(self):
+        """BPE tokenizer with 16 threads and varying settings."""
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(self.bpe_path)
+        text = "hello world tokenizer thread safety"
+
+        def worker(tid):
+            for i in range(40):
+                self._encode_with_varying_settings(tokenizer, text, tid * 40 + i)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+            futures = [pool.submit(worker, i) for i in range(16)]
+            for f in concurrent.futures.as_completed(futures, timeout=60):
+                f.result()
+
+    def test_multiple_tokenizer_instances(self):
+        """Multiple tokenizer instances should not interfere."""
+        tok1 = PreTrainedTokenizerFast.from_pretrained(self.wordlevel_path)
+        tok2 = PreTrainedTokenizerFast.from_pretrained(self.bpe_path)
+        text = "hello world"
+
+        def worker1():
+            for _ in range(30):
+                tok1.encode(text, truncation=True, padding=True, max_length=8)
+
+        def worker2():
+            for _ in range(30):
+                tok2.encode(text, truncation=True, padding=True, max_length=8)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(worker1) for _ in range(4)] + [pool.submit(worker2) for _ in range(4)]
+            for f in concurrent.futures.as_completed(futures, timeout=60):
+                f.result()
+
+    def test_stress_many_threads_many_iterations(self):
+        """64 threads, 100 iterations, aggressive truncation toggling."""
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(self.wordlevel_path)
+        text = "hello world test tokenizer thread safety concurrent fast tokenization"
+
+        def worker():
+            for i in range(100):
+                trunc = "longest_first" if i % 2 == 0 else "only_first"
+                pad = i % 3 == 0
+                tokenizer.encode(text, truncation=trunc, padding=pad, max_length=8 + (i % 4))
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=64) as pool:
+            futures = [pool.submit(worker) for _ in range(64)]
+            for f in concurrent.futures.as_completed(futures, timeout=120):
+                f.result()
+
+    # ------------------------------------------------------------------
+    # Pickle / deep copy tests — lock must not break serialization
+    # ------------------------------------------------------------------
+
+    def test_pickle_round_trip(self):
+        """pickle.dumps/loads must round-trip and still encode/decode."""
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(self.wordlevel_path)
+        text = "hello world test tokenizer thread safety"
+        expected_ids = tokenizer.encode(text)
+        expected_decoded = tokenizer.decode(expected_ids, skip_special_tokens=True)
+
+        dumped = pickle.dumps(tokenizer)
+        restored = pickle.loads(dumped)
+
+        self.assertEqual(restored.encode(text), expected_ids)
+        self.assertEqual(
+            restored.decode(expected_ids, skip_special_tokens=True),
+            expected_decoded,
+        )
+
+    def test_deepcopy_round_trip(self):
+        """copy.deepcopy must round-trip and still encode/decode."""
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(self.wordlevel_path)
+        text = "hello world test tokenizer"
+        expected_ids = tokenizer.encode(text)
+        expected_decoded = tokenizer.decode(expected_ids, skip_special_tokens=True)
+
+        copied = copy.deepcopy(tokenizer)
+        self.assertEqual(copied.encode(text), expected_ids)
+        self.assertEqual(
+            copied.decode(expected_ids, skip_special_tokens=True),
+            expected_decoded,
+        )
+
+    def test_pickle_does_not_break_thread_safety(self):
+        """After unpickling, concurrent use must still be race-free."""
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(self.wordlevel_path)
+        text = "hello world test tokenizer thread safety concurrent fast tokenization"
+        restored = pickle.loads(pickle.dumps(tokenizer))
+
+        def worker():
+            for i in range(50):
+                trunc = "longest_first" if i % 2 == 0 else "only_first"
+                pad = i % 3 == 0
+                restored.encode(text, truncation=trunc, padding=pad, max_length=8 + (i % 4))
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(worker) for _ in range(8)]
+            for f in concurrent.futures.as_completed(futures, timeout=120):
+                f.result()
 
 
 @require_tokenizers


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47417)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47417)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47085: Fast (Rust-backed) tokenizers are not thread-safe anymore.

## Root cause

`set_truncation_and_padding()` calls `&mut self` methods on the underlying `tokenizers::Tokenizer`, while `encode_batch()` and `decode()` call `&self` methods that release the GIL. When multiple threads share a single `PreTrainedTokenizerFast` instance and one thread is mutating truncation/padding settings while another is encoding, the Rust borrow checker raises `RuntimeError: Already borrowed`.

This fires on nearly every call under concurrent load — ~99.7% error rate with 16 threads in the reporter's reproduction script.

## Fix

Added a per-instance `threading.RLock` that serializes the critical section:

1. **`_encode_plus`** — the entire block from `set_truncation_and_padding` through `encode_batch` is now wrapped in `with self._lock`
2. **`_decode`** — the `self._tokenizer.decode()` call is wrapped in `with self._lock`
3. **Pickle compatibility** — `__getstate__` drops the lock (not picklable), `__setstate__` recreates it on unpickle

The lock is initialized in `__init__` after the tokenizer is validated but before any Rust-side mutation.

## Tests

Extended `ReduceMutableBorrowTests` with 7 new tests:
- `test_concurrent_mixed_settings` — 16 threads × 50 iterations with varying truncation/padding (original repro)
- `test_concurrent_encode_with_decode` — interleaved encoding and decoding on the same tokenizer
- `test_batch_encode_concurrent` — concurrent batch encoding with varying settings
- `test_bpe_concurrent_mixed_settings` — BPE tokenizer with 16 threads
- `test_multiple_tokenizer_instances` — multiple tokenizer instances should not interfere
- `test_stress_many_threads_many_iterations` — 64 threads × 100 iterations
- `test_pickle_round_trip` / `test_deepcopy_round_trip` / `test_pickle_does_not_break_thread_safety` — serialization round-trips preserve thread safety

All tests use offline tokenizers (WordLevel + BPE) built in `setUpClass`, no network calls.

## Before submitting

- [ ] This PR fixes an issue (Fixes: #47085)
- [x] I have ensured code style is correct by running `make style`
- [x] I have included appropriate tests
- [x] I have not modified any generated/modular files