### PR TITLE
Fix incorrect documented default for downsample_in_first_stage in RegNetConfig.

### DIFF
--- a/src/transformers/models/regnet/configuration_regnet.py
+++ b/src/transformers/models/regnet/configuration_regnet.py
@@ -29,7 +29,7 @@ class RegNetConfig(PreTrainedConfig):
         The layer to use, it can be either `"x" or `"y"`. An `x` layer is a ResNet's BottleNeck layer with
         `reduction` fixed to `1`. While a `y` layer is a `x` but with squeeze and excitation. Please refer to the
         paper for a detailed explanation of how these layers were constructed.
-    downsample_in_first_stage (`bool`, *optional*, defaults to `False`):
+    downsample_in_first_stage (`bool`, *optional*, defaults to `True`):
         If `True`, the first stage will downsample the inputs using a `stride` of 2.
 
     Example:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47572)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47572)
<!-- ci-dashboard-badge:end -->

`RegNetConfig`'s docstring states that `downsample_in_first_stage` defaults to `False`, but the actual default is `True`:

    from transformers import RegNetConfig
    RegNetConfig().downsample_in_first_stage  # -> True

This field controls whether the first stage downsamples (stride 2 vs 1), so the documented default is misleading.

The code default (`True`) is the correct one, not the docstring:
- The checkpoint this config documents, `facebook/regnet-y-040`, has `"downsample_in_first_stage": true`.
- Every other `RegNetConfig` default already mirrors that checkpoint (`depths`, `hidden_sizes`, `groups_width`, ...), and the docstring's own example states `RegNetConfig()` produces a "regnet-y-40 style configuration".

So this is a docs-only fix with no behavioral change: the docstring is updated to reflect the actual default.