### PR TITLE
Run only @slow tests in PR comment CI

### DIFF
--- a/.github/workflows/self-comment-ci.yml
+++ b/.github/workflows/self-comment-ci.yml
@@ -188,6 +188,7 @@ jobs:
       commit_sha: ${{ needs.check-timestamps.outputs.PR_MERGE_SHA }}
       subdirs: ${{ needs.get-tests.outputs.models }}
       pr_number: ${{ needs.get-pr-number.outputs.PR_NUMBER }}
+      pytest_marker: slow
     secrets: inherit
 
   quantization-ci:

--- a/conftest.py
+++ b/conftest.py
@@ -241,6 +241,7 @@ def pytest_configure(config):
             if getattr(_mod, "hf_hub_download", None) is _original_hf_hub_download:
                 _mod.hf_hub_download = _wrapped_hf_hub_download
 
+    config.addinivalue_line("markers", "slow: mark test as slow")
     config.addinivalue_line("markers", "is_pipeline_test: mark test to run only when pipelines are tested")
     config.addinivalue_line("markers", "is_staging_test: mark test to run only in the staging environment")
     config.addinivalue_line("markers", "accelerate_tests: mark test that require accelerate")

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -428,8 +428,11 @@ def slow(test_case):
     Slow tests are skipped by default. Set the RUN_SLOW environment variable to a truthy value to run them.
 
     """
-    import pytest  # We don't need a hard dependency on pytest in the main library
-    test_case = pytest.mark.slow(test_case)
+    try:
+        import pytest  # We don't need a hard dependency on pytest in the main library
+        test_case = pytest.mark.slow(test_case)
+    except ImportError:
+        pass
     return unittest.skipUnless(_run_slow_tests, "test is slow")(test_case)
 
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -428,6 +428,7 @@ def slow(test_case):
     Slow tests are skipped by default. Set the RUN_SLOW environment variable to a truthy value to run them.
 
     """
+    test_case = pytest.mark.slow(test_case)
     return unittest.skipUnless(_run_slow_tests, "test is slow")(test_case)
 
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -428,6 +428,7 @@ def slow(test_case):
     Slow tests are skipped by default. Set the RUN_SLOW environment variable to a truthy value to run them.
 
     """
+    import pytest  # We don't need a hard dependency on pytest in the main library
     test_case = pytest.mark.slow(test_case)
     return unittest.skipUnless(_run_slow_tests, "test is slow")(test_case)
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -430,6 +430,7 @@ def slow(test_case):
     """
     try:
         import pytest  # We don't need a hard dependency on pytest in the main library
+
         test_case = pytest.mark.slow(test_case)
     except ImportError:
         pass


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47521)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47521)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Add pytest.mark.slow to the slow() decorator, register it in conftest.py, and pass pytest_marker: slow to self-scheduled.yml from self-comment-ci.yml so that run-slow PR comment triggers only run @slow-decorated tests.