### PR TITLE
Fix vision position-embedding init width fallback in Phi4Multimodal

### DIFF
--- a/src/transformers/models/phi4_multimodal/modeling_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/modeling_phi4_multimodal.py
@@ -233,7 +233,7 @@ class Phi4MultimodalVisionPreTrainedModel(PreTrainedModel):
             width = (
                 self.config.hidden_size
                 if isinstance(self.config, Phi4MultimodalVisionConfig)
-                else self.config.hidden_size
+                else self.config.vision_config.hidden_size
             )
             init.normal_(module.position_embedding.weight, std=1 / np.sqrt(width))
         elif isinstance(module, nn.Embedding):

--- a/src/transformers/models/phi4_multimodal/modular_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/modular_phi4_multimodal.py
@@ -351,7 +351,7 @@ class Phi4MultimodalVisionPreTrainedModel(SiglipPreTrainedModel):
             width = (
                 self.config.hidden_size
                 if isinstance(self.config, Phi4MultimodalVisionConfig)
-                else self.config.hidden_size
+                else self.config.vision_config.hidden_size
             )
             init.normal_(module.position_embedding.weight, std=1 / np.sqrt(width))
         elif isinstance(module, nn.Embedding):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47437)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47437)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`Phi4MultimodalVisionPreTrainedModel._init_weights` contains a ternary whose two branches are identical:

```python
width = (
    self.config.hidden_size
    if isinstance(self.config, Phi4MultimodalVisionConfig)
    else self.config.hidden_size  # <- same as the if-branch
)
```

The code is derived from SigLIP's `_init_weights`, where the fallback branch reads the *composite* config's `vision_config.hidden_size`:

```python
# modeling_siglip.py
width = (
    self.config.vision_config.hidden_size
    if isinstance(self.config, SiglipConfig)
    else self.config.hidden_size
)
```

so the Phi4Multimodal fallback was clearly intended to read `self.config.vision_config.hidden_size` when `self.config` is the composite `Phi4MultimodalConfig`. As written, that path would initialize the vision position embedding with the text model's width (e.g. 3072) instead of the vision width (1152), producing a wrong init std. This PR mirrors the SigLIP original.

Fixed in `modular_phi4_multimodal.py` and regenerated `modeling_phi4_multimodal.py` with the modular converter (verified with `utils/check_modular_conversion.py`).

Tests: `pytest tests/models/phi4_multimodal/test_modeling_phi4_multimodal.py` — 128 passed, 3575 subtests passed.

## Before submitting
- [ ] This PR fixes a typo or improves the docs
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [ ] Was this discussed/approved via a Github issue or the forum?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@Cyrilvallez

🤖 Generated with [Claude Code](https://claude.com/claude-code)