### PR TITLE
doc: Add missing overflow_to_sample_mapping to PreTrainedTokenizerBase.__call__ documentation

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -899,6 +899,7 @@ ENCODE_PLUS_ADDITIONAL_KWARGS_DOCSTRING = r"""
 
             - **overflowing_tokens** -- List of overflowing tokens sequences (when a `max_length` is specified and
               `return_overflowing_tokens=True`).
+            - **overflow_to_sample_mapping** -- List of indices mapping each overflowing token to its corresponding input in the batch (when a `max_length` is specified and `return_overflowing_tokens=True`).
             - **num_truncated_tokens** -- Number of tokens truncated (when a `max_length` is specified and
               `return_overflowing_tokens=True`).
             - **special_tokens_mask** -- List of 0s and 1s, with 1 specifying added special tokens and 0 specifying


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47501)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47501)
<!-- ci-dashboard-badge:end -->

Fixes #9059 by documenting the overflow_to_sample_mapping field that was missing from the PreTrainedTokenizerBase.__call__ method documentation, while it was already implemented in the code and used in examples.