### PR TITLE
docs: fix typo in gptq.md

### DIFF
--- a/docs/source/en/quantization/gptq.md
+++ b/docs/source/en/quantization/gptq.md
@@ -32,7 +32,7 @@ Then run the command below to install GPT-QModel.
 pip install gptqmodel --no-build-isolation
 ```
 
-Create a [`GPTQConfig`] class and set the number of bits to quantize to, a dataset to calbrate the weights for quantization, and a tokenizer to prepare the dataset.
+Create a [`GPTQConfig`] class and set the number of bits to quantize to, a dataset to calibrate the weights for quantization, and a tokenizer to prepare the dataset.
 
 ```py
 from transformers import AutoModelForCausalLM, AutoTokenizer, GPTQConfig


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47550)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47550)
<!-- ci-dashboard-badge:end -->

Small typo fix: "dataset to calbrate the weights" -> "dataset to calibrate the weights".

Docs only, no functional changes.