### PR TITLE
[fix] inkling: mps + cuda mel spec extraction

### DIFF
--- a/src/transformers/models/inkling/feature_extraction_inkling.py
+++ b/src/transformers/models/inkling/feature_extraction_inkling.py
@@ -109,6 +109,7 @@ class InklingFeatureExtractor(SequenceFeatureExtractor):
         self.mel_filters = torch.from_numpy(np.ascontiguousarray(mel_filters.T, dtype=np.float32))
 
     def _torch_extract_fbank_features(self, waveform: torch.Tensor, device: str = "cpu") -> torch.Tensor:
+        waveform = waveform.to(device)
         right_pad = math.ceil(waveform.shape[-1] / self.hop_length) * self.hop_length - waveform.shape[-1]
         left_pad = max(self.n_fft - self.hop_length, 0)
         waveform = F.pad(waveform, (left_pad, right_pad))
@@ -232,7 +233,7 @@ class InklingFeatureExtractor(SequenceFeatureExtractor):
         # Number of valid frames per clip == ceil(audio_length / hop_length); everything beyond it is
         # padding, which we zero out so it carries `padding_value`.
         num_frames = torch.div(
-            padded_inputs.audio_lengths + self.hop_length - 1, self.hop_length, rounding_mode="floor"
+            padded_inputs.audio_lengths.to(device) + self.hop_length - 1, self.hop_length, rounding_mode="floor"
         )
         input_features_mask = torch.arange(input_features.shape[1], device=device)[None, :] < num_frames[:, None]
         input_features = input_features * input_features_mask.unsqueeze(-1)

--- a/src/transformers/models/inkling/processing_inkling.py
+++ b/src/transformers/models/inkling/processing_inkling.py
@@ -78,13 +78,16 @@ class InklingProcessor(ProcessorMixin):
         self.num_dmel_bins = num_dmel_bins
         self.dmel_min_value = dmel_min_value
         self.dmel_max_value = dmel_max_value
-        self.bin_centers = torch.linspace(dmel_min_value, dmel_max_value, num_dmel_bins, dtype=torch.float64)
+        # float64 then cast to float32: reproduces the float64 bins exactly
+        self.bin_centers = torch.linspace(dmel_min_value, dmel_max_value, num_dmel_bins, dtype=torch.float64).to(
+            torch.float32
+        )
 
         super().__init__(feature_extractor, image_processor, tokenizer, chat_template=chat_template)
 
     def _extract_dmel_bins(self, input_features: "torch.Tensor") -> "torch.Tensor":
         bin_centers = self.bin_centers.to(input_features.device)
-        mel = input_features.to(torch.float64).clamp(min=self.dmel_min_value, max=self.dmel_max_value)
+        mel = input_features.to(torch.float32).clamp(min=self.dmel_min_value, max=self.dmel_max_value)
         return (mel.unsqueeze(-1) - bin_centers).abs().argmin(dim=-1).to(torch.int32)
 
     def _process_audio(self, audio, **kwargs):

--- a/src/transformers/models/inkling/processing_inkling.py
+++ b/src/transformers/models/inkling/processing_inkling.py
@@ -87,7 +87,7 @@ class InklingProcessor(ProcessorMixin):
 
     def _extract_dmel_bins(self, input_features: "torch.Tensor") -> "torch.Tensor":
         bin_centers = self.bin_centers.to(input_features.device)
-        mel = input_features.to(torch.float32).clamp(min=self.dmel_min_value, max=self.dmel_max_value)
+        mel = input_features.clamp(min=self.dmel_min_value, max=self.dmel_max_value)
         return (mel.unsqueeze(-1) - bin_centers).abs().argmin(dim=-1).to(torch.int32)
 
     def _process_audio(self, audio, **kwargs):

--- a/tests/models/inkling/test_processing_inkling.py
+++ b/tests/models/inkling/test_processing_inkling.py
@@ -23,7 +23,14 @@ from parameterized import parameterized
 from safetensors.torch import load_file
 
 from transformers import AutoProcessor, InklingProcessor, is_torch_available
-from transformers.testing_utils import get_tests_dir, require_librosa, require_vision, slow
+from transformers.testing_utils import (
+    get_tests_dir,
+    require_librosa,
+    require_torch_accelerator,
+    require_vision,
+    slow,
+    torch_device,
+)
 from transformers.utils import is_vision_available
 
 from ...test_processing_common import MODALITY_INPUT_DATA, ProcessorTesterMixin
@@ -209,6 +216,7 @@ class InklingProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
 
 @slow
+@require_torch_accelerator
 class InklingProcessingIntegrationTest(unittest.TestCase):
     """
     Check against sglang reference..
@@ -262,22 +270,27 @@ class InklingProcessingIntegrationTest(unittest.TestCase):
         return torch.cat(per_audio, dim=0)
 
     def _assert_matches_sglang(self, case: str, messages: list, has_audio: bool = False):
-        inputs = self.processor.apply_chat_template(
-            messages,
-            add_generation_prompt=True,
-            tokenize=True,
-            return_dict=True,
-            return_tensors="pt",
-        )
         expected = self._load_expected(case)
+        for device in ["cpu", torch_device]:
+            processor_kwargs = {} if device == "cpu" else {"audio_kwargs": {"device": device}}
+            inputs = self.processor.apply_chat_template(
+                messages,
+                add_generation_prompt=True,
+                tokenize=True,
+                return_dict=True,
+                return_tensors="pt",
+                processor_kwargs=processor_kwargs,
+            ).to(device)
 
-        input_ids = inputs["input_ids"][0]
-        expected_input_ids = self._remap_sentinels(expected["input_ids"].to(torch.int64))
-        torch.testing.assert_close(input_ids, expected_input_ids, rtol=0, atol=0)
+            input_ids = inputs["input_ids"][0]
+            expected_input_ids = self._remap_sentinels(expected["input_ids"].to(torch.int64)).to(device)
+            torch.testing.assert_close(input_ids, expected_input_ids, rtol=0, atol=0)
 
-        if has_audio:
-            dmel = self._expected_dmel_from_inputs(inputs)
-            torch.testing.assert_close(dmel, expected["audio_dmel"].to(torch.int32), rtol=0, atol=0)
+            if has_audio:
+                dmel = self._expected_dmel_from_inputs(inputs)
+                torch.testing.assert_close(
+                    dmel, expected["audio_dmel"].to(dtype=torch.int32, device=device), rtol=0, atol=0
+                )
 
     def test_apply_chat_template_text(self):
         messages = [{"role": "user", "content": [{"type": "text", "text": "What is the capital of France?"}]}]


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47432)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47432)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

fixes 
1. cast to correct device when device="cuda"
2. fix float64 incompatibility on MPS via just moving to float32

verified via running dMel extraction on:
Test set | Clips | dMel bins compared | Differences
-- | -- | -- | --
AMI (test) | 12,643 | 50,409,440 | 0
LibriSpeech (test.clean) | 2,620 | 31,219,840 | 0
FLEURS en_us (test) | 647 | 10,241,680 | 0
FLEURS fr_fr (test) | 676 | 11,259,120 | 0
FLEURS de_de (test) | 862 | 18,187,680 | 0
FLEURS hi_in (test) | 418 | 7,744,960 | 0
Total | 17,866 | 129,062,720 | 0

</body></html>

closes #47392