### PR TITLE
Fix ESMFold error when explicitly cast to fp16

### DIFF
--- a/src/transformers/models/esm/modeling_esmfold.py
+++ b/src/transformers/models/esm/modeling_esmfold.py
@@ -134,11 +134,14 @@ class EsmForProteinFoldingOutput(ModelOutput):
     max_predicted_aligned_error: torch.FloatTensor | None = None
 
 
-def is_fp16_enabled(device_type):
+def is_fp16_enabled(device_type, tensor):
     # Autocast world
     autocast_dtype = torch.get_autocast_dtype(device_type)
     fp16_enabled = autocast_dtype == torch.float16
     fp16_enabled = fp16_enabled and torch.is_autocast_enabled(device_type)
+
+    # Explicit cast world
+    fp16_enabled = fp16_enabled or tensor.dtype == torch.float16
 
     return fp16_enabled
 
@@ -861,14 +864,24 @@ class EsmFoldTriangleMultiplicativeUpdate(nn.Module):
         b = b * self.linear_b_p(z)
 
         device_type = a.device.type if a.device.type != "mps" else "cpu"
-        if is_fp16_enabled(device_type):
+        if is_fp16_enabled(device_type, a):
             with maybe_autocast(device_type=device_type, enabled=False):
                 x = self._combine_projections(a.float(), b.float())
+
+                # Use fp32 for layer norm to avoid fp16 overflow
+                x = torch.nn.functional.layer_norm(
+                    x,
+                    self.layer_norm_out.normalized_shape,
+                    self.layer_norm_out.weight.float(),
+                    self.layer_norm_out.bias.float(),
+                    self.layer_norm_out.eps,
+                )
+            x = x.to(a.dtype)
         else:
             x = self._combine_projections(a, b)
+            x = self.layer_norm_out(x)
 
         del a, b
-        x = self.layer_norm_out(x)
         x = self.linear_z(x)
         g = self.sigmoid(self.linear_g(z))
         x = x * g
@@ -1484,7 +1497,7 @@ class EsmFoldInvariantPointAttention(nn.Module):
 
         # [*, H, N_res, N_res]
         device_type = q.device.type if q.device.type != "mps" else "cpu"
-        if is_fp16_enabled(device_type):
+        if is_fp16_enabled(device_type, q):
             with maybe_autocast(device_type=device_type, enabled=False):
                 a = torch.matmul(
                     permute_final_dims(q.float(), (1, 0, 2)),  # [*, H, N_res, C_hidden]


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47471)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47471)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

When running ESMFold in fp16 precision on my Mac mini, I got an error (details in #47470). This appears to be a general ESMFold fp16 bug, not specific to Apple Silicon.

**Root cause**: fp16 has a smaller range than fp32 or bf16, so most sequences lead to an overflow in ESMFold.

**Fix**: check for fp16 tensor type in the existing `is_fp16_enabled` function, but keep fp32 during `layer_norm_out` (downcast afterwards) since the inputs to the layer norm are too large to fit in fp16.

Fixes #47470

## Who can review?

cc: @Rocketknight1