### PR TITLE
feat(data_collator): add position_ids_start parameter to DataCollatorWithFlattening

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -1383,6 +1383,7 @@ class DataCollatorWithFlattening(DefaultDataCollator):
         self,
         *args,
         return_position_ids=True,
+        position_ids_start=0,
         separator_id=-100,
         return_flash_attn_kwargs=False,
         return_seq_idx=False,
@@ -1390,6 +1391,7 @@ class DataCollatorWithFlattening(DefaultDataCollator):
     ):
         super().__init__(*args, **kwargs)
         self.return_position_ids = return_position_ids
+        self.position_ids_start = position_ids_start
         self.separator_id = separator_id
         self.return_flash_attn_kwargs = return_flash_attn_kwargs
         self.return_seq_idx = return_seq_idx
@@ -1427,7 +1429,7 @@ class DataCollatorWithFlattening(DefaultDataCollator):
             else:
                 batch["labels"] += [separator_id] + input_ids[1:]
             if self.return_position_ids:
-                batch["position_ids"] += list(range(len(input_ids)))
+                batch["position_ids"] += list(range(self.position_ids_start, self.position_ids_start + len(input_ids)))
             if self.return_seq_idx:
                 batch["seq_idx"] += [seq_idx for _ in range(len(input_ids))]
             if self.return_flash_attn_kwargs:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47592)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47592)
<!-- ci-dashboard-badge:end -->

## Description
This PR resolves issue #47496 by adding a `position_ids_start` parameter to `DataCollatorWithFlattening` in `src/transformers/data/data_collator.py`.

## Details
- Allows configuring non-zero initial position offsets (e.g., `position_ids_start=2` for RoBERTa, XLM-RoBERTa, and MPNet architecture families where position IDs start at `padding_idx + 1`).