### PR TITLE
fix(compressed_tensors): collect zero_point for asymmetric MoE expert decompression

### DIFF
--- a/src/transformers/integrations/compressed_tensors.py
+++ b/src/transformers/integrations/compressed_tensors.py
@@ -51,11 +51,13 @@ class DecompressExperts(ConversionOps):
         compressor = BaseCompressor.get_value_from_registry(format)
 
         class DummyModule(nn.Module):
-            def __init__(self, weight, scale, shape):
+            def __init__(self, weight, scale, shape, zero_point=None):
                 super().__init__()
                 self.weight_packed = nn.Parameter(weight, requires_grad=False)
                 self.weight_scale = nn.Parameter(scale, requires_grad=False)
                 self.weight_shape = nn.Parameter(shape, requires_grad=False)
+                if zero_point is not None:
+                    self.weight_zero_point = nn.Parameter(zero_point, requires_grad=False)
 
         # `pack_factor` low-bit weights are packed per int32 along the packed dim.
         pack_factor = 32 // quantization_scheme.weights.num_bits
@@ -77,7 +79,14 @@ class DecompressExperts(ConversionOps):
                 # Under TP/EP sharding it leaves the 2-element `weight_shape` empty on most ranks
                 # Packed tensor can be used instead to rebuild `weight_shape`
                 shape = torch.tensor([quant.shape[0], quant.shape[1] * pack_factor])
-                module = DummyModule(quant, scale, shape)
+
+                # Look up zero_point for asymmetric quantization
+                zp_key = key.replace("weight_packed", "weight_zero_point")
+                zero_point = input_dict.get(zp_key, None)
+                if zero_point is not None:
+                    zero_point = zero_point[i]
+
+                module = DummyModule(quant, scale, shape, zero_point)
                 module.quantization_scheme = quantization_scheme
                 compressor.decompress_module(module)
 

--- a/src/transformers/quantizers/quantizer_compressed_tensors.py
+++ b/src/transformers/quantizers/quantizer_compressed_tensors.py
@@ -135,8 +135,9 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
                 packed_weight = [p + "_packed$" for p in weight_sources]
                 scale_sources = [p + "_scale$" for p in weight_sources]
                 shape_sources = [p + "_shape$" for p in weight_sources]
+                zp_sources = [p + "_zero_point$" for p in weight_sources]
                 other = [p for p in conv.source_patterns if not p.endswith(".weight")]
-                new_sources = packed_weight + scale_sources + shape_sources + other
+                new_sources = packed_weight + scale_sources + shape_sources + zp_sources + other
                 new_ops = [DecompressExperts(self)] + list(conv.operations)
                 conv = WeightConverter(
                     source_patterns=new_sources,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47430)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47430)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Fixes two bugs that prevent loading **asymmetric** compressed-tensors `pack-quantized` MoE checkpoints (schemes with `symmetric=False`, e.g. `W4A16_ASYM`) whose fused expert weights are stored as `nn.Parameter` (`gate_up_proj` / `down_proj`). This affects the LFM2.5, Qwen2-MoE, and similar fused-expert MoE families.

### Bug 1 — `quantizers/quantizer_compressed_tensors.py`

`update_weight_conversions()` builds the MoE-expert conversion source patterns from the base `.weight` patterns by appending `_packed$`, `_scale$`, `_shape$` suffixes — but it omits `_zero_point$`. As a result the asymmetric zero-point tensors are never collected from the state dict and never reach the decompressor.

### Bug 2 — `integrations/compressed_tensors.py`

`DecompressExperts.DummyModule` (the temporary module used to decompress each expert) exposes only `weight_packed`, `weight_scale`, `weight_shape` — no `weight_zero_point`. The pack-quantized decompressor asserts `zero_point is not None` for asymmetric schemes and crashes with:

```
Asymmetric quant requires zero-point values
```

### Fix

- Add `zp_sources = [p + "_zero_point$" for p in weight_sources]` to the conversion source patterns so zero-point tensors are routed into the decompressor.
- Thread an optional `zero_point` argument through `DummyModule`, looked up per expert from `input_dict` via `key.replace("weight_packed", "weight_zero_point")`.

Symmetric checkpoints are unaffected: `zero_point` stays `None`, matching the previous behavior exactly.

### Reproduction

Verified on a `W4A16_ASYM` (`group_size=128`) INT4 checkpoint of `LiquidAI/LFM2.5-8B-A1B` after REAP pruning + AWQ quantization (1,122 quantized weight tensors, asymmetric pack-quantized fused expert weights):

- **Before:** `AutoModelForCausalLM.from_pretrained(...)` crashes during weight conversion with `Asymmetric quant requires zero-point values`.
- **After:** loads cleanly and produces coherent generations; perplexity matches the bf16 decompressed reference.

### Related issues

- #47315 (non-32-divisible bit widths — orthogonal; this PR is about zero-point collection, not shape reconstruction)
- #47407 (`run_compressed=False` silent random init — different code path)

## Before submitting

- [x] This PR fixes a bug (not a feature/docs change).
- [x] Ran the relevant existing `tests/quantization/compressed_tensors_integration/` suite locally — no regressions for symmetric checkpoints.