### PR TITLE
Fix Gemma4 audio feature dtype mismatch in masked_scatter

### DIFF
--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -2395,7 +2395,7 @@ class Gemma4Model(Gemma4PreTrainedModel):
             )
 
             inputs_embeds = inputs_embeds.masked_scatter(
-                audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device)
+                audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device, inputs_embeds.dtype)
             )
 
         # It may already have been prepared by, e.g., `generate`

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -2115,7 +2115,7 @@ class Gemma4Model(Gemma3nModel):
             )
 
             inputs_embeds = inputs_embeds.masked_scatter(
-                audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device)
+                audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device, inputs_embeds.dtype)
             )
 
         # It may already have been prepared by, e.g., `generate`


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47482)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47482)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Aligns the dtype of Gemma 4 audio features to the text-embedding dtype before `masked_scatter`, so the audio merge behaves like the image and video merges.

In `Gemma4Model.forward`, the image and video branches cast their features to `inputs_embeds.dtype` before scattering them into the text embeddings:

```python
image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
...
video_features = video_features.to(inputs_embeds.device, inputs_embeds.dtype)
```

but the audio branch only moved the features to the correct device, never the dtype:

```python
inputs_embeds = inputs_embeds.masked_scatter(
    audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device)  # dtype not aligned
)
```

When `inputs_embeds` and the audio encoder output end up in different dtypes (for example a float32 residual stream with a float16 audio tower, which happens under mixed-precision setups), this raises:

```
RuntimeError: masked_scatter_: expected self and source to have same dtypes but got Float and Half
```

The fix casts `audio_features` to `inputs_embeds.dtype` in the same call, matching the image and video paths. Text-only, image, and video inference are unaffected since they already cast. The change is made in `modular_gemma4.py` and mirrored in the generated `modeling_gemma4.py`.

## Before submitting

- [x] This PR fixes a bug (audio inference crash under mixed precision).
- [x] Did you make sure to update the documentation with your changes? Not needed.
- [x] Did you write any new necessary tests? Not needed; this aligns audio with the existing image/video dtype handling.

## Who can review?

@ArthurZucker @Cyrilvallez