### PR TITLE
fix(models/phi3,phimoe): default logits_to_keep to 1 when None in prepare_inputs_for_generation

### DIFF
--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -534,7 +534,7 @@ class Phi3ForCausalLM(Phi3PreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             position_ids=position_ids,
             use_cache=use_cache,
-            logits_to_keep=logits_to_keep,
+            logits_to_keep=logits_to_keep if logits_to_keep is not None else 1,
             **kwargs,
         )
         return model_inputs

--- a/src/transformers/models/phimoe/modeling_phimoe.py
+++ b/src/transformers/models/phimoe/modeling_phimoe.py
@@ -905,7 +905,7 @@ class PhimoeForCausalLM(PhimoePreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             position_ids=position_ids,
             use_cache=use_cache,
-            logits_to_keep=logits_to_keep,
+            logits_to_keep=logits_to_keep if logits_to_keep is not None else 1,
             **kwargs,
         )
         return model_inputs


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47590)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47590)
<!-- ci-dashboard-badge:end -->

## Description
This PR resolves issue #47530 by coercing `logits_to_keep` to `1` when `None` in `prepare_inputs_for_generation()` in `modeling_phi3.py` and `modeling_phimoe.py`.

## Details
- Prevents 4-dim logits `(B, 1, S, V)` and `RuntimeError: prob_dist must be 1 or 2 dim` during sampling when `forward` is wrapped.