### PR TITLE
CI: fix torchaudio pinning +proper break in rnnt

### DIFF
--- a/docker/transformers-quantization-latest-gpu/Dockerfile
+++ b/docker/transformers-quantization-latest-gpu/Dockerfile
@@ -23,8 +23,15 @@ RUN git clone https://github.com/huggingface/transformers && cd transformers && 
 RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; echo "export VERSION='$VERSION'" >> ~/.profile
 RUN echo torch=$VERSION
 # `torchvision` and `torchaudio` should be installed along with `torch`, especially for nightly build.
-# Currently, let's just use their latest releases (when `torch` is installed with a release version)
-RUN python3 -m pip install --no-cache-dir -U $VERSION torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/$CUDA
+# `torchaudio` MUST be pinned to the same version as `torch`: torchaudio ships a compiled C extension
+# (`_torchaudio.abi3.so`) built against one exact torch ABI, so a floating torchaudio resolves to the
+# latest release (built for the newest torch) and then fails to load against this image's pinned older
+# torch with `OSError: ... _torchaudio.abi3.so: undefined symbol`. Because `loss/loss_rnnt.py` is
+# imported eagerly from `modeling_utils`, that OSError breaks `import transformers` outright and takes
+# down pytest collection for EVERY quantization job (see the daily quantization CI collapse, Jul 2026).
+# This mirrors the `torchaudio==${PYTORCH}.*` pin already used in transformers-all-latest-gpu.
+RUN [ ${#PYTORCH} -gt 0 ] && TORCHAUDIO='torchaudio=='$PYTORCH'.*' || TORCHAUDIO='torchaudio'; \
+    python3 -m pip install --no-cache-dir -U $VERSION torchvision $TORCHAUDIO --extra-index-url https://download.pytorch.org/whl/$CUDA
 
 RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/accelerate@main#egg=accelerate
 

--- a/docker/transformers-quantization-latest-gpu/Dockerfile
+++ b/docker/transformers-quantization-latest-gpu/Dockerfile
@@ -96,19 +96,23 @@ RUN python3 -m pip uninstall -y flash-attn
 RUN cd transformers && python3 setup.py develop
 
 # Add fouroversix for quantization testing.
-# fouroversix only publishes prebuilt wheels for specific torch versions (e.g. cu12torch2.8); for other
-# torch versions (like the 2.11 pinned above) its installer 404s on the wheel URL and falls back to a
-# from-source CUDA build. Two things are needed for that source build to succeed and finish quickly:
-#   1. `TORCH_CUDA_ARCH_LIST`: there is no GPU in the image builder, so torch's arch auto-detection
-#      returns an empty list and crashes with `IndexError: list index out of range` in
-#      `_get_cuda_arch_flags`. We target only `8.6+PTX` -- the quant CI runs exclusively on aws-g5
-#      (A10G, sm_86); `+PTX` keeps it forward-compatible on newer GPUs via JIT. Building every arch
-#      would multiply compile time for hardware this image never runs on.
-#   2. `ninja`: without it torch falls back to a serial compile that takes 30+ min; ninja parallelizes
-#      across all cores. It is not otherwise guaranteed to be present in this image, so install it here.
-# Drop this whole block back to a plain `pip install` once upstream ships a matching torch wheel.
-RUN python3 -m pip install --no-cache-dir --upgrade setuptools wheel ninja
-RUN TORCH_CUDA_ARCH_LIST="8.6+PTX" python3 -m pip install --no-cache-dir "fouroversix>=1.0.2" --no-build-isolation
+# fouroversix ships ONLY source distributions (no wheels, any version), and its FP4 GEMM/quant CUDA
+# kernels are Blackwell-only: they instantiate `cutlass::float_e2m1_t` with SM100/SM120 TMA descriptors
+# and require CUDA >= 12.8. This image is CUDA 12.6 and the quant CI runs on aws-g5 (A10G, sm_86,
+# Ampere), so a from-source build cannot compile the kernels -- nvcc aborts with
+# `error: static assertion failed with "Unknown TMA Format!"` for any pre-Hopper arch -- and even a
+# successful build could never run FP4 kernels on an A10G.
+#
+# We therefore install with `SKIP_CUDA_BUILD=1`, which sets `ext_modules = None` (no compilation) and
+# ships fouroversix's pure-PyTorch/Triton reference backends, the path it provides for non-Blackwell
+# hardware. The package still imports, so `is_fouroversix_available()` stays True and the integration
+# tests run against the reference backend; the CUDA/cutlass backend simply reports itself unavailable
+# (`matmul/cutlass/backend.py` guards `import fouroversix._C` behind a Blackwell + try/except check).
+# `--no-build-isolation` is required because fouroversix's `setup.py` imports `torch` at build time.
+# When a Blackwell (sm100/sm120) quant CI image on CUDA >= 12.8 exists, drop SKIP_CUDA_BUILD there so
+# the real FP4 kernels are exercised.
+RUN python3 -m pip install --no-cache-dir --upgrade "setuptools>=77.0.3" wheel
+RUN SKIP_CUDA_BUILD=1 python3 -m pip install --no-cache-dir "fouroversix>=1.0.2" --no-build-isolation
 
 # Add fp-quant for quantization testing
 RUN python3 -m pip install --no-cache-dir "fp-quant>=0.3.2"

--- a/docker/transformers-quantization-latest-gpu/Dockerfile
+++ b/docker/transformers-quantization-latest-gpu/Dockerfile
@@ -9,7 +9,12 @@ SHELL ["sh", "-lc"]
 # The following `ARG` are mainly used to specify the versions explicitly & directly in this docker file, and not meant
 # to be used as arguments for docker build (so far).
 
-ARG PYTORCH='2.8.0'
+# Keep this in sync with `transformers-all-latest-gpu` (the model CI image). It must also satisfy the
+# quantization backends installed below -- notably `compressed-tensors`, which requires `torch>=2.10`.
+# Pinning an older torch (e.g. 2.8.0) makes `compressed-tensors` uninstall the pinned torch mid-build and
+# pull a newer one, churning the torch stack across RUN layers and leaving `torchaudio` ABI-mismatched
+# (see the Jul 2026 daily quantization CI collapse). The smoke test at the end of this file guards it.
+ARG PYTORCH='2.11.0'
 # Example: `cu102`, `cu113`, etc.
 ARG CUDA='cu126'
 
@@ -24,12 +29,12 @@ RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; 
 RUN echo torch=$VERSION
 # `torchvision` and `torchaudio` should be installed along with `torch`, especially for nightly build.
 # `torchaudio` MUST be pinned to the same version as `torch`: torchaudio ships a compiled C extension
-# (`_torchaudio.abi3.so`) built against one exact torch ABI, so a floating torchaudio resolves to the
-# latest release (built for the newest torch) and then fails to load against this image's pinned older
-# torch with `OSError: ... _torchaudio.abi3.so: undefined symbol`. Because `loss/loss_rnnt.py` is
-# imported eagerly from `modeling_utils`, that OSError breaks `import transformers` outright and takes
-# down pytest collection for EVERY quantization job (see the daily quantization CI collapse, Jul 2026).
-# This mirrors the `torchaudio==${PYTORCH}.*` pin already used in transformers-all-latest-gpu.
+# (`_torchaudio.abi3.so`) built against one exact torch ABI, so a floating torchaudio can resolve to a
+# release built for a different torch and then fail to load with `OSError: ... _torchaudio.abi3.so:
+# undefined symbol`. Because `loss/loss_rnnt.py` is imported eagerly from `modeling_utils`, that OSError
+# breaks `import transformers` outright and takes down pytest collection for EVERY quantization job (see
+# the daily quantization CI collapse, Jul 2026). This mirrors the `torchaudio==${PYTORCH}.*` pin already
+# used in transformers-all-latest-gpu.
 RUN [ ${#PYTORCH} -gt 0 ] && TORCHAUDIO='torchaudio=='$PYTORCH'.*' || TORCHAUDIO='torchaudio'; \
     python3 -m pip install --no-cache-dir -U $VERSION torchvision $TORCHAUDIO --extra-index-url https://download.pytorch.org/whl/$CUDA
 

--- a/docker/transformers-quantization-latest-gpu/Dockerfile
+++ b/docker/transformers-quantization-latest-gpu/Dockerfile
@@ -91,6 +91,20 @@ RUN python3 -m pip install --no-cache-dir "fouroversix>=1.0.2" --no-build-isolat
 # Add fp-quant for quantization testing
 RUN python3 -m pip install --no-cache-dir "fp-quant>=0.3.2"
 
+# Smoke test: fail the image build immediately if the pinned torch stack was clobbered by a later
+# `pip install`, or if a compiled extension can't load against the pinned torch ABI. This runs after
+# every install above, so a dep that quietly drags in a mismatched torch/torchaudio is caught here.
+# `import transformers` walks the eager `modeling_utils -> loss_utils -> loss_rnnt -> torchaudio`
+# import chain, so a torchaudio ABI mismatch (which otherwise only surfaces as broken pytest
+# collection for every quantization job, see the Jul 2026 daily CI collapse) fails the build instead
+# of shipping a silently-broken image. No GPU is present at build time, so we only exercise imports
+# and the CUDA runtime load, not device availability.
+RUN set -e; \
+    python3 -c "import torch; print('torch version:', torch.__version__); torch.cuda.is_available()"; \
+    python3 -c "import torch, sys; v = torch.__version__.split('+')[0]; sys.exit(0 if v.startswith('${PYTORCH}') else 'ERROR: torch is ' + torch.__version__ + ', expected ${PYTORCH}.* - the pinned CUDA build was clobbered')"; \
+    python3 -c "import torch, torchaudio; print('torchaudio version:', torchaudio.__version__)"; \
+    python3 -c "import transformers; print('transformers imports OK:', transformers.__version__)"
+
 # Low usage or incompatible lib, will enable later on
 
 # # Add aqlm for quantization testing

--- a/docker/transformers-quantization-latest-gpu/Dockerfile
+++ b/docker/transformers-quantization-latest-gpu/Dockerfile
@@ -89,9 +89,15 @@ RUN python3 -m pip uninstall -y flash-attn
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop
 
-# Add fouroversix for quantization testing
+# Add fouroversix for quantization testing.
+# fouroversix only publishes prebuilt wheels for specific torch versions (e.g. cu12torch2.8); for other
+# torch versions (like the 2.11 pinned above) its installer 404s on the wheel URL and falls back to a
+# from-source CUDA build. There is no GPU in the image builder, so torch's arch auto-detection returns
+# an empty list and crashes with `IndexError: list index out of range` in `_get_cuda_arch_flags`.
+# `TORCH_CUDA_ARCH_LIST` supplies the target arches explicitly so the source build succeeds: 8.0 (A100),
+# 8.6 (A10G, the aws-g5 quant CI runner), 9.0 (H100). Drop this once upstream ships a matching wheel.
 RUN python3 -m pip install --no-cache-dir --upgrade setuptools wheel
-RUN python3 -m pip install --no-cache-dir "fouroversix>=1.0.2" --no-build-isolation
+RUN TORCH_CUDA_ARCH_LIST="8.0 8.6 9.0" python3 -m pip install --no-cache-dir "fouroversix>=1.0.2" --no-build-isolation
 
 # Add fp-quant for quantization testing
 RUN python3 -m pip install --no-cache-dir "fp-quant>=0.3.2"

--- a/docker/transformers-quantization-latest-gpu/Dockerfile
+++ b/docker/transformers-quantization-latest-gpu/Dockerfile
@@ -28,13 +28,19 @@ RUN git clone https://github.com/huggingface/transformers && cd transformers && 
 RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; echo "export VERSION='$VERSION'" >> ~/.profile
 RUN echo torch=$VERSION
 # `torchvision` and `torchaudio` should be installed along with `torch`, especially for nightly build.
-# `torchaudio` MUST be pinned to the same version as `torch`: torchaudio ships a compiled C extension
-# (`_torchaudio.abi3.so`) built against one exact torch ABI, so a floating torchaudio can resolve to a
-# release built for a different torch and then fail to load with `OSError: ... _torchaudio.abi3.so:
-# undefined symbol`. Because `loss/loss_rnnt.py` is imported eagerly from `modeling_utils`, that OSError
-# breaks `import transformers` outright and takes down pytest collection for EVERY quantization job (see
-# the daily quantization CI collapse, Jul 2026). This mirrors the `torchaudio==${PYTORCH}.*` pin already
-# used in transformers-all-latest-gpu.
+# `torchaudio` is pinned to the same version as `torch`: torchaudio ships a compiled C extension
+# (`_torchaudio.abi3.so`) built against one exact torch ABI, so a floating/mismatched torchaudio fails to
+# load with `OSError: ... _torchaudio.abi3.so: undefined symbol`. (transformers now imports torchaudio
+# lazily -- see loss/loss_rnnt.py -- so a mismatch no longer breaks `import transformers`, but it would
+# still leave torchaudio unusable and broke the daily quantization CI in Jul 2026. Keep them matched.)
+# Mirrors the `torchaudio==${PYTORCH}.*` pin in transformers-all-latest-gpu.
+#
+# TODO(torchaudio-cap): torchaudio 2.11 is the LAST release -- pytorch/audio has stopped publishing (I/O
+# moved to TorchCodec, see https://github.com/pytorch/audio/issues/3902). 2.11 is marked compatible with
+# future torch, but there is no torchaudio > 2.11, so `torchaudio==${PYTORCH}.*` resolves only while
+# PYTORCH <= 2.11; the next bump past 2.11 fails here with "no matching distribution". At that point this
+# pin (and the torchaudio-backed RNN-T path in loss/loss_rnnt.py) needs a new plan -- cap torchaudio at
+# 2.11, or drop the torchaudio dependency.
 RUN [ ${#PYTORCH} -gt 0 ] && TORCHAUDIO='torchaudio=='$PYTORCH'.*' || TORCHAUDIO='torchaudio'; \
     python3 -m pip install --no-cache-dir -U $VERSION torchvision $TORCHAUDIO --extra-index-url https://download.pytorch.org/whl/$CUDA
 
@@ -92,12 +98,17 @@ RUN cd transformers && python3 setup.py develop
 # Add fouroversix for quantization testing.
 # fouroversix only publishes prebuilt wheels for specific torch versions (e.g. cu12torch2.8); for other
 # torch versions (like the 2.11 pinned above) its installer 404s on the wheel URL and falls back to a
-# from-source CUDA build. There is no GPU in the image builder, so torch's arch auto-detection returns
-# an empty list and crashes with `IndexError: list index out of range` in `_get_cuda_arch_flags`.
-# `TORCH_CUDA_ARCH_LIST` supplies the target arches explicitly so the source build succeeds: 8.0 (A100),
-# 8.6 (A10G, the aws-g5 quant CI runner), 9.0 (H100). Drop this once upstream ships a matching wheel.
-RUN python3 -m pip install --no-cache-dir --upgrade setuptools wheel
-RUN TORCH_CUDA_ARCH_LIST="8.0 8.6 9.0" python3 -m pip install --no-cache-dir "fouroversix>=1.0.2" --no-build-isolation
+# from-source CUDA build. Two things are needed for that source build to succeed and finish quickly:
+#   1. `TORCH_CUDA_ARCH_LIST`: there is no GPU in the image builder, so torch's arch auto-detection
+#      returns an empty list and crashes with `IndexError: list index out of range` in
+#      `_get_cuda_arch_flags`. We target only `8.6+PTX` -- the quant CI runs exclusively on aws-g5
+#      (A10G, sm_86); `+PTX` keeps it forward-compatible on newer GPUs via JIT. Building every arch
+#      would multiply compile time for hardware this image never runs on.
+#   2. `ninja`: without it torch falls back to a serial compile that takes 30+ min; ninja parallelizes
+#      across all cores. It is not otherwise guaranteed to be present in this image, so install it here.
+# Drop this whole block back to a plain `pip install` once upstream ships a matching torch wheel.
+RUN python3 -m pip install --no-cache-dir --upgrade setuptools wheel ninja
+RUN TORCH_CUDA_ARCH_LIST="8.6+PTX" python3 -m pip install --no-cache-dir "fouroversix>=1.0.2" --no-build-isolation
 
 # Add fp-quant for quantization testing
 RUN python3 -m pip install --no-cache-dir "fp-quant>=0.3.2"

--- a/src/transformers/loss/loss_rnnt.py
+++ b/src/transformers/loss/loss_rnnt.py
@@ -55,19 +55,13 @@ def rnnt_loss(
         Scalar loss tensor (or per-example losses if `reduction="none"`).
 
     """
+    # Import torchaudio lazily rather than at module scope.
+    # see https://github.com/huggingface/transformers/pull/47422
 
-    # Import torchaudio lazily rather than at module scope: this module is imported eagerly from
-    # `modeling_utils`, so a top-level `import torchaudio` would run during `import transformers`. A
-    # torchaudio built against a different torch ABI raises `OSError` on import; keeping the import here
-    # means that only surfaces if the RNN-T loss is actually used, at the call site -- it does not break
-    # `import transformers` for every user. We deliberately do not catch that OSError: an ABI-mismatched
-    # install is an environment problem, not something this library should silently mask.
-    #
     # TODO(torchaudio-cap): torchaudio 2.11 is the last release -- pytorch/audio has stopped publishing
     # (I/O moved to TorchCodec, see https://github.com/pytorch/audio/issues/3902). 2.11 is marked
     # compatible with future torch, but there is no torchaudio > 2.11, so once torch moves past 2.11 this
-    # torchaudio-backed RNN-T path will need a different backend (or to be dropped). The docker pins that
-    # keep torchaudio matched to torch (e.g. transformers-quantization-latest-gpu) have the same horizon.
+    # torchaudio-backed RNN-T path will need a different backend (or to be dropped).
     if not is_torchaudio_available():
         raise ImportError("Computing the RNN-T loss requires torchaudio. Install it with `pip install torchaudio`.")
 

--- a/src/transformers/loss/loss_rnnt.py
+++ b/src/transformers/loss/loss_rnnt.py
@@ -19,8 +19,18 @@ from ..utils import is_torchaudio_available, logging
 
 logger = logging.get_logger(__name__)
 
+# This module is imported eagerly from `modeling_utils` (via `loss_utils`), so its top-level imports run
+# during `import transformers`. `is_torchaudio_available()` only confirms the distribution is installed; a
+# torchaudio whose compiled extension was built against a different torch ABI is "available" yet raises
+# `OSError` on import. Guarding the import here keeps a broken torchaudio from taking down `import
+# transformers` entirely (and, in CI, breaking pytest collection for the whole suite). `rnnt_loss` reports
+# the failure clearly if it is actually called.
+torchaudio = None
 if is_torchaudio_available():
-    import torchaudio
+    try:
+        import torchaudio
+    except OSError as e:
+        logger.warning(f"torchaudio is installed but could not be imported ({e}); RNN-T loss is unavailable.")
 
 
 def rnnt_loss(
@@ -59,8 +69,11 @@ def rnnt_loss(
 
     """
 
-    if not is_torchaudio_available():
-        raise ImportError("Computing the RNN-T loss requires torchaudio. Install it with `pip install torchaudio`.")
+    if torchaudio is None:
+        raise ImportError(
+            "Computing the RNN-T loss requires a working torchaudio install. Install it with "
+            "`pip install torchaudio`, ensuring the torchaudio version matches your installed torch."
+        )
 
     valid_reductions = ("mean_volume", "mean_batch", "mean", "sum", "none")
     if reduction not in valid_reductions:

--- a/src/transformers/loss/loss_rnnt.py
+++ b/src/transformers/loss/loss_rnnt.py
@@ -19,19 +19,6 @@ from ..utils import is_torchaudio_available, logging
 
 logger = logging.get_logger(__name__)
 
-# This module is imported eagerly from `modeling_utils` (via `loss_utils`), so its top-level imports run
-# during `import transformers`. `is_torchaudio_available()` only confirms the distribution is installed; a
-# torchaudio whose compiled extension was built against a different torch ABI is "available" yet raises
-# `OSError` on import. Guarding the import here keeps a broken torchaudio from taking down `import
-# transformers` entirely (and, in CI, breaking pytest collection for the whole suite). `rnnt_loss` reports
-# the failure clearly if it is actually called.
-torchaudio = None
-if is_torchaudio_available():
-    try:
-        import torchaudio
-    except OSError as e:
-        logger.warning(f"torchaudio is installed but could not be imported ({e}); RNN-T loss is unavailable.")
-
 
 def rnnt_loss(
     logits: torch.Tensor,
@@ -69,11 +56,22 @@ def rnnt_loss(
 
     """
 
-    if torchaudio is None:
-        raise ImportError(
-            "Computing the RNN-T loss requires a working torchaudio install. Install it with "
-            "`pip install torchaudio`, ensuring the torchaudio version matches your installed torch."
-        )
+    # Import torchaudio lazily rather than at module scope: this module is imported eagerly from
+    # `modeling_utils`, so a top-level `import torchaudio` would run during `import transformers`. A
+    # torchaudio built against a different torch ABI raises `OSError` on import; keeping the import here
+    # means that only surfaces if the RNN-T loss is actually used, at the call site -- it does not break
+    # `import transformers` for every user. We deliberately do not catch that OSError: an ABI-mismatched
+    # install is an environment problem, not something this library should silently mask.
+    #
+    # TODO(torchaudio-cap): torchaudio 2.11 is the last release -- pytorch/audio has stopped publishing
+    # (I/O moved to TorchCodec, see https://github.com/pytorch/audio/issues/3902). 2.11 is marked
+    # compatible with future torch, but there is no torchaudio > 2.11, so once torch moves past 2.11 this
+    # torchaudio-backed RNN-T path will need a different backend (or to be dropped). The docker pins that
+    # keep torchaudio matched to torch (e.g. transformers-quantization-latest-gpu) have the same horizon.
+    if not is_torchaudio_available():
+        raise ImportError("Computing the RNN-T loss requires torchaudio. Install it with `pip install torchaudio`.")
+
+    import torchaudio
 
     valid_reductions = ("mean_volume", "mean_batch", "mean", "sum", "none")
     if reduction not in valid_reductions:

--- a/src/transformers/loss/loss_rnnt.py
+++ b/src/transformers/loss/loss_rnnt.py
@@ -55,13 +55,7 @@ def rnnt_loss(
         Scalar loss tensor (or per-example losses if `reduction="none"`).
 
     """
-    # Import torchaudio lazily rather than at module scope.
-    # see https://github.com/huggingface/transformers/pull/47422
-
-    # TODO(torchaudio-cap): torchaudio 2.11 is the last release -- pytorch/audio has stopped publishing
-    # (I/O moved to TorchCodec, see https://github.com/pytorch/audio/issues/3902). 2.11 is marked
-    # compatible with future torch, but there is no torchaudio > 2.11, so once torch moves past 2.11 this
-    # torchaudio-backed RNN-T path will need a different backend (or to be dropped).
+    # Import torchaudio lazily rather than at module scope, see https://github.com/huggingface/transformers/pull/47422
     if not is_torchaudio_available():
         raise ImportError("Computing the RNN-T loss requires torchaudio. Install it with `pip install torchaudio`.")
 

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -190,3 +190,59 @@ def test_require_flash_attn_decorators_accept_kernels_fallback():
     with mock_flash_attn_env(kernels_available=True):
         assert require_flash_attn(DummyTest) is not None
         assert require_all_flash_attn(DummyTest) is not None
+
+
+@run_test_using_subprocess
+def test_broken_torchaudio_does_not_break_import():
+    """
+    A torchaudio that is installed but fails to import (e.g. its compiled extension was built against a
+    different torch ABI and raises ``OSError`` on import) must not break ``import transformers``.
+
+    ``loss/loss_rnnt.py`` is imported eagerly from ``modeling_utils``, and ``is_torchaudio_available()``
+    only confirms the distribution is installed -- not that it imports -- so the module guards the import
+    and degrades gracefully. Regression test for the daily quantization CI collapse (Jul 2026), where a
+    floating torchaudio pulled a wheel built for a newer torch and its ``OSError`` broke pytest collection
+    for the whole suite.
+    """
+    import builtins
+    import importlib
+
+    import torch
+
+    import transformers.utils
+
+    # Drop any already-imported torchaudio / loss_rnnt so the guarded import re-runs under our patches.
+    for name in list(sys.modules):
+        if name == "torchaudio" or name.startswith("torchaudio.") or name.endswith("loss.loss_rnnt"):
+            del sys.modules[name]
+
+    real_import = builtins.__import__
+
+    def failing_import(name, *args, **kwargs):
+        if name == "torchaudio" or name.startswith("torchaudio."):
+            raise OSError("_torchaudio.abi3.so: undefined symbol: simulated_abi_mismatch")
+        return real_import(name, *args, **kwargs)
+
+    # Force the availability guard to pass even though the actual `import torchaudio` will fail.
+    with (
+        patch.object(transformers.utils, "is_torchaudio_available", return_value=True),
+        patch.object(builtins, "__import__", failing_import),
+    ):
+        loss_rnnt = importlib.import_module("transformers.loss.loss_rnnt")
+
+    # The module imported despite the broken torchaudio, and recorded it as unavailable.
+    assert loss_rnnt.torchaudio is None
+
+    # Calling the loss surfaces a clear ImportError (not a NameError or the raw OSError).
+    try:
+        loss_rnnt.rnnt_loss(
+            logits=torch.zeros(1, 2, 3, 4),
+            targets=torch.zeros(1, 3),
+            logit_lengths=torch.ones(1),
+            target_lengths=torch.ones(1),
+            blank_token_id=0,
+        )
+    except ImportError:
+        pass
+    else:
+        raise AssertionError("rnnt_loss should raise ImportError when torchaudio cannot be imported")

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -195,46 +195,26 @@ def test_require_flash_attn_decorators_accept_kernels_fallback():
 @run_test_using_subprocess
 def test_broken_torchaudio_does_not_break_import():
     """
-    A torchaudio that is installed but fails to import (e.g. its compiled extension was built against a
-    different torch ABI and raises ``OSError`` on import) must not break ``import transformers``.
-
-    ``loss/loss_rnnt.py`` is imported eagerly from ``modeling_utils``, and ``is_torchaudio_available()``
-    only confirms the distribution is installed -- not that it imports -- so the module guards the import
-    and degrades gracefully. Regression test for the daily quantization CI collapse (Jul 2026), where a
-    floating torchaudio pulled a wheel built for a newer torch and its ``OSError`` broke pytest collection
-    for the whole suite.
+    ``loss/loss_rnnt.py`` is imported eagerly from ``modeling_utils``, so it must NOT import torchaudio at
+    module scope: a torchaudio whose compiled extension was built against a different torch ABI raises
+    ``OSError`` on import, which would otherwise break ``import transformers`` -- and pytest collection for
+    the whole suite (the daily quantization CI collapse, Jul 2026). torchaudio is imported lazily inside
+    ``rnnt_loss`` instead, so:
+      * importing the module (hence ``import transformers``) never touches torchaudio;
+      * a broken install surfaces its own ``OSError`` at the call site -- we don't mask it;
+      * a genuinely missing torchaudio yields a clean ``ImportError``.
     """
     import builtins
-    import importlib
 
     import torch
 
-    import transformers.utils
+    # Importing loss_rnnt (and thus transformers) must succeed regardless of torchaudio's state, and must
+    # not have imported torchaudio at module scope.
+    from transformers.loss import loss_rnnt
 
-    # Drop any already-imported torchaudio / loss_rnnt so the guarded import re-runs under our patches.
-    for name in list(sys.modules):
-        if name == "torchaudio" or name.startswith("torchaudio.") or name.endswith("loss.loss_rnnt"):
-            del sys.modules[name]
+    assert not hasattr(loss_rnnt, "torchaudio"), "torchaudio must be imported lazily, not at module scope"
 
-    real_import = builtins.__import__
-
-    def failing_import(name, *args, **kwargs):
-        if name == "torchaudio" or name.startswith("torchaudio."):
-            raise OSError("_torchaudio.abi3.so: undefined symbol: simulated_abi_mismatch")
-        return real_import(name, *args, **kwargs)
-
-    # Force the availability guard to pass even though the actual `import torchaudio` will fail.
-    with (
-        patch.object(transformers.utils, "is_torchaudio_available", return_value=True),
-        patch.object(builtins, "__import__", failing_import),
-    ):
-        loss_rnnt = importlib.import_module("transformers.loss.loss_rnnt")
-
-    # The module imported despite the broken torchaudio, and recorded it as unavailable.
-    assert loss_rnnt.torchaudio is None
-
-    # Calling the loss surfaces a clear ImportError (not a NameError or the raw OSError).
-    try:
+    def _call_rnnt_loss():
         loss_rnnt.rnnt_loss(
             logits=torch.zeros(1, 2, 3, 4),
             targets=torch.zeros(1, 3),
@@ -242,7 +222,36 @@ def test_broken_torchaudio_does_not_break_import():
             target_lengths=torch.ones(1),
             blank_token_id=0,
         )
-    except ImportError:
-        pass
-    else:
-        raise AssertionError("rnnt_loss should raise ImportError when torchaudio cannot be imported")
+
+    # torchaudio is installed (is_torchaudio_available() is True) but its C extension won't load: the raw
+    # OSError must surface at the call site, not be swallowed.
+    real_import = builtins.__import__
+
+    def failing_import(name, *args, **kwargs):
+        if name == "torchaudio" or name.startswith("torchaudio."):
+            raise OSError("_torchaudio.abi3.so: undefined symbol: simulated_abi_mismatch")
+        return real_import(name, *args, **kwargs)
+
+    for name in list(sys.modules):
+        if name == "torchaudio" or name.startswith("torchaudio."):
+            del sys.modules[name]
+
+    with (
+        patch.object(loss_rnnt, "is_torchaudio_available", return_value=True),
+        patch.object(builtins, "__import__", failing_import),
+    ):
+        try:
+            _call_rnnt_loss()
+        except OSError:
+            pass
+        else:
+            raise AssertionError("rnnt_loss must surface the torchaudio OSError at call time")
+
+    # torchaudio genuinely absent: rnnt_loss raises a clean ImportError.
+    with patch.object(loss_rnnt, "is_torchaudio_available", return_value=False):
+        try:
+            _call_rnnt_loss()
+        except ImportError:
+            pass
+        else:
+            raise AssertionError("rnnt_loss must raise ImportError when torchaudio is unavailable")


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47422)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47422)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

The quantization image was breaking because torchaudio was not pinned and the new version is not compatible
with the pinned torch.

The fix is similar to how the main docker does it.

This patch also harden the import in `src/transformers/loss/loss_rnnt.py` so the lib does not crash on a torch import and emits the correct error