### PR TITLE
Fix `causal_conv1d_fn` positional `activation` colliding with hub kernel's `seq_idx`

### DIFF
--- a/src/transformers/models/bamba/modeling_bamba.py
+++ b/src/transformers/models/bamba/modeling_bamba.py
@@ -548,7 +548,7 @@ class BambaMixer(nn.Module):
                 hidden_states,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/falcon_h1/modeling_falcon_h1.py
+++ b/src/transformers/models/falcon_h1/modeling_falcon_h1.py
@@ -547,7 +547,7 @@ class FalconH1Mixer(nn.Module):
                 hidden_states,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/falcon_mamba/modeling_falcon_mamba.py
+++ b/src/transformers/models/falcon_mamba/modeling_falcon_mamba.py
@@ -274,7 +274,7 @@ class FalconMambaMixer(nn.Module):
                 hidden_states,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
@@ -431,7 +431,7 @@ class GraniteMoeHybridMambaLayer(nn.Module):
                 hidden_states,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -355,7 +355,7 @@ class JambaMambaMixer(nn.Module):
                 hidden_states,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -245,7 +245,7 @@ class MambaMixer(nn.Module):
                 hidden_states,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -308,7 +308,7 @@ class Mamba2Mixer(nn.Module):
                 hidden_states,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modeling_nemotron_h.py
@@ -298,7 +298,7 @@ class NemotronHMamba2Mixer(nn.Module):
                 hidden_states,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -498,7 +498,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 mixed_qkv,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -265,7 +265,7 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
                 mixed_qkv,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -495,7 +495,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
                 mixed_qkv,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modeling_qwen3_next.py
@@ -647,7 +647,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 mixed_qkv,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/qwen3_next/modular_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modular_qwen3_next.py
@@ -485,7 +485,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 mixed_qkv,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/zamba/modeling_zamba.py
+++ b/src/transformers/models/zamba/modeling_zamba.py
@@ -343,7 +343,7 @@ class ZambaMambaMixer(nn.Module):
                 hidden_states,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 

--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -588,7 +588,7 @@ class Zamba2MambaMixer(nn.Module):
                 hidden_states,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
-                self.activation,
+                activation=self.activation,
                 seq_idx=kwargs.get("seq_idx"),
             )
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47527)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47527)
<!-- ci-dashboard-badge:end -->

#47452 calls `causal_conv1d_fn(..., self.activation, seq_idx=...)` with `activation` positional. That matches the native fallback, but the `kernels-community/causal-conv1d` hub kernel has `seq_idx` as its 4th positional param, so `activation` binds to `seq_idx` and collides with the keyword → `TypeError: causal_conv1d_fn() got multiple values for argument 'seq_idx'` whenever the hub kernel is loaded (GPU + `USE_HUB_KERNELS=YES`).

Fix: pass `activation=` by keyword at every migrated call site (mamba, mamba2, bamba, falcon_h1, falcon_mamba, granitemoehybrid, jamba, zamba, zamba2, qwen3_5, qwen3_5_moe, qwen3_next, nemotron_h).

Reported at https://github.com/huggingface/trl/issues/6536
Closes https://github.com/huggingface/transformers/issues/47526