### PR TITLE
Fix ESMFold error in fp16 precision

### DIFF
--- a/src/transformers/models/esm/modeling_esmfold.py
+++ b/src/transformers/models/esm/modeling_esmfold.py
@@ -134,11 +134,14 @@ class EsmForProteinFoldingOutput(ModelOutput):
     max_predicted_aligned_error: torch.FloatTensor | None = None
 
 
-def is_fp16_enabled(device_type):
+def is_fp16_enabled(device_type, tensor):
     # Autocast world
     autocast_dtype = torch.get_autocast_dtype(device_type)
     fp16_enabled = autocast_dtype == torch.float16
     fp16_enabled = fp16_enabled and torch.is_autocast_enabled(device_type)
+
+    # Explicit cast world
+    fp16_enabled = fp16_enabled or tensor.dtype == torch.float16
 
     return fp16_enabled
 
@@ -861,14 +864,24 @@ class EsmFoldTriangleMultiplicativeUpdate(nn.Module):
         b = b * self.linear_b_p(z)
 
         device_type = a.device.type if a.device.type != "mps" else "cpu"
-        if is_fp16_enabled(device_type):
+        if is_fp16_enabled(device_type, a):
             with maybe_autocast(device_type=device_type, enabled=False):
                 x = self._combine_projections(a.float(), b.float())
+
+                # Use fp32 for layer norm to avoid fp16 overflow
+                x = torch.nn.functional.layer_norm(
+                    x,
+                    self.layer_norm_out.normalized_shape,
+                    self.layer_norm_out.weight.float(),
+                    self.layer_norm_out.bias.float(),
+                    self.layer_norm_out.eps,
+                )
+            x = x.to(a.dtype)
         else:
             x = self._combine_projections(a, b)
+            x = self.layer_norm_out(x)
 
         del a, b
-        x = self.layer_norm_out(x)
         x = self.linear_z(x)
         g = self.sigmoid(self.linear_g(z))
         x = x * g
@@ -1484,7 +1497,7 @@ class EsmFoldInvariantPointAttention(nn.Module):
 
         # [*, H, N_res, N_res]
         device_type = q.device.type if q.device.type != "mps" else "cpu"
-        if is_fp16_enabled(device_type):
+        if is_fp16_enabled(device_type, q):
             with maybe_autocast(device_type=device_type, enabled=False):
                 a = torch.matmul(
                     permute_final_dims(q.float(), (1, 0, 2)),  # [*, H, N_res, C_hidden]

--- a/tests/models/esm/test_modeling_esmfold.py
+++ b/tests/models/esm/test_modeling_esmfold.py
@@ -16,7 +16,14 @@
 import unittest
 
 from transformers import EsmConfig, is_torch_available
-from transformers.testing_utils import TestCasePlus, is_flaky, require_torch, slow, torch_device
+from transformers.testing_utils import (
+    TestCasePlus,
+    is_flaky,
+    require_torch,
+    require_torch_fp16,
+    slow,
+    torch_device,
+)
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, ids_tensor, random_attention_mask
@@ -257,3 +264,13 @@ class EsmModelIntegrationTest(TestCasePlus):
         position_outputs = model(input_ids)["positions"]
         expected_slice = torch.tensor([2.5828, 0.7993, -10.9334], dtype=torch.float32)
         torch.testing.assert_close(position_outputs[0, 0, 0, 0], expected_slice, rtol=1e-4, atol=1e-4)
+
+    @slow
+    @require_torch_fp16
+    def test_inference_protein_folding_fp16(self):
+        model = EsmForProteinFolding.from_pretrained("facebook/esmfold_v1", dtype=torch.float16)
+        model = model.to(torch_device).eval()
+        input_ids = torch.tensor([[0, 6, 4, 13, 5, 4, 16, 12, 11, 7, 2]]).to(torch_device)
+        with torch.no_grad():
+            position_outputs = model(input_ids)["positions"]
+        self.assertFalse(torch.isnan(position_outputs).any().item())


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47472)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47472)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

When running ESMFold in fp16 precision on my Mac mini, I got an error (details in #47470). This appears to be a general ESMFold fp16 bug, not specific to Apple Silicon.

**Root cause**: fp16 has a smaller numeric range than fp32 or bf16, so most sequences lead to an fp16 NaN overflow in ESMFold.

**Fix**: check for fp16 tensor type in the existing `is_fp16_enabled` function, but keep fp32 during `layer_norm_out` (and downcast afterwards) since the inputs to the layer norm are too large to fit in fp16.

Fixes #47470

## Testing
Adds `test_inference_protein_folding_fp16`, which asserts that ESMFold does not produce NaN in fp16. (Same pattern as `test_batched_nan_fp16` in OPT and XGLM.)

## Who can review?

cc: @Rocketknight1