### PR TITLE
fix: guard DTensor import in sharding_utils.py for PyTorch < 2.5

### DIFF
--- a/src/transformers/distributed/sharding_utils.py
+++ b/src/transformers/distributed/sharding_utils.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from ..utils import is_torch_available
 
+_dtensor_available = False
 
 if TYPE_CHECKING:
     import torch
@@ -25,10 +26,15 @@ if TYPE_CHECKING:
 
 if is_torch_available():
     import torch
-    from torch.distributed.tensor import DTensor
-    from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
-    from torch.distributed.tensor.placement_types import Shard
+    try:
+        from torch.distributed.tensor import DTensor
+        from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
+        from torch.distributed.tensor.placement_types import Shard
+        _dtensor_available = True
+    except ImportError:
+        _dtensor_available = False
 
+if _dtensor_available:
     # torch < 2.10 names as an underscore before `local_shard_size_and_offset`: alias it the non-underscored version
     if not hasattr(Shard, "local_shard_size_and_offset") and hasattr(Shard, "_local_shard_size_and_offset"):
         Shard.local_shard_size_and_offset = Shard._local_shard_size_and_offset

--- a/src/transformers/distributed/sharding_utils.py
+++ b/src/transformers/distributed/sharding_utils.py
@@ -23,8 +23,6 @@ if TYPE_CHECKING:
     import torch
     from torch.distributed.tensor import DTensor
 
-_dtensor_available = False
-
 if is_torch_available() and is_torch_greater_or_equal("2.5"):
     import torch
 
@@ -32,9 +30,6 @@ if is_torch_available() and is_torch_greater_or_equal("2.5"):
     from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
     from torch.distributed.tensor.placement_types import Shard
 
-    _dtensor_available = True
-
-if _dtensor_available:
     # torch < 2.10 names as an underscore before `local_shard_size_and_offset`: alias it the non-underscored version
     if not hasattr(Shard, "local_shard_size_and_offset") and hasattr(Shard, "_local_shard_size_and_offset"):
         Shard.local_shard_size_and_offset = Shard._local_shard_size_and_offset

--- a/src/transformers/distributed/sharding_utils.py
+++ b/src/transformers/distributed/sharding_utils.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from ..utils import is_torch_available
 
+
 if TYPE_CHECKING:
     import torch
     from torch.distributed.tensor import DTensor

--- a/src/transformers/distributed/sharding_utils.py
+++ b/src/transformers/distributed/sharding_utils.py
@@ -27,10 +27,12 @@ _dtensor_available = False
 
 if is_torch_available():
     import torch
+
     try:
         from torch.distributed.tensor import DTensor
         from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
         from torch.distributed.tensor.placement_types import Shard
+
         _dtensor_available = True
     except ImportError:
         _dtensor_available = False

--- a/src/transformers/distributed/sharding_utils.py
+++ b/src/transformers/distributed/sharding_utils.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
 
 if is_torch_available() and is_torch_greater_or_equal("2.5"):
     import torch
-
     from torch.distributed.tensor import DTensor
     from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
     from torch.distributed.tensor.placement_types import Shard

--- a/src/transformers/distributed/sharding_utils.py
+++ b/src/transformers/distributed/sharding_utils.py
@@ -18,11 +18,11 @@ from typing import TYPE_CHECKING
 
 from ..utils import is_torch_available
 
-_dtensor_available = False
-
 if TYPE_CHECKING:
     import torch
     from torch.distributed.tensor import DTensor
+
+_dtensor_available = False
 
 if is_torch_available():
     import torch

--- a/src/transformers/distributed/sharding_utils.py
+++ b/src/transformers/distributed/sharding_utils.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
-from ..utils import is_torch_available
+from ..utils import is_torch_available, is_torch_greater_or_equal
 
 
 if TYPE_CHECKING:
@@ -25,17 +25,14 @@ if TYPE_CHECKING:
 
 _dtensor_available = False
 
-if is_torch_available():
+if is_torch_available() and is_torch_greater_or_equal("2.5"):
     import torch
 
-    try:
-        from torch.distributed.tensor import DTensor
-        from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
-        from torch.distributed.tensor.placement_types import Shard
+    from torch.distributed.tensor import DTensor
+    from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
+    from torch.distributed.tensor.placement_types import Shard
 
-        _dtensor_available = True
-    except ImportError:
-        _dtensor_available = False
+    _dtensor_available = True
 
 if _dtensor_available:
     # torch < 2.10 names as an underscore before `local_shard_size_and_offset`: alias it the non-underscored version


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47481)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47481)
<!-- ci-dashboard-badge:end -->

Wrap  in a try/except
to prevent ImportError on older PyTorch versions where DTensor is not available. The file already uses ,
so type annotations are lazy-evaluated — only the runtime imports need protection.

Fixes the cascading import failure:
  core_model_loading.py -> sharding_utils.py -> DTensor ImportError
which breaks downstream CI (e.g. accelerate minimum env with PT 2.4.0).

Closes #47480