### PR TITLE
Return feature attention masks from Wav2Vec2-derived models

### DIFF
--- a/src/transformers/modeling_outputs.py
+++ b/src/transformers/modeling_outputs.py
@@ -1314,12 +1314,15 @@ class Wav2Vec2BaseModelOutput(ModelOutput):
 
             Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
             heads.
+        attention_mask (`torch.BoolTensor` of shape `(batch_size, sequence_length)`, *optional*, returned when `attention_mask` is passed):
+            Feature-vector attention mask after feature extraction.
     """
 
     last_hidden_state: torch.FloatTensor | None = None
     extract_features: torch.FloatTensor | None = None
     hidden_states: tuple[torch.FloatTensor, ...] | None = None
     attentions: tuple[torch.FloatTensor, ...] | None = None
+    attention_mask: torch.BoolTensor | None = None
 
 
 @dataclass

--- a/src/transformers/models/data2vec/modeling_data2vec_audio.py
+++ b/src/transformers/models/data2vec/modeling_data2vec_audio.py
@@ -787,6 +787,7 @@ class Data2VecAudioModel(Data2VecAudioPreTrainedModel):
             extract_features=extract_features,
             hidden_states=encoder_outputs.hidden_states,
             attentions=encoder_outputs.attentions,
+            attention_mask=attention_mask,
         )
 
 

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -1372,6 +1372,7 @@ class Wav2Vec2Model(Wav2Vec2PreTrainedModel):
             extract_features=extract_features,
             hidden_states=encoder_outputs.hidden_states,
             attentions=encoder_outputs.attentions,
+            attention_mask=attention_mask,
         )
 
 

--- a/src/transformers/models/wav2vec2_conformer/modeling_wav2vec2_conformer.py
+++ b/src/transformers/models/wav2vec2_conformer/modeling_wav2vec2_conformer.py
@@ -1186,6 +1186,7 @@ class Wav2Vec2ConformerModel(Wav2Vec2ConformerPreTrainedModel):
             extract_features=extract_features,
             hidden_states=encoder_outputs.hidden_states,
             attentions=encoder_outputs.attentions,
+            attention_mask=attention_mask,
         )
 
 

--- a/src/transformers/models/wavlm/modeling_wavlm.py
+++ b/src/transformers/models/wavlm/modeling_wavlm.py
@@ -1085,6 +1085,7 @@ class WavLMModel(WavLMPreTrainedModel):
             extract_features=extract_features,
             hidden_states=encoder_outputs.hidden_states,
             attentions=encoder_outputs.attentions,
+            attention_mask=attention_mask,
         )
 
 

--- a/tests/models/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_wav2vec2.py
@@ -256,6 +256,21 @@ class Wav2Vec2ModelTester:
             result.last_hidden_state.shape, (self.batch_size, self.output_seq_length, self.hidden_size)
         )
 
+    def create_and_check_model_output_attention_mask(self, config, input_values, attention_mask):
+        model = Wav2Vec2Model(config=config)
+        model.to(torch_device)
+        model.eval()
+
+        attention_mask = torch.ones_like(attention_mask)
+        attention_mask[1, attention_mask.shape[1] // 2 :] = 0
+        result = model(input_values, attention_mask=attention_mask)
+
+        expected_attention_mask = model._get_feature_vector_attention_mask(
+            result.last_hidden_state.shape[1], attention_mask
+        )
+        self.parent.assertEqual(result.attention_mask.shape, result.last_hidden_state.shape[:2])
+        self.parent.assertTrue(torch.equal(result.attention_mask, expected_attention_mask))
+
     def create_and_check_model_with_adapter(self, config, input_values, attention_mask):
         config.add_adapter = True
         model = Wav2Vec2Model(config=config)
@@ -501,6 +516,10 @@ class Wav2Vec2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
+
+    def test_model_output_attention_mask(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_model_output_attention_mask(*config_and_inputs)
 
     def test_model_with_adapter(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47554)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47554)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Fixes #25307.

Wav2Vec2-derived base models already compute a feature-vector attention mask for padded inputs but did not expose it in their return-dict outputs. This adds an optional `attention_mask` field to `Wav2Vec2BaseModelOutput` and returns the exact reduced mask from `Wav2Vec2Model`, WavLM, Data2Vec Audio, and Wav2Vec2 Conformer.

The mask aligns with `last_hidden_state`; `return_dict=False` tuple layouts are unchanged.

The WavLM, Data2Vec Audio, and Wav2Vec2 Conformer return sites are generated from their modular definitions, so they are included to keep repository modular consistency valid.

## Code Agent Policy

This was a human-led contribution. AI assistance was used for implementation and testing; the human submitter reviewed every changed line and validated the behavior locally.

- Coordination: #25307, including the maintainer’s July 24, 2026 invitation to revive this work.
- Related work: closed PR #25471; this retains only the generated Wav2Vec2-derived output paths required by current repository consistency.
- Validation:
  - `python -m pytest tests/models/wav2vec2/test_modeling_wav2vec2.py -q` — 211 passed, 199 skipped
  - affected WavLM, Data2Vec Audio, and Wav2Vec2 Conformer suites — 251 passed, 403 skipped
  - exact modular conversion check
  - `make style`

## Before submitting

- [x] This was discussed and approved in #25307.
- [x] Added a regression test for the public reduced-mask output.
- [x] Updated the public output docstring.