### PR TITLE
Clean up deprecated legacy code for v5

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -477,15 +477,6 @@ class GenerationConfig(PushToHubMixin):
             )
             warnings.warn(msg, FutureWarning, stacklevel=2)
 
-        # Deprecated (moved to the Hub). TODO remove for v5
-        self.low_memory = kwargs.pop("low_memory", None)
-        self.penalty_alpha = kwargs.pop("penalty_alpha", None)
-        self.dola_layers = kwargs.pop("dola_layers", None)
-        self.diversity_penalty = kwargs.pop("diversity_penalty", None)
-        self.num_beam_groups = kwargs.pop("num_beam_groups", None)
-        self.constraints = kwargs.pop("constraints", None)
-        self.force_words_ids = kwargs.pop("force_words_ids", None)
-
         self.prefill_chunk_size = kwargs.pop("prefill_chunk_size", None)
 
         # Common attributes
@@ -542,25 +533,13 @@ class GenerationConfig(PushToHubMixin):
         """
         # TODO joao: find out a way of not depending on external fields (e.g. `assistant_model`), then make this a
         # property and part of the `__repr__`
-        if self.constraints is not None or self.force_words_ids is not None:
-            generation_mode = GenerationMode.CONSTRAINED_BEAM_SEARCH
-        elif self.num_beams is None or self.num_beams == 1:
+        if self.num_beams is None or self.num_beams == 1:
             if self.do_sample is not True:
-                if (
-                    self.top_k is not None
-                    and self.top_k > 1
-                    and self.penalty_alpha is not None
-                    and self.penalty_alpha > 0
-                ):
-                    generation_mode = GenerationMode.CONTRASTIVE_SEARCH
-                else:
-                    generation_mode = GenerationMode.GREEDY_SEARCH
+                generation_mode = GenerationMode.GREEDY_SEARCH
             else:
                 generation_mode = GenerationMode.SAMPLE
         else:
-            if self.num_beam_groups is not None and self.num_beam_groups > 1:
-                generation_mode = GenerationMode.GROUP_BEAM_SEARCH
-            elif self.do_sample is True:
+            if self.do_sample is True:
                 generation_mode = GenerationMode.BEAM_SAMPLE
             else:
                 generation_mode = GenerationMode.BEAM_SEARCH
@@ -581,17 +560,6 @@ class GenerationConfig(PushToHubMixin):
                     f"current flags) is {generation_mode} -- some of the set flags will be ignored."
                 )
 
-        # DoLa generation may extend some generation modes
-        # TODO joao, manuel: remove this in v4.62.0
-        if self.dola_layers is not None:
-            if generation_mode in ("greedy_search", "sample"):
-                generation_mode = GenerationMode.DOLA_GENERATION
-            else:
-                logger.warning(
-                    "You've set `dola_layers`, which triggers DoLa generate. Currently, DoLa generate "
-                    "is only supported with Greedy Search and Sample.  However, the base decoding mode (based on "
-                    f"current flags) is {generation_mode} -- some of the set flags will be ignored."
-                )
         return generation_mode
 
     @staticmethod
@@ -636,9 +604,6 @@ class GenerationConfig(PushToHubMixin):
             "assistant_confidence_threshold": 0.4,
             "assistant_lookbehind": 10,
             "target_lookbehind": 10,
-            # Deprecated arguments (moved to the Hub). TODO joao, manuel: remove in v4.62.0
-            "num_beam_groups": 1,
-            "diversity_penalty": 0.0,
         }
 
     def validate(self, strict=False, user_set_attributes: set[str] | None = None):

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2183,30 +2183,6 @@ class GenerationMixin(ContinuousMixin):
             if switch:
                 self.set_experts_implementation(original_experts_implementation)
 
-    def _get_deprecated_gen_repo(
-        self,
-        generation_mode: GenerationMode,
-        trust_remote_code: bool,
-        custom_generate: str | None = None,
-    ) -> str | None:
-        """
-        Returns the Hub repo for a deprecated generation mode, if any.
-        """
-        if custom_generate is not None or "/" not in (repo := GENERATION_MODES_MAPPING[generation_mode]):
-            return None
-
-        logger.warning_once(
-            f"{generation_mode.name.replace('_', ' ').title()} was moved to a `custom_generate` repo: https://hf.co/{repo}. "
-            f"To prevent loss of backward compatibility, add `custom_generate='{repo}'` "
-            "to your `generate` call before v4.62.0."
-        )
-        if not trust_remote_code:
-            raise ValueError(
-                f"{generation_mode.name.replace('_', ' ').title()} requires `trust_remote_code=True` in your `generate` call, "
-                f"since it loads https://hf.co/{repo}."
-            )
-        return repo
-
     def _extract_generation_mode_kwargs(
         self,
         custom_generate,
@@ -2455,37 +2431,14 @@ class GenerationMixin(ContinuousMixin):
         generation_config, model_kwargs = self._prepare_generation_config(generation_config, **kwargs)
 
         generation_mode = generation_config.get_generation_mode(assistant_model)
-        deprecated_mode_repo = self._get_deprecated_gen_repo(generation_mode, trust_remote_code, custom_generate)
-
         if isinstance(custom_generate, Callable):
             decoding_method = custom_generate
-        elif deprecated_mode_repo is None:
+        else:
             # type() required to access the unbound class-level method
             decoding_method = getattr(type(self), GENERATION_MODES_MAPPING[generation_mode])
 
         self._validate_model_kwargs(model_kwargs.copy())
         self._validate_generation_mode(generation_mode, generation_config, generation_mode_kwargs)
-
-        # Deprecation-related step: set Hub repo for deprecated strategies.
-        # NOTE: This must come after initializing generation_config, since we need it to determine if this is a deprecated mode.
-        # It must also be before any preparation steps, since Hub repos expect to be loaded before preparation steps.
-        # TODO joao, manuel: remove this in v4.62.0
-        if deprecated_mode_repo is not None:
-            return GenerationMixin.generate(
-                self,
-                inputs=inputs,
-                generation_config=generation_config,
-                logits_processor=logits_processor,
-                stopping_criteria=stopping_criteria,
-                prefix_allowed_tokens_fn=prefix_allowed_tokens_fn,
-                assistant_model=assistant_model,
-                negative_prompt_ids=negative_prompt_ids,
-                negative_prompt_attention_mask=negative_prompt_attention_mask,
-                custom_generate=deprecated_mode_repo,
-                trust_remote_code=trust_remote_code,
-                **generation_mode_kwargs,
-                **kwargs,
-            )
 
         # 2. Set generation parameters if not already defined
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
@@ -3271,15 +3224,6 @@ class GenerationMixin(ContinuousMixin):
             (torch.ones((num_beams), dtype=torch.bool), torch.zeros((beams_to_keep - num_beams), dtype=torch.bool)),
             dim=0,
         ).to(input_ids.device)
-
-        # (joao) feature lost in the refactor. Probably won't implement, hurts readability with minimal gains (there
-        # are newer low-memory alternatives like the offloaded cache)
-        sequential = generation_config.low_memory
-        if sequential:
-            raise ValueError(
-                "`low_memory=True` is not supported after the beam search refactor. Please check the discussion in "
-                "#35802 *after the PR got merged*, and add a comment there if your questions are not yet answered."
-            )
 
         # 2. init output tuples
         all_scores = () if (return_dict_in_generate and output_scores) else None

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -604,17 +604,6 @@ def validate_preprocess_arguments(
     if do_rescale and rescale_factor is None:
         raise ValueError("`rescale_factor` must be specified if `do_rescale` is `True`.")
 
-    if do_pad and pad_size is None:
-        # Processors pad images using different args depending on the model, so the below check is pointless
-        # but we keep it for BC for now. TODO: remove in v5
-        # Usually padding can be called with:
-        #   - "pad_size/size" if we're padding to specific values
-        #   - "size_divisor" if we're padding to any value divisible by X
-        #   - "None" if we're padding to the maximum size image in batch
-        raise ValueError(
-            "Depending on the model, `size_divisor` or `pad_size` or `size` must be specified if `do_pad` is `True`."
-        )
-
     if do_normalize and (image_mean is None or image_std is None):
         raise ValueError("`image_mean` and `image_std` must both be specified if `do_normalize` is `True`.")
 

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -378,10 +378,6 @@ class GenerationConfigTest(unittest.TestCase):
         config = GenerationConfig(num_beams=2)
         self.assertEqual(config.get_generation_mode(), GenerationMode.BEAM_SEARCH)
 
-        # TODO joao, manuel: remove this in v4.62.0
-        config = GenerationConfig(top_k=10, do_sample=False, penalty_alpha=0.6)
-        self.assertEqual(config.get_generation_mode(), GenerationMode.CONTRASTIVE_SEARCH)
-
         config = GenerationConfig()
         self.assertEqual(config.get_generation_mode(assistant_model="foo"), GenerationMode.ASSISTED_GENERATION)
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47586)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47586)
<!-- ci-dashboard-badge:end -->

This PR removes legacy backward-compatibility hooks and configuration parameters that were explicitly marked for removal in `v5` (and earlier in `v4.62.0`).

### Changes made:
- **`image_utils.py`**: Removed the obsolete `do_pad` backward compatibility validation logic (`TODO: remove in v5`).
- **`generation/configuration_utils.py`**: Removed deprecated attributes from the `GenerationConfig` constructor (`low_memory`, `penalty_alpha`, `dola_layers`, `diversity_penalty`, `num_beam_groups`, `constraints`, `force_words_ids`) that were moved to the Hub.
- **`generation/utils.py`**: Removed the deprecated strategy interception (`_get_deprecated_gen_repo()`) and legacy generation mode derivations that were scheduled for removal.

These cleanups reduce branching complexity in generation utils and formally align the codebase with v5 API expectations.