### PR TITLE
Fix torch_float casting to int instead of float

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -739,11 +739,11 @@ def torch_float(x):
     Casts an input to a torch float32 tensor if we are in a tracing context, otherwise to a Python float.
     """
     if not _is_torch_available:
-        return int(x)
+        return float(x)
 
     import torch
 
-    return x.to(torch.float32) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else int(x)
+    return x.to(torch.float32) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else float(x)
 
 
 def filter_out_non_signature_kwargs(extra: list | None = None):

--- a/tests/utils/test_generic.py
+++ b/tests/utils/test_generic.py
@@ -34,7 +34,7 @@ from transformers.utils import (
     to_py_obj,
     transpose,
 )
-from transformers.utils.generic import retry, split_attention_implementation
+from transformers.utils.generic import retry, split_attention_implementation, torch_float
 
 
 if is_torch_available():
@@ -66,6 +66,11 @@ class GenericTester(unittest.TestCase):
         }
 
         self.assertEqual(flatten_dict(input_dict), expected_dict)
+
+    def test_torch_float(self):
+        result = torch_float(9.797958971132712)
+        self.assertIsInstance(result, float)
+        self.assertEqual(result, 9.797958971132712)
 
     def test_transpose_numpy(self):
         x = np.random.randn(3, 4)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47468)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47468)
<!-- ci-dashboard-badge:end -->

`torch_float` casts to `int` in both non-tracing branches (looks like a copy-paste from `torch_int`), so it truncates instead of returning a float, which contradicts the docstring.

This shows up in imagegpt attention scaling, `attn_weights / torch_float(value.size(-1) ** 0.5)`: when the head dim isn't a perfect square, `sqrt(head_dim)` gets truncated (e.g. 9.79 -> 9) and the logits are scaled wrong.