### PR TITLE
[Quantization] Fix CT `apply_quantization_config`

### DIFF
--- a/src/transformers/models/hunyuan_vl/modeling_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modeling_hunyuan_vl.py
@@ -1017,8 +1017,6 @@ class HunYuanVLModel(HunYuanVLPreTrainedModel):
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | BaseModelOutputWithPooling:
         r"""
-        Encode images and return the complete vision tower outputs.
-
         pixel_values (`torch.FloatTensor`):
             Flat per-patch pixel features produced by the image processor.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):

--- a/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
@@ -1229,8 +1229,6 @@ class HunYuanVLModel(Qwen2VLModel):
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | BaseModelOutputWithPooling:
         r"""
-        Encode images and return the complete vision tower outputs.
-
         pixel_values (`torch.FloatTensor`):
             Flat per-patch pixel features produced by the image processor.
         image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):

--- a/src/transformers/quantizers/quantizer_compressed_tensors.py
+++ b/src/transformers/quantizers/quantizer_compressed_tensors.py
@@ -62,12 +62,14 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
         return dtype
 
     def _process_model_before_weight_loading(self, model, **kwargs):
-        from compressed_tensors.quantization import apply_quantization_config
+        from compressed_tensors.quantization import apply_quantization_config, QuantizationStatus
+        from compressed_tensors.utils import patch_attr
 
         ct_quantization_config = self.compressor.quantization_config
 
         # Always initialize compressed wrappers to match the checkpoint
-        apply_quantization_config(model, ct_quantization_config, self.run_compressed)
+        with patch_attr(ct_quantization_config, "quantization_status", QuantizationStatus.FROZEN):
+            apply_quantization_config(model, ct_quantization_config, self.run_compressed)
         if self.quantization_config.is_quantization_compressed:
             self.compressor.compress_model(model=model)
 

--- a/src/transformers/quantizers/quantizer_compressed_tensors.py
+++ b/src/transformers/quantizers/quantizer_compressed_tensors.py
@@ -62,7 +62,7 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
         return dtype
 
     def _process_model_before_weight_loading(self, model, **kwargs):
-        from compressed_tensors.quantization import apply_quantization_config, QuantizationStatus
+        from compressed_tensors.quantization import QuantizationStatus, apply_quantization_config
         from compressed_tensors.utils import patch_attr
 
         ct_quantization_config = self.compressor.quantization_config


### PR DESCRIPTION
## Background ##
The `compressed-tensors` quantization lifecycle assumes that all modules undero go a linear sequence of statuses

1. Initialized: Quantization parameters are initialized to empty values
2. Calibration: Quantization parameters are being calibrated, observers are attached
3. Frozen: Quantization parameters are fully calibrated, observers are removed
4. Compressed: All parameters are quantized to target dtype. If the weight param is no longer applicable (i.e. if "weight" has been converted to "weight_packed"), the weight param is pruned from the module.
5. Decompressed: Parameters are converted back into frozen state. Quantization params remain on the module so that the module can be compressed, but params are pruned if they are no longer applicable or needed for compression (i.e. if "weight_packed" has been converted to "weight"). Additionally, weight qdq is skipped during forward passes for better performance

When loading these modules in transformers, we essentially apply this lifecycle to the meta model so that the module parameters match whatever lifecycle status the model is in.

The bug that currently exists is that, when `apply_quantization_config` is called, it attaches modules with the quantization status of whatever config is being applied. For compressed models, this status is `Compressed`. However, this breaks lifecycle assumptions, because the next step is `compress_model`, which assumes that modules in the `frozen` state.

## Purpose ##
