### PR TITLE
Align the MXFP4 `kernels` version message with the version actually enforced

### DIFF
--- a/src/transformers/quantizers/quantizer_mxfp4.py
+++ b/src/transformers/quantizers/quantizer_mxfp4.py
@@ -27,6 +27,7 @@ from ..utils import (
     is_triton_available,
     logging,
 )
+from ..utils.import_utils import KERNELS_MAX_VERSION, KERNELS_MIN_VERSION
 from .quantizers_utils import get_module_from_name
 
 
@@ -127,8 +128,9 @@ class Mxfp4HfQuantizer(HfQuantizer):
 
             if not kernels_installed:
                 logger.warning_once(
-                    "MXFP4 quantization requires the `kernels` package: "
-                    "`pip install kernels>=0.12.0`. "
+                    "MXFP4 quantization requires the `kernels` package. "
+                    f"Please install a compatible version ({KERNELS_MIN_VERSION} <= version < {KERNELS_MAX_VERSION}), "
+                    f"e.g. `pip install kernels=={KERNELS_MIN_VERSION}`. "
                     "We will default to dequantizing the model to bf16."
                 )
                 self.quantization_config.dequantize = True
@@ -144,7 +146,11 @@ class Mxfp4HfQuantizer(HfQuantizer):
                 "XPU/CPU requires Triton >= 3.5.0. Please install triton: `pip install triton`"
             )
         elif not kernels_installed:
-            raise ValueError("MXFP4 quantization requires the `kernels` package: `pip install kernels>=0.12.0`")
+            raise ValueError(
+                "MXFP4 quantization requires the `kernels` package. "
+                f"Please install a compatible version ({KERNELS_MIN_VERSION} <= version < {KERNELS_MAX_VERSION}), "
+                f"e.g. `pip install kernels=={KERNELS_MIN_VERSION}`"
+            )
 
         if not self.pre_quantized:
             self._lazy_import_kernels()

--- a/tests/quantization/mxfp4/test_mxfp4.py
+++ b/tests/quantization/mxfp4/test_mxfp4.py
@@ -31,6 +31,7 @@ from transformers.testing_utils import (
 from transformers.utils import (
     is_torch_available,
 )
+from transformers.utils.import_utils import KERNELS_MAX_VERSION, KERNELS_MIN_VERSION
 
 
 if is_torch_available():
@@ -240,6 +241,41 @@ class Mxfp4QuantizerTest(unittest.TestCase):
             # Should automatically set dequantize=True and warn
             quantizer.validate_environment()
             self.assertTrue(quantizer.quantization_config.dequantize)
+
+    def test_kernels_message_states_the_enforced_bounds(self):
+        """The message must quote the bounds `is_kernels_available` actually enforces (#47455)."""
+        from transformers.quantizers.quantizer_mxfp4 import Mxfp4HfQuantizer
+
+        config = Mxfp4Config()
+        quantizer = Mxfp4HfQuantizer(config)
+        quantizer.pre_quantized = True
+
+        with (
+            _patch_no_accelerator(),
+            patch("transformers.quantizers.quantizer_mxfp4.is_triton_available", return_value=True),
+            patch("transformers.quantizers.quantizer_mxfp4.is_kernels_available", return_value=False),
+            self.assertLogs("transformers", level="WARNING") as cm,
+        ):
+            quantizer.validate_environment()
+
+        warning_text = " ".join(cm.output)
+        self.assertIn(KERNELS_MIN_VERSION, warning_text)
+        self.assertIn(KERNELS_MAX_VERSION, warning_text)
+
+        config = Mxfp4Config()
+        quantizer = Mxfp4HfQuantizer(config)
+        quantizer.pre_quantized = False
+
+        with (
+            _patch_no_accelerator(),
+            patch("transformers.quantizers.quantizer_mxfp4.is_triton_available", return_value=True),
+            patch("transformers.quantizers.quantizer_mxfp4.is_kernels_available", return_value=False),
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                quantizer.validate_environment()
+
+        self.assertIn(KERNELS_MIN_VERSION, str(ctx.exception))
+        self.assertIn(KERNELS_MAX_VERSION, str(ctx.exception))
 
     def test_is_trainable(self):
         """Test trainability"""

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -8,10 +8,13 @@ from parameterized import parameterized
 
 from transformers.testing_utils import run_test_using_subprocess
 from transformers.utils.import_utils import (
+    KERNELS_MAX_VERSION,
+    KERNELS_MIN_VERSION,
     _is_package_available,
     clear_import_cache,
     is_flash_attn_2_available,
     is_flash_attn_3_available,
+    is_kernels_available,
 )
 
 
@@ -57,6 +60,36 @@ def test_is_package_available_edge_cases():
             patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
         ):
             assert _is_package_available(pkg_name, return_version=True) == expected
+
+
+@contextmanager
+def mock_installed_kernels_version(kernels_version: str):
+    """Pretend `kernels==kernels_version` is installed, bypassing `is_kernels_available`'s `lru_cache`."""
+    with patch("transformers.utils.import_utils._is_package_available", return_value=(True, kernels_version)):
+        is_kernels_available.cache_clear()
+        try:
+            yield
+        finally:
+            is_kernels_available.cache_clear()
+
+
+@parameterized.expand(
+    [
+        ("0.14.0", False),  # below the floor
+        (KERNELS_MIN_VERSION, True),  # the floor is inclusive
+        (KERNELS_MAX_VERSION, False),  # the ceiling is exclusive -- the case reported in #47455
+    ]
+)
+def test_is_kernels_available_version_bounds(kernels_version: str, expected: bool):
+    with mock_installed_kernels_version(kernels_version):
+        assert is_kernels_available() is expected
+
+
+def test_is_kernels_available_does_not_compare_versions_as_strings():
+    # `"0.9.0" >= "0.15.2"` is True as a string comparison but False as a version comparison. Bounds are passed
+    # explicitly so this keeps testing the double-digit minor regardless of what the pin is bumped to.
+    with mock_installed_kernels_version("0.9.0"):
+        assert not is_kernels_available(MIN_VERSION="0.15.2", MAX_VERSION="0.16.0")
 
 
 @contextmanager


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47565)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47565)
<!-- ci-dashboard-badge:end -->

Fixes #47455

**Problem.** With `kernels==0.16.0` installed, MXFP4 warns ``MXFP4 quantization requires the `kernels` package: `pip install kernels>=0.12.0` `` — but 0.16.0 *is* greater than 0.12.0, so the warning reads as a false positive.

**Cause.** The gate is `is_kernels_available()`, which enforces `KERNELS_MIN_VERSION <= version < KERNELS_MAX_VERSION`, i.e. `0.15.2 <= v < 0.16.0` (`src/transformers/utils/import_utils.py:144-145`, matching the `kernels>=0.15.2,<0.16` pin in `setup.py`). So 0.16.0 is genuinely unsupported and the check is right — only the message is wrong. The `0.12.0` literal at `src/transformers/quantizers/quantizer_mxfp4.py:131` and `:147` went stale when the pin was bumped in #46039.

**Fix.** Both messages now derive from `KERNELS_MIN_VERSION`/`KERNELS_MAX_VERSION` and state both bounds, matching the wording already used in `hub_kernels.py`, `deepgemm.py`, `finegrained_fp8.py` and `modeling_utils.py` — `quantizer_mxfp4.py` was the only straggler. **The pin itself is unchanged**, per @vasqu's comment on the issue.

No string-comparison bug here: `is_kernels_available` (and `is_triton_available`) parse with `packaging.version` on both sides. Added a guard test anyway, since `"0.9.0" >= "0.15.2"` holds as a string comparison.

**Tests.** Bounds — below floor / at floor / at ceiling (the reported case) — plus the double-digit-minor case in `tests/utils/test_import_utils.py`; message-matches-check in `tests/quantization/mxfp4/test_mxfp4.py`, asserting on the constants rather than copied literals. The latter fails if the source change is reverted.

cc @vasqu @MekkCyber

<sub>Out of scope, noting it only: `KERNELS_{MIN,MAX}_VERSION` are still a hand-maintained copy of the `setup.py` pin, which drifted once before (#43753).</sub>