### PR TITLE
General maintenance 

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -60,29 +60,35 @@ _FLOAT_TAG_KEY = "__float__"
 _FLOAT_TAG_VALUES = {"Infinity": float("inf"), "-Infinity": float("-inf"), "NaN": float("nan")}
 
 
-ALLOWED_LAYER_TYPES = (
+ALLOWED_ATTN_LAYER_TYPES = (
     "full_attention",
     "sliding_attention",
     "chunked_attention",
     "compressed_sparse_attention",  # CSA, used in deepseek_v4
     "heavily_compressed_attention",  # HCA, used in deepseek_v4
     "minimax_m3_sparse",  # lightning-index sparse attention, used in minimax_m3_vl
-    "conv",  # used in LFMv2
-    "sparse",
-    "dense",
+    "conv",
     "hybrid",  # layers that combine attention + mamba/linear-attention-shaped states (zamba2, falcon_h1, zaya1)
     "hybrid_sliding",  # layers that combine sliding attention + linear-attention-shaped states (zaya1)
-    "moe",  # for nemotron_h, which uses either attention, mamba or moe
     "deepseek_sparse_attention",  # for models with DSA indexer (GLM MoE DSA, DeepSeek V32)
     # Recurrent layers (mamba / mamba2 / GDN / minimax-lightning)
     "linear_attention",
 )
 
+ALLOWED_MLP_LAYER_TYPES = (
+    "sparse",
+    "dense",
+    "moe",  # for nemotron_h, which uses either attention, mamba or moe
+)
+
+# Keep a complete list of layer types as well for BC
+ALLOWED_LAYER_TYPES = ALLOWED_ATTN_LAYER_TYPES + ALLOWED_MLP_LAYER_TYPES
 
 # Legacy ``layer_types`` strings → current ``linear_attention`` / ``full_attention`` convention.
 # Configs call ``remap_legacy_layer_types`` in their ``__post_init__`` so checkpoints stored on
 # the Hub with the old names (``mamba``, ``attention``) load transparently.
 _LEGACY_LAYER_TYPE_REMAP = {
+    "conv": "linear_attention",  # only in LFMv2
     "mamba": "linear_attention",
     "attention": "full_attention",
 }
@@ -505,24 +511,43 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin, Heterogeneous
                     )
 
     def validate_layer_type(self):
+        "Legacy method that unifies both layer type checks into one."
+        # We kept the other two meth as private to not trigger running it twice
+        # Hub's strict automatically triggers all public meth that startwith `validate_XXX`
+        self._validate_mlp_layer_type()
+        self._validate_attn_layer_type()
+
+    def _validate_mlp_layer_type(self):
+        """Check that `mlp_layer_types` is correctly defined."""
+        layers = getattr(self, "mlp_layer_types", None)
+        if not (layers is not None and hasattr(self, "num_hidden_layers")):
+            return
+        if not all(layer_type in ALLOWED_MLP_LAYER_TYPES for layer_type in layers):
+            raise ValueError(f"The `mlp_layer_types` entries must be in {ALLOWED_MLP_LAYER_TYPES} but got {layers}")
+        elif self.num_hidden_layers is not None and self.num_hidden_layers != len(layers):
+            raise ValueError(
+                f"`num_hidden_layers` ({self.num_hidden_layers}) must be equal to the number of `mlp_layer_types` "
+                f"({len(layers)})"
+            )
+
+    def _validate_attn_layer_type(self):
         """Check that `layer_types` is correctly defined."""
-        for layer_types in ["layer_types", "mlp_layer_types"]:
-            layers = getattr(self, layer_types, None)
-            if not (layers is not None and hasattr(self, "num_hidden_layers")):
-                return
-            if self.is_custom_code():
-                # Custom code may have legacy layer types that need to be remapped
-                if (remapped := remap_legacy_layer_types(layers)) != layers:
-                    # Only try setattr if layers changed in case layer_types is a read-only property
-                    setattr(self, layer_types, remapped)
-                layers = remapped
-            if not all(layer_type in ALLOWED_LAYER_TYPES for layer_type in layers):
-                raise ValueError(f"The `{layer_types}` entries must be in {ALLOWED_LAYER_TYPES} but got {layers}")
-            elif self.num_hidden_layers is not None and self.num_hidden_layers != len(layers):
-                raise ValueError(
-                    f"`num_hidden_layers` ({self.num_hidden_layers}) must be equal to the number of `{layer_types}` "
-                    f"({len(layers)})"
-                )
+        layers = getattr(self, "layer_types", None)
+        if not (layers is not None and hasattr(self, "num_hidden_layers")):
+            return
+        if self.is_custom_code():
+            # Custom code may have legacy layer types that need to be remapped
+            if (remapped := remap_legacy_layer_types(layers)) != layers:
+                # Only try setattr if layers changed in case layer_types is a read-only property
+                setattr(self, "layer_types", remapped)
+            layers = remapped
+        if not all(layer_type in ALLOWED_ATTN_LAYER_TYPES for layer_type in layers):
+            raise ValueError(f"The `layer_types` entries must be in {ALLOWED_ATTN_LAYER_TYPES} but got {layers}")
+        elif self.num_hidden_layers is not None and self.num_hidden_layers != len(layers):
+            raise ValueError(
+                f"`num_hidden_layers` ({self.num_hidden_layers}) must be equal to the number of `layer_types` "
+                f"({len(layers)})"
+            )
 
     @property
     def rope_scaling(self):

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -68,6 +68,7 @@ ALLOWED_ATTN_LAYER_TYPES = (
     "heavily_compressed_attention",  # HCA, used in deepseek_v4
     "minimax_m3_sparse",  # lightning-index sparse attention, used in minimax_m3_vl
     "conv",
+    "moe",  # for nemotron_h, which uses either attention, mamba or moe
     "hybrid",  # layers that combine attention + mamba/linear-attention-shaped states (zamba2, falcon_h1, zaya1)
     "hybrid_sliding",  # layers that combine sliding attention + linear-attention-shaped states (zaya1)
     "deepseek_sparse_attention",  # for models with DSA indexer (GLM MoE DSA, DeepSeek V32)
@@ -78,7 +79,6 @@ ALLOWED_ATTN_LAYER_TYPES = (
 ALLOWED_MLP_LAYER_TYPES = (
     "sparse",
     "dense",
-    "moe",  # for nemotron_h, which uses either attention, mamba or moe
 )
 
 # Keep a complete list of layer types as well for BC
@@ -511,43 +511,26 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin, Heterogeneous
                     )
 
     def validate_layer_type(self):
-        "Legacy method that unifies both layer type checks into one."
-        # We kept the other two meth as private to not trigger running it twice
-        # Hub's strict automatically triggers all public meth that startwith `validate_XXX`
-        self._validate_mlp_layer_type()
-        self._validate_attn_layer_type()
-
-    def _validate_mlp_layer_type(self):
-        """Check that `mlp_layer_types` is correctly defined."""
-        layers = getattr(self, "mlp_layer_types", None)
-        if not (layers is not None and hasattr(self, "num_hidden_layers")):
-            return
-        if not all(layer_type in ALLOWED_MLP_LAYER_TYPES for layer_type in layers):
-            raise ValueError(f"The `mlp_layer_types` entries must be in {ALLOWED_MLP_LAYER_TYPES} but got {layers}")
-        elif self.num_hidden_layers is not None and self.num_hidden_layers != len(layers):
-            raise ValueError(
-                f"`num_hidden_layers` ({self.num_hidden_layers}) must be equal to the number of `mlp_layer_types` "
-                f"({len(layers)})"
-            )
-
-    def _validate_attn_layer_type(self):
-        """Check that `layer_types` is correctly defined."""
-        layers = getattr(self, "layer_types", None)
-        if not (layers is not None and hasattr(self, "num_hidden_layers")):
-            return
-        if self.is_custom_code():
-            # Custom code may have legacy layer types that need to be remapped
-            if (remapped := remap_legacy_layer_types(layers)) != layers:
-                # Only try setattr if layers changed in case layer_types is a read-only property
-                setattr(self, "layer_types", remapped)
-            layers = remapped
-        if not all(layer_type in ALLOWED_ATTN_LAYER_TYPES for layer_type in layers):
-            raise ValueError(f"The `layer_types` entries must be in {ALLOWED_ATTN_LAYER_TYPES} but got {layers}")
-        elif self.num_hidden_layers is not None and self.num_hidden_layers != len(layers):
-            raise ValueError(
-                f"`num_hidden_layers` ({self.num_hidden_layers}) must be equal to the number of `layer_types` "
-                f"({len(layers)})"
-            )
+        """Check that `mlp_layer_types` and `layer_types` is correctly defined."""
+        for allowed_types, layer_types in zip(
+            [ALLOWED_ATTN_LAYER_TYPES, ALLOWED_MLP_LAYER_TYPES], ["layer_types", "mlp_layer_types"]
+        ):
+            layers = getattr(self, layer_types, None)
+            if not (layers is not None and hasattr(self, "num_hidden_layers")):
+                return
+            if self.is_custom_code():
+                # Custom code may have legacy layer types that need to be remapped
+                if (remapped := remap_legacy_layer_types(layers)) != layers:
+                    # Only try setattr if layers changed in case layer_types is a read-only property
+                    setattr(self, layer_types, remapped)
+                layers = remapped
+            if not all(layer_type in allowed_types for layer_type in layers):
+                raise ValueError(f"The `{layer_types}` entries must be in {allowed_types} but got {layers}")
+            elif self.num_hidden_layers is not None and self.num_hidden_layers != len(layers):
+                raise ValueError(
+                    f"`num_hidden_layers` ({self.num_hidden_layers}) must be equal to the number of `{layer_types}` "
+                    f"({len(layers)})"
+                )
 
     @property
     def rope_scaling(self):

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -419,21 +419,31 @@ class PermuteForRope(ConversionOps):
     Applies the permutation required to convert complex RoPE weights to the split sin/cos format.
     """
 
-    def __init__(self):
-        pass
+    def __init__(self, subconfig_key: str | None = None, inverse: bool = False):
+        self.subconfig_key = subconfig_key
+        self.inverse = inverse
 
     def _apply(self, tensor: torch.Tensor) -> torch.Tensor:
-        dim1, dim2 = tensor.shape
-        n_heads = self.config.getattr("num_attention_heads", 1)
+        dim0 = tensor.shape[0]
+        config = self.config
+        if self.subconfig_key is not None:
+            config = getattr(self.config, self.subconfig_key, self.config)
+        n_heads = getattr(config, "num_attention_heads", 1)
+        half_head = dim0 // n_heads // 2
 
-        tensor = tensor.view(n_heads, dim1 // n_heads // 2, 2, dim2)
-        tensor = tensor.transpose(1, 2).reshape(dim1, dim2)
+        head_shape = (2, half_head) if self.inverse else (half_head, 2)
+        if tensor.ndim == 2:
+            tensor = tensor.view(n_heads, *head_shape, tensor.shape[1])
+            tensor = tensor.transpose(1, 2).reshape(dim0, tensor.shape[-1])
+        elif tensor.ndim == 1:
+            tensor = tensor.view(n_heads, *head_shape)
+            tensor = tensor.transpose(1, 2).reshape(dim0)
         return tensor
 
     @torch.no_grad
     def convert(
         self,
-        input_dict: dict[str, list[torch.Tensor]],
+        input_dict: dict[str, list[torch.Tensor] | torch.Tensor],
         source_patterns: list[str],
         target_patterns: list[str],
         config,
@@ -442,14 +452,16 @@ class PermuteForRope(ConversionOps):
         self.config = config
         output: dict[str, list[torch.Tensor]] = {}
         for key, tensors in input_dict.items():
-            if len(tensors) != 1:
-                raise ValueError("PermuteForRope expects a single tensor per key.")
-            output[key] = [self._apply(tensors[0])]
+            if isinstance(tensors, list):
+                if len(tensors) != 1:
+                    raise ValueError("PermuteForRope expects a single tensor per key.")
+                tensors = tensors[0]
+            output[key] = self._apply(tensors)
         return output
 
     @property
     def reverse_op(self) -> ConversionOps:
-        return PermuteForRope()
+        return PermuteForRope(subconfig_key=self.subconfig_key, inverse=not self.inverse)
 
 
 class VisionFuseAndPermuteForRope(ConversionOps):
@@ -460,9 +472,10 @@ class VisionFuseAndPermuteForRope(ConversionOps):
     NOTE: this conversion applies only to a vision backbone in multimodal models, because it checks `config.vision_config`
     """
 
-    def __init__(self, dim: int = 0, permute_layer_names: list[str] | None = None):
+    def __init__(self, dim: int = 0, permute_layer_names: list[str] | None = None, inverse: bool = True):
         self.dim = dim
         self.permute_layer_names = permute_layer_names or []
+        self.inverse = inverse
 
     def _apply_permutation(self, tensor: torch.Tensor) -> torch.Tensor:
         dim0 = tensor.shape[0]
@@ -470,11 +483,12 @@ class VisionFuseAndPermuteForRope(ConversionOps):
         half_head = dim0 // n_heads // 2
 
         # Permute weights and biases if available
+        head_shape = (2, half_head) if self.inverse else (half_head, 2)
         if tensor.ndim == 2:
-            tensor = tensor.view(n_heads, 2, half_head, tensor.shape[1])
+            tensor = tensor.view(n_heads, *head_shape, tensor.shape[1])
             tensor = tensor.transpose(1, 2).reshape(dim0, tensor.shape[-1])
         elif tensor.ndim == 1:
-            tensor = tensor.view(n_heads, 2, half_head)
+            tensor = tensor.view(n_heads, *head_shape)
             tensor = tensor.transpose(1, 2).reshape(dim0)
         return tensor
 
@@ -508,7 +522,7 @@ class VisionFuseAndPermuteForRope(ConversionOps):
 
     @property
     def reverse_op(self) -> ConversionOps:
-        return VisionUnfuseAndPermuteForRope(self.dim, self.permute_layer_names)
+        return VisionUnfuseAndPermuteForRope(self.dim, self.permute_layer_names, inverse=not self.inverse)
 
 
 class VisionUnfuseAndPermuteForRope(ConversionOps):
@@ -519,9 +533,10 @@ class VisionUnfuseAndPermuteForRope(ConversionOps):
     NOTE: this conversion applies only to a vision backbone in multimodal models, because it checks `config.vision_config`
     """
 
-    def __init__(self, dim: int = 0, permute_layer_names: list[str] | None = None):
+    def __init__(self, dim: int = 0, permute_layer_names: list[str] | None = None, inverse: bool = False):
         self.dim = dim
         self.permute_layer_names = permute_layer_names or []
+        self.inverse = inverse
 
     def _apply_permutation(self, tensor: torch.Tensor) -> torch.Tensor:
         dim0 = tensor.shape[0]
@@ -529,11 +544,12 @@ class VisionUnfuseAndPermuteForRope(ConversionOps):
         half_head = dim0 // n_heads // 2
 
         # Permute weights and biases if available
+        head_shape = (2, half_head) if self.inverse else (half_head, 2)
         if tensor.ndim == 2:
-            tensor = tensor.view(n_heads, half_head, 2, tensor.shape[1])
+            tensor = tensor.view(n_heads, *head_shape, tensor.shape[1])
             tensor = tensor.transpose(1, 2).reshape(dim0, tensor.shape[-1])
         elif tensor.ndim == 1:
-            tensor = tensor.view(n_heads, half_head, 2)
+            tensor = tensor.view(n_heads, *head_shape)
             tensor = tensor.transpose(1, 2).reshape(dim0)
         return tensor
 
@@ -567,7 +583,7 @@ class VisionUnfuseAndPermuteForRope(ConversionOps):
 
     @property
     def reverse_op(self) -> ConversionOps:
-        return VisionFuseAndPermuteForRope(self.dim, self.permute_layer_names)
+        return VisionFuseAndPermuteForRope(self.dim, self.permute_layer_names, inverse=not self.inverse)
 
 
 class ErnieFuseAndSplitTextVisionExperts(ConversionOps):

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -419,9 +419,12 @@ class PermuteForRope(ConversionOps):
     Applies the permutation required to convert complex RoPE weights to the split sin/cos format.
     """
 
-    def __init__(self, subconfig_key: str | None = None, inverse: bool = False):
+    def __init__(
+        self, subconfig_key: str | None = None, permute_layer_names: list[str] | None = None, inverse: bool = False
+    ):
         self.subconfig_key = subconfig_key
         self.inverse = inverse
+        self.permute_layer_names = permute_layer_names
 
     def _apply(self, tensor: torch.Tensor) -> torch.Tensor:
         dim0 = tensor.shape[0]
@@ -452,16 +455,24 @@ class PermuteForRope(ConversionOps):
         self.config = config
         output: dict[str, list[torch.Tensor]] = {}
         for key, tensors in input_dict.items():
+            # Permute q and key weights back (skip biases) to match original RoPE implementation
+            if not any(name in key for name in self.permute_layer_names):
+                output[key] = tensors
+                continue
+
             if isinstance(tensors, list):
                 if len(tensors) != 1:
                     raise ValueError("PermuteForRope expects a single tensor per key.")
                 tensors = tensors[0]
+            print(key, tensors.shape, self.inverse)
             output[key] = self._apply(tensors)
         return output
 
     @property
     def reverse_op(self) -> ConversionOps:
-        return PermuteForRope(subconfig_key=self.subconfig_key, inverse=not self.inverse)
+        return PermuteForRope(
+            subconfig_key=self.subconfig_key, permute_layer_names=self.permute_layer_names, inverse=not self.inverse
+        )
 
 
 class VisionFuseAndPermuteForRope(ConversionOps):
@@ -473,24 +484,14 @@ class VisionFuseAndPermuteForRope(ConversionOps):
     """
 
     def __init__(self, dim: int = 0, permute_layer_names: list[str] | None = None, inverse: bool = True):
-        self.dim = dim
-        self.permute_layer_names = permute_layer_names or []
-        self.inverse = inverse
-
-    def _apply_permutation(self, tensor: torch.Tensor) -> torch.Tensor:
-        dim0 = tensor.shape[0]
-        n_heads = getattr(self.config.vision_config, "num_attention_heads", 1)
-        half_head = dim0 // n_heads // 2
-
-        # Permute weights and biases if available
-        head_shape = (2, half_head) if self.inverse else (half_head, 2)
-        if tensor.ndim == 2:
-            tensor = tensor.view(n_heads, *head_shape, tensor.shape[1])
-            tensor = tensor.transpose(1, 2).reshape(dim0, tensor.shape[-1])
-        elif tensor.ndim == 1:
-            tensor = tensor.view(n_heads, *head_shape)
-            tensor = tensor.transpose(1, 2).reshape(dim0)
-        return tensor
+        logger.warning(
+            "`VisionUnfuseAndPermuteForRope` is deprecated and will be removed in v5.20. Use `PermuteForRope()` and `Concatenate()` "
+            "consecutively instead to permute back and fuse projections."
+        )
+        self.concat_op = Concatenate(dim=dim)
+        self.permute_op = PermuteForRope(
+            subconfig_key="vision_config", permute_layer_names=permute_layer_names, inverse=inverse
+        )
 
     @torch.no_grad
     def convert(
@@ -501,18 +502,18 @@ class VisionFuseAndPermuteForRope(ConversionOps):
         config,
         **kwargs,
     ) -> dict[str, torch.Tensor]:
-        self.config = config
-        target_pattern = self.get_target_pattern(target_patterns)
-
-        all_tensors = []
-        for source_pattern in source_patterns:
-            tensors = input_dict[source_pattern][0]
-            # Permute q and key weights back (skip biases) to match original RoPE implementation
-            if any(name in source_pattern for name in self.permute_layer_names) and tensors.ndim == 2:
-                tensors = self._apply_permutation(tensors)
-            all_tensors.append(tensors)
-
-        return {target_pattern: torch.cat(all_tensors, dim=self.dim)}
+        input_dict = self.permute_op.convert(
+            input_dict=input_dict,
+            source_patterns=source_patterns,
+            target_patterns=target_patterns,
+            config=config,
+        )
+        input_dict = self.concat_op.convert(
+            input_dict=input_dict,
+            source_patterns=source_patterns,
+            target_patterns=target_patterns,
+        )
+        return input_dict
 
     def get_target_pattern(self, target_patterns: list[str]) -> str:
         # Here we always return the target pattern
@@ -534,24 +535,14 @@ class VisionUnfuseAndPermuteForRope(ConversionOps):
     """
 
     def __init__(self, dim: int = 0, permute_layer_names: list[str] | None = None, inverse: bool = False):
-        self.dim = dim
-        self.permute_layer_names = permute_layer_names or []
-        self.inverse = inverse
-
-    def _apply_permutation(self, tensor: torch.Tensor) -> torch.Tensor:
-        dim0 = tensor.shape[0]
-        n_heads = getattr(self.config.vision_config, "num_attention_heads", 1)
-        half_head = dim0 // n_heads // 2
-
-        # Permute weights and biases if available
-        head_shape = (2, half_head) if self.inverse else (half_head, 2)
-        if tensor.ndim == 2:
-            tensor = tensor.view(n_heads, *head_shape, tensor.shape[1])
-            tensor = tensor.transpose(1, 2).reshape(dim0, tensor.shape[-1])
-        elif tensor.ndim == 1:
-            tensor = tensor.view(n_heads, *head_shape)
-            tensor = tensor.transpose(1, 2).reshape(dim0)
-        return tensor
+        logger.warning(
+            "`VisionUnfuseAndPermuteForRope` is deprecated and will be removed in v5.20. Use `Chunk()` and `PermuteForRope()` "
+            "consecutively instead to unfuse projections and permute for block-split RoPE"
+        )
+        self.chunk_op = Chunk(dim=dim)
+        self.permute_op = PermuteForRope(
+            subconfig_key="vision_config", permute_layer_names=permute_layer_names, inverse=inverse
+        )
 
     @torch.no_grad
     def convert(
@@ -562,18 +553,18 @@ class VisionUnfuseAndPermuteForRope(ConversionOps):
         config,
         **kwargs,
     ) -> dict[str, torch.Tensor]:
-        self.config = config
-
-        tensor = next(iter(input_dict.values()))[0]
-        targets = self.get_target_patterns(input_dict, target_patterns)
-        chunks = torch.chunk(tensor, len(targets), dim=self.dim)
-
-        output: dict[str, torch.Tensor] = dict(zip(targets, chunks))
-        for key, value in output.items():
-            # Permute q and key weights (skip biases) to match RoPE implementation
-            if any(name in key for name in self.permute_layer_names):
-                output[key] = self._apply_permutation(value)
-        return output
+        input_dict = self.chunk_op.convert(
+            input_dict=input_dict,
+            source_patterns=source_patterns,
+            target_patterns=target_patterns,
+        )
+        input_dict = self.permute_op.convert(
+            input_dict=input_dict,
+            source_patterns=source_patterns,
+            target_patterns=target_patterns,
+            config=config,
+        )
+        return input_dict
 
     def get_target_patterns(self, input_dict: dict, target_patterns: list[str]) -> list[str]:
         # Here we always return the target patterns

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -464,7 +464,6 @@ class PermuteForRope(ConversionOps):
                 if len(tensors) != 1:
                     raise ValueError("PermuteForRope expects a single tensor per key.")
                 tensors = tensors[0]
-            print(key, tensors.shape, self.inverse)
             output[key] = self._apply(tensors)
         return output
 
@@ -488,6 +487,9 @@ class VisionFuseAndPermuteForRope(ConversionOps):
             "`VisionUnfuseAndPermuteForRope` is deprecated and will be removed in v5.20. Use `PermuteForRope()` and `Concatenate()` "
             "consecutively instead to permute back and fuse projections."
         )
+        self.dim = dim
+        self.permute_layer_names = permute_layer_names
+        self.inverse = inverse
         self.concat_op = Concatenate(dim=dim)
         self.permute_op = PermuteForRope(
             subconfig_key="vision_config", permute_layer_names=permute_layer_names, inverse=inverse
@@ -539,6 +541,9 @@ class VisionUnfuseAndPermuteForRope(ConversionOps):
             "`VisionUnfuseAndPermuteForRope` is deprecated and will be removed in v5.20. Use `Chunk()` and `PermuteForRope()` "
             "consecutively instead to unfuse projections and permute for block-split RoPE"
         )
+        self.dim = dim
+        self.permute_layer_names = permute_layer_names
+        self.inverse = inverse
         self.chunk_op = Chunk(dim=dim)
         self.permute_op = PermuteForRope(
             subconfig_key="vision_config", permute_layer_names=permute_layer_names, inverse=inverse

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -1142,7 +1142,56 @@ class TestConvertAndLoadStateDict(unittest.TestCase):
 
 
 class TestConversionMapping(unittest.TestCase):
-    def test_unfuse_and_permute_rope(self):
+    def test_permute_rope(self):
+        text_config = PreTrainedConfig(hidden_size=16, head_dim=8, num_attention_heads=2)
+        config = PreTrainedConfig(text_config=text_config)
+
+        q_proj = torch.randn(text_config.hidden_size, text_config.hidden_size, dtype=torch.float32)
+        k_proj = torch.randn(text_config.hidden_size, text_config.hidden_size, dtype=torch.float32)
+        q_bias = torch.randn(text_config.hidden_size, dtype=torch.float32)
+        k_bias = torch.randn(text_config.hidden_size, dtype=torch.float32)
+
+        q_proj_permuted = q_proj.view(
+            text_config.num_attention_heads, text_config.head_dim // 2, 2, text_config.hidden_size
+        )
+        q_proj_permuted = q_proj_permuted.transpose(1, 2).reshape(text_config.hidden_size, text_config.hidden_size)
+        q_bias_permuted = q_bias.view(text_config.num_attention_heads, text_config.head_dim // 2, 2)
+        q_bias_permuted = q_bias_permuted.transpose(1, 2).reshape(text_config.hidden_size)
+
+        k_proj_permuted = k_proj.view(
+            text_config.num_attention_heads, text_config.head_dim // 2, 2, text_config.hidden_size
+        )
+        k_proj_permuted = k_proj_permuted.transpose(1, 2).reshape(text_config.hidden_size, text_config.hidden_size)
+        k_bias_permuted = k_bias.view(text_config.num_attention_heads, text_config.head_dim // 2, 2)
+        k_bias_permuted = k_bias_permuted.transpose(1, 2).reshape(text_config.hidden_size)
+
+        permute = PermuteForRope(subconfig_key="text_config")
+        inverse_permute = PermuteForRope(subconfig_key="text_config", inverse=True)
+
+        permuted_output = permute.convert(
+            {"q_proj": q_proj, "k_proj": k_proj, "q_bias": q_bias, "k_bias": k_bias},
+            ["q_proj", "k_proj", "q_bias", "k_bias"],
+            ["q_proj", "k_proj", "q_bias", "k_bias"],
+            config=config,
+        )
+        reverted_output = inverse_permute.convert(
+            {
+                "q_proj": q_proj_permuted,
+                "k_proj": k_proj_permuted,
+                "q_bias": q_bias_permuted,
+                "k_bias": k_bias_permuted,
+            },
+            ["q_proj", "k_proj", "q_bias", "k_bias"],
+            ["q_proj", "k_proj", "q_bias", "k_bias"],
+            config=config,
+        )
+
+        torch.testing.assert_close(permuted_output["q_proj"], q_proj_permuted)
+        torch.testing.assert_close(permuted_output["k_proj"], k_proj_permuted)
+        torch.testing.assert_close(reverted_output["q_proj"], q_proj)
+        torch.testing.assert_close(reverted_output["k_proj"], k_proj)
+
+    def test_unfuse_and_permute_rope_vision(self):
         vision_config = PreTrainedConfig(hidden_size=16, head_dim=8, num_attention_heads=2)
         config = PreTrainedConfig(vision_config=vision_config)
         qkv_weight = torch.randn(3 * vision_config.hidden_size, vision_config.hidden_size, dtype=torch.float32)
@@ -1160,7 +1209,7 @@ class TestConversionMapping(unittest.TestCase):
         k_proj = k_proj.transpose(1, 2).reshape(vision_config.hidden_size, vision_config.hidden_size)
 
         unfuse = VisionUnfuseAndPermuteForRope(dim=0, permute_layer_names=["q_proj", "k_proj"])
-        fuse = VisionFuseAndPermuteForRope(dim=0, permute_layer_names=["q_proj", "k_proj"])
+        fuse = VisionFuseAndPermuteForRope(dim=0, permute_layer_names=["q_proj", "k_proj"], inverse=True)
 
         unfused_output = unfuse.convert({"qkv": [qkv_weight]}, ["qkv"], ["q_proj", "k_proj", "v_proj"], config=config)
         fused_output = fuse.convert(

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -30,7 +30,6 @@ from transformers.core_model_loading import (
     Concatenate,
     Conv3dToLinear,
     ErnieFuseAndSplitTextVisionExperts,
-    GroupWeightRename,
     LinearToConv3d,
     MergeModulelist,
     PermuteForRope,
@@ -1140,60 +1139,43 @@ class TestConvertAndLoadStateDict(unittest.TestCase):
         # Make sure both saved state_dict are identical
         self.assertTrue(compare_state_dicts(reversed_state_dict, state_dict))
 
+    def test_qkv_chunk_rope_permute_vision_config(self):
+        n_heads = 2
+        head_dim = 8
 
-class TestConversionMapping(unittest.TestCase):
-    def test_permute_rope(self):
-        text_config = PreTrainedConfig(hidden_size=16, head_dim=8, num_attention_heads=2)
-        config = PreTrainedConfig(text_config=text_config)
+        class RopeProjector(nn.Module):
+            def __init__(self, in_dim, out_dim):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(out_dim, in_dim))
 
-        q_proj = torch.randn(text_config.hidden_size, text_config.hidden_size, dtype=torch.float32)
-        k_proj = torch.randn(text_config.hidden_size, text_config.hidden_size, dtype=torch.float32)
-        q_bias = torch.randn(text_config.hidden_size, dtype=torch.float32)
-        k_bias = torch.randn(text_config.hidden_size, dtype=torch.float32)
+        class RopeSelfAttn(nn.Module):
+            def __init__(self, fused_qkv: bool = False):
+                super().__init__()
+                if fused_qkv:
+                    self.qkv_proj = RopeProjector(n_heads * head_dim, n_heads * head_dim * 3)
+                else:
+                    self.q_proj = RopeProjector(n_heads * head_dim, n_heads * head_dim)
+                    self.k_proj = RopeProjector(n_heads * head_dim, n_heads * head_dim)
+                    self.v_proj = RopeProjector(n_heads * head_dim, n_heads * head_dim)
 
-        q_proj_permuted = q_proj.view(
-            text_config.num_attention_heads, text_config.head_dim // 2, 2, text_config.hidden_size
-        )
-        q_proj_permuted = q_proj_permuted.transpose(1, 2).reshape(text_config.hidden_size, text_config.hidden_size)
-        q_bias_permuted = q_bias.view(text_config.num_attention_heads, text_config.head_dim // 2, 2)
-        q_bias_permuted = q_bias_permuted.transpose(1, 2).reshape(text_config.hidden_size)
+        class RopeLayer(nn.Module):
+            def __init__(self, fused_qkv: bool = False):
+                super().__init__()
+                self.self_attn = RopeSelfAttn(fused_qkv=fused_qkv)
 
-        k_proj_permuted = k_proj.view(
-            text_config.num_attention_heads, text_config.head_dim // 2, 2, text_config.hidden_size
-        )
-        k_proj_permuted = k_proj_permuted.transpose(1, 2).reshape(text_config.hidden_size, text_config.hidden_size)
-        k_bias_permuted = k_bias.view(text_config.num_attention_heads, text_config.head_dim // 2, 2)
-        k_bias_permuted = k_bias_permuted.transpose(1, 2).reshape(text_config.hidden_size)
+        class RopeModel(PreTrainedModel):
+            base_model_prefix = "model"
 
-        permute = PermuteForRope(subconfig_key="text_config")
-        inverse_permute = PermuteForRope(subconfig_key="text_config", inverse=True)
+            def __init__(self, config, fused_qkv: bool = False):
+                super().__init__(config)
+                self.layers = nn.ModuleList([RopeLayer(fused_qkv=fused_qkv)])
+                self.post_init()
 
-        permuted_output = permute.convert(
-            {"q_proj": q_proj, "k_proj": k_proj, "q_bias": q_bias, "k_bias": k_bias},
-            ["q_proj", "k_proj", "q_bias", "k_bias"],
-            ["q_proj", "k_proj", "q_bias", "k_bias"],
-            config=config,
-        )
-        reverted_output = inverse_permute.convert(
-            {
-                "q_proj": q_proj_permuted,
-                "k_proj": k_proj_permuted,
-                "q_bias": q_bias_permuted,
-                "k_bias": k_bias_permuted,
-            },
-            ["q_proj", "k_proj", "q_bias", "k_bias"],
-            ["q_proj", "k_proj", "q_bias", "k_bias"],
-            config=config,
-        )
-
-        torch.testing.assert_close(permuted_output["q_proj"], q_proj_permuted)
-        torch.testing.assert_close(permuted_output["k_proj"], k_proj_permuted)
-        torch.testing.assert_close(reverted_output["q_proj"], q_proj)
-        torch.testing.assert_close(reverted_output["k_proj"], k_proj)
-
-    def test_unfuse_and_permute_rope_vision(self):
         vision_config = PreTrainedConfig(hidden_size=16, head_dim=8, num_attention_heads=2)
         config = PreTrainedConfig(vision_config=vision_config)
+        model = RopeModel(config)
+        model_fused = RopeModel(config, fused_qkv=True)
+
         qkv_weight = torch.randn(3 * vision_config.hidden_size, vision_config.hidden_size, dtype=torch.float32)
 
         q_proj, k_proj, v_proj = torch.chunk(qkv_weight, 3, dim=0)
@@ -1208,73 +1190,65 @@ class TestConversionMapping(unittest.TestCase):
         )
         k_proj = k_proj.transpose(1, 2).reshape(vision_config.hidden_size, vision_config.hidden_size)
 
-        unfuse = VisionUnfuseAndPermuteForRope(dim=0, permute_layer_names=["q_proj", "k_proj"])
-        fuse = VisionFuseAndPermuteForRope(dim=0, permute_layer_names=["q_proj", "k_proj"], inverse=True)
-
-        unfused_output = unfuse.convert({"qkv": [qkv_weight]}, ["qkv"], ["q_proj", "k_proj", "v_proj"], config=config)
-        fused_output = fuse.convert(
-            {k: [v] for k, v in unfused_output.items()}, ["q_proj", "k_proj", "v_proj"], ["qkv"], config=config
-        )
-
-        torch.testing.assert_close(unfused_output["v_proj"], v_proj)
-        torch.testing.assert_close(unfused_output["q_proj"], q_proj)
-        torch.testing.assert_close(unfused_output["k_proj"], k_proj)
-        torch.testing.assert_close(fused_output["qkv"], qkv_weight)
-
-    def test_group_weight_rename(self):
-        model = DummyModelWithNorm(PreTrainedConfig())
-
-        bad_serialized_checkpoints = {
-            k.replace("norm1", "norm0").replace("norm2", "norm1"): v.clone() for k, v in model.state_dict().items()
-        }
+        state_dict_fused = {"model.layers.0.self_attn.qkv_proj.weight": qkv_weight.clone()}
         weight_mapping = [
-            GroupWeightRename(
-                source_patterns=[r"norm0", r"norm1"],
-                target_patterns=[r"norm1", r"norm2"],
+            WeightConverter(
+                "self_attn.qkv_proj.weight",
+                [
+                    "self_attn.q_proj.weight",
+                    "self_attn.k_proj.weight",
+                    "self_attn.v_proj.weight",
+                ],
+                operations=[VisionUnfuseAndPermuteForRope(dim=0, permute_layer_names=["q_proj", "k_proj"])],
             )
         ]
+        load_config = LoadStateDictConfig(weight_mapping=weight_mapping)
+        loading_info, _ = convert_and_load_state_dict_in_model(model, state_dict_fused, load_config, tp_plan=None)
 
-        loading_info, _ = convert_and_load_state_dict_in_model(
-            model,
-            bad_serialized_checkpoints,
-            LoadStateDictConfig(weight_mapping=copy.deepcopy(weight_mapping)),
-            tp_plan=None,
-        )
-
-        # Assert we can load without issues
         self.assertEqual(loading_info.missing_keys, set())
         self.assertEqual(loading_info.unexpected_keys, set())
         self.assertEqual(loading_info.mismatched_keys, set())
         self.assertEqual(loading_info.conversion_errors, {})
 
-        # Assert that re-saving will lead to the exact same state_dict
-        saved_state_dict = revert_weight_conversion(model, model.state_dict())
-        self.assertEqual(set(bad_serialized_checkpoints.keys()), set(saved_state_dict.keys()))
-        for k, v in saved_state_dict.items():
-            self.assertTrue((v == bad_serialized_checkpoints[k]).all())
+        model_state = model.state_dict()
+        torch.testing.assert_close(model_state["layers.0.self_attn.q_proj.weight"], q_proj)
+        torch.testing.assert_close(model_state["layers.0.self_attn.k_proj.weight"], k_proj)
+        torch.testing.assert_close(model_state["layers.0.self_attn.v_proj.weight"], v_proj)
 
-        # Now, check that using the same conversion with already good keys works when loading and resaving
-        good_serialized_checkpoints = {k: v.clone() for k, v in model.state_dict().items()}
-
+        # Now test if the revert conversion works
+        state_dict_unfused = {
+            "model.layers.0.self_attn.q_proj.weight": q_proj.clone(),
+            "model.layers.0.self_attn.k_proj.weight": k_proj.clone(),
+            "model.layers.0.self_attn.v_proj.weight": v_proj.clone(),
+        }
+        weight_mapping = [
+            WeightConverter(
+                [
+                    "self_attn.q_proj.weight",
+                    "self_attn.k_proj.weight",
+                    "self_attn.v_proj.weight",
+                ],
+                "self_attn.qkv_proj.weight",
+                operations=[
+                    VisionFuseAndPermuteForRope(dim=0, permute_layer_names=["q_proj", "k_proj"], inverse=True)
+                ],
+            )
+        ]
+        load_config = LoadStateDictConfig(weight_mapping=weight_mapping)
         loading_info, _ = convert_and_load_state_dict_in_model(
-            model,
-            good_serialized_checkpoints,
-            LoadStateDictConfig(weight_mapping=copy.deepcopy(weight_mapping)),
-            tp_plan=None,
+            model_fused, state_dict_unfused, load_config, tp_plan=None
         )
 
-        # Assert we can load without issues
         self.assertEqual(loading_info.missing_keys, set())
         self.assertEqual(loading_info.unexpected_keys, set())
         self.assertEqual(loading_info.mismatched_keys, set())
         self.assertEqual(loading_info.conversion_errors, {})
 
-        # Assert that re-saving will lead to the exact same state_dict
-        saved_state_dict = revert_weight_conversion(model, model.state_dict())
-        self.assertEqual(set(good_serialized_checkpoints.keys()), set(saved_state_dict.keys()))
-        for k, v in saved_state_dict.items():
-            self.assertTrue((v == good_serialized_checkpoints[k]).all())
+        model_state = model_fused.state_dict()
+        torch.testing.assert_close(model_state["layers.0.self_attn.qkv_proj.weight"], qkv_weight)
 
+
+class TestConversionMapping(unittest.TestCase):
     def test_conv3d_linear_conversion_ops(self):
         weight_name = "patch_embed.proj.weight"
         kernel_size = (2, 2, 2)

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -30,6 +30,7 @@ from transformers.core_model_loading import (
     Concatenate,
     Conv3dToLinear,
     ErnieFuseAndSplitTextVisionExperts,
+    GroupWeightRename,
     LinearToConv3d,
     MergeModulelist,
     PermuteForRope,
@@ -1249,6 +1250,60 @@ class TestConvertAndLoadStateDict(unittest.TestCase):
 
 
 class TestConversionMapping(unittest.TestCase):
+    def test_group_weight_rename(self):
+        model = DummyModelWithNorm(PreTrainedConfig())
+
+        bad_serialized_checkpoints = {
+            k.replace("norm1", "norm0").replace("norm2", "norm1"): v.clone() for k, v in model.state_dict().items()
+        }
+        weight_mapping = [
+            GroupWeightRename(
+                source_patterns=[r"norm0", r"norm1"],
+                target_patterns=[r"norm1", r"norm2"],
+            )
+        ]
+
+        loading_info, _ = convert_and_load_state_dict_in_model(
+            model,
+            bad_serialized_checkpoints,
+            LoadStateDictConfig(weight_mapping=copy.deepcopy(weight_mapping)),
+            tp_plan=None,
+        )
+
+        # Assert we can load without issues
+        self.assertEqual(loading_info.missing_keys, set())
+        self.assertEqual(loading_info.unexpected_keys, set())
+        self.assertEqual(loading_info.mismatched_keys, set())
+        self.assertEqual(loading_info.conversion_errors, {})
+
+        # Assert that re-saving will lead to the exact same state_dict
+        saved_state_dict = revert_weight_conversion(model, model.state_dict())
+        self.assertEqual(set(bad_serialized_checkpoints.keys()), set(saved_state_dict.keys()))
+        for k, v in saved_state_dict.items():
+            self.assertTrue((v == bad_serialized_checkpoints[k]).all())
+
+        # Now, check that using the same conversion with already good keys works when loading and resaving
+        good_serialized_checkpoints = {k: v.clone() for k, v in model.state_dict().items()}
+
+        loading_info, _ = convert_and_load_state_dict_in_model(
+            model,
+            good_serialized_checkpoints,
+            LoadStateDictConfig(weight_mapping=copy.deepcopy(weight_mapping)),
+            tp_plan=None,
+        )
+
+        # Assert we can load without issues
+        self.assertEqual(loading_info.missing_keys, set())
+        self.assertEqual(loading_info.unexpected_keys, set())
+        self.assertEqual(loading_info.mismatched_keys, set())
+        self.assertEqual(loading_info.conversion_errors, {})
+
+        # Assert that re-saving will lead to the exact same state_dict
+        saved_state_dict = revert_weight_conversion(model, model.state_dict())
+        self.assertEqual(set(good_serialized_checkpoints.keys()), set(saved_state_dict.keys()))
+        for k, v in saved_state_dict.items():
+            self.assertTrue((v == good_serialized_checkpoints[k]).all())
+
     def test_conv3d_linear_conversion_ops(self):
         weight_name = "patch_embed.proj.weight"
         kernel_size = (2, 2, 2)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47517)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47517)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Some quick things i wanted to fix, can split into two PRs for layer-type and for conversion

1) bring back the two layer type convention (fixes https://github.com/huggingface/transformers/issues/46245)
2) fix `PermuteForRope` which on main actually permutes back from block-split llama format, while we usually want the other way round

TBH we can get rid of `VisionFuseAndPermute` imo and use the corrected rope conversion with `Chunk(dim=0)`. Technically breaking but no-one would actually use `VisionFuseAndPermute` no?