### PR TITLE
Fix NemotronH: Register `"mlp"` in the cache layer-type mappings

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1190,6 +1190,7 @@ DYNAMIC_LAYER_TYPE_MAPPING = {
     # "conv" reuses the same cache shape as linear attention but stores a conv state buffer rather than recurrent SSM state
     "conv": LinearAttentionLayer,
     "moe": LinearAttentionLayer,
+    "mlp": LinearAttentionLayer,
     "linear_attention": LinearAttentionLayer,
     # Hybrid layers carry both a linear-attention state and a dynamic-attention state.
     "hybrid": LinearAttentionAndFullAttentionLayer,
@@ -1206,6 +1207,7 @@ STATIC_LAYER_TYPE_MAPPING = {
     # LinearAttention layers are considered both static and dynamic (they are static, but are used as-is for any cache type)
     "conv": LinearAttentionLayer,
     "moe": LinearAttentionLayer,
+    "mlp": LinearAttentionLayer,
     "linear_attention": LinearAttentionLayer,
     # Hybrid layers carry both a linear-attention state and a dynamic-attention state.
     "hybrid": LinearAttentionAndStaticFullAttentionLayer,

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1189,14 +1189,18 @@ DYNAMIC_LAYER_TYPE_MAPPING = {
     # Linear-attention-shaped placeholders (no per-token KV; recurrent state only).
     # "conv" reuses the same cache shape as linear attention but stores a conv state buffer rather than recurrent SSM state
     "conv": LinearAttentionLayer,
-    "moe": LinearAttentionLayer,
-    "mlp": LinearAttentionLayer,
     "linear_attention": LinearAttentionLayer,
     # Hybrid layers carry both a linear-attention state and a dynamic-attention state.
     "hybrid": LinearAttentionAndFullAttentionLayer,
     "hybrid_sliding": LinearAttentionAndSlidingWindowAttentionLayer,
     # More exotic implementations
     "deepseek_sparse_attention": DynamicIndexedLayer,
+    # Note: we want `moe` and `mlp` layers to be LinearAttentionLayer, so that we can correctly grab sequence length etc from
+    # attention layers. Since they will stay empty (they don't need any cache), we don't want them to collide for mask creation etc
+    # TODO: maybe use a dummy layer in those cases, or a dictionary {idx: Layer} for self.layers, so that we can skipthe indices
+    # we don't need
+    "moe": LinearAttentionLayer,
+    "mlp": LinearAttentionLayer,
 }
 # Same but for StaticCache
 STATIC_LAYER_TYPE_MAPPING = {
@@ -1206,14 +1210,18 @@ STATIC_LAYER_TYPE_MAPPING = {
     "chunked_attention": StaticSlidingWindowLayer,
     # LinearAttention layers are considered both static and dynamic (they are static, but are used as-is for any cache type)
     "conv": LinearAttentionLayer,
-    "moe": LinearAttentionLayer,
-    "mlp": LinearAttentionLayer,
     "linear_attention": LinearAttentionLayer,
     # Hybrid layers carry both a linear-attention state and a dynamic-attention state.
     "hybrid": LinearAttentionAndStaticFullAttentionLayer,
     "hybrid_sliding": LinearAttentionAndStaticSlidingWindowAttentionLayer,
     # More exotic implementations
     "deepseek_sparse_attention": StaticIndexedLayer,
+    # Note: we want `moe` and `mlp` layers to be LinearAttentionLayer, so that we can correctly grab sequence length etc from
+    # attention layers. Since they will stay empty (they don't need any cache), we don't want them to collide for mask creation etc
+    # TODO: maybe use a dummy layer in those cases, or a dictionary {idx: Layer} for self.layers, so that we can skipthe indices
+    # we don't need
+    "moe": LinearAttentionLayer,
+    "mlp": LinearAttentionLayer,
 }
 
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47535)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47535)
<!-- ci-dashboard-badge:end -->

`NemotronHConfig` emits four layer types (`linear_attention`, `moe`, `full_attention`, `mlp`), but `cache_utils.py` only knows three (`"moe"` is registered as a cache-less placeholder) `"mlp"` was left out.

So building any cache for a Nemotron-H config with `-` (MLP) blocks raises `KeyError: 'mlp'`.

That breaks the whole original Nemotron-H family (`nvidia/Nemotron-H-8B-Base-8K`, `nvidia/Nemotron-H-4B-Instruct-128K`, pattern `M-M-M-M*-...`) — `generate()` fails before any forward, as well as `NemotronHConfig()`'s default `layer_types`.

Fix: register `"mlp"` next to `"moe"` in `DYNAMIC_LAYER_TYPE_MAPPING` and `STATIC_LAYER_TYPE_MAPPING`. From the cache's point of view they are the same thing: a feed-forward block with no per-token KV and no recurrent state.

Regression from #47118.

Closes #47534