### PR TITLE
Fix Phi3/Phimoe prepare_inputs_for_generation forwarding    logits_to_keep=None

### DIFF
--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -516,6 +516,16 @@ class Phi3ForCausalLM(Phi3PreTrainedModel, GenerationMixin):
         # Overwritten -- this model may need to switch between short and long rope, invalidating the cache in the
         # process
 
+        # `logits_to_keep=None` must not reach `forward()`: `None` as a slice index turns the
+        # lm_head slice into an unsqueeze (`hidden_states[:, None, :]`) -> 4D logits -> sampling
+        # crash ("prob_dist must be 1 or 2 dim" in `torch.multinomial`). `None` survives here
+        # whenever `_supports_logits_to_keep()` cannot introspect a wrapped `forward()` (e.g.
+        # TRL/PEFT training stacks) and thus never injects its default of 1. Generation only
+        # consumes the last position, so coerce; assisted decoding overrides
+        # `model_inputs["logits_to_keep"]` afterwards and is unaffected.
+        if logits_to_keep is None:
+            logits_to_keep = 1
+
         # When the first time input length reached long and short factor switching point, enforce re-compute cache
         # It will cause downside of slower at this single token position, however, better than current failure.
         if (

--- a/src/transformers/models/phi3/modular_phi3.py
+++ b/src/transformers/models/phi3/modular_phi3.py
@@ -222,6 +222,16 @@ class Phi3ForCausalLM(MistralForCausalLM):
         # Overwritten -- this model may need to switch between short and long rope, invalidating the cache in the
         # process
 
+        # `logits_to_keep=None` must not reach `forward()`: `None` as a slice index turns the
+        # lm_head slice into an unsqueeze (`hidden_states[:, None, :]`) -> 4D logits -> sampling
+        # crash ("prob_dist must be 1 or 2 dim" in `torch.multinomial`). `None` survives here
+        # whenever `_supports_logits_to_keep()` cannot introspect a wrapped `forward()` (e.g.
+        # TRL/PEFT training stacks) and thus never injects its default of 1. Generation only
+        # consumes the last position, so coerce; assisted decoding overrides
+        # `model_inputs["logits_to_keep"]` afterwards and is unaffected.
+        if logits_to_keep is None:
+            logits_to_keep = 1
+
         # When the first time input length reached long and short factor switching point, enforce re-compute cache
         # It will cause downside of slower at this single token position, however, better than current failure.
         if (

--- a/src/transformers/models/phimoe/modeling_phimoe.py
+++ b/src/transformers/models/phimoe/modeling_phimoe.py
@@ -887,6 +887,16 @@ class PhimoeForCausalLM(PhimoePreTrainedModel, GenerationMixin):
         # Overwritten -- this model may need to switch between short and long rope, invalidating the cache in the
         # process
 
+        # `logits_to_keep=None` must not reach `forward()`: `None` as a slice index turns the
+        # lm_head slice into an unsqueeze (`hidden_states[:, None, :]`) -> 4D logits -> sampling
+        # crash ("prob_dist must be 1 or 2 dim" in `torch.multinomial`). `None` survives here
+        # whenever `_supports_logits_to_keep()` cannot introspect a wrapped `forward()` (e.g.
+        # TRL/PEFT training stacks) and thus never injects its default of 1. Generation only
+        # consumes the last position, so coerce; assisted decoding overrides
+        # `model_inputs["logits_to_keep"]` afterwards and is unaffected.
+        if logits_to_keep is None:
+            logits_to_keep = 1
+
         # When the first time input length reached long and short factor switching point, enforce re-compute cache
         # It will cause downside of slower at this single token position, however, better than current failure.
         if (

--- a/src/transformers/models/phimoe/modular_phimoe.py
+++ b/src/transformers/models/phimoe/modular_phimoe.py
@@ -376,6 +376,16 @@ class PhimoeForCausalLM(MixtralForCausalLM):
         # Overwritten -- this model may need to switch between short and long rope, invalidating the cache in the
         # process
 
+        # `logits_to_keep=None` must not reach `forward()`: `None` as a slice index turns the
+        # lm_head slice into an unsqueeze (`hidden_states[:, None, :]`) -> 4D logits -> sampling
+        # crash ("prob_dist must be 1 or 2 dim" in `torch.multinomial`). `None` survives here
+        # whenever `_supports_logits_to_keep()` cannot introspect a wrapped `forward()` (e.g.
+        # TRL/PEFT training stacks) and thus never injects its default of 1. Generation only
+        # consumes the last position, so coerce; assisted decoding overrides
+        # `model_inputs["logits_to_keep"]` afterwards and is unaffected.
+        if logits_to_keep is None:
+            logits_to_keep = 1
+
         # When the first time input length reached long and short factor switching point, enforce re-compute cache
         # It will cause downside of slower at this single token position, however, better than current failure.
         if (


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47531)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47531)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes a generation crash in Phi3 and Phimoe: their `prepare_inputs_for_generation` overrides default `logits_to_keep=None` and forward it unconditionally into `forward()`. When `GenerationMixin._supports_logits_to_keep()` cannot introspect a wrapped `forward()` (e.g. TRL/PEFT training stacks wrap forward without `functools.wraps`), `generate()` never injects its default of `1`, so `None` reaches `forward()` — where `None` as a slice index turns the lm_head slice into an unsqueeze (`hidden_states[:, None, :]`), producing 4-dim logits and crashing sampling with `RuntimeError: prob_dist must be 1 or 2 dim` in `torch.multinomial`.

The fix coerces `None -> 1` in the two overrides (modular + regenerated modeling files): generation only consumes the last position, and assisted decoding overrides `model_inputs["logits_to_keep"]` afterwards, so it is unaffected. `Phi4Multimodal` already avoids the bug by defaulting to `0` in its own override; all non-overriding models are unaffected because the kwarg is simply absent.

Fixes #47530

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed via a GitHub issue? Link: #47530
- [x] `make fix-repo` consistency: modular converter regenerates identical files.

## Who can review?

@gante