### PR TITLE
Fix model parallel device mismatch in `create_bidirectional_sliding_window_mask`

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -1280,7 +1280,11 @@ def create_bidirectional_sliding_window_mask(
         raise ValueError("Could not find a `sliding_window` argument in the config, or it is not set")
 
     embeds = encoder_hidden_states if encoder_hidden_states is not None else inputs_embeds
-    batch_size, dtype, device = embeds.shape[0], embeds.dtype, embeds.device
+    batch_size, dtype = embeds.shape[0], embeds.dtype
+    # Use `inputs_embeds.device` to stay consistent with `_preprocess_mask_arguments`, which moves the 2D
+    # `attention_mask` to that device. In model parallel setups, `encoder_hidden_states` may live on a different
+    # device than `inputs_embeds` (e.g. cross-attention from a decoder to encoder states).
+    device = inputs_embeds.device
     mask_factory_function = sliding_window_bidirectional_mask_function(sliding_window)
     mask_interface = ALL_MASK_ATTENTION_FUNCTIONS[config._attn_implementation]
 

--- a/tests/utils/test_masking_utils.py
+++ b/tests/utils/test_masking_utils.py
@@ -26,11 +26,10 @@ if is_torch_available():
     import torch
     from torch.nn.attention.flex_attention import create_block_mask
 
-    from transformers import DynamicCache, Gemma2Config, LlamaConfig, Qwen3NextConfig
+    from transformers import DynamicCache, LlamaConfig, Qwen3NextConfig
     from transformers.cache_utils import DynamicSlidingWindowLayer
     from transformers.masking_utils import (
         create_bidirectional_mask,
-        create_bidirectional_sliding_window_mask,
         create_causal_mask,
         create_chunked_causal_mask,
         create_masks_for_generate,
@@ -376,34 +375,6 @@ class MaskTest(unittest.TestCase):
 
         self.assertTrue(padded_mask[0] is not None)
         self.assertTrue(padded_mask[1] is not None)
-
-    def test_bidirectional_masks_build_on_inputs_embeds_device(self):
-        """
-        Both bidirectional mask helpers must build the mask on `inputs_embeds.device`: under model
-        parallelism, `encoder_hidden_states` can live on a different device than the attention layer
-        consuming the mask. #46221 fixed `create_bidirectional_mask`; regression test for it and its
-        sliding-window sibling. The `meta` device stands in for "a different device" so the test also
-        runs single-device.
-        """
-        config = Gemma2Config(sliding_window=4)
-        config._attn_implementation = "sdpa"
-
-        inputs_embeds = torch.ones((2, 5, 8), device=torch_device, dtype=torch.float16)
-        encoder_hidden_states = torch.ones((2, 7, 8), device="meta", dtype=torch.float16)
-        # A padded row, otherwise the full-attention helper skips mask creation (all-ones fast
-        # path) and returns None instead of a tensor whose device we can check
-        cross_mask = torch.ones((2, 7), device=torch_device)
-        cross_mask[:, -1] = 0
-
-        for mask_fn in (create_bidirectional_mask, create_bidirectional_sliding_window_mask):
-            with self.subTest(mask_fn.__name__):
-                mask = mask_fn(
-                    config=config,
-                    inputs_embeds=inputs_embeds,
-                    attention_mask=cross_mask,
-                    encoder_hidden_states=encoder_hidden_states,
-                )
-                self.assertEqual(mask.device, inputs_embeds.device)
 
     def test_recurrent_mask_kept_on_continued_multi_token_forward(self):
         """

--- a/tests/utils/test_masking_utils.py
+++ b/tests/utils/test_masking_utils.py
@@ -26,10 +26,11 @@ if is_torch_available():
     import torch
     from torch.nn.attention.flex_attention import create_block_mask
 
-    from transformers import DynamicCache, LlamaConfig, Qwen3NextConfig
+    from transformers import DynamicCache, Gemma2Config, LlamaConfig, Qwen3NextConfig
     from transformers.cache_utils import DynamicSlidingWindowLayer
     from transformers.masking_utils import (
         create_bidirectional_mask,
+        create_bidirectional_sliding_window_mask,
         create_causal_mask,
         create_chunked_causal_mask,
         create_masks_for_generate,
@@ -375,6 +376,34 @@ class MaskTest(unittest.TestCase):
 
         self.assertTrue(padded_mask[0] is not None)
         self.assertTrue(padded_mask[1] is not None)
+
+    def test_bidirectional_masks_build_on_inputs_embeds_device(self):
+        """
+        Both bidirectional mask helpers must build the mask on `inputs_embeds.device`: under model
+        parallelism, `encoder_hidden_states` can live on a different device than the attention layer
+        consuming the mask. #46221 fixed `create_bidirectional_mask`; regression test for it and its
+        sliding-window sibling. The `meta` device stands in for "a different device" so the test also
+        runs single-device.
+        """
+        config = Gemma2Config(sliding_window=4)
+        config._attn_implementation = "sdpa"
+
+        inputs_embeds = torch.ones((2, 5, 8), device=torch_device, dtype=torch.float16)
+        encoder_hidden_states = torch.ones((2, 7, 8), device="meta", dtype=torch.float16)
+        # A padded row, otherwise the full-attention helper skips mask creation (all-ones fast
+        # path) and returns None instead of a tensor whose device we can check
+        cross_mask = torch.ones((2, 7), device=torch_device)
+        cross_mask[:, -1] = 0
+
+        for mask_fn in (create_bidirectional_mask, create_bidirectional_sliding_window_mask):
+            with self.subTest(mask_fn.__name__):
+                mask = mask_fn(
+                    config=config,
+                    inputs_embeds=inputs_embeds,
+                    attention_mask=cross_mask,
+                    encoder_hidden_states=encoder_hidden_states,
+                )
+                self.assertEqual(mask.device, inputs_embeds.device)
 
     def test_recurrent_mask_kept_on_continued_multi_token_forward(self):
         """


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47560)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47560)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47559

#46221 fixed `create_bidirectional_mask` building the mask on `encoder_hidden_states`' device instead of `inputs_embeds`' — but its sliding-window sibling `create_bidirectional_sliding_window_mask` kept the pre-#46221 code, so under model parallelism (encoder states on another device) it still returns the mask on the wrong device while the consuming attention runs on the query device. The call sites that pass `encoder_hidden_states` to the sliding-window variant are `gemma4_assistant` and `gemma4_unified_assistant` (cross-attention to sliding-window encoder states); the full survey of call sites is in the issue.

This PR mirrors #46221 onto the sibling (device comes from `inputs_embeds`, consistent with `_preprocess_mask_arguments`; the explanatory comment is copied verbatim from the fixed function so the two stay symmetric), and adds a regression test covering **both** helpers — #46221 landed without one. The test puts `encoder_hidden_states` on the `meta` device as a stand-in for "a different device", so it runs on single-device CI: on current main the sliding-window subtest fails with `AssertionError: device(type='meta') != device(type='cpu')`, with this patch both helpers return the mask on `inputs_embeds.device`.

Not a duplicate: no open/closed PR or issue touches `create_bidirectional_sliding_window_mask` device handling (searched before opening; the only open masking_utils PR, #47014, is about T5 SDPA backends and does not overlap).

Tests and checks run locally:

```bash
python -m pytest tests/utils/test_masking_utils.py
# 12 passed (pytest 8.4.2; includes the new test, both subtests green)
```

RED on main / GREEN with this patch for `MaskTest::test_bidirectional_masks_build_on_inputs_embeds_device` (the `create_bidirectional_sliding_window_mask` subtest). The cpu↔mps contrast repro from the issue also flips from `cpu` to `mps:0` on the sibling with this patch. `ruff check` / `ruff format --check` clean on both changed files (pinned ruff 0.14.10).

AI usage disclosure: parts of this PR (code and text) were drafted with an AI assistant (Claude). I reviewed, ran, and stand behind every line; the reproduction, the RED→GREEN test runs, and the cpu↔mps contrast were executed on my machine.

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.

Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
for reviewers and other users and will almost certainly get you blocked.

For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. — #47559
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

@vasqu (attention/masking per the template's routing; merged #46221 and reviewed #47087 in the same area)