### PR TITLE
Fix multi-device mxfp4 dequantization race in `_convert_moe_packed_tensors`

### DIFF
--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -288,18 +288,22 @@ def _convert_moe_packed_tensors(
         exp = scales[r0:r1]
         sub = out[r0:r1]
 
-        # This vector is only used to index into `lut`, but is hugeee in GPU memory so we delete it immediately
-        idx_lo = (blk & 0x0F).to(torch.int)
-        sub[:, 0::2] = lut[idx_lo]
-        del idx_lo
+        # XPU workaround: with device_map="auto", tensors on a non-current XPU device are not
+        # ordered after their async H2D copy, so the compute below may read garbage and emit
+        # out-of-bounds `lut` indices. Aligning the active device orders it (no-op on CUDA/CPU).
+        with on_device(blk.device):
+            # This vector is only used to index into `lut`, but is hugeee in GPU memory so we delete it immediately
+            idx_lo = (blk & 0x0F).to(torch.int)
+            sub[:, 0::2] = lut[idx_lo]
+            del idx_lo
 
-        # This vector is only used to index into `lut`, but is hugeee in GPU memory so we delete it immediately
-        idx_hi = (blk >> 4).to(torch.int)
-        sub[:, 1::2] = lut[idx_hi]
-        del idx_hi
+            # This vector is only used to index into `lut`, but is hugeee in GPU memory so we delete it immediately
+            idx_hi = (blk >> 4).to(torch.int)
+            sub[:, 1::2] = lut[idx_hi]
+            del idx_hi
 
-        # Perform op
-        torch.ldexp(sub, exp, out=sub)
+            # Perform op
+            torch.ldexp(sub, exp, out=sub)
         del blk, exp, sub
 
     out = out.reshape(*prefix_shape, G, B * 2).view(*prefix_shape, G * B * 2)

--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -288,9 +288,10 @@ def _convert_moe_packed_tensors(
         exp = scales[r0:r1]
         sub = out[r0:r1]
 
-        # XPU workaround: with device_map="auto", tensors on a non-current XPU device are not
+        # With device_map="auto", tensors sitting on a non-current accelerator device are not
         # ordered after their async H2D copy, so the compute below may read garbage and emit
-        # out-of-bounds `lut` indices. Aligning the active device orders it (no-op on CUDA/CPU).
+        # out-of-bounds `lut` indices (illegal memory access on CUDA, indexing abort on XPU).
+        # Aligning the active device with the tensor's device orders it correctly (no-op on CPU).
         with on_device(blk.device):
             # This vector is only used to index into `lut`, but is hugeee in GPU memory so we delete it immediately
             idx_lo = (blk & 0x0F).to(torch.int)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47423)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47423)
<!-- ci-dashboard-badge:end -->

When loading an mxfp4 model (e.g. openai/gpt-oss-20b) with device_map="auto" across multiple Intel XPUs and use_kernels=True, loading aborts during dequantization: 
```
torch-xpu-ops/.../Indexing.h:622: Assertion `index >= -sizes_[i] && index < sizes_[i] && "index out of bounds"` failed.
```
Root cause: 
the multi-threaded weight loader copies each shard to its target device; for a tensor on a non-current XPU device (e.g. xpu:1 while the active device is xpu:0), the subsequent blk & 0x0F compute is not ordered after that copy, reads not-yet-valid memory, and produces out-of-bounds lut indices. Instrumentation confirmed idx_lo on xpu:1 goes 0–15 → 0–255 → garbage [-2147483648, 2139160448], while xpu:0 is always correct.

Fix:
wrap the per-chunk dequant compute in the tensor's own XPU device context with `on_device` context manager. Verified: load + generation of gpt-oss-20b across XPUs now succeeds; no assertions.

Pls help review, thx! @SunMarc @IlyasMoutawwakil