### PR TITLE
CI: add reproduce mode to serge verify caller

### DIFF
--- a/.github/workflows/serge-verify-caller.yml
+++ b/.github/workflows/serge-verify-caller.yml
@@ -15,14 +15,23 @@ name: serge verify (GPU)
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: "verify (baseline+patched red→green gate) | reproduce (baseline only, confirm the failure is real before serge investigates)"
+        required: false
+        type: choice
+        options:
+          - verify
+          - reproduce
+        default: verify
       base_sha:
         description: "Pre-patch commit — targeted tests MUST be red here (baseline-red guard)"
         required: true
         type: string
       commit_sha:
-        description: "serge's candidate commit — targeted tests should be green here"
-        required: true
+        description: "serge's candidate commit — targeted tests should be green here (unused when mode=reproduce)"
+        required: false
         type: string
+        default: ""
       test_nodeids:
         description: "Space-separated pytest node-ids for the group"
         required: true
@@ -58,7 +67,7 @@ on:
 # The run name embeds the correlation id: a workflow_dispatch run's head_sha is
 # the ref (not serge's candidate commit), so serge correlates the run it just
 # dispatched by matching this id in the run name rather than by sha.
-run-name: "serge verify ${{ inputs.model }} ${{ inputs.machine_type }} [${{ inputs.correlation_id }}]"
+run-name: "serge ${{ inputs.mode }} ${{ inputs.model }} ${{ inputs.machine_type }} [${{ inputs.correlation_id }}]"
 
 # Granted here and bound onto the reusable workflow's job token.
 permissions:
@@ -69,6 +78,7 @@ jobs:
     if: github.repository == 'huggingface/transformers'
     uses: huggingface/transformers-ci/.github/workflows/serge-verify-slow.yml@main # main
     with:
+      mode: ${{ inputs.mode }}
       base_sha: ${{ inputs.base_sha }}
       commit_sha: ${{ inputs.commit_sha }}
       test_nodeids: ${{ inputs.test_nodeids }}


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47492)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47492)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Pass a `mode` input (verify|reproduce) through to the transformers-ci reusable serge-verify-slow workflow. `reproduce` runs the targeted tests only on the baseline tree so serge can confirm a failure is real BEFORE spending LLM budget investigating it; `verify` (default) is unchanged.

- `commit_sha` is now optional (reproduce does not use it).
- run-name embeds the mode; serge still correlates on the [correlation_id] substring, so matching is unaffected.