### PR TITLE
docs: fix typo in kimi_k25.md

### DIFF
--- a/docs/source/en/model_doc/kimi_k25.md
+++ b/docs/source/en/model_doc/kimi_k25.md
@@ -32,7 +32,7 @@ Kimi K2.5 is an open-source, native multimodal agentic model that advances pract
 Kimi K2.5 achieves significant improvements on complex, end-to-end coding tasks, generalizing robustly across programming languages (Rust, Go, Python) and domains spanning front-end, DevOps, and performance optimization. The model is capable of transforming simple prompts and visual inputs into production-ready interfaces and lightweight full-stack workflows, generating structured layouts, interactive elements, and rich animations with deliberate aesthetic precision.
 
 This model was contributed by [RaushanTurganbay](https://huggingface.co/RaushanTurganbay).
-The offical checkpoints are [moonshotai/Kimi-K2.5](https://huggingface.co/moonshotai/Kimi-K2.5), [moonshotai/Kimi-K2.6](https://huggingface.co/moonshotai/Kimi-K2.6) and [moonshotai/Kimi-K2.7-Code](https://huggingface.co/moonshotai/Kimi-K2.7-Code).
+The official checkpoints are [moonshotai/Kimi-K2.5](https://huggingface.co/moonshotai/Kimi-K2.5), [moonshotai/Kimi-K2.6](https://huggingface.co/moonshotai/Kimi-K2.6) and [moonshotai/Kimi-K2.7-Code](https://huggingface.co/moonshotai/Kimi-K2.7-Code).
 
 
 ## Usage examples


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47551)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47551)
<!-- ci-dashboard-badge:end -->

Small typo fix: "The offical checkpoints" -> "The official checkpoints".

Docs only, no functional changes.