### PR TITLE
fix(masking_utils): build bidirectional sliding window mask on inputs_embeds device

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -1280,7 +1280,10 @@ def create_bidirectional_sliding_window_mask(
         raise ValueError("Could not find a `sliding_window` argument in the config, or it is not set")
 
     embeds = encoder_hidden_states if encoder_hidden_states is not None else inputs_embeds
-    batch_size, dtype, device = embeds.shape[0], embeds.dtype, embeds.device
+    batch_size, dtype = embeds.shape[0], embeds.dtype
+    # The mask should always be created on the device of `inputs_embeds`. In model parallel setups, `encoder_hidden_states` may live on a different
+    # device than `inputs_embeds` (e.g. cross-attention from a decoder to encoder states).
+    device = inputs_embeds.device
     mask_factory_function = sliding_window_bidirectional_mask_function(sliding_window)
     mask_interface = ALL_MASK_ATTENTION_FUNCTIONS[config._attn_implementation]
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47589)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47589)
<!-- ci-dashboard-badge:end -->

## Description
This PR resolves issue #47559 by using `inputs_embeds.device` in `create_bidirectional_sliding_window_mask()` (`src/transformers/masking_utils.py`).

## Details
- Fixes device mismatch in model-parallel setups when `encoder_hidden_states` is on a different device than `inputs_embeds`.