### PR TITLE
fix(models/mamba2,nemotron_h): squeeze sequence dimension in cuda_kernels_forward single-token decode branch

### DIFF
--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -376,6 +376,7 @@ class Mamba2Mixer(nn.Module):
         recurrent_state = cache_params.layers[self.layer_idx].recurrent_states[0] if use_precomputed_states else None
         # Single step calculations via cache
         if use_precomputed_states and seq_len == 1:
+            gate, hidden_states, B, C, dt = (x.squeeze(1) if x.dim() == 3 else x for x in (gate, hidden_states, B, C, dt))
             # 3. SSM transformation
             A = A[:, None, ...][:, :, None].expand(-1, self.head_dim, self.ssm_state_size).to(dtype=torch.float32)
             dt = dt.transpose(1, 2).expand(-1, -1, self.head_dim)

--- a/src/transformers/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modeling_nemotron_h.py
@@ -366,6 +366,7 @@ class NemotronHMamba2Mixer(nn.Module):
         recurrent_state = cache_params.layers[self.layer_idx].recurrent_states[0] if use_precomputed_states else None
         # Single step calculations via cache
         if use_precomputed_states and seq_len == 1:
+            gate, hidden_states, B, C, dt = (x.squeeze(1) if x.dim() == 3 else x for x in (gate, hidden_states, B, C, dt))
             # 3. SSM transformation
             A = A[:, None, ...][:, :, None].expand(-1, self.head_dim, self.ssm_state_size).to(dtype=torch.float32)
             dt = dt.transpose(1, 2).expand(-1, -1, self.head_dim)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47593)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47593)
<!-- ci-dashboard-badge:end -->

## Description
This PR resolves issue #47532 by squeezing the 3-D sequence dimension (`x.squeeze(1)`) when `use_precomputed_states and seq_len == 1` in `cuda_kernels_forward()` (`modeling_mamba2.py`, `modeling_nemotron_h.py`).

## Details
- Fixes `RuntimeError: expand(...): the number of sizes provided must be greater or equal to the number of dimensions in the tensor` during single-token decode steps.