### PR TITLE
Use --flake-runs=1 in check_bad_commit.py for PR comment CI

### DIFF
--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -25,12 +25,13 @@ import git
 import requests
 
 
-def create_script(target_test):
+def create_script(target_test, flake_runs=4):
     """Create a python script to be run by `git bisect run` to determine if `target_test` passes or fails.
     If a test is not found in a commit, the script with exit code `0` (i.e. `Success`).
 
     Args:
         target_test (`str`): The test to check.
+        flake_runs (`int`): Number of times to run the test to detect flakiness. Defaults to 4.
 
     Returns:
         `str`: The script to be run by `git bisect run`.
@@ -47,7 +48,7 @@ _ = subprocess.run(
 )
 
 result = subprocess.run(
-    ["python3", "-m", "pytest", "-v", "--flake-finder", "--flake-runs=4", "-rfEp", f"{target_test}"],
+    ["python3", "-m", "pytest", "-v", "--flake-finder", "--flake-runs={flake_runs}", "-rfEp", f"{target_test}"],
     capture_output = True,
     text=True,
 )
@@ -78,7 +79,7 @@ exit(0)
         fp.write(script.strip())
 
 
-def is_bad_commit(target_test, commit):
+def is_bad_commit(target_test, commit, flake_runs=4):
     repo = git.Repo(".")  # or specify path to your repo
 
     # Save the current HEAD reference
@@ -87,7 +88,7 @@ def is_bad_commit(target_test, commit):
     # Checkout to the commit
     repo.git.checkout(commit)
 
-    create_script(target_test=target_test)
+    create_script(target_test=target_test, flake_runs=flake_runs)
 
     result = subprocess.run(
         ["python3", "target_script.py"],
@@ -136,6 +137,7 @@ def find_bad_commit(target_test, start_commit, end_commit):
     }
 
     is_pr_ci = os.environ.get("GITHUB_EVENT_NAME") in ["issue_comment", "pull_request"]
+    flake_runs = 1 if is_pr_ci else 4
 
     # For PR comment CI, we "assume" all tests at `end_commit` passed, so any failing test during a PR CI run is
     # "a new failing test", and we can perform more detailed checks with this script.
@@ -147,7 +149,7 @@ def find_bad_commit(target_test, start_commit, end_commit):
     #   - if both failing and passing at end_commit: mark it as flaky
 
     # check if `end_commit` fails the test
-    failed_before, n_failed, n_passed, failure_at_base_commit = is_bad_commit(target_test, end_commit)
+    failed_before, n_failed, n_passed, failure_at_base_commit = is_bad_commit(target_test, end_commit, flake_runs=flake_runs)
     # We only need one failure to conclude the test is flaky on the previous run with `end_commit`.
     # However, when running on CI, we need at least one failure and one pass to conclude.
     is_flaky_at_end_commit = ((not is_pr_ci) and n_failed > 0) or (is_pr_ci and n_failed > 0 and n_passed > 0)
@@ -177,7 +179,7 @@ def find_bad_commit(target_test, start_commit, end_commit):
     # Now, we are (almost) sure `target_test` is not failing at `end_commit`. (For a PR CI, it may fail at `end_commit`)
     # Check if `start_commit` fails the test.
     # **IMPORTANT** we only need one pass to conclude the test is flaky on the current run with `start_commit`!
-    _, n_failed, n_passed, failure_at_workflow_commit = is_bad_commit(target_test, start_commit)
+    _, n_failed, n_passed, failure_at_workflow_commit = is_bad_commit(target_test, start_commit, flake_runs=flake_runs)
     if n_passed > 0:
         # failed on CI run, but not reproducible here --> don't report
         result["status"] = (
@@ -220,7 +222,7 @@ def find_bad_commit(target_test, start_commit, end_commit):
         return result
 
     # The test fails on `start_commit` but passed on `end_commit`.
-    create_script(target_test=target_test)
+    create_script(target_test=target_test, flake_runs=flake_runs)
 
     bash = f"""
 git bisect reset
@@ -253,7 +255,7 @@ git bisect run python3 target_script.py
     failure_at_bad_commit = ""
     if len(commits) > 0:
         bad_commit = commits[0]
-        _, _, _, failure_at_bad_commit = is_bad_commit(target_test, bad_commit)
+        _, _, _, failure_at_bad_commit = is_bad_commit(target_test, bad_commit, flake_runs=flake_runs)
 
     print(f"Between `start_commit` {start_commit} and `end_commit` {end_commit}")
     print(f"bad_commit: {bad_commit}\n")

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -149,7 +149,9 @@ def find_bad_commit(target_test, start_commit, end_commit):
     #   - if both failing and passing at end_commit: mark it as flaky
 
     # check if `end_commit` fails the test
-    failed_before, n_failed, n_passed, failure_at_base_commit = is_bad_commit(target_test, end_commit, flake_runs=flake_runs)
+    failed_before, n_failed, n_passed, failure_at_base_commit = is_bad_commit(
+        target_test, end_commit, flake_runs=flake_runs
+    )
     # We only need one failure to conclude the test is flaky on the previous run with `end_commit`.
     # However, when running on CI, we need at least one failure and one pass to conclude.
     is_flaky_at_end_commit = ((not is_pr_ci) and n_failed > 0) or (is_pr_ci and n_failed > 0 and n_passed > 0)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47522)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47522)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

When the CI is triggered by a PR comment (`self-comment-ci.yml`, i.e. `GITHUB_EVENT_NAME == "issue_comment"`), use `--flake-runs=1` instead of `--flake-runs=4` in `check_bad_commit.py`.

The `is_pr_ci` flag is already computed inside `find_bad_commit()` for other purposes, so no workflow changes are needed — `flake_runs` is simply derived from it and threaded through `create_script()` and `is_bad_commit()`.

This reduces unnecessary re-runs during PR comment CI where speed matters more than flakiness detection accuracy.