### PR TITLE
feat[vLLM]: Make VoxtralProcessor compatible with the Transformers modeling backend for vLLM

### DIFF
--- a/src/transformers/models/voxtral/processing_voxtral.py
+++ b/src/transformers/models/voxtral/processing_voxtral.py
@@ -104,6 +104,10 @@ class VoxtralProcessor(ProcessorMixin):
 
         return torch.cat(input_features_list)
 
+    def _get_audio_token_length(self, audio_lengths, pad_to_multiple_of):
+        # audio tokens per padded 30s chunk: 1500 * 1280 // 5120 = 375
+        return ((audio_lengths - 1) // pad_to_multiple_of + 1) * (1500 * 1280 // 5120)
+
     def apply_chat_template(
         self,
         conversation: list[dict[str, str]] | list[list[dict[str, str]]],
@@ -234,20 +238,45 @@ class VoxtralProcessor(ProcessorMixin):
     def __call__(
         self,
         text: TextInput | PreTokenizedInput | list[TextInput] | list[PreTokenizedInput] | None,
+        audio: AudioInput | None = None,
         **kwargs: Unpack[VoxtralProcessorKwargs],
     ):
         if isinstance(text, str):
             text = [text]
 
-        if any(self.audio_token in t for t in text):
-            raise ValueError(
-                f"{self.audio_token} is present in the provided text which is not supported by VoxtralProcessor. Please use the `apply_chat_template` method instead."
-            )
-
         output_kwargs = self._merge_kwargs(VoxtralProcessorKwargs, **kwargs)
-        out = self.tokenizer(text, **output_kwargs["text_kwargs"])
+        text_kwargs = output_kwargs["text_kwargs"]
+        audio_kwargs = output_kwargs["audio_kwargs"]
+        return_tensors = text_kwargs.get("return_tensors", None)
 
-        return BatchFeature(data=out, tensor_type=output_kwargs["text_kwargs"].get("return_tensors", None))
+        if audio is None:
+            # `MistralCommonBackend.__call__` only accepts tokenizer kwargs
+            text_kwargs["return_tensors"] = None
+            text_kwargs.pop("return_dict", None)
+            text_kwargs.pop("tokenize", None)
+            text_kwargs.pop("return_mm_token_type_ids", None)
+            out = self.tokenizer(text, **text_kwargs)
+            return BatchFeature(data=out, tensor_type=return_tensors)
+
+        audio = make_list_of_audio(audio)
+        max_source_positions = audio_kwargs.pop("max_source_positions")
+        input_features = self._retrieve_input_features(audio, max_source_positions, **audio_kwargs)
+        audio_lengths = torch.tensor([audio_array.shape[-1] for audio_array in audio])
+        num_audio_tokens = self._get_audio_token_length(audio_lengths, audio_kwargs["pad_to_multiple_of"])
+
+        # `MistralCommonBackend` does not encode `[AUDIO]`, so splice the id in
+        num_audio_tokens_iter = iter(num_audio_tokens.tolist())
+        input_ids = []
+        for prompt in text:
+            segments = prompt.split(self.audio_token)
+            ids = self.tokenizer.encode(segments[0])
+            for segment in segments[1:]:
+                ids += [self.audio_token_id] * next(num_audio_tokens_iter)
+                ids += self.tokenizer.encode(segment, add_special_tokens=False)
+            input_ids.append(ids)
+
+        data = {"input_ids": input_ids, "input_features": input_features}
+        return BatchFeature(data=data, tensor_type=return_tensors)
 
     # TODO: @eustlb, this should be moved to mistral_common + testing
     @requires(backends=("mistral-common",))


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47574)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47574)
<!-- ci-dashboard-badge:end -->

### What does this PR do?

→ A blocker to the [companion vLLM PR](https://github.com/vllm-project/vllm/pull/49958) for Voxtral audio generation through the Transformers backend.
→ `VoxtralProcessor.__call__` rejects audio-token text and routes audio only through `apply_chat_template`. Makes `__call__` accept `audio` like the other audio processors; since `MistralCommonBackend` does not encode `[AUDIO]` from text, splices the audio token id into the encoded segments. No modeling changes needed.
→ <ins>Verified no regressions on the Transformers-side</ins> in `tests/models/voxtral/` (143 non-slow pass; the 5 failing slow integration tests fail identically on `main` locally, exact-match generation drift, unrelated to this change).
→ I've tried to explain why each non-trivial change was made in a one-line comment given much of this involved unwrapping failure modes layer by layer and uncovering deeper issues in the call chain :)

cc: @eustlb @ebezzam @vasqu

**Before (vLLM Voxtral Generation)**

<img src="https://github.com/user-attachments/assets/1b4c6223-e079-4d03-b661-596721d1be86" /><br>

**After (vLLM Voxtral Generation, After Both PRs)**

<img src="https://github.com/user-attachments/assets/3fdb3f56-5f70-453b-9e3c-c59ea4a0417b" /><br>

### Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

### Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you fix any necessary existing tests?