### PR TITLE
Fix stale phonemizer_lang in Wav2Vec2PhonemeCTCTokenizer

### DIFF
--- a/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
+++ b/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
@@ -223,7 +223,7 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
             self.do_phonemize = do_phonemize
 
         # set the correct phonemizer language
-        if phonemizer_lang is not None:
+        if phonemizer_lang is not None and phonemizer_lang != self.phonemizer_lang:
             self.phonemizer_lang = phonemizer_lang
             self.init_backend(phonemizer_lang)
 
@@ -255,6 +255,7 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
 
         word_delimiter = self.word_delimiter_token + " " if self.word_delimiter_token is not None else ""
         if phonemizer_lang is not None and phonemizer_lang != self.phonemizer_lang:
+            self.phonemizer_lang = phonemizer_lang
             self.init_backend(phonemizer_lang)
         else:
             phonemizer_lang = self.phonemizer_lang


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47461)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47461)
<!-- ci-dashboard-badge:end -->

Fixes #46614.

When switching `phonemizer_lang` dynamically in `phonemize()` and `prepare_for_tokenization()`, the tokenizer correctly re-initialized the backend but failed to update `self.phonemizer_lang`. This caused subsequent calls with the original language to skip backend re-initialization (due to a stale language comparison) and phonemize text using the wrong backend.

This minimal PR ensures `self.phonemizer_lang` is correctly updated whenever the backend changes, resolving the state-mutation bug.