### PR TITLE
Fix incorrect type hint

### DIFF
--- a/src/transformers/integrations/heterogeneity/configuration_utils.py
+++ b/src/transformers/integrations/heterogeneity/configuration_utils.py
@@ -308,7 +308,7 @@ class HeterogeneousConfigMixin:
         return hasattr(self, "_heterogeneity_spec")
 
     @property
-    def per_layer_config(self) -> Sequence[PreTrainedConfig] | None:
+    def per_layer_config(self) -> Sequence[PreTrainedConfig]:
         return _PerLayerConfigView(self)
 
     @per_layer_config.setter


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47519)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47519)
<!-- ci-dashboard-badge:end -->

Since https://github.com/huggingface/transformers/pull/47384 this `property` can no longer be `None`