### PR TITLE
fixed the benchmark script with DistributedConfig 

### DIFF
--- a/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
+++ b/benchmark_v2/benchmark_scripts/continuous_batching_overall.py
@@ -25,6 +25,7 @@ from lighteval.tasks.requests import Doc
 from tabulate import tabulate
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, ContinuousBatchingConfig, GenerationConfig
+from transformers.distributed import DistributedConfig
 from transformers.utils.logging import disable_progress_bar
 
 
@@ -191,9 +192,9 @@ class BenchmarkResults:
 
     def _get_model(self) -> Any:
         self.cleanup()
-        # tp_plan and device_map are mutually exclusive — TP uses its own placement.
+        # distributed_config and device_map are mutually exclusive — TP uses its own placement.
         if self.tp_size > 1:
-            placement = {"tp_plan": "auto"}
+            placement = {"distributed_config": DistributedConfig(tp_size=self.tp_size)}
         elif self.dp_size > 1:
             placement = {"device_map": self.local_rank}
         else:

--- a/benchmark_v2/framework/benchmark_config.py
+++ b/benchmark_v2/framework/benchmark_config.py
@@ -2,11 +2,13 @@ import hashlib
 import itertools
 import json
 import logging
+import os
 from functools import lru_cache
 from typing import Any
 
 import torch
 
+from transformers.distributed import DistributedConfig
 from transformers.generation.configuration_utils import CompileConfig
 from transformers.utils import is_torch_accelerator_available
 from transformers.utils.import_utils import is_flash_attn_2_available, is_kernels_available
@@ -139,6 +141,21 @@ class BenchmarkConfig:
     @property
     def hash(self) -> str:
         return hashlib.sha256(json.dumps(self.to_dict()).encode()).hexdigest()
+
+    @property
+    def distributed_config(self) -> DistributedConfig | None:
+        """Translate `tp_plan` into the `DistributedConfig` that `from_pretrained` expects, or `None` if no TP."""
+        if self.tp_plan is None:
+            return None
+        # `torchrun` sets WORLD_SIZE; without it there is no process group to shard over.
+        tp_size = int(os.environ.get("WORLD_SIZE", 1))
+        if tp_size <= 1:
+            raise ValueError(
+                "Tensor parallelism was requested, but WORLD_SIZE is not set to more than 1. Launch the benchmark "
+                "with `torchrun --nproc_per_node=<num_gpus> ...` to run with tensor parallelism."
+            )
+        # `DistributedConfig.tp_plan` only takes an explicit plan; leaving it as None makes it use the model's own.
+        return DistributedConfig(tp_size=tp_size, tp_plan=self.tp_plan if isinstance(self.tp_plan, dict) else None)
 
     def infer_name(self, compact: bool = True) -> str:
         """Infer a human-readable name for the benchmark config, either compact or verbose."""

--- a/benchmark_v2/framework/benchmark_runner.py
+++ b/benchmark_v2/framework/benchmark_runner.py
@@ -212,7 +212,9 @@ class BenchmarkRunner:
         self.logger.debug(f"Loading model {model_id} on device {config.device}...")
         dtype = getattr(torch, config.dtype.removeprefix("torch."))
         use_kernels = config.kernelize and kernelize is not None and Mode is not None
-        device_map = config.device if config.tp_plan is None else None
+        # `distributed_config` and `device_map` are mutually exclusive — TP does its own placement.
+        distributed_config = config.distributed_config
+        device_map = config.device if distributed_config is None else None
         self.model = AutoModelForCausalLM.from_pretrained(
             model_id,
             dtype=dtype,
@@ -220,7 +222,7 @@ class BenchmarkRunner:
             generation_config=generation_config,
             use_kernels=use_kernels,
             device_map=device_map,
-            tp_plan=config.tp_plan,
+            distributed_config=distributed_config,
         )
         self.model = self.model.eval()
         self.inputs = self.inputs.to(self.model.device)

--- a/benchmark_v2/run_benchmarks.py
+++ b/benchmark_v2/run_benchmarks.py
@@ -51,7 +51,11 @@ if __name__ == "__main__":
     )
     parser.add_argument("--config-file", type=str, help="Path to a config file stored as a json or jsonl format")
     parser.add_argument("--num-tokens-to-profile", "-p", type=int, default=0, help="Number of tokens to profile")
-    parser.add_argument("--enable-tp", action="store_true", help="Enable tensor parallelism with tp_plan=auto")
+    parser.add_argument(
+        "--enable-tp",
+        action="store_true",
+        help="Enable tensor parallelism over WORLD_SIZE devices (requires launching with torchrun)",
+    )
 
     parser.add_argument("--branch-name", type=str, help="Git branch name")
     parser.add_argument("--commit-id", type=str, help="Git commit ID (if not provided, will auto-detect from git)")

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4037,13 +4037,6 @@ class PreTrainedModel(
                 `DistributedConfig(tp_size=N)` for tensor parallelism, or
                 `DistributedConfig(fsdp_size=N)` for FSDP2. Requires `torchrun` and an initialized
                 process group when `tp_size > 1` or `fsdp_size > 1`. Mutually exclusive with `device_map`.
-            tp_plan (`Optional[Union[dict, str]]`, *optional*):
-                A torch tensor parallel plan, see [here](https://pytorch.org/tutorials/intermediate/TP_tutorial.html). Use `tp_plan="auto"` to
-                use the predefined plan based on the model. If it's a dict, then it should match between module names and desired layout.
-                Note that if you use it, you should launch your script accordingly with `torchrun [args] script.py`. This will be much
-                faster than using a `device_map`, but has limitations.
-            tp_size (`str`, *optional*):
-                A torch tensor parallel degree. If not provided would default to world size.
             device_mesh (`torch.distributed.DeviceMesh`, *optional*):
                 A torch device mesh. If not provided would default to world size. Used only for tensor parallel for now.
                 If provided, it has to contain dimension named `"tp"` in case it's > 1 dimensional, this dimension will be used for tensor parallelism


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47568)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47568)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

The benchmark script was still using `tp_plan` so it started to fail after #47352 was commited

see https://github.com/huggingface/transformers/actions/runs/30232815285/job/89874748333

```
Traceback (most recent call last):
  File "/__w/transformers/transformers/benchmark_v2/run_benchmarks.py", line 127, in <module>
    timestamp, results = runner.run_benchmarks(
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
  File "/__w/transformers/transformers/benchmark_v2/framework/benchmark_runner.py", line 357, in run_benchmarks
    self.setup_benchmark(model_id, config)
  File "/__w/transformers/transformers/benchmark_v2/framework/benchmark_runner.py", line 216, in setup_benchmark
    self.model = AutoModelForCausalLM.from_pretrained(
  File "/__w/transformers/transformers/src/transformers/models/auto/auto_factory.py", line 402, in from_pretrained
    return model_class.from_pretrained(
  File "/__w/transformers/transformers/src/transformers/modeling_utils.py", line 4324, in from_pretrained
    model = cls(config, *model_args, **model_kwargs)
TypeError: LlamaForCausalLM.__init__() got an unexpected keyword argument 'tp_plan'
Error: Error: failed to run script step: command terminated with non-zero exit code: error executing command [sh -e /__w/_temp/8e433f30-8965-11f1-8693-93b63fa6b661.sh], exit code 1
Error: Process completed with exit code 1.
Error: Executing the custom container implementation failed. Please contact your self hosted runner administrator.
```

This patch fixes it and cleans up the docsting for `from_pretrained`