### PR TITLE
Fix potential ReDoS by escaping tokenizer filename used as regex pattern

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1692,7 +1692,9 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         elif pretrained_model_name_or_path and os.path.isdir(pretrained_model_name_or_path):
             remote_files = os.listdir(pretrained_model_name_or_path)
 
-        if "tokenizer_file" in vocab_files and not re.search(vocab_files["tokenizer_file"], "".join(remote_files)):
+        if "tokenizer_file" in vocab_files and not re.search(
+            re.escape(vocab_files["tokenizer_file"]), "".join(remote_files)
+        ):
             # mistral tokenizer names are different, but we can still convert them if
             # mistral common is not there
             other_pattern = r"tekken\.json|tokenizer\.model\.*|tiktoken\.model" + "|".join(

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1692,9 +1692,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         elif pretrained_model_name_or_path and os.path.isdir(pretrained_model_name_or_path):
             remote_files = os.listdir(pretrained_model_name_or_path)
 
-        if "tokenizer_file" in vocab_files and not re.search(
-            re.escape(vocab_files["tokenizer_file"]), "".join(remote_files)
-        ):
+        if "tokenizer_file" in vocab_files and vocab_files["tokenizer_file"] not in "\n".join(remote_files):
             # mistral tokenizer names are different, but we can still convert them if
             # mistral common is not there
             other_pattern = r"tekken\.json|tokenizer\.model\.*|tiktoken\.model" + "|".join(


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47498)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47498)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

In `PreTrainedTokenizerBase.from_pretrained`, the tokenizer filename from `vocab_files["tokenizer_file"]` is passed directly to `re.search()` as a regex pattern when checking whether the file exists in the repo file list. This filename comes from the model repo's `tokenizer_config.json`, so a repo controlled string ends up interpreted as a regex. A crafted filename with regex metacharacters could cause wrong matches or catastrophic backtracking (ReDoS) during `from_pretrained`.

The check only needs to test for the literal filename, so this wraps it in `re.escape()`. No behavior change for normal filenames.

## Code Agent Policy

- [x] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent - I did not use any agent to write the code. However, I used Claude to cross verify and test the changes I have made.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? - Not applicable. Small self contained fix.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)? - Not applicable - No user facing behavior change.
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)? - No new test, one line escape of an internal regex check. Existing tokenizer loading tests cover the path.

## Who can review?

@ArthurZucker @itazap