### PR TITLE
Hoist special-token lookups in wav2vec2 decode paths and drop a dead filter in wav2vec2_phoneme

### DIFF
--- a/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
@@ -281,9 +281,10 @@ class Wav2Vec2CTCTokenizer(PreTrainedTokenizer):
             return self._added_tokens_decoder[ids].content if ids in self._added_tokens_decoder else self.unk_token
 
         tokens = []
+        all_special_ids = set(self.all_special_ids)
         for index in ids:
             index = int(index)
-            if skip_special_tokens and index in self.all_special_ids:
+            if skip_special_tokens and index in all_special_ids:
                 continue
             if index in self.decoder:
                 tokens.append(self.decoder[index])
@@ -426,8 +427,9 @@ class Wav2Vec2CTCTokenizer(PreTrainedTokenizer):
         filtered_tokens = self.convert_ids_to_tokens(token_ids, skip_special_tokens=False)
 
         result = []
+        all_special_tokens = set(self.all_special_tokens)
         for token in filtered_tokens:
-            if skip_special_tokens and token in self.all_special_tokens and token != self.word_delimiter_token:
+            if skip_special_tokens and token in all_special_tokens and token != self.word_delimiter_token:
                 continue
             result.append(token)
 

--- a/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
+++ b/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
@@ -422,14 +422,8 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
         """
         filtered_tokens = self.convert_ids_to_tokens(token_ids, skip_special_tokens=skip_special_tokens)
 
-        result = []
-        for token in filtered_tokens:
-            if skip_special_tokens and token in self.all_special_ids:
-                continue
-            result.append(token)
-
         string_output = self.convert_tokens_to_string(
-            result,
+            filtered_tokens,
             group_tokens=group_tokens,
             spaces_between_special_tokens=spaces_between_special_tokens,
             filter_word_delimiter_token=filter_word_delimiter_token,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47557)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47557)
<!-- ci-dashboard-badge:end -->

## What this does

Fixes #47556. Finishes the per-token special-token cleanup from #47425 for the wav2vec2 family.

- `Wav2Vec2CTCTokenizer.convert_ids_to_tokens`: hoist `set(self.all_special_ids)` out of the id loop. The property rebuilds its list on every access, so the loop paid a rebuild per id.
- `Wav2Vec2CTCTokenizer._decode`: same hoist for `self.all_special_tokens` in the token loop.
- `Wav2Vec2PhonemeCTCTokenizer._decode`: delete a filter loop that never matches. It compares token strings against `all_special_ids` (ints), and `convert_ids_to_tokens` was already called with `skip_special_tokens` passed through, so even a type-corrected check would find nothing to remove.

## Numbers

20k ids, 205 special tokens (the MMS shape: one added special per language), M1 CPU:

```
convert_ids_to_tokens: 751.6 ms -> 1.3 ms
decode:                362.3 ms -> 16.7 ms
```

## Behavior

No output changes anywhere:

- wav2vec2 + wav2vec2_phoneme tokenization suites: identical results on this branch and on main (49 passed, 31 subtests both).
- phoneme decode compared byte-for-byte on main vs branch across `skip_special_tokens` True/False, with base vocab, delimiter, added and special tokens in the input: identical. That is the proof the deleted loop was dead.

## Notes

#46578 (open) touches the same `convert_ids_to_tokens` line to change word-delimiter handling. This PR does not change that logic either way; the two compose semantically and I am happy to rebase whichever lands second.

AI-assisted; I reviewed every line and ran the tests and benchmarks above.