### PR TITLE
skip invalid test cases for inkling tests

### DIFF
--- a/tests/models/inkling/test_modeling_inkling.py
+++ b/tests/models/inkling/test_modeling_inkling.py
@@ -250,6 +250,22 @@ class InklingAudio2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
     def test_flash_attn_2_inference_equivalence_right_padding(self):
         pass
 
+    @unittest.skip(
+        reason="Inkling attention always adds a relative position bias, which requires a float additive mask that is incompatible with the SDPA flash backend"
+    )
+    def test_sdpa_can_dispatch_on_flash(self):
+        pass
+
+    @unittest.skip(reason="Inkling uses a custom hybrid cache that is incompatible with quantized cache")
+    def test_generate_with_quant_cache(self):
+        pass
+
+    @unittest.skip(
+        reason="The audio tower and embeddings are non-splittable and hold almost all of the weights, so device_map='auto' can't split the model across GPUs"
+    )
+    def test_model_parallelism(self):
+        pass
+
 
 class InklingVision2TextModelTester:
     def __init__(
@@ -360,6 +376,7 @@ class InklingVision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitt
     all_model_classes = (InklingModel, InklingForConditionalGeneration) if is_torch_available() else ()
     all_generative_model_classes = (InklingForConditionalGeneration,) if is_torch_available() else ()
     test_all_params_have_gradient = False  # e-score correction bias is only used for expert routing
+    test_torch_exportable = False  # data-dependent control flow in the HMLP vision tower (time/space folding)
     model_split_percents = [0.85, 0.9]
 
     def setUp(self):
@@ -437,6 +454,22 @@ class InklingVision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitt
 
     @unittest.skip("Image placeholder embeddings are replaced when pixel values are provided")
     def test_inputs_embeds_matches_input_ids(self):
+        pass
+
+    @unittest.skip(
+        reason="Inkling attention always adds a relative position bias, which requires a float additive mask that is incompatible with the SDPA flash backend"
+    )
+    def test_sdpa_can_dispatch_on_flash(self):
+        pass
+
+    @unittest.skip(reason="Inkling uses a custom hybrid cache that is incompatible with quantized cache")
+    def test_generate_with_quant_cache(self):
+        pass
+
+    @unittest.skip(
+        reason="The vision tower and embeddings are non-splittable and hold almost all of the weights, so device_map='auto' can't split the model across GPUs"
+    )
+    def test_model_parallelism(self):
         pass
 
     @unittest.skip(


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47493)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47493)
<!-- ci-dashboard-badge:end -->

@ydshieh , pls help review, thx!
This PR skips following invalid test cases for inkling:
```
FAILED tests/models/inkling/test_modeling_inkling.py::InklingAudio2TextModelTest::test_generate_with_quant_cache - ValueError: `QuantizedCache` is only supported for models with only full attention layers. We found the following invalid layer types: {'hybrid', 'hybrid_sliding'}
FAILED tests/models/inkling/test_modeling_inkling.py::InklingAudio2TextModelTest::test_model_parallelism - AttributeError: 'InklingModel' object has no attribute 'hf_device_map'
FAILED tests/models/inkling/test_modeling_inkling.py::InklingAudio2TextModelTest::test_sdpa_can_dispatch_on_flash - RuntimeError: No available kernel. Aborting execution.                                                                                                                       
FAILED tests/models/inkling/test_modeling_inkling.py::InklingVision2TextModelTest::test_generate_with_quant_cache - ValueError: `QuantizedCache` is only supported for models with only full attention layers. We found the following invalid layer types: {'hybrid', 'hybrid_sliding'}
FAILED tests/models/inkling/test_modeling_inkling.py::InklingVision2TextModelTest::test_model_parallelism - AttributeError: 'InklingModel' object has no attribute 'hf_device_map'
FAILED tests/models/inkling/test_modeling_inkling.py::InklingVision2TextModelTest::test_sdpa_can_dispatch_on_flash - RuntimeError: No available kernel. Aborting execution.                                                                                                                  
FAILED tests/models/inkling/test_modeling_inkling.py::InklingVision2TextModelTest::test_torch_export_dynamic - torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression Eq(u0, 1) (unhinted: Eq(u0, 1)).  (Size-like symbols: none)
FAILED tests/models/inkling/test_modeling_inkling.py::InklingVision2TextModelTest::test_torch_export_generate_dynamic - torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression Eq(u0, 1) (unhinted: Eq(u0, 1)).  (Size-like symbols: none)
FAILED tests/models/inkling/test_modeling_inkling.py::InklingVision2TextModelTest::test_torch_export_generate_static - torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression Eq(u0, 1) (unhinted: Eq(u0, 1)).  (Size-like symbols: none) 
FAILED tests/models/inkling/test_modeling_inkling.py::InklingVision2TextModelTest::test_torch_export_static - torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression Eq(u0, 1) (unhinted: Eq(u0, 1)).  (Size-like symbols: none)
```