### PR TITLE
Fix Gemma3n crash when resizing token embeddings for multimodal model

### DIFF
--- a/src/transformers/models/gemma3n/modeling_gemma3n.py
+++ b/src/transformers/models/gemma3n/modeling_gemma3n.py
@@ -2097,11 +2097,6 @@ class Gemma3nModel(Gemma3nPreTrainedModel):
         if input_ids is not None:
             inputs_embeds = self.get_input_embeddings()(input_ids)
 
-            # Prepare per-layer inputs from inputs_ids
-            per_layer_inputs_mask = torch.logical_and(input_ids >= 0, input_ids < self.vocab_size_per_layer_input)
-            per_layer_inputs_tokens = torch.where(per_layer_inputs_mask, input_ids, torch.zeros_like(input_ids))
-            per_layer_inputs = self.language_model.get_per_layer_inputs(per_layer_inputs_tokens)
-
             # Handle vision tokens (>= embed_vision.vocab_offset and < embed_audio.vocab_offset)
             vision_mask = torch.logical_and(
                 input_ids >= self.embed_vision.vocab_offset, input_ids < self.embed_audio.vocab_offset
@@ -2113,14 +2108,22 @@ class Gemma3nModel(Gemma3nPreTrainedModel):
             expanded_vision_mask = vision_mask.unsqueeze(-1)
             inputs_embeds = torch.where(expanded_vision_mask, vision_embeds, inputs_embeds)
 
-            # Handle audio tokens (>= embed_audio.vocab_offset)
-            audio_mask = input_ids >= self.embed_audio.vocab_offset
+            # Handle audio tokens (bounded to actual audio vocab range)
+            audio_mask = torch.logical_and(
+                input_ids >= self.embed_audio.vocab_offset,
+                input_ids < self.embed_audio.vocab_offset + self.embed_audio.vocab_size,
+            )
             dummy_audio_token_id = self.embed_audio.vocab_offset + self.embed_audio.vocab_size - 1
             audio_input_ids = torch.where(audio_mask, input_ids, dummy_audio_token_id).to(inputs_embeds.device)
             audio_embeds = self.embed_audio(input_ids=audio_input_ids)
             audio_embeds = audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
             expanded_audio_mask = audio_mask.unsqueeze(-1)
             inputs_embeds = torch.where(expanded_audio_mask, audio_embeds, inputs_embeds)
+
+            # Prepare per-layer inputs: exclude multimodal tokens which have their own embeddings
+            per_layer_inputs_mask = (input_ids >= 0) & ~vision_mask & ~audio_mask
+            per_layer_inputs_tokens = torch.where(per_layer_inputs_mask, input_ids, torch.zeros_like(input_ids))
+            per_layer_inputs = self.language_model.get_per_layer_inputs(per_layer_inputs_tokens)
         else:
             per_layer_inputs = None
 

--- a/src/transformers/models/gemma3n/modular_gemma3n.py
+++ b/src/transformers/models/gemma3n/modular_gemma3n.py
@@ -2214,11 +2214,6 @@ class Gemma3nModel(PaliGemmaModel):
         if input_ids is not None:
             inputs_embeds = self.get_input_embeddings()(input_ids)
 
-            # Prepare per-layer inputs from inputs_ids
-            per_layer_inputs_mask = torch.logical_and(input_ids >= 0, input_ids < self.vocab_size_per_layer_input)
-            per_layer_inputs_tokens = torch.where(per_layer_inputs_mask, input_ids, torch.zeros_like(input_ids))
-            per_layer_inputs = self.language_model.get_per_layer_inputs(per_layer_inputs_tokens)
-
             # Handle vision tokens (>= embed_vision.vocab_offset and < embed_audio.vocab_offset)
             vision_mask = torch.logical_and(
                 input_ids >= self.embed_vision.vocab_offset, input_ids < self.embed_audio.vocab_offset
@@ -2230,14 +2225,22 @@ class Gemma3nModel(PaliGemmaModel):
             expanded_vision_mask = vision_mask.unsqueeze(-1)
             inputs_embeds = torch.where(expanded_vision_mask, vision_embeds, inputs_embeds)
 
-            # Handle audio tokens (>= embed_audio.vocab_offset)
-            audio_mask = input_ids >= self.embed_audio.vocab_offset
+            # Handle audio tokens (bounded to actual audio vocab range)
+            audio_mask = torch.logical_and(
+                input_ids >= self.embed_audio.vocab_offset,
+                input_ids < self.embed_audio.vocab_offset + self.embed_audio.vocab_size,
+            )
             dummy_audio_token_id = self.embed_audio.vocab_offset + self.embed_audio.vocab_size - 1
             audio_input_ids = torch.where(audio_mask, input_ids, dummy_audio_token_id).to(inputs_embeds.device)
             audio_embeds = self.embed_audio(input_ids=audio_input_ids)
             audio_embeds = audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
             expanded_audio_mask = audio_mask.unsqueeze(-1)
             inputs_embeds = torch.where(expanded_audio_mask, audio_embeds, inputs_embeds)
+
+            # Prepare per-layer inputs: exclude multimodal tokens which have their own embeddings
+            per_layer_inputs_mask = (input_ids >= 0) & ~vision_mask & ~audio_mask
+            per_layer_inputs_tokens = torch.where(per_layer_inputs_mask, input_ids, torch.zeros_like(input_ids))
+            per_layer_inputs = self.language_model.get_per_layer_inputs(per_layer_inputs_tokens)
         else:
             per_layer_inputs = None
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47524)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47524)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Fixes the crash in `Gemma3nForConditionalGeneration` when calling `resize_token_embeddings()` after adding new special tokens (reported in #39921).

**Root cause:** The audio mask in `Gemma3nModel.forward()` uses an unbounded check (`input_ids >= self.embed_audio.vocab_offset`). After `resize_token_embeddings` appends new tokens at the end of the vocab (IDs 262400+), they match this audio mask since `embed_audio.vocab_offset` is 262272. These new text tokens are then passed to `embed_audio`, which does `self.embedding(input_ids - self.vocab_offset)` — giving index 128+ into a table with only 128 entries, causing the CUDA error.

**Fix:**
1. Bound the audio mask to the actual audio vocab range (matching how the vision mask is already bounded):
```python
audio_mask = torch.logical_and(
    input_ids >= self.embed_audio.vocab_offset,
    input_ids < self.embed_audio.vocab_offset + self.embed_audio.vocab_size,
)
```

2. Move the per-layer inputs mask computation after the vision/audio masks, and use them to exclude multimodal tokens. This way new text tokens correctly receive per-layer embeddings without relying on the `vocab_size_per_layer_input` boundary.

## Who can review?

@zucchini-nlp @ArthurZucker

Fixes #39921