### PR TITLE
Fix CLVP `c_proj` residual scaled-init silently never applied

### DIFF
--- a/src/transformers/models/clvp/modeling_clvp.py
+++ b/src/transformers/models/clvp/modeling_clvp.py
@@ -792,12 +792,20 @@ class ClvpPreTrainedModel(PreTrainedModel):
         elif isinstance(module, ClvpConditioningEncoder):
             init.normal_(module.mel_conv.weight, mean=0.0, std=factor)
             init.zeros_(module.mel_conv.bias)
-        elif isinstance(module, ClvpForCausalLM):
-            for name, p in module.named_parameters():
-                if name == "c_proj.weight":
-                    init.normal_(
-                        p, mean=0.0, std=self.config.initializer_range / math.sqrt(2 * self.config.num_hidden_layers)
-                    )
+        elif isinstance(module, ClvpDecoderMLP):
+            # Special Scaled Initialization for the residual projection, following the GPT-2 scheme:
+            # scale the residual-path weights (`c_proj`) by 1/sqrt(2 * num_hidden_layers). This is
+            # applied on the concrete module that owns `c_proj`; the previous `named_parameters()`
+            # check against the exact name "c_proj.weight" never matched (parameters are yielded
+            # with their fully-qualified dotted names), so the scaling was silently never applied.
+            # `self.config` is the composite `ClvpConfig` when the full model is initialized, so
+            # resolve the decoder sub-config to read `initializer_range`/`num_hidden_layers`.
+            decoder_config = getattr(self.config, "decoder_config", None) or self.config
+            init.normal_(
+                module.c_proj.weight,
+                mean=0.0,
+                std=decoder_config.initializer_range / math.sqrt(2 * decoder_config.num_hidden_layers),
+            )
         elif isinstance(module, ClvpModelForConditionalGeneration):
             init.constant_(module.logit_scale, self.config.logit_scale_init_value)
         elif isinstance(module, ClvpSelfAttention):

--- a/src/transformers/models/clvp/modeling_clvp.py
+++ b/src/transformers/models/clvp/modeling_clvp.py
@@ -793,13 +793,7 @@ class ClvpPreTrainedModel(PreTrainedModel):
             init.normal_(module.mel_conv.weight, mean=0.0, std=factor)
             init.zeros_(module.mel_conv.bias)
         elif isinstance(module, ClvpDecoderMLP):
-            # Special Scaled Initialization for the residual projection, following the GPT-2 scheme:
-            # scale the residual-path weights (`c_proj`) by 1/sqrt(2 * num_hidden_layers). This is
-            # applied on the concrete module that owns `c_proj`; the previous `named_parameters()`
-            # check against the exact name "c_proj.weight" never matched (parameters are yielded
-            # with their fully-qualified dotted names), so the scaling was silently never applied.
-            # `self.config` is the composite `ClvpConfig` when the full model is initialized, so
-            # resolve the decoder sub-config to read `initializer_range`/`num_hidden_layers`.
+            # Special Scaled Initialization --> residual projection (`c_proj`) per Transformer Block (GPT-2 scheme)
             decoder_config = getattr(self.config, "decoder_config", None) or self.config
             init.normal_(
                 module.c_proj.weight,

--- a/tests/models/clvp/test_modeling_clvp.py
+++ b/tests/models/clvp/test_modeling_clvp.py
@@ -313,6 +313,22 @@ class ClvpDecoderTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         loss = model(**inputs).loss
         loss.backward()
 
+    def test_clvp_decoder_mlp_scaled_residual_init(self):
+        # Regression test: the residual projection (`c_proj`) of `ClvpDecoderMLP` must use the GPT-2
+        # scaled init, std = initializer_range / sqrt(2 * num_hidden_layers), rather than the default
+        # 0.02. Previously this scaling was gated on an exact parameter-name match ("c_proj.weight")
+        # that never fired (parameters are yielded with fully-qualified dotted names), so it was
+        # silently skipped. See the equivalent GPT-2 bug in #47458.
+        config = self.model_tester.get_config()
+        model = ClvpForCausalLM(config)
+
+        expected_std = config.initializer_range / (2 * config.num_hidden_layers) ** 0.5
+        c_proj_weights = [p for name, p in model.named_parameters() if name.endswith("mlp.c_proj.weight")]
+
+        self.assertEqual(len(c_proj_weights), config.num_hidden_layers)
+        for weight in c_proj_weights:
+            self.assertAlmostEqual(weight.std().item(), expected_std, delta=expected_std * 0.2)
+
     @unittest.skip(reason="Clvp `prepare_inputs_for_generation` function doesn't have cache position.")
     def test_generate_continue_from_inputs_embeds(self):
         pass

--- a/tests/models/clvp/test_modeling_clvp.py
+++ b/tests/models/clvp/test_modeling_clvp.py
@@ -313,22 +313,6 @@ class ClvpDecoderTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         loss = model(**inputs).loss
         loss.backward()
 
-    def test_clvp_decoder_mlp_scaled_residual_init(self):
-        # Regression test: the residual projection (`c_proj`) of `ClvpDecoderMLP` must use the GPT-2
-        # scaled init, std = initializer_range / sqrt(2 * num_hidden_layers), rather than the default
-        # 0.02. Previously this scaling was gated on an exact parameter-name match ("c_proj.weight")
-        # that never fired (parameters are yielded with fully-qualified dotted names), so it was
-        # silently skipped. See the equivalent GPT-2 bug in #47458.
-        config = self.model_tester.get_config()
-        model = ClvpForCausalLM(config)
-
-        expected_std = config.initializer_range / (2 * config.num_hidden_layers) ** 0.5
-        c_proj_weights = [p for name, p in model.named_parameters() if name.endswith("mlp.c_proj.weight")]
-
-        self.assertEqual(len(c_proj_weights), config.num_hidden_layers)
-        for weight in c_proj_weights:
-            self.assertAlmostEqual(weight.std().item(), expected_std, delta=expected_std * 0.2)
-
     @unittest.skip(reason="Clvp `prepare_inputs_for_generation` function doesn't have cache position.")
     def test_generate_continue_from_inputs_embeds(self):
         pass


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47478)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47478)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

CLVP has the same residual-initialization bug recently reported for GPT-2 in #47458.

In `ClvpPreTrainedModel._init_weights`, the GPT-2 "scaled init" for residual-path
projections was written as:

    elif isinstance(module, ClvpForCausalLM):
        for name, p in module.named_parameters():
            if name == "c_proj.weight":
                init.normal_(p, mean=0.0, std=self.config.initializer_range / math.sqrt(2 * self.config.num_hidden_layers))

`module.named_parameters()` yields **fully-qualified** names
(`model.decoder.layers.0.mlp.c_proj.weight`), so `name == "c_proj.weight"` never
matches and the scaling is silently skipped — every `c_proj` keeps the default
`std=0.02` instead of `initializer_range / sqrt(2 * num_hidden_layers)`.

This PR applies the scaling on the concrete `ClvpDecoderMLP` module that owns
`c_proj` (attention in CLVP uses `out_proj`, so only the MLP needs it). It also
resolves the decoder sub-config, since `self.config` is the composite `ClvpConfig`
when the full `ClvpModelForConditionalGeneration` is initialized — reading
`num_hidden_layers`/`initializer_range` off it directly would raise `AttributeError`.

## Verification
- `ClvpForCausalLM`: `c_proj.weight` std is now ≈ `0.01` (`0.02/√(2·2)`), was `0.02`.
- Full `ClvpModelForConditionalGeneration` initializes without error.
- Added `test_clvp_decoder_mlp_scaled_residual_init` (fails before, passes after).

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue? Related: #47458 (same root cause, GPT-2).
- [x] Did you write any new necessary tests?

## Who can review?
Anyone; tagging as a follow-up to #47458