### PR TITLE
feat[vLLM x v5]: Make audio optional and support multiple audios in VibeVoice ASR processor

### DIFF
--- a/src/transformers/models/vibevoice_asr/processing_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/processing_vibevoice_asr.py
@@ -95,7 +95,7 @@ class VibeVoiceAsrProcessor(ProcessorMixin):
     def __call__(
         self,
         text: TextInput | list[TextInput],
-        audio: AudioInput,
+        audio: AudioInput | None = None,
         output_labels: bool | None = False,
         **kwargs: Unpack[VibeVoiceAsrProcessorKwargs],
     ) -> BatchFeature:
@@ -137,23 +137,26 @@ class VibeVoiceAsrProcessor(ProcessorMixin):
         elif not isinstance(text, (list, tuple)):
             raise ValueError("text input must be a string or list of strings")
 
-        audio = make_list_of_audio(audio)
-        if len(text) != len(audio):
-            raise ValueError(f"Got {len(text)} text but {len(audio)} audios; they must match 1:1.")
-        data = self.feature_extractor(audio, **audio_kwargs)
+        if audio is not None:
+            audio = make_list_of_audio(audio)
+            data = self.feature_extractor(audio, **audio_kwargs)
+            audio_lengths = data["padding_mask"].sum(dim=-1).cpu().numpy()
 
-        # Replace audio duration placeholders in text
-        audio_lengths = data["padding_mask"].sum(dim=-1).cpu().numpy()
-        audio_durations = audio_lengths / self.feature_extractor.sampling_rate
-        audio_duration_pattern = re.compile(re.escape(self.audio_duration_token))
-        for i in range(len(text)):
-            text[i] = audio_duration_pattern.sub(f"{audio_durations[i]:.2f}", text[i])
+            # Replace audio duration placeholders in text
+            audio_durations = audio_lengths / self.feature_extractor.sampling_rate
+            audio_durations_iter = iter(audio_durations)
+            audio_duration_pattern = re.compile(re.escape(self.audio_duration_token))
+            for i in range(len(text)):
+                text[i] = audio_duration_pattern.sub(lambda _: f"{next(audio_durations_iter):.2f}", text[i])
 
-        # Expand audio tokens in text
-        num_audio_tokens = np.ceil(audio_lengths / audio_kwargs["pad_to_multiple_of"]).astype(int).tolist()
-        audio_token_pattern = re.compile(re.escape(self.audio_token))
-        for i, num_tokens in enumerate(num_audio_tokens):
-            text[i] = audio_token_pattern.sub(self.audio_token * num_tokens, text[i])
+            # Expand audio tokens in text
+            num_audio_tokens = np.ceil(audio_lengths / audio_kwargs["pad_to_multiple_of"]).astype(int).tolist()
+            num_audio_tokens_iter = iter(num_audio_tokens)
+            audio_token_pattern = re.compile(re.escape(self.audio_token))
+            for i in range(len(text)):
+                text[i] = audio_token_pattern.sub(lambda _: self.audio_token * next(num_audio_tokens_iter), text[i])
+        else:
+            data = {}
 
         text_inputs = self.tokenizer(text, **text_kwargs)
         data.update(text_inputs)

--- a/tests/models/vibevoice_asr/test_processing_vibevoice_asr.py
+++ b/tests/models/vibevoice_asr/test_processing_vibevoice_asr.py
@@ -16,7 +16,8 @@ import shutil
 import tempfile
 import unittest
 
-from parameterized import parameterized
+import numpy as np
+import torch
 
 from transformers import (
     AutoProcessor,
@@ -31,6 +32,7 @@ from ...test_processing_common import ProcessorTesterMixin
 
 class VibeVoiceAsrProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = VibeVoiceAsrProcessor
+    audio_input_name = "input_values"
     # Tiny processor created with make_tiny_processor.py from "microsoft/VibeVoice-ASR-HF"
     tiny_model_id = "hf-internal-testing/tiny-processor-vibevoice_asr"
 
@@ -110,12 +112,101 @@ class VibeVoiceAsrProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             self.assertIn(key, helper_outputs)
             self.assertTrue(helper_outputs[key].equal(manual_outputs[key]))
 
-    @parameterized.expand([(1, "np"), (1, "pt"), (2, "np"), (2, "pt")])
-    def test_apply_chat_template_audio(self, batch_size: int, return_tensors: str):
-        self.skipTest("VibeVoiceAsrProcessor does not support chat templates with text-only inputs.")
+    # Override: VibeVoice's chat template does not support `continue_final_message`.
+    @require_torch
+    def _test_apply_chat_template(
+        self,
+        modality: str,
+        batch_size: int,
+        return_tensors: str,
+        input_name: str,
+        processor_name: str,
+        input_data: list[str],
+    ):
+        if return_tensors != "pt":
+            self.skipTest("VibeVoiceAsrProcessor only supports PyTorch tensors")
+        processor = self.get_processor()
+        if processor.chat_template is None:
+            self.skipTest("Processor has no chat template")
 
-    def test_apply_chat_template_assistant_mask(self):
-        self.skipTest("VibeVoiceAsrProcessor does not support chat templates with text-only inputs.")
+        if processor_name not in self.processor_class.get_attributes():
+            self.skipTest(f"{processor_name} attribute not present in {self.processor_class}")
+
+        # some models have only Fast image processor
+        if getattr(processor, processor_name).__class__.__name__.endswith("Fast"):
+            return_tensors = "pt"
+
+        batch_messages = [
+            [
+                {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]},
+                {"role": "user", "content": [{"type": "text", "text": "Describe this."}]},
+            ]
+        ] * batch_size
+
+        # Test that jinja can be applied
+        formatted_prompt = processor.apply_chat_template(batch_messages, add_generation_prompt=True, tokenize=False)
+        self.assertEqual(len(formatted_prompt), batch_size)
+
+        # Test that tokenizing with template and directly with `self.tokenizer` gives same output
+        formatted_prompt_tokenized = processor.apply_chat_template(
+            batch_messages, add_generation_prompt=True, tokenize=True, return_tensors=return_tensors
+        )
+        add_special_tokens = True
+        if processor.tokenizer.bos_token is not None and formatted_prompt[0].startswith(processor.tokenizer.bos_token):
+            add_special_tokens = False
+        tok_output = processor.tokenizer(
+            formatted_prompt, return_tensors=return_tensors, add_special_tokens=add_special_tokens
+        )
+        expected_output = tok_output.input_ids
+        self.assertListEqual(expected_output.tolist(), formatted_prompt_tokenized.tolist())
+
+        # Test that kwargs passed to processor's `__call__` are actually used
+        tokenized_prompt_100 = processor.apply_chat_template(
+            batch_messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_tensors=return_tensors,
+            processor_kwargs={
+                "padding": "max_length",
+                "truncation": True,
+                "max_length": self.chat_template_max_length,
+            },
+        )
+        self.assertEqual(len(tokenized_prompt_100[0]), self.chat_template_max_length)
+
+        # Test that `return_dict=True` returns text related inputs in the dict
+        out_dict_text = processor.apply_chat_template(
+            batch_messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors=return_tensors,
+        )
+        self.assertTrue(all(key in out_dict_text for key in ["input_ids", "attention_mask"]))
+        self.assertEqual(len(out_dict_text["input_ids"]), batch_size)
+        self.assertEqual(len(out_dict_text["attention_mask"]), batch_size)
+
+        # Test that with modality URLs and `return_dict=True`, we get modality inputs in the dict
+        for idx, url in enumerate(input_data[:batch_size]):
+            batch_messages[idx][1]["content"] = [batch_messages[idx][1]["content"][0], {"type": modality, "url": url}]
+
+        out_dict = processor.apply_chat_template(
+            batch_messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors=return_tensors,
+            processor_kwargs={"num_frames": 2},  # by default no more than 2 frames, otherwise too slow
+        )
+        input_name = getattr(self, input_name)
+        self.assertTrue(input_name in out_dict)
+        self.assertEqual(len(out_dict["input_ids"]), batch_size)
+        self.assertEqual(len(out_dict["attention_mask"]), batch_size)
+        self.assertEqual(len(out_dict[input_name]), batch_size)
+
+        return_tensor_to_type = {"pt": torch.Tensor, "np": np.ndarray, None: list}
+        for k in out_dict:
+            self.assertIsInstance(out_dict[k], return_tensor_to_type[return_tensors])
 
     @require_torch
     def test_decode_output_formats(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47483)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47483)
<!-- ci-dashboard-badge:end -->

### What does this PR do?

→ Unblocks the [vLLM Transformers audio backend PR](https://github.com/vllm-project/vllm/pull/39330) by making `VibeVoiceAsrProcessor` compatible with [test_processing_correctness](https://github.com/vllm-project/vllm/blob/main/tests/models/multimodal/processing/test_common.py#L423).
→ Makes `audio` optional (`audio: AudioInput | None = None`) and relaxes the processor from a strict 1:1 text-audio mapping to support multiple audios per prompt, matching other audio processors. No modeling changes are needed.
→ Verified no regressions in `tests/models/vibevoice_asr/`, enabled previously skipped processor/chat-template tests, and spot-checked coherent single and multi-audio generation.

cc: @ebezzam @eustlb @vasqu

### Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

### Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you fix any necessary existing tests?