### PR TITLE
CI: let's run integration failure cron at 10pm

### DIFF
--- a/.github/workflows/nightly-integration-failure-triage-caller.yml
+++ b/.github/workflows/nightly-integration-failure-triage-caller.yml
@@ -7,7 +7,7 @@ name: Nightly integration-failure triage
 #
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 22 * * *"
   # Allow manual triggers for testing. GitHub only lets users with write access
   # to this repo run workflow_dispatch, so no extra authorization gate is needed.
   workflow_dispatch:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47537)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47537)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

The integration failure cron now runs against GPU but triggers at the same time the daily run does, so we are all racing for GPU workers. Let's move this one to 10pm so we don't stress the queue