### PR TITLE
[Bugfix] [Modeling] Fix DSV4 norm

### DIFF
--- a/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
+++ b/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
@@ -45,6 +45,9 @@ from .configuration_deepseek_v4 import DeepseekV4Config
 @use_kernel_forward_from_hub("RMSNorm")
 class DeepseekV4RMSNorm(nn.Module):
     def __init__(self, hidden_size, eps: float = 1e-6) -> None:
+        """
+        DeepseekV4RMSNorm is equivalent to T5LayerNorm
+        """
         super().__init__()
         self.weight = nn.Parameter(torch.ones(hidden_size))
         self.variance_epsilon = eps

--- a/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
+++ b/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
@@ -45,9 +45,6 @@ from .configuration_deepseek_v4 import DeepseekV4Config
 @use_kernel_forward_from_hub("RMSNorm")
 class DeepseekV4RMSNorm(nn.Module):
     def __init__(self, hidden_size, eps: float = 1e-6) -> None:
-        """
-        DeepseekV4RMSNorm is equivalent to T5LayerNorm
-        """
         super().__init__()
         self.weight = nn.Parameter(torch.ones(hidden_size))
         self.variance_epsilon = eps
@@ -57,7 +54,8 @@ class DeepseekV4RMSNorm(nn.Module):
         hidden_states = hidden_states.to(torch.float32)
         variance = hidden_states.pow(2).mean(-1, keepdim=True)
         hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
-        return self.weight * hidden_states.to(input_dtype)
+        # DSV4: cast output to `input_dtype` to handle float32 norm weights
+        return (self.weight * hidden_states.to(input_dtype)).to(input_dtype)
 
     def extra_repr(self):
         return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"

--- a/src/transformers/models/deepseek_v4/modular_deepseek_v4.py
+++ b/src/transformers/models/deepseek_v4/modular_deepseek_v4.py
@@ -64,7 +64,21 @@ def apply_rotary_pos_emb(
 
 
 class DeepseekV4RMSNorm(DeepseekV3RMSNorm):
-    pass
+    def __init__(self, hidden_size, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        # DSV4: cast output to `input_dtype` to handle float32 norm weights
+        return (self.weight * hidden_states.to(input_dtype)).to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
 
 
 class DeepseekV4UnweightedRMSNorm(nn.Module):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47486)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47486)
<!-- ci-dashboard-badge:end -->

## Purpose ##
* Fix modeling for deepseek v4 architecture when there is no fp8 quantization config

## Changes ##
* DSV4 has specialized modeling, where norm weights are kept in float32. This means that the output of `DeepseekV4RMSNorm` gets upcast to float32, which does not match the model dtype. Add a dtype cast at the end to cast back to model dtype

## Testing ##
```python3
from transformers import AutoModelForCausalLM, AutoTokenizer

model_id = "inference-optimization/DeepSeek-V4-Pro-0.5B-A0.37B"
model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto")
tokenizer = AutoTokenizer.from_pretrained(model_id)

input_ids = tokenizer("According to all known laws", return_tensors="pt").input_ids.to(model.device)
output = model.generate(input_ids, max_new_tokens=20)
print(tokenizer.decode(output[0]))
```

Before:
```
...
  File "/home/kylesayrs/transformers/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py", line 816, in forwa
rd
    q_residual = self.q_a_norm(self.q_a_proj(hidden_states))
  File "/home/kylesayrs/transformers/env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1779, in _wra
pped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/kylesayrs/transformers/env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1790, in _cal
l_impl
    return forward_call(*args, **kwargs)
  File "/home/kylesayrs/transformers/env/lib/python3.10/site-packages/torch/nn/modules/linear.py", line 134, in forwa
rd
    return F.linear(input, self.weight, self.bias)
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: float != c10::BFloat16
```

After:
```
According to all known laws of aviation, there is no way a bee should be able to fly. Its wings are too small
```