### PR TITLE
fix: remove unreachable return in special token builder

### DIFF
--- a/src/transformers/tokenization_python.py
+++ b/src/transformers/tokenization_python.py
@@ -930,7 +930,6 @@ class PythonBackend(PreTrainedTokenizerBase):
                     f"are not defined (bos_token_id={self.bos_token_id}; eos_token_id={self.eos_token_id})"
                     "Set the required special tokens in tokenizer or update `tokenizer.special_tokens_pattern`"
                 )
-                return token_ids_0 if token_ids_1 is None else token_ids_0 + token_ids_1
 
             if token_ids_1 is None:
                 return [self.bos_token_id] + token_ids_0 + [self.eos_token_id]


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47420)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47420)
<!-- ci-dashboard-badge:end -->

Summary
This PR removes a dead return statement in the bos_eos branch of build_inputs_with_special_tokens. The control flow already exits via the preceding ValueError, so the return was unreachable and misleading.

Changes
Remove the unreachable return statement after the ValueError in the bos_eos branch.
Keep the existing behavior unchanged.

Why
Eliminates dead code.
Makes the control flow easier to read and maintain.
Avoids implying that the branch has a fallback path when it does not.

Testing
Not run, since this change is limited to dead-code removal and does not alter runtime behavior.