### PR TITLE
Fix GPT-2 c_proj depth scaling initialization

### DIFF
--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -444,11 +444,10 @@ class GPT2PreTrainedModel(PreTrainedModel):
         #   >   -- GPT-2 :: https://openai.com/blog/better-language-models/
         #
         # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py
-        if isinstance(module, PreTrainedModel):
-            for name, p in module.named_parameters():
-                if name == "c_proj.weight":
-                    # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
-                    init.normal_(p, mean=0.0, std=self.config.initializer_range / math.sqrt(2 * self.config.n_layer))
+        if isinstance(module, (GPT2Attention, GPT2MLP)):
+            # Special Scaled Initialization --> 2 residual paths (attention and MLP) per Transformer Block
+            std = self.config.initializer_range / math.sqrt(2 * self.config.n_layer)
+            init.normal_(module.c_proj.weight, mean=0.0, std=std)
 
 
 @auto_docstring(

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import unittest
 
 import pytest
@@ -314,6 +315,16 @@ class GPT2ModelTest(CausalLMModelTest, unittest.TestCase):
             (self.model_tester.batch_size, self.model_tester.seq_length, self.model_tester.vocab_size),
         )
         result.loss.backward()
+
+    def test_gpt2_weight_initialization(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        config, *_ = config_and_inputs
+        model = GPT2Model(config)
+        expected_std = config.initializer_range / math.sqrt(2 * config.num_hidden_layers)
+        for key in model.state_dict():
+            if "c_proj" in key and "weight" in key:
+                self.assertLessEqual(abs(torch.std(model.state_dict()[key]) - expected_std), 0.001)
+                self.assertLessEqual(abs(torch.mean(model.state_dict()[key]) - 0.0), 0.01)
 
     def test_training_gradient_checkpointing(self):
         # overwritten: GPT2DoubleHeadsModel fails this test, non-standard class

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 import unittest
 
 import pytest
@@ -315,16 +314,6 @@ class GPT2ModelTest(CausalLMModelTest, unittest.TestCase):
             (self.model_tester.batch_size, self.model_tester.seq_length, self.model_tester.vocab_size),
         )
         result.loss.backward()
-
-    def test_gpt2_weight_initialization(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        config, *_ = config_and_inputs
-        model = GPT2Model(config)
-        expected_std = config.initializer_range / math.sqrt(2 * config.num_hidden_layers)
-        for key in model.state_dict():
-            if "c_proj" in key and "weight" in key:
-                self.assertLessEqual(abs(torch.std(model.state_dict()[key]) - expected_std), 0.001)
-                self.assertLessEqual(abs(torch.mean(model.state_dict()[key]) - 0.0), 0.01)
 
     def test_training_gradient_checkpointing(self):
         # overwritten: GPT2DoubleHeadsModel fails this test, non-standard class


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47459)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47459)
<!-- ci-dashboard-badge:end -->

# What does this PR do?
This PR resolves the silent bug where the scaling of GPT2's `c_proj` weights (contained in each attention and MLP block) which is never applied.

`_init_weights` is called via `smart_apply()`, which performs a depth-first tree walk. `isinstance(module, PreTrainedModel)` is only satisfied at the top-level model, where `named_parameters()` returns fully-qualified names like `h.0.attn.c_proj.weight`. Thus, `name == "c_proj.weight"` will never match, and therefore the scaled initialisation is silently skipped. Leaving the `c_proj` weights to be drawn from the default $N(0, \text{InitializerRange})$ distribution.

# Whats implemented
The updated code intercepts at `GPT2Attention` and `GPT2MLP` directly, where `module.c_proj` is a direct attribute, and applies the correct scaling (`std = InitializerRange / sqrt(2 * n_layer)`).

# Testing
A regression test was also added to ensure that all `c_proj` weights are initialised with the expected scaled standard deviation after model initialisation. Local testing confirmed that attention and MLP `c_proj` weights are correctly sampled from $$N(0, \frac{\text{InitializerRange}}{\sqrt{2 \times \text{nLayer}}})$$.

Fixes #47458

## AI assistance
I identified the bug, wrote the fix and created the test. Claude Code was used as a review and feedback tool during development.

## Before submitting
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?
@ArthurZucker @Cyrilvallez