### PR TITLE
Fix Mamba2-family decode step: restore the seq-dim squeeze

### DIFF
--- a/src/transformers/models/bamba/modeling_bamba.py
+++ b/src/transformers/models/bamba/modeling_bamba.py
@@ -616,6 +616,7 @@ class BambaMixer(nn.Module):
         recurrent_state = cache_params.layers[self.layer_idx].recurrent_states[0] if use_precomputed_states else None
         # Single step calculations via cache
         if use_precomputed_states and seq_len == 1:
+            gate, hidden_states, B, C, dt = (x.squeeze(1) for x in (gate, hidden_states, B, C, dt))
             # 3. SSM transformation
             A = A[:, None, ...][:, :, None].expand(-1, self.head_dim, self.ssm_state_size).to(dtype=torch.float32)
             dt = dt[:, :, None].expand(-1, -1, self.head_dim)

--- a/src/transformers/models/falcon_h1/modeling_falcon_h1.py
+++ b/src/transformers/models/falcon_h1/modeling_falcon_h1.py
@@ -618,6 +618,7 @@ class FalconH1Mixer(nn.Module):
         recurrent_state = cache_params.layers[self.layer_idx].recurrent_states[0] if use_precomputed_states else None
         # getting projected states from cache if it exists
         if use_precomputed_states and seq_len == 1:
+            gate, hidden_states, B, C, dt = (x.squeeze(1) for x in (gate, hidden_states, B, C, dt))
             # 3. SSM transformation
             A = A[:, None, ...][:, :, None].expand(-1, self.head_dim, self.ssm_state_size).to(dtype=torch.float32)
             dt = dt[:, :, None].expand(-1, -1, self.head_dim)

--- a/src/transformers/models/falcon_h1/modular_falcon_h1.py
+++ b/src/transformers/models/falcon_h1/modular_falcon_h1.py
@@ -232,6 +232,7 @@ class FalconH1Mixer(BambaMixer):
         recurrent_state = cache_params.layers[self.layer_idx].recurrent_states[0] if use_precomputed_states else None
         # getting projected states from cache if it exists
         if use_precomputed_states and seq_len == 1:
+            gate, hidden_states, B, C, dt = (x.squeeze(1) for x in (gate, hidden_states, B, C, dt))
             # 3. SSM transformation
             A = A[:, None, ...][:, :, None].expand(-1, self.head_dim, self.ssm_state_size).to(dtype=torch.float32)
             dt = dt[:, :, None].expand(-1, -1, self.head_dim)

--- a/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
@@ -499,6 +499,7 @@ class GraniteMoeHybridMambaLayer(nn.Module):
         recurrent_state = cache_params.layers[self.layer_idx].recurrent_states[0] if use_precomputed_states else None
         # Single step calculations via cache
         if use_precomputed_states and seq_len == 1:
+            gate, hidden_states, B, C, dt = (x.squeeze(1) for x in (gate, hidden_states, B, C, dt))
             # 3. SSM transformation
             A = A[:, None, ...][:, :, None].expand(-1, self.head_dim, self.ssm_state_size).to(dtype=torch.float32)
             dt = dt[:, :, None].expand(-1, -1, self.head_dim)

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -376,6 +376,7 @@ class Mamba2Mixer(nn.Module):
         recurrent_state = cache_params.layers[self.layer_idx].recurrent_states[0] if use_precomputed_states else None
         # Single step calculations via cache
         if use_precomputed_states and seq_len == 1:
+            gate, hidden_states, B, C, dt = (x.squeeze(1) for x in (gate, hidden_states, B, C, dt))
             # 3. SSM transformation
             A = A[:, None, ...][:, :, None].expand(-1, self.head_dim, self.ssm_state_size).to(dtype=torch.float32)
             dt = dt[:, :, None].expand(-1, -1, self.head_dim)

--- a/src/transformers/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modeling_nemotron_h.py
@@ -366,6 +366,7 @@ class NemotronHMamba2Mixer(nn.Module):
         recurrent_state = cache_params.layers[self.layer_idx].recurrent_states[0] if use_precomputed_states else None
         # Single step calculations via cache
         if use_precomputed_states and seq_len == 1:
+            gate, hidden_states, B, C, dt = (x.squeeze(1) for x in (gate, hidden_states, B, C, dt))
             # 3. SSM transformation
             A = A[:, None, ...][:, :, None].expand(-1, self.head_dim, self.ssm_state_size).to(dtype=torch.float32)
             dt = dt[:, :, None].expand(-1, -1, self.head_dim)

--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -656,6 +656,7 @@ class Zamba2MambaMixer(nn.Module):
         recurrent_state = cache_params.layers[self.layer_idx].recurrent_states[0] if use_precomputed_states else None
         # Single step calculations via cache
         if use_precomputed_states and seq_len == 1:
+            gate, hidden_states, B, C, dt = (x.squeeze(1) for x in (gate, hidden_states, B, C, dt))
             # 3. SSM transformation
             A = A[:, None, ...][:, :, None].expand(-1, self.head_dim, self.ssm_state_size).to(dtype=torch.float32)
             dt = dt[:, :, None].expand(-1, -1, self.head_dim)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47533)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47533)
<!-- ci-dashboard-badge:end -->

#47452 hoisted `self.in_proj(...)` out of the `use_precomputed_states and seq_len == 1` branch and dropped the old `hidden_states.squeeze(1)`, but the branch body still assumes 2-D `(batch, ...)` tensors. At decode time `dt` is now `(B, 1, nheads)`, so `dt[:, :, None].expand(-1, -1, head_dim)` gets a 4-D tensor → `RuntimeError: expand(...): the number of sizes provided (3) must be greater or equal to the number of dimensions in the tensor (4)`. `B`/`C`/`gate` are silently wrong for the same reason.

Fix: squeeze the sequence dim at the top of the branch, in `mamba2`, `bamba`, `falcon_h1`, `granitemoehybrid`, `nemotron_h`, `zamba2`.

Only reachable with the hub kernels loaded (GPU + `kernels` installed), so CPU CI does not see it. Caught by TRL's GPU CI: https://github.com/huggingface/trl/actions/runs/30136696609/job/89621931460

Verified on tiny configs and on real checkpoints (`AntonV/mamba2-130m-hf`, `nvidia/Nemotron-H-4B-Instruct-128K`): crash before, coherent generation after.

Closes #47532


cc @vasqu @Cyrilvallez