### PR TITLE
fix: relax tokenizers upper bound to <0.24.0 (fixes #47429)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ _deps = [
     "tomli",
     "tiktoken",
     "timm>=1.0.23",
-    "tokenizers>=0.22.0,<=0.23.0",
+    "tokenizers>=0.22.0,<0.24.0",
     "torch>=2.4",
     "torchaudio",
     "torchvision",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -73,7 +73,7 @@ deps = {
     "tomli": "tomli",
     "tiktoken": "tiktoken",
     "timm": "timm>=1.0.23",
-    "tokenizers": "tokenizers>=0.22.0,<=0.23.0",
+    "tokenizers": "tokenizers>=0.22.0,<0.24.0",
     "torch": "torch>=2.4",
     "torchaudio": "torchaudio",
     "torchvision": "torchvision",


### PR DESCRIPTION
## Summary

`tokenizers==0.23.0` was never published — the tokenizers team skipped straight to 0.23.1. The previous constraint `<=0.23.0` blocks 0.23.1, which contains the fix for XSS vulnerability AIKIDO-2026-10636.

## Change

```
- tokenizers>=0.22.0,<=0.23.0
+ tokenizers>=0.22.0,<0.24.0
```

## Files Changed

- `src/transformers/dependency_versions_table.py`
- `setup.py`

## Impact

Users can now install `transformers` with `tokenizers==0.23.1` to get the security fix.

```bash
pip install transformers tokenizers==0.23.1  # now works
```

Closes #47429