### PR TITLE
fix(models/wav2vec2): optimize special tokens lookups in tokenization decode loops

### DIFF
--- a/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
@@ -281,9 +281,10 @@ class Wav2Vec2CTCTokenizer(PreTrainedTokenizer):
             return self._added_tokens_decoder[ids].content if ids in self._added_tokens_decoder else self.unk_token
 
         tokens = []
+        special_ids = set(self.all_special_ids) if skip_special_tokens else set()
         for index in ids:
             index = int(index)
-            if skip_special_tokens and index in self.all_special_ids:
+            if skip_special_tokens and index in special_ids:
                 continue
             if index in self.decoder:
                 tokens.append(self.decoder[index])
@@ -422,12 +423,12 @@ class Wav2Vec2CTCTokenizer(PreTrainedTokenizer):
         same as tokens of the base vocabulary and therefore the function `convert_tokens_to_string` has to be called on
         the whole token list and not individually on added tokens
         """
-        # Don't skip special tokens in convert_ids_to_tokens so we can handle word_delimiter_token specially
         filtered_tokens = self.convert_ids_to_tokens(token_ids, skip_special_tokens=False)
 
+        special_tokens = set(self.all_special_tokens) if skip_special_tokens else set()
         result = []
         for token in filtered_tokens:
-            if skip_special_tokens and token in self.all_special_tokens and token != self.word_delimiter_token:
+            if skip_special_tokens and token in special_tokens and token != self.word_delimiter_token:
                 continue
             result.append(token)
 

--- a/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
+++ b/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
@@ -420,13 +420,7 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
         the same as tokens of the base vocabulary and therefore the function `convert_tokens_to_string` has to be
         called on the whole token list and not individually on added tokens
         """
-        filtered_tokens = self.convert_ids_to_tokens(token_ids, skip_special_tokens=skip_special_tokens)
-
-        result = []
-        for token in filtered_tokens:
-            if skip_special_tokens and token in self.all_special_ids:
-                continue
-            result.append(token)
+        result = self.convert_ids_to_tokens(token_ids, skip_special_tokens=skip_special_tokens)
 
         string_output = self.convert_tokens_to_string(
             result,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47591)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47591)
<!-- ci-dashboard-badge:end -->

## Description
This PR resolves issue #47556 by hoisting `all_special_ids` and `all_special_tokens` lookups out of loops into sets in `tokenization_wav2vec2.py` and removing a redundant filter loop in `tokenization_wav2vec2_phoneme.py`.

## Details
- Prevents property rebuilds of special token lists per token during decoding.
- Removes dead type-mismatched filter loop in `Wav2Vec2PhonemeCTCTokenizer._decode`.