### PR TITLE
Fix PPFormulaNet training-loss double-shift in encoder-decoder forward

### DIFF
--- a/src/transformers/models/pp_formulanet/modeling_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/modeling_pp_formulanet.py
@@ -1104,7 +1104,11 @@ class PPFormulaNetForConditionalGeneration(PPFormulaNetPreTrainedModel, Generati
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.text_config.vocab_size,
+                shift_labels=labels,
+                **kwargs,
             )
 
         return Seq2SeqLMOutput(

--- a/src/transformers/models/pp_formulanet/modular_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/modular_pp_formulanet.py
@@ -489,7 +489,11 @@ class PPFormulaNetForConditionalGeneration(Florence2ForConditionalGeneration):
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.text_config.vocab_size,
+                shift_labels=labels,
+                **kwargs,
             )
 
         return Seq2SeqLMOutput(


### PR DESCRIPTION
# What does this PR do?

Fixes #47317

`PPFormulaNetForConditionalGeneration.forward()` computes its loss with
`self.loss_function()` → `ForCausalLMLoss`, which shifts labels left by one
(`labels[..., 1:]`) when `shift_labels` is not supplied. PPFormulaNet is an
**encoder-decoder** model, so its logits are already aligned with `labels` and
no shift is needed. The extra shift drops the last target token and trains the
model against misaligned labels.

This passes `shift_labels=labels` to `ForCausalLMLoss`, which takes the
"already-shifted" path and leaves the labels aligned with the logits.

This is the **same fix already merged for Florence2 in #46898** (and Moonshine
before it). PPFormulaNet's modular model inherits from
`Florence2ForConditionalGeneration` but **overrides `forward()`**, so the
Florence2 fix never propagated to it — `eliaghazal` flagged PPFormulaNet as
likely-affected in the #47090 discussion.

Change is applied to `modular_pp_formulanet.py` (source of truth) and the
regenerated `modeling_pp_formulanet.py`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [PR checks](https://huggingface.co/docs/transformers/pr_checks)?
- [x] Was this discussed/approved via a Github issue? Yes — #47317.
- [ ] Did you make sure to update the documentation?
- [ ] Did you write any new necessary tests? — No new test, matching the merged precedent #46898 (source-only); happy to add a loss-alignment regression test if preferred.

> Note: AI assistance was used to help locate and draft this fix.

## Who can review?

@zucchini-nlp (reviewed & merged the identical Florence2 fix #46898)