### PR TITLE
Fix Gemma 4 JSON regex lookbehind and robust boolean parsing

### DIFF
--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -286,9 +286,9 @@ def recursive_parse(
                 raise TypeError(
                     f"Expected a string or bool for schema node with type boolean, got {type(node_content).__name__}: {node_content}"
                 )
-            if node_content.lower() in ("true", "1"):
+            if node_content.strip().lower() in ("true", "1"):
                 return True
-            elif node_content.lower() in ("false", "0"):
+            elif node_content.strip().lower() in ("false", "0"):
                 return False
             else:
                 raise ValueError(f"Invalid boolean value: {node_content}")

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -37,7 +37,7 @@ def _gemma4_json_to_json(text: str) -> str:
     # Grab the inside of gemma-quotes and store them for later
     text = re.sub(r'<\|"\|>(.*?)<\|"\|>', _capture, text, flags=re.DOTALL)
     # Add quotes to the bare keys elsewhere
-    text = re.sub(r"(?<=[{,])(\w+):", r'"\1":', text)
+    text = re.sub(r'([\{,])\s*(\w+)\s*:', r'\1"\2":', text)
 
     # Put the inside of the quotes back afterwards
     for i, s in enumerate(strings):

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -37,7 +37,7 @@ def _gemma4_json_to_json(text: str) -> str:
     # Grab the inside of gemma-quotes and store them for later
     text = re.sub(r'<\|"\|>(.*?)<\|"\|>', _capture, text, flags=re.DOTALL)
     # Add quotes to the bare keys elsewhere
-    text = re.sub(r'([\{,])\s*(\w+)\s*:', r'\1"\2":', text)
+    text = re.sub(r"([\{,])\s*(\w+)\s*:", r'\1"\2":', text)
 
     # Put the inside of the quotes back afterwards
     for i, s in enumerate(strings):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47520)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47520)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This PR addresses two parsing issues in the chat template/tool calling utilities:

1. **Gemma 4 Regex Whitespace Bug:** 
The previous regex `(?<=[{,])(\w+):` used a fixed-width lookbehind. If a language model generated a space after a comma (e.g., `{"key1": "val1", key2: "val2"}`), the regex failed to quote the bare key, resulting in invalid JSON. This PR replaces the lookbehind with capture groups `([\{,])\s*(\w+)\s*:` to handle optional whitespace robustly.

2. **Boolean Hallucination Parsing:** 
Language models occasionally generate booleans with leading/trailing whitespaces (e.g., `" true "` or `"True\n"`). The existing parser strictly checked `node_content.lower() in ("true", "1")`. This PR adds `.strip()` to make the boolean extraction more fault-tolerant.

## Who can review?
@Rocketknight1 @ArthurZucker

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md) doc.
- [x] I have checked that code added/modified is covered by tests.
- [x] All new and existing tests pass.