### PR TITLE
Vectorize NoRepeatNGramLogitsProcessor and remove its host sync

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -14,7 +14,7 @@
 
 import inspect
 import math
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -1070,21 +1070,6 @@ def _get_generated_ngrams(banned_ngrams, prev_input_ids, ngram_size, cur_len):
     return banned_ngrams.get(ngram_idx, [])
 
 
-def _calc_banned_ngram_tokens(
-    ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int, cur_len: int
-) -> list[Iterable[int]]:
-    """Copied from fairseq for no_repeat_ngram in beam_search"""
-    if cur_len + 1 < ngram_size:
-        # return no banned tokens if we haven't generated no_repeat_ngram_size tokens yet
-        return [[] for _ in range(num_hypos)]
-    generated_ngrams = _get_ngrams(ngram_size, prev_input_ids, num_hypos)
-    banned_tokens = [
-        _get_generated_ngrams(generated_ngrams[hypo_idx], prev_input_ids[hypo_idx], ngram_size, cur_len)
-        for hypo_idx in range(num_hypos)
-    ]
-    return banned_tokens
-
-
 class NoRepeatNGramLogitsProcessor(LogitsProcessor):
     r"""
     N-grams are groups of "n" consecutive words, characters, or tokens taken from a sequence of text. Given the
@@ -1134,14 +1119,24 @@ class NoRepeatNGramLogitsProcessor(LogitsProcessor):
 
     @add_start_docstrings(LOGITS_PROCESSOR_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor) -> torch.FloatTensor:
-        num_batch_hypotheses = scores.shape[0]
         cur_len = input_ids.shape[-1]
-        scores_processed = scores.clone()
-        banned_batch_tokens = _calc_banned_ngram_tokens(self.ngram_size, input_ids, num_batch_hypotheses, cur_len)
-        for i, banned_tokens in enumerate(banned_batch_tokens):
-            scores_processed[i, banned_tokens] = -float("inf")
+        # No complete ngram yet, so nothing to ban
+        if cur_len < self.ngram_size:
+            return scores
 
-        return scores_processed
+        # An ngram can only be completed by the next token if it starts with the current suffix, so we match that one
+        # prefix against every window instead of building all ngrams. A matching window bans its own last token. (The
+        # window starting at the prefix needs one token more than we have, so a prefix never bans its own successor.)
+        prefix = input_ids[:, cur_len + 1 - self.ngram_size :]
+        windows = input_ids.unfold(dimension=1, size=self.ngram_size, step=1)
+        matches = (windows[..., :-1] == prefix.unsqueeze(1)).all(dim=-1)
+
+        # Non-matching windows go to a spare column past the vocab, where they can't unban another window's token
+        vocab_size = scores.shape[-1]
+        banned_mask = scores.new_zeros((scores.shape[0], vocab_size + 1), dtype=torch.bool)
+        banned_mask.scatter_(1, torch.where(matches, windows[..., -1], vocab_size), True)
+
+        return scores.masked_fill(banned_mask[:, :vocab_size], -float("inf"))
 
 
 class EncoderNoRepeatNGramLogitsProcessor(LogitsProcessor):

--- a/tests/generation/test_logits_process.py
+++ b/tests/generation/test_logits_process.py
@@ -649,6 +649,31 @@ class LogitsProcessorTest(unittest.TestCase):
         self.assertFalse(torch.all(scores == filtered_scores_2_gram))
         self.assertFalse(torch.all(scores == filtered_scores_3_gram))
 
+    def test_no_repeat_ngram_dist_processor_banned_token_reappears(self):
+        vocab_size = 10
+        batch_size = 1
+
+        # The 3-gram (1, 2, 5) repeats the current (1, 2) suffix and bans 5. The later 3-gram (7, 8, 5) ends in the
+        # same token without repeating the suffix, and must not undo that ban.
+        input_ids = torch.tensor([[1, 2, 5, 7, 8, 5, 1, 2]], device=torch_device, dtype=torch.long)
+        scores = self._get_uniform_logits(batch_size, vocab_size)
+
+        filtered_scores = NoRepeatNGramLogitsProcessor(3)(input_ids, scores)
+
+        self.assertListEqual(torch.isinf(filtered_scores).nonzero()[:, 1].tolist(), [5])
+
+    def test_no_repeat_ngram_dist_processor_sequence_shorter_than_ngram(self):
+        vocab_size = 3
+        batch_size = 2
+
+        # The sequences are one token short of holding a 3-gram, so nothing can be banned yet
+        input_ids = torch.tensor([[1, 2], [0, 1]], device=torch_device, dtype=torch.long)
+        scores = self._get_uniform_logits(batch_size, vocab_size)
+
+        filtered_scores = NoRepeatNGramLogitsProcessor(3)(input_ids, scores)
+
+        self.assertFalse(torch.isinf(filtered_scores).any())
+
     def test_encoder_no_repeat_ngram_dist_processor(self):
         vocab_size = 3
         num_beams = 2


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47571)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47571)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`NoRepeatNGramLogitsProcessor` rebuilds a dict of **every** ngram in the sequence on **every** decoding step, then throws it away. Only one prefix is ever looked up. It also calls `.tolist()` to build that dict, which is a device to host sync on every step.

This looks up that one prefix directly, with tensor ops only.

### How

Only ngrams whose first `ngram_size - 1` tokens match the current suffix can be completed by the next token. So `unfold` gives every window of `ngram_size` tokens, all windows are compared against that prefix at once, and a matching window bans its own last token.

The ban mask gets one column past the vocab, and this bit is load bearing. `scatter_` is last write wins, so without somewhere to discard them, a non-matching window ending in an already banned token silently unbans it. There's a test for exactly that.

## Device sync and torch.compile

Removing the per step `.tolist()` is the main win. It stalls the pipeline on GPU whether or not anything is compiled.

`torch._dynamo.explain` on the processor also goes from 2 graph breaks / 3 graphs to **0 breaks / 1 graph**. Being precise about what that buys, since it's easy to overstate: `generate` compiles `model_forward` only (`get_compiled_call`), and logits processors run in eager outside that region, so this doesn't by itself change the built in compiled path. It matters if you compile the sampling loop yourself, and it removes a reason the processor couldn't be pulled into a graph later.

`cur_len` grows every step, but automatic dynamic shapes absorb that: 20 successive lengths give 2 unique graphs by default, 1 with `dynamic=True`, not one per length. `cache_implementation="static"` produces output ids identical to eager.

## Speed

CPU, single thread, vocab 128k, `ngram_size=3`, median of 11 rounds, ms per call:

| batch x length | before | after |
|---|---|---|
| 1 x 512 | 0.15 | **0.17** |
| 1 x 4096 | 1.45 | **0.21** |
| 8 x 2048 | 30.90 | **1.42** |
| 32 x 1024 | 60.08 | **6.05** |
| 4 x 16384 | 120.99 | **1.26** |

The old timings are also very noisy, presumably GC on all those short lived dicts. At 1 x 4096 it ranges 1.32 to 12.82 across rounds where the new one stays in 0.21 to 0.36, so tail latency improves more than the medians show.

Below ~640 tokens the old version is very slightly ahead, by hundredths of a millisecond, since there's now a fixed tensor op cost instead of a tiny Python loop. Memory is a transient `batch x windows x (ngram_size - 1)` bool tensor, about 40MB at batch 64 / length 32k / `ngram_size=20`.

## Correctness

Diffed against the old implementation, tensors compared exactly: 3000 randomized cases (batch 1-4, length 1-12, `ngram_size` 1-6) and a 1500 case sweep (vocab 2-64, `ngram_size` 1-10, length 1-257, batch 1/3/8), **0 mismatches**. Tiny vocabs are deliberate, they force the token collisions the spare column exists to handle. End to end `generate()` greedy and 3 beams at `no_repeat_ngram_size` 2/3/5 gives **identical output ids** in all 6 combinations.

That covers `ngram_size=1` and the `cur_len == ngram_size - 1` boundary, where the early return condition shifted from `cur_len + 1 < ngram_size` to `cur_len < ngram_size`. Same result, different route.

## Tests

Two new cases in `tests/generation/test_logits_process.py`, both for invariants nothing covered before. I checked each actually fails when you break what it guards:

| test | fails when |
|---|---|
| `..._banned_token_reappears` | spare mask column removed, bans `[]` instead of `[5]` |
| `..._sequence_shorter_than_ngram` | early return removed, `RuntimeError` from `unfold` |

Full file: 46 passed.

## Also

* `_calc_banned_ngram_tokens` is unused after this so it's removed. Nothing else references it.
* `EncoderNoRepeatNGramLogitsProcessor` is untouched, it builds its ngrams once in `__init__` rather than per step.
* The early return passes `scores` through instead of cloning, matching `WatermarkLogitsProcessor` and others. Nothing aliases badly: `LogitsProcessorList` reassigns, `generate` already passes a copy, and no 2D processor writes to `scores` in place. Happy to clone if you'd rather keep strict parity.

## Before submitting
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Acknowledgement
I came up with the logic myself but want to acknowledge that I used AI Agents to optimize it, write test cases and draft this PR.

## Who can review?

@Cyrilvallez @zucchini-nlp @molbap 