### PR TITLE
fix: allow tokenizers 0.23.1 by relaxing upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ _deps = [
     "tomli",
     "tiktoken",
     "timm>=1.0.23",
-    "tokenizers>=0.22.0,<=0.23.0",
+    "tokenizers>=0.22.0,<0.24.0",
     "torch>=2.4",
     "torchaudio",
     "torchvision",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -73,7 +73,7 @@ deps = {
     "tomli": "tomli",
     "tiktoken": "tiktoken",
     "timm": "timm>=1.0.23",
-    "tokenizers": "tokenizers>=0.22.0,<=0.23.0",
+    "tokenizers": "tokenizers>=0.22.0,<0.24.0",
     "torch": "torch>=2.4",
     "torchaudio": "torchaudio",
     "torchvision": "torchvision",


### PR DESCRIPTION
# What does this PR do?

`tokenizers==0.23.0` was never published; the first 0.23.x release is `0.23.1` (includes the EncodingVisualizer XSS fix, AIKIDO-2026-10636). Transformers currently pins `tokenizers>=0.22.0,<=0.23.0`, which blocks installing the only available 0.23.x release and therefore blocks users from applying that security fix without breaking their install.

Relax the upper bound to `<0.24.0` in:
- `setup.py`
- `src/transformers/dependency_versions_table.py`

Fixes #47429

## Code Agent Policy

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@ArthurZucker @itazap (tokenizers)
