### PR TITLE
Hoist special-token lookups out of per-token loops in six slow tokenizers

### DIFF
--- a/src/transformers/models/esm/tokenization_esm.py
+++ b/src/transformers/models/esm/tokenization_esm.py
@@ -125,7 +125,8 @@ class EsmTokenizer(PreTrainedTokenizer):
                     "ids is already formatted with special tokens for the model."
                 )
 
-            return [1 if token in self.all_special_ids else 0 for token in token_ids_0]
+            all_special_ids = set(self.all_special_ids)
+            return [1 if token in all_special_ids else 0 for token in token_ids_0]
         mask = [1] + ([0] * len(token_ids_0)) + [1]
         if token_ids_1 is not None:
             mask += [0] * len(token_ids_1) + [1]

--- a/src/transformers/models/gpt_sw3/tokenization_gpt_sw3.py
+++ b/src/transformers/models/gpt_sw3/tokenization_gpt_sw3.py
@@ -168,12 +168,13 @@ class GPTSw3Tokenizer(SentencePieceBackend):
 
     def convert_tokens_to_string(self, tokens: list[str]) -> str:
         """Converts a sequence of tokens (strings) to a single string. Special tokens remain intact."""
+        all_special_tokens = set(self.all_special_tokens)
         current_sub_tokens = []
         out_string = ""
         prev_is_special = False
         for token in tokens:
             # make sure that special tokens are not decoded using sentencepiece model
-            if token in self.all_special_tokens:
+            if token in all_special_tokens:
                 # TODO: Check if this is needed, as it ensures that decode(encode(doc)) != doc by adding extra whitespace in the decoded document
                 if not prev_is_special:
                     out_string += " "

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -209,11 +209,12 @@ class M2M100Tokenizer(PreTrainedTokenizer):
 
     def convert_tokens_to_string(self, tokens):
         """Converts a sequence of tokens (string) in a single string."""
+        all_special_tokens = set(self.all_special_tokens)
         current_sub_tokens = []
         out_string = ""
         for token in tokens:
             # make sure that special tokens are not decoded using sentencepiece model
-            if token in self.all_special_tokens:
+            if token in all_special_tokens:
                 out_string += self.sp_model.decode(current_sub_tokens) + token
                 current_sub_tokens = []
             else:

--- a/src/transformers/models/marian/tokenization_marian.py
+++ b/src/transformers/models/marian/tokenization_marian.py
@@ -278,11 +278,12 @@ class MarianTokenizer(PreTrainedTokenizer):
     def convert_tokens_to_string(self, tokens: list[str]) -> str:
         """Uses source spm if _decode_use_source_tokenizer is True, and target spm otherwise"""
         sp_model = self.spm_source if self._decode_use_source_tokenizer else self.spm_target
+        all_special_tokens = set(self.all_special_tokens)
         current_sub_tokens = []
         out_string = ""
         for token in tokens:
             # make sure that special tokens are not decoded using sentencepiece model
-            if token in self.all_special_tokens:
+            if token in all_special_tokens:
                 out_string += sp_model.decode_pieces(current_sub_tokens) + token + " "
                 current_sub_tokens = []
             else:

--- a/src/transformers/models/siglip/tokenization_siglip.py
+++ b/src/transformers/models/siglip/tokenization_siglip.py
@@ -314,12 +314,13 @@ class SiglipTokenizer(SentencePieceBackend):
 
     def convert_tokens_to_string(self, tokens):
         """Converts a sequence of tokens (string) in a single string."""
+        all_special_tokens = set(self.all_special_tokens)
         current_sub_tokens = []
         out_string = ""
         prev_is_special = False
         for token in tokens:
             # make sure that special tokens are not decoded using sentencepiece model
-            if token in self.all_special_tokens:
+            if token in all_special_tokens:
                 if not prev_is_special:
                     out_string += " "
                 out_string += self.sp_model.decode(current_sub_tokens) + token

--- a/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
@@ -188,11 +188,12 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
 
     def convert_tokens_to_string(self, tokens: list[str]) -> str:
         """Converts a sequence of tokens (strings for sub-words) in a single string."""
+        all_special_tokens = set(self.all_special_tokens)
         current_sub_tokens = []
         out_string = ""
         for token in tokens:
             # make sure that special tokens are not decoded using sentencepiece model
-            if token in self.all_special_tokens:
+            if token in all_special_tokens:
                 decoded = self.sp_model.decode(current_sub_tokens)
                 out_string += (decoded.upper() if self.do_upper_case else decoded) + token + " "
                 current_sub_tokens = []


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47425)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47425)
<!-- ci-dashboard-badge:end -->

## What this fixes

Fixes #47424. Third instance of the pattern from #46323 and #46535: `all_special_tokens` / `all_special_ids` are rebuilt on every property access, and six slow tokenizers read them once per token inside decode or mask loops.

## The fix

Hoist the lookup into a local `set(...)` before each loop. Files: `esm` (get_special_tokens_mask), `marian`, `m2m_100`, `speech_to_text`, `gpt_sw3`, `siglip` (convert_tokens_to_string). 6 files, +12/-6, membership results unchanged (set vs list membership is identical for these strings/ints).

Left out on purpose: `wav2vec2` (same pattern, but open PR #46578 edits that line; can follow up after it lands), `wav2vec2_phoneme` (that check compares a str against int ids and is dead as written; noted in the issue), `bartpho` (same read but in `save_vocabulary`, not a hot path).

## Numbers

ESM, `get_special_tokens_mask` on 20k ids (M1, CPU): 26.8 ms before, 0.3 ms after, identical mask.

## Tests

```
python -m pytest tests/models/{esm,marian,m2m_100,speech_to_text,gpt_sw3,siglip}/test_tokenization_*.py
# 167 passed, 117 subtests passed; remaining failures/errors are identical on unmodified main (network/fixture dependent)
```

## Notes

Not a duplicate: the only open PR mentioning `all_special_ids` (#46574) is an unrelated CodeLlama decode fix; #46578 covers wav2vec2 only. AI-assisted; I reviewed every line and ran the tests and benchmark above.