### PR TITLE
Fix Wav2Vec2CTCTokenizer word delimiter leaking into special-token APIs

### DIFF
--- a/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
@@ -283,7 +283,10 @@ class Wav2Vec2CTCTokenizer(PreTrainedTokenizer):
         tokens = []
         for index in ids:
             index = int(index)
-            if skip_special_tokens and index in self.all_special_ids:
+            # The word delimiter is registered as a special token but is real
+            # vocabulary content (a word boundary); skipping it would silently
+            # drop word boundaries, so exempt it here as _decode already does.
+            if skip_special_tokens and index in self.all_special_ids and index != self.word_delimiter_token_id:
                 continue
             if index in self.decoder:
                 tokens.append(self.decoder[index])
@@ -292,6 +295,30 @@ class Wav2Vec2CTCTokenizer(PreTrainedTokenizer):
             else:
                 tokens.append(self.unk_token)
         return tokens
+
+    def get_special_tokens_mask(
+        self,
+        token_ids_0: list[int],
+        token_ids_1: list[int] | None = None,
+        already_has_special_tokens: bool = False,
+    ) -> list[int]:
+        """Overridden to exempt the word delimiter from the special-tokens mask.
+
+        The delimiter is registered as a special token but represents a word
+        boundary (real content), so masking it would silently drop word
+        boundaries in label masking / WER filtering (see #46552). Only the
+        ``already_has_special_tokens=True`` path is adjusted; there the mask
+        aligns 1:1 with the input ids.
+        """
+        mask = super().get_special_tokens_mask(
+            token_ids_0, token_ids_1, already_has_special_tokens=already_has_special_tokens
+        )
+        if already_has_special_tokens:
+            wdt_id = self.word_delimiter_token_id
+            ids = list(token_ids_0) + (list(token_ids_1) if token_ids_1 is not None else [])
+            if len(mask) == len(ids):
+                mask = [0 if (m and tid == wdt_id) else m for m, tid in zip(mask, ids)]
+        return mask
 
     def convert_tokens_to_string(
         self,

--- a/tests/models/wav2vec2/test_tokenization_wav2vec2.py
+++ b/tests/models/wav2vec2/test_tokenization_wav2vec2.py
@@ -76,6 +76,35 @@ class Wav2Vec2CTCTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.assertDictEqual(before_vocab, reloaded.get_vocab())
 
+    def test_word_delimiter_not_masked_or_skipped(self):
+        # Regression for #46552: in v5 the word delimiter is registered as a
+        # special token, but it is real content (a word boundary) and must not
+        # be dropped by the special-token-aware APIs, mirroring _decode. It
+        # should survive save/load too. Genuine special tokens (e.g. pad) must
+        # still be masked/skipped.
+        vocab_path = get_tests_dir("fixtures/vocab.json")
+        for label, tok in (("fresh", self.tokenizer_class(vocab_path, word_delimiter_token="|")),):
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                tok.save_pretrained(tmp_dir)
+                reloaded = self.tokenizer_class.from_pretrained(tmp_dir)
+            for name, tokenizer in ((label, tok), ("reload", reloaded)):
+                ids = tokenizer("hello world")["input_ids"]
+                wdt_id = tokenizer.word_delimiter_token_id
+                self.assertIn(wdt_id, ids, name)
+                mask = tokenizer.get_special_tokens_mask(ids, already_has_special_tokens=True)
+                self.assertEqual(0, mask[ids.index(wdt_id)], f"{name}: delimiter must not be masked")
+                self.assertIn(
+                    tokenizer.word_delimiter_token,
+                    tokenizer.convert_ids_to_tokens(ids, skip_special_tokens=True),
+                    f"{name}: delimiter must survive skip_special_tokens",
+                )
+                # a genuine special token is still masked
+                self.assertEqual(
+                    [1],
+                    tokenizer.get_special_tokens_mask([tokenizer.pad_token_id], already_has_special_tokens=True),
+                    f"{name}: real special tokens must still be masked",
+                )
+
     def test_tokenizer_add_token_chars(self):
         tokenizer = self.tokenizer_class.from_pretrained("facebook/wav2vec2-base-960h")
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47428)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47428)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #46552. In v5 the Wav2Vec2 word delimiter (`"|"`) is registered as a special token, and it started leaking into the special-token-aware APIs, silently dropping word boundaries:

- `get_special_tokens_mask(ids, already_has_special_tokens=True)` marks every delimiter position as special (was all-zeros in v4.57).
- `convert_ids_to_tokens(ids, skip_special_tokens=True)` drops the delimiter entirely.

Both feed ASR label masking and WER computation, so word boundaries vanish with no warning (the reporter's repro is a self-contained script that runs in seconds on CPU).

`_decode` already special-cases the delimiter (`... and token != self.word_delimiter_token`). This applies the **same exemption** to the two other APIs, matching the reporter's option (B):

- `convert_ids_to_tokens` keeps the delimiter under `skip_special_tokens=True`.
- a `get_special_tokens_mask` override un-marks the delimiter, and only on the `already_has_special_tokens=True` path where the mask aligns 1:1 with the ids.

Genuine special tokens (`pad`/`bos`/`eos`/`unk`) remain masked and skipped. Kept the delimiter's "special" registration rather than changing the v5 auto-promotion of `*_token` init kwargs, since that promotion also happens on the `from_pretrained` reload path and changing it is a broader base-class change; the localized exemption is consistent across fresh construction and reload.

## Verification

- New regression test `test_word_delimiter_not_masked_or_skipped` (mask, `skip_special_tokens`, save/load round-trip; asserts real special tokens are still masked). Passes fresh and after reload.
- Existing `tests/models/wav2vec2/test_tokenization_wav2vec2.py::Wav2Vec2CTCTokenizerTest` suite passes unchanged (49 passed, 24 skipped).
- `ruff check` clean on both files.

## Before submitting

- [x] This PR fixes a bug (link: #46552).
- [x] Did you make sure to update the documentation with your changes? (behavior restored to v4; no public API change)
- [x] Did you write any new necessary tests? Yes.

_Disclosure: AI assistance was used while writing this fix; I reviewed every line and ran the tests myself._

cc @eustlb