### PR TITLE
CI: use a single function for GH calls

### DIFF
--- a/tests/repo_utils/test_github_utils.py
+++ b/tests/repo_utils/test_github_utils.py
@@ -1,0 +1,198 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+
+git_repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+sys.path.append(os.path.join(git_repo_path, "utils"))
+
+import github_utils as gh  # noqa: E402
+from github_utils import (  # noqa: E402
+    build_github_headers,
+    get_github_json,
+    github_request,
+)
+
+
+class Headers(dict):
+    """A dict with a ``.get(key, default)`` like the header mappings GitHub responses expose."""
+
+    def get(self, key, default=None):
+        return dict.get(self, key, default)
+
+
+def _response(status, headers=None, body=""):
+    """Build the ``(status, headers, body)`` tuple that :func:`github_utils._request` returns."""
+    return status, Headers(headers or {}), body
+
+
+class BuildGithubHeadersTest(unittest.TestCase):
+    def test_adds_authorization_when_token_present(self):
+        headers = build_github_headers("secret-token")
+        self.assertEqual(headers["Authorization"], "Bearer secret-token")
+        self.assertEqual(headers["Accept"], "application/vnd.github+json")
+
+    def test_omits_authorization_without_token(self):
+        for token in (None, ""):
+            with self.subTest(token=token):
+                self.assertNotIn("Authorization", build_github_headers(token))
+
+
+class IsExpiredOrBadTokenTest(unittest.TestCase):
+    def test_non_401_is_never_a_token_problem(self):
+        for status in (200, 403, 404, 429, 500):
+            with self.subTest(status=status):
+                self.assertIsNone(gh._is_expired_or_bad_token(status, "Bad credentials"))
+
+    def test_401_is_always_a_rejected_token_even_without_a_body(self):
+        self.assertEqual(gh._is_expired_or_bad_token(401, ""), "rejected")
+        self.assertEqual(gh._is_expired_or_bad_token(401, None), "rejected")
+
+    def test_401_body_sharpens_the_reason(self):
+        self.assertEqual(gh._is_expired_or_bad_token(401, "Bad credentials"), "bad credentials")
+        # GitHub wording is not guaranteed; matching is case-insensitive and substring based.
+        self.assertEqual(gh._is_expired_or_bad_token(401, "This token has EXPIRED"), "expired")
+
+
+class RateLimitWaitTest(unittest.TestCase):
+    def test_non_rate_limit_status_returns_none(self):
+        self.assertIsNone(gh._rate_limit_wait(200, Headers({}), "", 0))
+
+    def test_permission_403_is_not_a_rate_limit(self):
+        # A 403 with no rate-limit signal is a genuine permission error and must not be retried.
+        wait = gh._rate_limit_wait(403, Headers({}), "Resource not accessible by integration", 0)
+        self.assertIsNone(wait)
+
+    def test_429_is_always_a_rate_limit(self):
+        self.assertIsNotNone(gh._rate_limit_wait(429, Headers({}), "", 0))
+
+    def test_secondary_rate_limit_detected_from_body(self):
+        wait = gh._rate_limit_wait(403, Headers({}), "You have exceeded a secondary rate limit", 0)
+        self.assertIsNotNone(wait)
+
+    def test_retry_after_header_is_honored_and_clamped(self):
+        # Retry-After below the floor is clamped up to 30s; above the ceiling down to 300s.
+        self.assertEqual(gh._rate_limit_wait(429, Headers({"Retry-After": "5"}), "", 0), 30)
+        self.assertEqual(gh._rate_limit_wait(429, Headers({"Retry-After": "9999"}), "", 0), 300)
+
+    def test_primary_limit_uses_reset_epoch(self):
+        with patch.object(gh.time, "time", return_value=1_000):
+            wait = gh._rate_limit_wait(
+                403, Headers({"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1120"}), "", 0
+            )
+        self.assertEqual(wait, 120)
+
+    def test_secondary_limit_without_hints_grows_per_attempt(self):
+        first = gh._rate_limit_wait(429, Headers({}), "", 0)
+        later = gh._rate_limit_wait(429, Headers({}), "", 2)
+        self.assertLess(first, later)
+
+
+class GithubRequestTest(unittest.TestCase):
+    def setUp(self):
+        # Never actually sleep while exercising the retry loop.
+        sleep_patcher = patch.object(gh.time, "sleep", return_value=None)
+        self.addCleanup(sleep_patcher.stop)
+        sleep_patcher.start()
+
+    def _patch_request(self, side_effect):
+        patcher = patch.object(gh, "_request", side_effect=side_effect)
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+    def test_returns_parsed_json_on_200(self):
+        self._patch_request([_response(200, body='{"ok": true}')])
+        self.assertEqual(github_request("https://api.github.com/x", token="t"), {"ok": True})
+
+    def test_get_github_json_is_a_get_shortcut(self):
+        mock = self._patch_request([_response(200, body='{"n": 1}')])
+        self.assertEqual(get_github_json("https://api.github.com/x", token="t"), {"n": 1})
+        self.assertEqual(mock.call_args.kwargs["method"], "GET")
+
+    def test_empty_body_returns_none(self):
+        # A 204 (e.g. a DELETE) has no body to parse.
+        self._patch_request([_response(204, body="")])
+        self.assertIsNone(github_request("https://api.github.com/x", token="t", method="DELETE"))
+
+    def test_rejected_token_401_fails_hard_without_retry(self):
+        mock = self._patch_request([_response(401, body="Bad credentials")])
+        with self.assertRaises(RuntimeError) as ctx:
+            github_request("https://api.github.com/x", token="expired")
+        self.assertIn("bad credentials", str(ctx.exception).lower())
+        # Fail hard: the transport is hit exactly once, never retried.
+        self.assertEqual(mock.call_count, 1)
+
+    def test_401_never_falls_back_to_anonymous(self):
+        # The whole point: a rejected token must not trigger a token-less retry (which would only
+        # trip the anonymous rate limit into a cascade of 403s). Every call keeps the auth header.
+        mock = self._patch_request([_response(401, body="Bad credentials")])
+        with self.assertRaises(RuntimeError):
+            github_request("https://api.github.com/x", token="expired")
+        for call in mock.call_args_list:
+            headers = call.args[1]
+            self.assertEqual(headers["Authorization"], "Bearer expired")
+
+    def test_404_fails_hard_without_retry(self):
+        mock = self._patch_request([_response(404, body="Not Found")])
+        with self.assertRaises(RuntimeError):
+            github_request("https://api.github.com/x", token="t")
+        self.assertEqual(mock.call_count, 1)
+
+    def test_5xx_fails_hard_without_retry(self):
+        # Only rate limiting is retried; a server error is raised immediately.
+        mock = self._patch_request([_response(503, body="boom")])
+        with self.assertRaises(RuntimeError):
+            github_request("https://api.github.com/x", token="t")
+        self.assertEqual(mock.call_count, 1)
+
+    def test_network_error_fails_hard(self):
+        self._patch_request(gh.urllib.error.URLError("connection reset"))
+        with self.assertRaises(RuntimeError) as ctx:
+            github_request("https://api.github.com/x", token="t")
+        self.assertIn("connection reset", str(ctx.exception))
+
+    def test_rate_limit_is_retried_then_succeeds(self):
+        mock = self._patch_request(
+            [
+                _response(403, body="You have exceeded a secondary rate limit"),
+                _response(200, body='{"ok": true}'),
+            ]
+        )
+        self.assertEqual(github_request("https://api.github.com/x", token="t"), {"ok": True})
+        self.assertEqual(mock.call_count, 2)
+
+    def test_rate_limit_exhausts_retries_and_raises(self):
+        # Always rate limited: loop up to max_retries, then fail loudly.
+        mock = self._patch_request([_response(429, body="rate limit") for _ in range(5)])
+        with self.assertRaises(RuntimeError) as ctx:
+            github_request("https://api.github.com/x", token="t", max_retries=3)
+        self.assertIn("still rate limited", str(ctx.exception))
+        self.assertEqual(mock.call_count, 3)
+
+    def test_post_sends_json_payload_and_parses_response(self):
+        mock = self._patch_request([_response(201, body='{"id": 5}')])
+        result = github_request("https://api.github.com/x", token="t", method="POST", payload={"body": "hi"})
+        self.assertEqual(result, {"id": 5})
+        headers = mock.call_args.args[1]
+        self.assertEqual(headers["Content-Type"], "application/json")
+        self.assertEqual(mock.call_args.kwargs["method"], "POST")
+        self.assertEqual(mock.call_args.kwargs["data"], b'{"body": "hi"}')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/repo_utils/test_github_utils.py
+++ b/tests/repo_utils/test_github_utils.py
@@ -53,21 +53,6 @@ class BuildGithubHeadersTest(unittest.TestCase):
                 self.assertNotIn("Authorization", build_github_headers(token))
 
 
-class IsExpiredOrBadTokenTest(unittest.TestCase):
-    def test_non_401_is_never_a_token_problem(self):
-        for status in (200, 403, 404, 429, 500):
-            with self.subTest(status=status):
-                self.assertIsNone(gh._is_expired_or_bad_token(status, "Bad credentials"))
-
-    def test_401_is_always_a_rejected_token_even_without_a_body(self):
-        self.assertEqual(gh._is_expired_or_bad_token(401, ""), "rejected")
-        self.assertEqual(gh._is_expired_or_bad_token(401, None), "rejected")
-
-    def test_401_body_sharpens_the_reason(self):
-        self.assertEqual(gh._is_expired_or_bad_token(401, "Bad credentials"), "bad credentials")
-        # GitHub wording is not guaranteed; matching is case-insensitive and substring based.
-        self.assertEqual(gh._is_expired_or_bad_token(401, "This token has EXPIRED"), "expired")
-
 
 class RateLimitWaitTest(unittest.TestCase):
     def test_non_rate_limit_status_returns_none(self):
@@ -103,12 +88,81 @@ class RateLimitWaitTest(unittest.TestCase):
         self.assertLess(first, later)
 
 
+class LogTokenStatusTest(unittest.TestCase):
+    def setUp(self):
+        # Reset the once-per-process guard before every test.
+        gh._token_status_logged = False
+
+    def _patch_request(self, side_effect):
+        patcher = patch.object(gh, "_request", side_effect=side_effect)
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+    def test_ci_without_token_raises(self):
+        with patch.dict(os.environ, {"CI": "true"}):
+            with self.assertRaises(RuntimeError) as ctx:
+                gh._log_token_status(token=None)
+        self.assertIn("no github token", str(ctx.exception).lower())
+
+    def test_no_ci_without_token_does_not_raise(self):
+        env = {k: v for k, v in os.environ.items() if k != "CI"}
+        with patch.dict(os.environ, env, clear=True):
+            self._patch_request([_response(200, body='{"resources": {"core": {"limit": 60, "remaining": 59, "reset": 9999999999}}}')])
+            gh._log_token_status(token=None)  # must not raise
+
+    def test_token_rejected_401_raises(self):
+        self._patch_request([_response(401, body="Bad credentials")])
+        with self.assertRaises(RuntimeError) as ctx:
+            gh._log_token_status(token="bad-token")
+        self.assertIn("rejected", str(ctx.exception).lower())
+
+    def test_401_with_token_raises_with_refresh_message(self):
+        self._patch_request([_response(401, body="Bad credentials")])
+        with self.assertRaises(RuntimeError) as ctx:
+            gh._log_token_status(token="bad-token")
+        self.assertIn("refresh the token", str(ctx.exception).lower())
+
+    def test_401_without_token_raises_with_unexpected_message(self):
+        self._patch_request([_response(401, body="")])
+        with self.assertRaises(RuntimeError) as ctx:
+            gh._log_token_status(token=None)
+        self.assertIn("unexpected", str(ctx.exception).lower())
+
+    def test_remaining_zero_raises(self):
+        self._patch_request([_response(200, body='{"resources": {"core": {"limit": 5000, "remaining": 0, "reset": 9999999999}}}')])
+        with self.assertRaises(RuntimeError) as ctx:
+            gh._log_token_status(token="t")
+        self.assertIn("exhausted", str(ctx.exception).lower())
+
+    def test_remaining_nonzero_does_not_raise(self):
+        self._patch_request([_response(200, body='{"resources": {"core": {"limit": 5000, "remaining": 4999, "reset": 9999999999}}}')])
+        gh._log_token_status(token="t")  # must not raise
+
+    def test_called_only_once(self):
+        mock = self._patch_request([_response(200, body='{"resources": {"core": {"limit": 5000, "remaining": 4999, "reset": 9999999999}}}')])
+        gh._log_token_status(token="t")
+        gh._log_token_status(token="t")
+        self.assertEqual(mock.call_count, 1)
+
+    def test_network_error_does_not_raise(self):
+        # A connectivity failure is logged but must not abort the caller.
+        self._patch_request(gh.urllib.error.URLError("timeout"))
+        gh._log_token_status(token="t")  # must not raise
+
+
 class GithubRequestTest(unittest.TestCase):
     def setUp(self):
         # Never actually sleep while exercising the retry loop.
         sleep_patcher = patch.object(gh.time, "sleep", return_value=None)
         self.addCleanup(sleep_patcher.stop)
         sleep_patcher.start()
+
+        # Bypass the pre-flight token check — it is tested separately in LogTokenStatusTest
+        # and would otherwise consume mock responses intended for the actual API call.
+        token_check_patcher = patch.object(gh, "_log_token_status", return_value=None)
+        self.addCleanup(token_check_patcher.stop)
+        token_check_patcher.start()
+        gh._token_status_logged = False
 
     def _patch_request(self, side_effect):
         patcher = patch.object(gh, "_request", side_effect=side_effect)
@@ -134,6 +188,7 @@ class GithubRequestTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as ctx:
             github_request("https://api.github.com/x", token="expired")
         self.assertIn("bad credentials", str(ctx.exception).lower())
+        self.assertIn("401", str(ctx.exception))
         # Fail hard: the transport is hit exactly once, never retried.
         self.assertEqual(mock.call_count, 1)
 

--- a/tests/repo_utils/test_github_utils.py
+++ b/tests/repo_utils/test_github_utils.py
@@ -53,7 +53,6 @@ class BuildGithubHeadersTest(unittest.TestCase):
                 self.assertNotIn("Authorization", build_github_headers(token))
 
 
-
 class RateLimitWaitTest(unittest.TestCase):
     def test_non_rate_limit_status_returns_none(self):
         self.assertIsNone(gh._rate_limit_wait(200, Headers({}), "", 0))
@@ -107,7 +106,9 @@ class LogTokenStatusTest(unittest.TestCase):
     def test_no_ci_without_token_does_not_raise(self):
         env = {k: v for k, v in os.environ.items() if k != "CI"}
         with patch.dict(os.environ, env, clear=True):
-            self._patch_request([_response(200, body='{"resources": {"core": {"limit": 60, "remaining": 59, "reset": 9999999999}}}')])
+            self._patch_request(
+                [_response(200, body='{"resources": {"core": {"limit": 60, "remaining": 59, "reset": 9999999999}}}')]
+            )
             gh._log_token_status(token=None)  # must not raise
 
     def test_token_rejected_401_raises(self):
@@ -129,17 +130,23 @@ class LogTokenStatusTest(unittest.TestCase):
         self.assertIn("unexpected", str(ctx.exception).lower())
 
     def test_remaining_zero_raises(self):
-        self._patch_request([_response(200, body='{"resources": {"core": {"limit": 5000, "remaining": 0, "reset": 9999999999}}}')])
+        self._patch_request(
+            [_response(200, body='{"resources": {"core": {"limit": 5000, "remaining": 0, "reset": 9999999999}}}')]
+        )
         with self.assertRaises(RuntimeError) as ctx:
             gh._log_token_status(token="t")
         self.assertIn("exhausted", str(ctx.exception).lower())
 
     def test_remaining_nonzero_does_not_raise(self):
-        self._patch_request([_response(200, body='{"resources": {"core": {"limit": 5000, "remaining": 4999, "reset": 9999999999}}}')])
+        self._patch_request(
+            [_response(200, body='{"resources": {"core": {"limit": 5000, "remaining": 4999, "reset": 9999999999}}}')]
+        )
         gh._log_token_status(token="t")  # must not raise
 
     def test_called_only_once(self):
-        mock = self._patch_request([_response(200, body='{"resources": {"core": {"limit": 5000, "remaining": 4999, "reset": 9999999999}}}')])
+        mock = self._patch_request(
+            [_response(200, body='{"resources": {"core": {"limit": 5000, "remaining": 4999, "reset": 9999999999}}}')]
+        )
         gh._log_token_status(token="t")
         gh._log_token_status(token="t")
         self.assertEqual(mock.call_count, 1)

--- a/tests/repo_utils/test_github_utils.py
+++ b/tests/repo_utils/test_github_utils.py
@@ -124,9 +124,12 @@ class LogTokenStatusTest(unittest.TestCase):
         self.assertIn("refresh the token", str(ctx.exception).lower())
 
     def test_401_without_token_raises_with_unexpected_message(self):
-        self._patch_request([_response(401, body="")])
-        with self.assertRaises(RuntimeError) as ctx:
-            gh._log_token_status(token=None)
+        # Must unset CI so the no-token-in-CI guard doesn't fire before the /rate_limit call.
+        env = {k: v for k, v in os.environ.items() if k != "CI"}
+        with patch.dict(os.environ, env, clear=True):
+            self._patch_request([_response(401, body="")])
+            with self.assertRaises(RuntimeError) as ctx:
+                gh._log_token_status(token=None)
         self.assertIn("unexpected", str(ctx.exception).lower())
 
     def test_remaining_zero_raises(self):

--- a/tests/repo_utils/test_update_pr_ci_dashboard_recap.py
+++ b/tests/repo_utils/test_update_pr_ci_dashboard_recap.py
@@ -283,24 +283,24 @@ class GetCiRecapTest(unittest.TestCase):
 class GithubPaginateTest(unittest.TestCase):
     def test_stops_on_short_page(self):
         page = [{"i": n} for n in range(100)]
-        with patch.object(recap_mod, "request_json", side_effect=[page, [{"i": 100}]]) as mocked:
+        with patch.object(recap_mod, "github_request", side_effect=[page, [{"i": 100}]]) as mocked:
             items = github_paginate("/repos/x/y/pulls", token="t")
         self.assertEqual(len(items), 101)
         self.assertEqual(mocked.call_count, 2)
 
     def test_stops_on_empty_first_page(self):
-        with patch.object(recap_mod, "request_json", return_value=[]) as mocked:
+        with patch.object(recap_mod, "github_request", return_value=[]) as mocked:
             items = github_paginate("/repos/x/y/pulls", token="t")
         self.assertEqual(items, [])
         self.assertEqual(mocked.call_count, 1)
 
     def test_extracts_keyed_payload(self):
-        with patch.object(recap_mod, "request_json", return_value={"jobs": [{"name": "a"}]}):
+        with patch.object(recap_mod, "github_request", return_value={"jobs": [{"name": "a"}]}):
             items = github_paginate("/repos/x/y/actions/runs/1/jobs", token="t", key="jobs")
         self.assertEqual(items, [{"name": "a"}])
 
     def test_builds_query_separator_when_path_has_query(self):
-        with patch.object(recap_mod, "request_json", return_value=[]) as mocked:
+        with patch.object(recap_mod, "github_request", return_value=[]) as mocked:
             github_paginate("/repos/x/y/pulls?state=open", token="t")
         url = mocked.call_args.args[0]
         self.assertIn("?state=open&per_page=100&page=1", url)
@@ -347,7 +347,7 @@ class DeleteOldCommentsTest(unittest.TestCase):
         ]
         with (
             patch.object(recap_mod, "github_paginate", return_value=comments),
-            patch.object(recap_mod, "request_json") as request_mock,
+            patch.object(recap_mod, "github_request") as request_mock,
         ):
             delete_old_dashboard_comments("x/y", "t", 5)
         self.assertEqual(request_mock.call_count, 1)
@@ -365,7 +365,7 @@ class RecreateCiRecapCommentTest(unittest.TestCase):
         recap = f"{RECAP_START}\nnew\n{RECAP_END}"
         with (
             patch.object(recap_mod, "github_paginate", return_value=comments),
-            patch.object(recap_mod, "request_json") as request_mock,
+            patch.object(recap_mod, "github_request") as request_mock,
         ):
             recreate_ci_recap_comment("x/y", "t", 5, recap)
 
@@ -385,7 +385,7 @@ class RecreateCiRecapCommentTest(unittest.TestCase):
         recap = f"{RECAP_START}\nnew\n{RECAP_END}"
         with (
             patch.object(recap_mod, "github_paginate", return_value=comments),
-            patch.object(recap_mod, "request_json") as request_mock,
+            patch.object(recap_mod, "github_request") as request_mock,
         ):
             recreate_ci_recap_comment("x/y", "t", 5, recap)
 
@@ -396,7 +396,7 @@ class RecreateCiRecapCommentTest(unittest.TestCase):
         recap = f"{RECAP_START}\nnew\n{RECAP_END}"
         with (
             patch.object(recap_mod, "github_paginate", return_value=[{"id": 1, "body": "unrelated"}]),
-            patch.object(recap_mod, "request_json") as request_mock,
+            patch.object(recap_mod, "github_request") as request_mock,
         ):
             recreate_ci_recap_comment("x/y", "t", 5, recap)
 

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -22,7 +22,7 @@ import subprocess
 from collections import defaultdict
 
 import git
-import requests
+from github_utils import get_github_json
 
 
 def create_script(target_test):
@@ -274,17 +274,13 @@ def get_commit_info(commit, pr_number=None, github_token=None):
     author = None
     merged_author = None
 
-    headers = (
-        {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {github_token}"} if github_token else {}
-    )
-
     # Use PR number from environment if not provided
     if pr_number is None:
         pr_number = os.environ.get("pr_number")
 
     # First, get commit info to check if it's a merge commit
     url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit}"
-    commit_info = requests.get(url, headers=headers).json()
+    commit_info = get_github_json(url, token=github_token)
 
     commit_to_query = commit
 
@@ -303,7 +299,7 @@ def get_commit_info(commit, pr_number=None, github_token=None):
     # The API can return an error dict (e.g. rate limit) instead of a list, so guard with isinstance.
     if not pr_number:
         url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit_to_query}/pulls"
-        pr_info_for_commit = requests.get(url, headers=headers).json()
+        pr_info_for_commit = get_github_json(url, token=github_token)
         if isinstance(pr_info_for_commit, list) and len(pr_info_for_commit) > 0:
             pr_number = pr_info_for_commit[0].get("number")
 
@@ -311,7 +307,7 @@ def get_commit_info(commit, pr_number=None, github_token=None):
     # Use .get() throughout: on rate-limit/403 the API returns an error dict, not the expected PR object.
     if pr_number:
         url = f"https://api.github.com/repos/huggingface/transformers/pulls/{pr_number}"
-        pr_for_commit = requests.get(url, headers=headers).json()
+        pr_for_commit = get_github_json(url, token=github_token)
         author = pr_for_commit.get("user", {}).get("login")
         merged_by = pr_for_commit.get("merged_by")
         if merged_by is not None:

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -296,7 +296,8 @@ def get_commit_info(commit, pr_number=None, github_token=None):
             commit_to_query = match.group(1)
 
     # If no PR number yet, try to discover it from the commit.
-    # The API can return an error dict (e.g. rate limit) instead of a list, so guard with isinstance.
+    # get_github_json either returns valid data or raises. Guard with isinstance in case the endpoint
+    # returns an unexpected shape (e.g. a single object instead of a list).
     if not pr_number:
         url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit_to_query}/pulls"
         pr_info_for_commit = get_github_json(url, token=github_token)
@@ -304,7 +305,8 @@ def get_commit_info(commit, pr_number=None, github_token=None):
             pr_number = pr_info_for_commit[0].get("number")
 
     # If we have a PR number, get author and merged_by info.
-    # Use .get() throughout: on rate-limit/403 the API returns an error dict, not the expected PR object.
+    # get_github_json either returns valid data or raises. Use .get() defensively in case the
+    # response shape differs from what is expected (e.g. API changes or missing fields).
     if pr_number:
         url = f"https://api.github.com/repos/huggingface/transformers/pulls/{pr_number}"
         pr_for_commit = get_github_json(url, token=github_token)

--- a/utils/check_self_hosted_runner.py
+++ b/utils/check_self_hosted_runner.py
@@ -1,23 +1,13 @@
 import argparse
 import json
-import subprocess
+
+from github_utils import get_github_json
 
 
 def get_runner_status(target_runners, token):
     offline_runners = []
 
-    cmd = [
-        "curl",
-        "-H",
-        "Accept: application/vnd.github+json",
-        "-H",
-        f"Authorization: Bearer {token}",
-        "https://api.github.com/repos/huggingface/transformers/actions/runners",
-    ]
-
-    output = subprocess.run(cmd, check=False, shell=True, stdout=subprocess.PIPE)
-    o = output.stdout.decode("utf-8")
-    status = json.loads(o)
+    status = get_github_json("https://api.github.com/repos/huggingface/transformers/actions/runners", token=token)
 
     runners = status["runners"]
     for runner in runners:

--- a/utils/get_ci_error_statistics.py
+++ b/utils/get_ci_error_statistics.py
@@ -5,113 +5,25 @@ import math
 import os
 import time
 import traceback
+import urllib.error
+import urllib.request
 import zipfile
 from collections import Counter
 
-import requests
+# All GitHub REST API access goes through the shared, standard-library-only helper so rate limiting,
+# retries, and rejected-token handling behave identically across every CI utility. `get_github_json`
+# is re-exported here because other modules import it as `from get_ci_error_statistics import ...`.
+from github_utils import build_github_headers, get_github_json  # noqa: F401
 
 
 logger = logging.getLogger(__name__)
 
 
-def _rate_limit_wait(response, attempt):
-    """Return how many seconds to wait before retrying a rate-limited GitHub response, or ``None``.
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Redirect handler that refuses to follow redirects, so the caller can read ``Location`` itself."""
 
-    Distinguishes the two GitHub rate limits, which look different on the wire:
-
-      * primary limit: ``X-RateLimit-Remaining: 0`` plus an ``X-RateLimit-Reset`` epoch;
-      * secondary limit: a 403/429 that does *not* touch the primary quota (``X-RateLimit-Remaining``
-        may still be non-zero) and often ships no ``Retry-After`` header, only a body message like
-        "You have exceeded a secondary rate limit". This is the one that breaks daily CI reporting
-        when it walks the ~24 pages of a large run's jobs, so it must be detected by body too.
-
-    see https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
-    """
-    if response.status_code not in (403, 429):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
         return None
-
-    retry_after = response.headers.get("Retry-After")
-    remaining = response.headers.get("X-RateLimit-Remaining")
-    reset = response.headers.get("X-RateLimit-Reset")
-    body = (response.text or "").lower()
-    # A 429 is always "too many requests"; a 403 only counts as a rate limit if something says so
-    # (a 403 without any rate-limit signal is a genuine permission error and must not be retried).
-    is_rate_limited = response.status_code == 429 or (
-        retry_after is not None
-        or remaining == "0"
-        or "rate limit" in body
-        or "secondary rate" in body
-        or "abuse" in body
-    )
-    if not is_rate_limited:
-        return None
-
-    if retry_after is not None:
-        wait = int(retry_after)
-    elif remaining == "0" and reset is not None:
-        wait = max(0, int(reset) - int(time.time()))
-    else:
-        # Secondary limit without hints: GitHub asks to wait ~1 min; grow it per attempt.
-        wait = 60 * (attempt + 1)
-    # Clamp so a far-off primary reset can't stall CI, but always wait long enough for a secondary
-    # limit (which is measured in tens of seconds) to actually clear.
-    return min(max(wait, 30), 300)
-
-
-def get_github_json(url, token=None, max_retries=8):
-    """GET a GitHub REST API URL and return the parsed JSON.
-
-    Hardened against the failure modes that silently broke daily CI reporting (the reports indexed
-    into the response with e.g. ``result["jobs"]`` / ``workflow_run["created_at"]`` and raised a
-    bare ``KeyError`` when GitHub returned an error payload instead of data):
-
-      * primary *and* secondary rate limiting: retried with a backoff (``Retry-After`` /
-        ``X-RateLimit-Reset`` when present, otherwise ~1 min for secondary limits), never parsed
-        as data. Retrying without the token would only lower the limit, so the token is kept.
-      * transient 5xx errors: retried with exponential backoff.
-
-    Only a genuine 401/404 with a token falls back to an unauthenticated retry; a 403 is treated as
-    a rate limit (above) or a non-retryable error, never as a reason to drop the token. Raises
-    ``RuntimeError`` if no usable response is obtained, so callers fail loudly instead of indexing
-    into an error payload.
-    """
-    headers = None
-    if token:
-        headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
-
-    response = None
-    for attempt in range(max_retries):
-        response = requests.get(url, headers=headers)
-        status = response.status_code
-
-        wait = _rate_limit_wait(response, attempt)
-        if wait is not None:
-            print(
-                f"GitHub API rate limited on {url} (status {status}); waiting {wait}s before "
-                f"retry {attempt + 1}/{max_retries}"
-            )
-            time.sleep(wait)
-            continue
-
-        # Genuine auth/not-found with a token: retry once unauthenticated (previous behaviour).
-        if headers is not None and status in (401, 404):
-            response = requests.get(url)
-            status = response.status_code
-
-        if status >= 500:
-            wait = min(2**attempt, 60)
-            print(f"GitHub API server error {status} on {url}; retrying in {wait}s ({attempt + 1}/{max_retries})")
-            time.sleep(wait)
-            continue
-
-        if status == 200:
-            return response.json()
-
-        # Any other (non-retryable) status: stop and fail loudly below.
-        break
-
-    last_status = response.status_code if response is not None else "no response"
-    raise RuntimeError(f"Could not fetch {url}: last status {last_status} after {max_retries} attempt(s)")
 
 
 def _get_paginated_items(url, key, token=None):
@@ -181,16 +93,24 @@ def download_artifact(artifact_name, artifact_url, output_dir, token):
     but it can't be used to download directly. We need to get a redirect URL first.
     See https://docs.github.com/en/rest/actions/artifacts#download-an-artifact
     """
-    headers = None
-    if token is not None:
-        headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
+    # First request keeps the auth header but must NOT follow the redirect, so we can read the signed
+    # download URL from `Location`. A redirect surfaces as an HTTPError once auto-redirection is off.
+    request = urllib.request.Request(artifact_url, headers=build_github_headers(token), method="GET")
+    opener = urllib.request.build_opener(_NoRedirect)
+    try:
+        with opener.open(request, timeout=30) as result:
+            download_url = result.headers["Location"]
+    except urllib.error.HTTPError as error:
+        if error.code not in (301, 302, 303, 307, 308) or "Location" not in error.headers:
+            raise
+        download_url = error.headers["Location"]
 
-    result = requests.get(artifact_url, headers=headers, allow_redirects=False)
-    download_url = result.headers["Location"]
-    response = requests.get(download_url, allow_redirects=True)
+    # Second request fetches the signed URL WITHOUT the GitHub auth header (it points at storage).
+    with urllib.request.urlopen(download_url, timeout=60) as response:
+        content = response.read()
     file_path = os.path.join(output_dir, f"{artifact_name}.zip")
     with open(file_path, "wb") as fp:
-        fp.write(response.content)
+        fp.write(content)
 
 
 def get_errors_from_single_artifact(artifact_zip_path, job_links=None):

--- a/utils/get_github_job_time.py
+++ b/utils/get_github_job_time.py
@@ -4,7 +4,7 @@ import time
 import traceback
 
 import dateutil.parser as date_parser
-import requests
+from github_utils import get_github_json
 
 
 def extract_time_from_single_job(job):
@@ -30,12 +30,8 @@ def extract_time_from_single_job(job):
 def get_job_time(workflow_run_id, token=None):
     """Extract time info for all jobs in a GitHub Actions workflow run"""
 
-    headers = None
-    if token is not None:
-        headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
-
     url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=50"
-    result = requests.get(url, headers=headers).json()
+    result = get_github_json(url, token=token)
     job_time = {}
 
     try:
@@ -44,7 +40,7 @@ def get_job_time(workflow_run_id, token=None):
 
         for i in range(pages_to_iterate_over):
             time.sleep(1)
-            result = requests.get(url + f"&page={i + 2}", headers=headers).json()
+            result = get_github_json(url + f"&page={i + 2}", token=token)
             job_time.update({job["name"]: extract_time_from_single_job(job) for job in result["jobs"]})
 
         return job_time

--- a/utils/github_utils.py
+++ b/utils/github_utils.py
@@ -1,0 +1,192 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared helper for talking to the GitHub REST API from CI utilities.
+
+Every GitHub API call in ``utils/`` should go through :func:`github_request` (or the
+:func:`get_github_json` GET shortcut) so that rate limiting, transient errors, and rejected tokens
+are handled identically everywhere. Two hard rules the whole repo relies on live here:
+
+  * **No anonymous fallback.** When a token is supplied it is *always* kept. A rejected token is a
+    reason to stop, never a reason to retry without auth: the anonymous 60-request/hour limit is
+    exhausted within a few pages of a large run and turns into a cascade of 403s that looks like a
+    rate-limit problem but is really an expired credential.
+  * **Fail hard.** A rejected token (401) or any other non-retryable status raises ``RuntimeError``
+    instead of returning an error payload, so callers never index into ``{"message": ...}`` by
+    mistake.
+
+This module is intentionally **standard-library only** (``urllib``, not ``requests``): it is
+imported by GitHub Actions steps that run a bare Python with no third-party packages installed.
+"""
+
+import json
+import time
+import urllib.error
+import urllib.request
+
+
+def build_github_headers(token=None):
+    """Build request headers for the GitHub REST API, adding the auth header only when a token is set."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "huggingface-transformers-ci",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _rate_limit_wait(status, response_headers, body, attempt):
+    """Return how many seconds to wait before retrying a rate-limited GitHub response, or ``None``.
+
+    Distinguishes the two GitHub rate limits, which look different on the wire:
+
+      * primary limit: ``X-RateLimit-Remaining: 0`` plus an ``X-RateLimit-Reset`` epoch;
+      * secondary limit: a 403/429 that does *not* touch the primary quota (``X-RateLimit-Remaining``
+        may still be non-zero) and often ships no ``Retry-After`` header, only a body message like
+        "You have exceeded a secondary rate limit". This is the one that breaks daily CI reporting
+        when it walks the ~24 pages of a large run's jobs, so it must be detected by body too.
+
+    see https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+    """
+    if status not in (403, 429):
+        return None
+
+    retry_after = response_headers.get("Retry-After")
+    remaining = response_headers.get("X-RateLimit-Remaining")
+    reset = response_headers.get("X-RateLimit-Reset")
+    body = (body or "").lower()
+    # A 429 is always "too many requests"; a 403 only counts as a rate limit if something says so
+    # (a 403 without any rate-limit signal is a genuine permission error and must not be retried).
+    is_rate_limited = status == 429 or (
+        retry_after is not None
+        or remaining == "0"
+        or "rate limit" in body
+        or "secondary rate" in body
+        or "abuse" in body
+    )
+    if not is_rate_limited:
+        return None
+
+    if retry_after is not None:
+        wait = int(retry_after)
+    elif remaining == "0" and reset is not None:
+        wait = max(0, int(reset) - int(time.time()))
+    else:
+        # Secondary limit without hints: GitHub asks to wait ~1 min; grow it per attempt.
+        wait = 60 * (attempt + 1)
+    # Clamp so a far-off primary reset can't stall CI, but always wait long enough for a secondary
+    # limit (which is measured in tens of seconds) to actually clear.
+    return min(max(wait, 30), 300)
+
+
+def _is_expired_or_bad_token(status, body):
+    """Return why a 401 rejected the token (``"expired"`` / ``"bad credentials"`` / ``"rejected"``), else ``None``.
+
+    A 401 (Unauthorized) is fundamentally a statement about the credential, not the resource: if a
+    token was sent and GitHub still answered 401, the token itself was refused. GitHub spells this
+    out in the body (``"Bad credentials"``; expired credentials also mention ``"expired"``), but any
+    401 received *while sending a token* is by definition a rejected token, so the body is only used
+    to sharpen the error message, never to decide.
+    """
+    if status != 401:
+        return None
+    body = (body or "").lower()
+    if "expired" in body:
+        return "expired"
+    return "bad credentials" if "bad credentials" in body else "rejected"
+
+
+def _request(url, headers, method="GET", data=None):
+    """Perform a single HTTP request and return ``(status, headers, body_text)``.
+
+    Non-2xx responses come back through :class:`urllib.error.HTTPError`, which is itself a response
+    object, so error bodies (rate-limit / auth messages) are returned like any other body instead of
+    raising. Only genuine network-level failures raise (``urllib.error.URLError``), for the caller to
+    treat as transient.
+    """
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status, response.headers, response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as error:
+        return error.code, error.headers, error.read().decode("utf-8", errors="replace")
+
+
+def github_request(url, token=None, method="GET", payload=None, max_retries=8):
+    """Call a GitHub REST API URL and return the parsed JSON (or ``None`` for an empty body, e.g. a 204).
+
+    Hardened against the failure modes that silently broke daily CI reporting (callers indexed into
+    the response with e.g. ``result["jobs"]`` and raised a bare ``KeyError`` when GitHub returned an
+    error payload instead of data).
+
+    **Rate limiting is the only thing that is ever retried.** Both the primary limit
+    (``X-RateLimit-Remaining: 0`` + ``X-RateLimit-Reset``) and the secondary limit are waited out
+    (``Retry-After`` / reset epoch when present, otherwise ~1 min, growing per attempt) up to
+    ``max_retries`` times, and the token is always kept -- retrying without it would only lower the
+    limit. Everything else fails hard immediately with ``RuntimeError`` (no retry):
+
+      * a 401 with a token: the token is bad/revoked/expired. It is *never* retried and *never* falls
+        back to an unauthenticated request, because the anonymous 60-request/hour limit is exhausted
+        almost at once while crawling a large run and every subsequent call comes back 403 -- an
+        expired credential masquerading as a rate limit.
+      * 5xx server errors, network failures, 404s, permission 403s, and any other non-2xx status:
+        raised at once so callers fail loudly instead of indexing into an error payload or masking a
+        real outage behind silent retries.
+    """
+    headers = build_github_headers(token)
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    for attempt in range(max_retries):
+        try:
+            status, response_headers, body = _request(url, headers, method=method, data=data)
+        except urllib.error.URLError as error:
+            # Network-level failure (DNS, connection reset, timeout): not a rate limit, so fail hard.
+            raise RuntimeError(f"GitHub API request to {method} {url} failed: {error}") from error
+
+        wait = _rate_limit_wait(status, response_headers, body, attempt)
+        if wait is not None:
+            print(
+                f"GitHub API rate limited on {method} {url} (status {status}); waiting {wait}s before "
+                f"retry {attempt + 1}/{max_retries}"
+            )
+            time.sleep(wait)
+            continue
+
+        # A rejected token (401) must not be retried and must not fall back to anonymous requests
+        # (that only trips the anonymous rate limit into a cascade of 403s). Fail hard so the
+        # operator refreshes the token instead of chasing phantom rate limits.
+        token_state = _is_expired_or_bad_token(status, body)
+        if token_state is not None:
+            raise RuntimeError(
+                f"GitHub rejected the token on {method} {url} with 401 ({token_state}). Not retrying "
+                "unauthenticated (that only trips the anonymous rate limit and returns 403s). Refresh "
+                "the token and rerun."
+            )
+
+        if 200 <= status < 300:
+            return json.loads(body) if body else None
+
+        # Anything else (5xx, 404, permission 403, ...) is non-retryable: fail hard.
+        raise RuntimeError(f"Could not complete {method} {url}: status {status}: {body[:300]}")
+
+    raise RuntimeError(f"GitHub API still rate limited on {method} {url} after {max_retries} attempt(s)")
+
+
+def get_github_json(url, token=None, max_retries=8):
+    """GET a GitHub REST API URL and return the parsed JSON. See :func:`github_request` for semantics."""
+    return github_request(url, token=token, method="GET", max_retries=max_retries)

--- a/utils/github_utils.py
+++ b/utils/github_utils.py
@@ -110,11 +110,16 @@ def _log_token_status(token=None):
         return
 
     if status == 401:
-        msg = "[token check] Token REJECTED by GitHub (HTTP 401) — token is invalid, expired, or revoked."
-        print(msg)
         if token:
-            raise RuntimeError(f"{msg} Refresh the token and rerun.")
-        return
+            raise RuntimeError(
+                "[token check] GitHub rejected the token (HTTP 401) — it is invalid, expired, or revoked. "
+                "Refresh the token and rerun."
+            )
+        else:
+            raise RuntimeError(
+                "[token check] GitHub rejected an anonymous /rate_limit request (HTTP 401) — unexpected, "
+                "as anonymous access should always be allowed. Check for a GitHub outage or network proxy issue."
+            )
 
     if status != 200:
         print(f"[token check] Unexpected status {status} from /rate_limit: {body[:200]!r}")

--- a/utils/github_utils.py
+++ b/utils/github_utils.py
@@ -30,6 +30,7 @@ imported by GitHub Actions steps that run a bare Python with no third-party pack
 """
 
 import json
+import os
 import time
 import urllib.error
 import urllib.request
@@ -45,6 +46,105 @@ def build_github_headers(token=None):
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers
+
+
+def _log_rate_limit_headers(response_headers, prefix=""):
+    """Print all GitHub rate-limit response headers for diagnostics."""
+    limit = response_headers.get("X-RateLimit-Limit", "n/a")
+    used = response_headers.get("X-RateLimit-Used", "n/a")
+    remaining = response_headers.get("X-RateLimit-Remaining", "n/a")
+    reset_ts = response_headers.get("X-RateLimit-Reset")
+    resource = response_headers.get("X-RateLimit-Resource", "n/a")
+    retry_after = response_headers.get("Retry-After")
+
+    if reset_ts is not None:
+        secs_until = int(reset_ts) - int(time.time())
+        reset_str = f"{reset_ts} (resets in {secs_until}s, i.e. {secs_until // 60}m {secs_until % 60}s)"
+    else:
+        reset_str = "n/a"
+
+    parts = [
+        f"limit={limit}",
+        f"used={used}",
+        f"remaining={remaining}",
+        f"reset={reset_str}",
+        f"resource={resource}",
+    ]
+    if retry_after is not None:
+        parts.append(f"Retry-After={retry_after}s")
+
+    tag = f"[{prefix}] " if prefix else ""
+    print(f"{tag}GitHub rate-limit: {', '.join(parts)}")
+
+
+_token_status_logged = False
+
+
+def _log_token_status(token=None):
+    """Call GET /rate_limit once to confirm token validity and log quota.
+
+    ``/rate_limit`` does not consume quota, so it is safe to call as a pure diagnostic.
+    Prints whether the token is accepted (authenticated, limit=5000+) or rejected (401).
+
+    Raises ``RuntimeError`` immediately if:
+      * running in CI (``CI`` env var) with no token — anonymous 60 req/hr is never enough;
+      * a token was provided but rejected (HTTP 401) — all subsequent calls will fail the same way;
+      * the quota is already exhausted (remaining=0) — no point starting any API calls.
+    """
+    global _token_status_logged
+    if _token_status_logged:
+        return
+    _token_status_logged = True
+
+    if not token and os.environ.get("CI"):
+        raise RuntimeError(
+            "[token check] No GitHub token provided in a CI environment. "
+            "Set the GITHUB_TOKEN env var — anonymous requests are limited to 60/hr and will "
+            "exhaust immediately on any multi-page crawl."
+        )
+
+    try:
+        status, response_headers, body = _request("https://api.github.com/rate_limit", build_github_headers(token))
+    except urllib.error.URLError as e:
+        print(f"[token check] Could not reach GitHub API: {e}")
+        return
+
+    if status == 401:
+        msg = "[token check] Token REJECTED by GitHub (HTTP 401) — token is invalid, expired, or revoked."
+        print(msg)
+        if token:
+            raise RuntimeError(f"{msg} Refresh the token and rerun.")
+        return
+
+    if status != 200:
+        print(f"[token check] Unexpected status {status} from /rate_limit: {body[:200]!r}")
+        return
+
+    # Parse the JSON body for richer quota info (headers only carry a subset).
+    try:
+        data = json.loads(body)
+        core = data.get("resources", {}).get("core", data.get("rate", {}))
+        remaining = str(core.get("remaining", "n/a"))
+        limit = str(core.get("limit", "n/a"))
+        reset_ts = core.get("reset")
+    except Exception:
+        remaining = response_headers.get("X-RateLimit-Remaining", "n/a")
+        limit = response_headers.get("X-RateLimit-Limit", "n/a")
+        reset_ts = response_headers.get("X-RateLimit-Reset")
+        reset_ts = int(reset_ts) if reset_ts is not None else None
+
+    if reset_ts is not None:
+        secs_until = int(reset_ts) - int(time.time())
+        reset_str = f"{reset_ts} (resets in {secs_until}s, i.e. {secs_until // 60}m {secs_until % 60}s)"
+    else:
+        reset_str = "n/a"
+
+    auth_status = "AUTHENTICATED" if token else "UNAUTHENTICATED"
+    print(f"[token check] {auth_status} — limit={limit}, remaining={remaining}, reset={reset_str}")
+
+    if remaining == "0":
+        msg = f"[token check] Rate-limit quota EXHAUSTED (remaining=0). Resets at {reset_str}."
+        raise RuntimeError(msg)
 
 
 def _rate_limit_wait(status, response_headers, body, attempt):
@@ -91,23 +191,6 @@ def _rate_limit_wait(status, response_headers, body, attempt):
     return min(max(wait, 30), 300)
 
 
-def _is_expired_or_bad_token(status, body):
-    """Return why a 401 rejected the token (``"expired"`` / ``"bad credentials"`` / ``"rejected"``), else ``None``.
-
-    A 401 (Unauthorized) is fundamentally a statement about the credential, not the resource: if a
-    token was sent and GitHub still answered 401, the token itself was refused. GitHub spells this
-    out in the body (``"Bad credentials"``; expired credentials also mention ``"expired"``), but any
-    401 received *while sending a token* is by definition a rejected token, so the body is only used
-    to sharpen the error message, never to decide.
-    """
-    if status != 401:
-        return None
-    body = (body or "").lower()
-    if "expired" in body:
-        return "expired"
-    return "bad credentials" if "bad credentials" in body else "rejected"
-
-
 def _request(url, headers, method="GET", data=None):
     """Perform a single HTTP request and return ``(status, headers, body_text)``.
 
@@ -145,6 +228,10 @@ def github_request(url, token=None, method="GET", payload=None, max_retries=8):
         raised at once so callers fail loudly instead of indexing into an error payload or masking a
         real outage behind silent retries.
     """
+    # Check token validity and quota once before entering the retry loop. Raises immediately if
+    # running in CI without a token, the token is rejected, or the quota is already exhausted.
+    _log_token_status(token)
+
     headers = build_github_headers(token)
     data = None
     if payload is not None:
@@ -152,31 +239,25 @@ def github_request(url, token=None, method="GET", payload=None, max_retries=8):
         headers["Content-Type"] = "application/json"
 
     for attempt in range(max_retries):
+        label = "initial" if attempt == 0 else f"retry {attempt}/{max_retries - 1}"
+
         try:
             status, response_headers, body = _request(url, headers, method=method, data=data)
         except urllib.error.URLError as error:
             # Network-level failure (DNS, connection reset, timeout): not a rate limit, so fail hard.
             raise RuntimeError(f"GitHub API request to {method} {url} failed: {error}") from error
 
+        print(f"[{label}] {method} {url} → HTTP {status}")
+        # Rate-limit headers are absent on 401 (auth rejected before rate-limit machinery runs).
+        if status != 401:
+            _log_rate_limit_headers(response_headers, prefix=label)
+
         wait = _rate_limit_wait(status, response_headers, body, attempt)
         if wait is not None:
-            print(
-                f"GitHub API rate limited on {method} {url} (status {status}); waiting {wait}s before "
-                f"retry {attempt + 1}/{max_retries}"
-            )
+            next_label = f"retry {attempt + 1}/{max_retries - 1}"
+            print(f"[{label}] Rate limited (HTTP {status}) — waiting {wait}s before {next_label}")
             time.sleep(wait)
             continue
-
-        # A rejected token (401) must not be retried and must not fall back to anonymous requests
-        # (that only trips the anonymous rate limit into a cascade of 403s). Fail hard so the
-        # operator refreshes the token instead of chasing phantom rate limits.
-        token_state = _is_expired_or_bad_token(status, body)
-        if token_state is not None:
-            raise RuntimeError(
-                f"GitHub rejected the token on {method} {url} with 401 ({token_state}). Not retrying "
-                "unauthenticated (that only trips the anonymous rate limit and returns 403s). Refresh "
-                "the token and rerun."
-            )
 
         if 200 <= status < 300:
             return json.loads(body) if body else None

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -23,10 +23,10 @@ import sys
 import time
 from typing import Any
 
-import requests
 from compare_test_runs import compare_job_sets
 from get_ci_error_statistics import get_jobs
 from get_previous_daily_ci import get_last_daily_ci_reports, get_last_daily_ci_run, get_last_daily_ci_workflow_run_id
+from github_utils import get_github_json
 from huggingface_hub import HfApi
 from slack_sdk import WebClient
 
@@ -1077,11 +1077,10 @@ if __name__ == "__main__":
 
         # Retrieve the PR title and author login to complete the report
         github_token = os.environ.get("GITHUB_TOKEN")
-        github_headers = {"Authorization": f"token {github_token}"} if github_token else {}
 
         commit_number = ci_url.split("/")[-1]
         ci_detail_url = f"https://api.github.com/repos/{repository_full_name}/commits/{commit_number}"
-        ci_details = requests.get(ci_detail_url, headers=github_headers).json()
+        ci_details = get_github_json(ci_detail_url, token=github_token)
 
         # We use `.get()` to avoid failures when the GitHub API returns an unexpected response (e.g. due to rate
         # limiting, where the response won't contain the expected fields). It's preferred to continue the CI run
@@ -1095,7 +1094,7 @@ if __name__ == "__main__":
         if len(numbers) > 0:
             pr_number = numbers[0]
             ci_detail_url = f"https://api.github.com/repos/{repository_full_name}/pulls/{pr_number}"
-            ci_details = requests.get(ci_detail_url, headers=github_headers).json()
+            ci_details = get_github_json(ci_detail_url, token=github_token)
 
             ci_author = ci_details.get("user", {}).get("login") or ci_author
             ci_url = f"https://github.com/{repository_full_name}/pull/{pr_number}"

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1082,10 +1082,9 @@ if __name__ == "__main__":
         ci_detail_url = f"https://api.github.com/repos/{repository_full_name}/commits/{commit_number}"
         ci_details = get_github_json(ci_detail_url, token=github_token)
 
-        # We use `.get()` to avoid failures when the GitHub API returns an unexpected response (e.g. due to rate
-        # limiting, where the response won't contain the expected fields). It's preferred to continue the CI run
-        # without failing even if we can't retrieve the author info. That said, the GITHUB_TOKEN should always be
-        # set during CI runs to avoid hitting the rate limit in the first place.
+        # get_github_json either returns valid data or raises (e.g. on rate limiting). We still use
+        # .get() defensively in case the response shape changes — it's preferred to continue the CI
+        # run without author info rather than abort the whole report.
         ci_author = (ci_details.get("author") or {}).get("login")
 
         merged_by = None

--- a/utils/update_pr_ci_dashboard_recap.py
+++ b/utils/update_pr_ci_dashboard_recap.py
@@ -23,6 +23,10 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+# GitHub REST calls go through the shared helper (rate-limit handling, no anonymous fallback, fail
+# hard on a rejected token); the local `request_json` below is kept only for the Grafana proxy.
+from github_utils import github_request
+
 
 GITHUB_API_URL = "https://api.github.com"
 GRAFANA_QUERY_URL = "https://transformers-ci.lor-e.huggingface.cool/api/datasources/proxy/uid/prometheus/api/v1/query"
@@ -58,28 +62,19 @@ def log_workflow_run(workflow_run):
     print("==========================================")
 
 
-def request_json(url, token=None, method="GET", payload=None):
-    """Send an HTTP request and parse the response body as JSON."""
-    headers = {
-        "Accept": "application/vnd.github+json" if "api.github.com" in url else "application/json",
-        "User-Agent": "transformers-ci-dashboard-recap",
-    }
-    if token is not None and "api.github.com" in url:
-        headers["Authorization"] = f"Bearer {token}"
-        headers["X-GitHub-Api-Version"] = "2022-11-28"
+def request_json(url):
+    """GET a URL and parse the response body as JSON (used for the Grafana datasource proxy).
 
-    data = None
-    if payload is not None:
-        data = json.dumps(payload).encode("utf-8")
-        headers["Content-Type"] = "application/json"
-
-    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    GitHub API access does *not* go through here -- see :func:`github_utils.github_request`.
+    """
+    headers = {"Accept": "application/json", "User-Agent": "transformers-ci-dashboard-recap"}
+    request = urllib.request.Request(url, headers=headers, method="GET")
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
             raw = response.read().decode("utf-8")
     except urllib.error.HTTPError as error:
         body = error.read().decode("utf-8", errors="replace")
-        raise RuntimeError(f"{method} {url} failed with {error.code}: {body}") from error
+        raise RuntimeError(f"GET {url} failed with {error.code}: {body}") from error
 
     if not raw:
         return None
@@ -93,7 +88,7 @@ def github_paginate(path, token, key=None):
     separator = "&" if "?" in path else "?"
     while True:
         url = f"{GITHUB_API_URL}{path}{separator}per_page=100&page={page}"
-        payload = request_json(url, token=token)
+        payload = github_request(url, token=token)
         page_items = payload[key] if key is not None else payload
         if not page_items:
             break
@@ -294,7 +289,7 @@ def delete_old_dashboard_comments(repo, token, pr_number):
     for comment in comments:
         body = comment.get("body") or ""
         if any(marker in body for marker in OLD_DASHBOARD_COMMENT_MARKERS):
-            request_json(
+            github_request(
                 f"{GITHUB_API_URL}/repos/{repo}/issues/comments/{comment['id']}", token=token, method="DELETE"
             )
 
@@ -305,13 +300,13 @@ def recreate_ci_recap_comment(repo, token, pr_number, recap):
     for comment in comments:
         if RECAP_START not in (comment.get("body") or ""):
             continue
-        request_json(
+        github_request(
             f"{GITHUB_API_URL}/repos/{repo}/issues/comments/{comment['id']}",
             token=token,
             method="DELETE",
         )
 
-    request_json(
+    github_request(
         f"{GITHUB_API_URL}/repos/{repo}/issues/{pr_number}/comments",
         token=token,
         method="POST",
@@ -363,7 +358,7 @@ def main():
     )
     updated_body = inject_ci_badge(pr.get("body"), badge_body)
     updated_body = remove_marked_block(updated_body, RECAP_START, RECAP_END)
-    request_json(
+    github_request(
         f"{GITHUB_API_URL}/repos/{repo}/pulls/{pr['number']}",
         token=token,
         method="PATCH",


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47474)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47474)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

- unify all GH calls to the same function
- make sure it uses vanilla Python so we can use it in all GH actions
- do not retry on 401 for expired tokens