### PR TITLE
Don't mutate class-level common_kwargs defaults in _merge_kwargs

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1602,7 +1602,7 @@ class ProcessorMixin(PushToHubMixin):
         output_kwargs.update(default_kwargs)
 
         # For `common_kwargs` just update all modality-specific kwargs with same key/values
-        common_kwargs = ModelProcessorKwargs._defaults.get("common_kwargs", {})
+        common_kwargs = ModelProcessorKwargs._defaults.get("common_kwargs", {}).copy()
         common_kwargs.update(kwargs.get("common_kwargs", {}))
         if common_kwargs:
             for kwarg in output_kwargs.values():

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -20,7 +20,9 @@ import random
 import shutil
 import sys
 import tempfile
+import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 from huggingface_hub import hf_hub_download
@@ -28,6 +30,8 @@ from parameterized import parameterized
 
 from transformers.processing_utils import (
     MODALITY_TO_AUTOPROCESSOR_MAPPING,
+    ProcessingKwargs,
+    ProcessorMixin,
     Unpack,
 )
 from transformers.testing_utils import (
@@ -2151,3 +2155,12 @@ class ProcessorTesterMixin:
         num_image_tokens_from_call = inputs.mm_token_type_ids.sum(-1).tolist()
         num_image_tokens_from_helper = processor._get_num_multimodal_tokens(image_sizes=image_sizes * 2)
         self.assertEqual(sum(num_image_tokens_from_call), sum(num_image_tokens_from_helper["num_image_tokens"]))
+
+
+class ProcessorMergeKwargsTest(unittest.TestCase):
+    def test_common_kwargs_defaults_are_not_mutated(self):
+        class DummyKwargs(ProcessingKwargs, total=False):
+            _defaults = {"common_kwargs": {"return_tensors": "pt"}}
+
+        ProcessorMixin._merge_kwargs(SimpleNamespace(), DummyKwargs, None, common_kwargs={"return_tensors": "np"})
+        self.assertEqual(DummyKwargs._defaults["common_kwargs"], {"return_tensors": "pt"})


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47469)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47469)
<!-- ci-dashboard-badge:end -->

`_merge_kwargs` reads the class-level `_defaults["common_kwargs"]` dict by reference and calls `.update()` on it with the call-time `common_kwargs`. Since `_defaults` is shared across all instances, this permanently mutates the default: after one call with e.g. `common_kwargs={"return_tensors": "np"}`, every subsequent call on any instance of that processor defaults to `np`.

The per-modality defaults a few lines above already `.copy()` for this reason; `common_kwargs` just missed it.