### PR TITLE
regression test covering the mlx-community/MiniCPM5-1B-8bit

### DIFF
--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -721,6 +721,35 @@ class NopConfig(PreTrainedConfig):
         tok = AutoProcessor.from_pretrained("mistralai/Ministral-3-8B-Instruct-2512-BF16").tokenizer
         self.assertTrue(tok.__class__ == TokenizersBackend)
 
+    @require_tokenizers
+    def test_tokenizers_backend_tokenizer_class(self):
+        self.assertIs(tokenizer_class_from_name("TokenizersBackend"), TokenizersBackend)
+
+        class FakeLlamaConfig:
+            model_type = "llama"
+            _name_or_path = "mlx-community/MiniCPM5-1B-8bit"
+
+        mock_tokenizer = mock.MagicMock(spec=TokenizersBackend)
+
+        with (
+            mock.patch(
+                "transformers.models.auto.tokenization_auto.AutoConfig.from_pretrained",
+                return_value=FakeLlamaConfig(),
+            ),
+            mock.patch(
+                "transformers.models.auto.tokenization_auto.get_tokenizer_config",
+                return_value={"tokenizer_class": "TokenizersBackend"},
+            ),
+            mock.patch.object(TokenizersBackend, "from_pretrained", return_value=mock_tokenizer) as mock_backend,
+        ):
+            result = AutoTokenizer.from_pretrained("mlx-community/MiniCPM5-1B-8bit")
+
+        mock_backend.assert_called_once_with(
+            "mlx-community/MiniCPM5-1B-8bit",
+            _from_auto=True,
+        )
+        self.assertIs(result, mock_tokenizer)
+
     def test_custom_tokenizer_with_mismatched_tokenizer_class(self):
         nop_tokenizer_code = """
 import transformers


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47561)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47561)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Adds regression coverage for `AutoTokenizer.from_pretrained` when a model repo’s `tokenizer_config.json` explicitly sets `"tokenizer_class": "TokenizersBackend"`.

This covers the failure reported for `mlx-community/MiniCPM5-1B-8bit`, where loading through downstream tools could raise:

`ValueError: Tokenizer class TokenizersBackend does not exist or is not currently imported.`

The test verifies that `TokenizersBackend` is resolved as a valid tokenizer class and that `AutoTokenizer` dispatches to `TokenizersBackend.from_pretrained(...)` for this metadata pattern.

Fixes #47553