### PR TITLE
Fix A.X-K2 fp8 modules_to_not_convert normalization for the gated-norm MLP

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -250,9 +250,12 @@ def _build_checkpoint_conversion_mapping():
                 operations=[MergeModulelist(dim=0)],
             ),
             # The gated norms store their low-rank gate MLP as `W_down` / `W_up`; the model reuses `CLIPMLP`
-            # (`fc1` / `fc2`). Bridge the names on load (and back on save).
-            WeightRenaming(source_patterns=r"\.W_down\.", target_patterns=".mlp.fc1."),
-            WeightRenaming(source_patterns=r"\.W_up\.", target_patterns=".mlp.fc2."),
+            # (`fc1` / `fc2`). Bridge the names on load (and back on save). Patterns are unanchored (no
+            # surrounding dots) so the same rename also normalizes the bare module names in an fp8 checkpoint's
+            # `modules_to_not_convert` (`W_down`/`W_up` -> `mlp.fc1`/`mlp.fc2`); a dot-anchored pattern would
+            # leave those bare names untouched and the gate MLP would be quantized by mistake.
+            WeightRenaming(source_patterns=r"W_down", target_patterns="mlp.fc1"),
+            WeightRenaming(source_patterns=r"W_up", target_patterns="mlp.fc2"),
             # The released checkpoints fuse the query up-projection and the attention output gate into a
             # single `q_b_proj` (vLLM layout); the model keeps it fused under the clearer name `q_gate_proj`
             # and splits the activation in the forward. A plain rename (kept fp8-safe: no weight split, and

--- a/tests/models/axk2/test_modeling_axk2.py
+++ b/tests/models/axk2/test_modeling_axk2.py
@@ -108,6 +108,55 @@ class AXK2ModelTest(CausalLMModelTest, unittest.TestCase):
         pass
 
 
+@require_torch
+class AXK2Fp8SkipListTest(unittest.TestCase):
+    def test_modules_to_not_convert_normalized_to_model_module_names(self):
+        # The released fp8 checkpoints keep the gated-norm gate MLP (stored as `W_down`/`W_up`) and the
+        # indexer's `weights_proj` unquantized via `modules_to_not_convert`. Those bare checkpoint names
+        # must normalize to the model's actual module names through the conversion mapping (as
+        # `FineGrainedFP8HfQuantizer._normalize_modules_to_not_convert` does), otherwise the gate MLP would
+        # be fp8-quantized by mistake. This guards the rename patterns staying unanchored.
+        from transformers import AXK2Config, AXK2ForCausalLM
+        from transformers.conversion_mapping import get_model_conversion_mapping
+
+        config = AXK2Config(
+            vocab_size=64,
+            hidden_size=32,
+            intermediate_size=64,
+            moe_intermediate_size=16,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            kv_lora_rank=16,
+            q_lora_rank=16,
+            qk_nope_head_dim=16,
+            qk_rope_head_dim=16,
+            v_head_dim=16,
+            index_n_heads=1,
+            index_head_dim=16,
+            index_topk=4,
+            gated_norm_rank=4,
+            max_position_embeddings=64,
+        )
+        model = AXK2ForCausalLM(config)
+        renamings = get_model_conversion_mapping(model)
+
+        def normalize(name):
+            for rename in renamings:
+                name, _ = rename.rename_source_key(name)
+            return name
+
+        self.assertEqual(normalize("W_down"), "mlp.fc1")
+        self.assertEqual(normalize("W_up"), "mlp.fc2")
+        # Entries that are already model module names must pass through unchanged.
+        self.assertEqual(normalize("weights_proj"), "weights_proj")
+        self.assertEqual(normalize("lm_head"), "lm_head")
+        # The normalized names correspond to real gate submodules that will then be skipped.
+        self.assertTrue(any(name.endswith("mlp.fc1") for name, _ in model.named_modules()))
+
+
 @slow
 @require_torch_accelerator
 class AXK1IntegrationTest(unittest.TestCase):

--- a/tests/models/axk2/test_modeling_axk2.py
+++ b/tests/models/axk2/test_modeling_axk2.py
@@ -108,55 +108,6 @@ class AXK2ModelTest(CausalLMModelTest, unittest.TestCase):
         pass
 
 
-@require_torch
-class AXK2Fp8SkipListTest(unittest.TestCase):
-    def test_modules_to_not_convert_normalized_to_model_module_names(self):
-        # The released fp8 checkpoints keep the gated-norm gate MLP (stored as `W_down`/`W_up`) and the
-        # indexer's `weights_proj` unquantized via `modules_to_not_convert`. Those bare checkpoint names
-        # must normalize to the model's actual module names through the conversion mapping (as
-        # `FineGrainedFP8HfQuantizer._normalize_modules_to_not_convert` does), otherwise the gate MLP would
-        # be fp8-quantized by mistake. This guards the rename patterns staying unanchored.
-        from transformers import AXK2Config, AXK2ForCausalLM
-        from transformers.conversion_mapping import get_model_conversion_mapping
-
-        config = AXK2Config(
-            vocab_size=64,
-            hidden_size=32,
-            intermediate_size=64,
-            moe_intermediate_size=16,
-            num_hidden_layers=2,
-            num_attention_heads=2,
-            num_key_value_heads=2,
-            n_routed_experts=4,
-            num_experts_per_tok=2,
-            kv_lora_rank=16,
-            q_lora_rank=16,
-            qk_nope_head_dim=16,
-            qk_rope_head_dim=16,
-            v_head_dim=16,
-            index_n_heads=1,
-            index_head_dim=16,
-            index_topk=4,
-            gated_norm_rank=4,
-            max_position_embeddings=64,
-        )
-        model = AXK2ForCausalLM(config)
-        renamings = get_model_conversion_mapping(model)
-
-        def normalize(name):
-            for rename in renamings:
-                name, _ = rename.rename_source_key(name)
-            return name
-
-        self.assertEqual(normalize("W_down"), "mlp.fc1")
-        self.assertEqual(normalize("W_up"), "mlp.fc2")
-        # Entries that are already model module names must pass through unchanged.
-        self.assertEqual(normalize("weights_proj"), "weights_proj")
-        self.assertEqual(normalize("lm_head"), "lm_head")
-        # The normalized names correspond to real gate submodules that will then be skipped.
-        self.assertTrue(any(name.endswith("mlp.fc1") for name, _ in model.named_modules()))
-
-
 @slow
 @require_torch_accelerator
 class AXK1IntegrationTest(unittest.TestCase):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47578)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47578)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

The A.X-K2 conversion mapping renames the gated-norm gate MLP `W_down`/`W_up`
to the model's `mlp.fc1`/`mlp.fc2`. The source patterns were dot-anchored
(`r"\.W_down\."`), which works for full weight keys
(`...input_layernorm.W_down.weight`) but not for the bare module names an fp8
checkpoint lists in `modules_to_not_convert`
(`["lm_head", "W_up", "W_down", "weights_proj"]`).

`FineGrainedFP8HfQuantizer._normalize_modules_to_not_convert` rewrites the
skip-list to the model's module tree by applying these same rename patterns to
each entry. The bare `"W_down"` (no surrounding dots) does not match
`r"\.W_down\."`, so it stays `"W_down"` and never matches the model's real
`...mlp.fc1` module — the gated-norm gate MLP that the released fp8 checkpoints
intentionally keep unquantized then gets fp8-quantized instead.

Making the patterns unanchored (`r"W_down"` -> `"mlp.fc1"`) fixes both:
- weight-key rename: `...input_layernorm.W_down.weight` -> `...mlp.fc1.weight` (unchanged)
- skip-list normalization: `"W_down"` -> `"mlp.fc1"` (now correct)

(The `r"W_down\."` variant does *not* work — it double-dots the weight key
`...input_layernorm..mlp.fc1.weight` and still fails to normalize the bare name.)

### Verification
- `WeightRenaming`: weight keys -> `mlp.fc1`/`mlp.fc2`; bare `W_down`/`W_up` -> `mlp.fc1`/`mlp.fc2`.
- `get_model_conversion_mapping(model)` on `["W_down","W_up","weights_proj","lm_head"]`
  -> `["mlp.fc1","mlp.fc2","weights_proj","lm_head"]`, matching the model's modules.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @molbap @guarin
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->