### PR TITLE
fix: correct typos in comments

### DIFF
--- a/src/transformers/integrations/compressed_tensors.py
+++ b/src/transformers/integrations/compressed_tensors.py
@@ -70,7 +70,7 @@ class DecompressExperts(ConversionOps):
 
             # Pre-allocate the stacked output buffer to reduce cuda mem fragmentation
             # Without pre-allocation the loop accumulates N tensors per expert and next
-            # `MergeModulelist` stacks the full list for MoE kernels compatipility, i.e. x2 memory
+            # `MergeModulelist` stacks the full list for MoE kernels compatibility, i.e. x2 memory
             output = None
             for i, (quant, scale) in enumerate(zip(quantized, scales)):
                 # The checkpoint's `weight_shape` is a 2D tensor of `(out-dim, in-dim)`

--- a/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
@@ -166,7 +166,7 @@ class HunYuanVLImageProcessorPil(PilBackend):
         for image in images:
             height, width = image.shape[-2:]
             # Match the original HunyuanOCR preprocessing with PIL.Image.resize
-            # FIXME: raushan, investiagte why the quality degrafes with our np-based transforms
+            # FIXME: raushan, investigate why the quality degrades with our np-based transforms
             if image.ndim == 3:
                 pil_image = Image.fromarray(np.transpose(image, (1, 2, 0)).astype(np.uint8))
             else:

--- a/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
@@ -393,7 +393,7 @@ class HunYuanVLImageProcessorPil(Qwen2VLImageProcessorPil):
         for image in images:
             height, width = image.shape[-2:]
             # Match the original HunyuanOCR preprocessing with PIL.Image.resize
-            # FIXME: raushan, investiagte why the quality degrafes with our np-based transforms
+            # FIXME: raushan, investigate why the quality degrades with our np-based transforms
             if image.ndim == 3:
                 pil_image = Image.fromarray(np.transpose(image, (1, 2, 0)).astype(np.uint8))
             else:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47446)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47446)
<!-- ci-dashboard-badge:end -->

## Summary
This PR fixes 3 typos in code comments:

- \compatipility\ → \compatibility\ in compressed_tensors.py
- \investiagte\ → \investigate\ in modular_hunyuan_vl.py
- \degrafes\ → \degrades\ in image_processing_pil_hunyuan_vl.py

## Changes
- src/transformers/integrations/compressed_tensors.py:73
- src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py:396
- src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py:169

## Testing
- Comment-only changes, no functional impact

Note: Local environment limitations, relying on CI/CD automated testing.