### PR TITLE
[Experimental / Do not Review] Add multi-method export + QNN (Qualcomm HTP) backend to the ExecuTorch exporter

### DIFF
--- a/src/transformers/exporters/configs.py
+++ b/src/transformers/exporters/configs.py
@@ -163,8 +163,15 @@ class ExecutorchConfig(DynamoConfig):
 
             - `"xnnpack"` — CPU inference via the XNNPACK library (default; runs anywhere).
             - `"cuda"` — GPU inference via the ExecuTorch CUDA backend.
+            - `"qnn"` — Qualcomm HTP inference via the ExecuTorch QNN backend.
+        backend_options (`dict[str, Any]`, *optional*):
+            Free-form, backend-owned options forwarded verbatim to the backend. The
+            exporter does not interpret its contents. For QNN (a full-export delegate):
+            `decoder_model` (static_llama key), `soc_model`, `model_mode`, `prompt`,
+            `calib_samples` (path), and `artifact_dir`.
     """
 
     export_format: ExportFormat = ExportFormat.EXECUTORCH
 
     backend: str = "xnnpack"
+    backend_options: dict[str, Any] | None = None

--- a/src/transformers/exporters/exporter_executorch.py
+++ b/src/transformers/exporters/exporter_executorch.py
@@ -36,10 +36,14 @@ edge deployment. The export pipeline runs:
 
 from __future__ import annotations
 
+import dataclasses
 import math
 import operator
+from collections import OrderedDict
 from collections.abc import MutableMapping
-from typing import Any
+from contextlib import nullcontext
+from dataclasses import dataclass, field
+from typing import Any, Callable, ContextManager, Optional
 
 from ..utils import logging
 from ..utils.import_utils import is_executorch_available, is_torch_available
@@ -87,6 +91,42 @@ if is_executorch_available():
 logger = logging.get_logger(__name__)
 
 
+@dataclass
+class GraphSpec:
+    """One graph in a (possibly multi-method) export.
+
+    ``module``/``sample_inputs`` are traced by the exporter, unless ``exported_program`` is
+    already supplied. ``mode`` selects the trace path: ``"hf"`` uses the transformers-aware
+    ``DynamoExporter.export`` + fx-fixes (raw HuggingFace models); ``"plain"`` uses bare
+    ``torch.export`` with NO fx-fixes (pre-surgered / already-quantized modules whose q/dq nodes
+    must not be rewritten). ``role="calibrate"`` marks a graph consumed by the lower hook but
+    never emitted into the ``.pte``.
+    """
+
+    module: Any = None
+    sample_inputs: Any = None
+    dynamic_shapes: Any = None
+    role: str = "deploy"
+    mode: str = "hf"
+    exported_program: Optional["ExportedProgram"] = None
+
+
+@dataclass
+class BackendExportPlan:
+    """Generic contract a backend's prepare may return to drive a multi-method export.
+
+    All fields are backend-agnostic. Simple backends set only ``method_set`` (often one entry)
+    and ``partitioner``; everything else is a no-op default that reproduces the single-method path.
+    """
+
+    method_set: "OrderedDict[str, GraphSpec]"
+    partitioner: Any = None
+    constant_methods: dict = field(default_factory=dict)
+    lower: Optional[Callable[["OrderedDict[str, ExportedProgram]", Any], "EdgeProgramManager"]] = None
+    backend_config: Any = None
+    lowering_context: Optional[ContextManager] = None
+
+
 class ExecutorchExporter(DynamoExporter):
     """Exporter that converts a [`PreTrainedModel`] to an ExecuTorch `ExecutorchProgramManager`.
 
@@ -110,7 +150,15 @@ class ExecutorchExporter(DynamoExporter):
         sample_inputs: MutableMapping[str, Any],
         config: ExecutorchConfig | dict[str, Any],
     ) -> ExecutorchProgramManager:
-        """Export a model to ExecuTorch, applying backend preparation and torch op patches."""
+        """Export a model to ExecuTorch, applying backend preparation and torch op patches.
+
+        Generic multi-graph flow: a backend's prepare returns either the legacy
+        ``(model, sample_inputs, partitioner)`` tuple (single-method, N=1) or a
+        ``BackendExportPlan`` declaring an ordered set of graphs to trace and lower together as
+        a multi-method program. The loop below traces each graph the normal way (or plainly, for
+        pre-surgered modules that aren't ``PreTrainedModel``s), optionally hands the collected
+        ``{name: ExportedProgram}`` to a backend ``lower`` hook, and serialises once.
+        """
         if isinstance(config, dict):
             config = ExecutorchConfig(**config)
         elif type(config) is not ExecutorchConfig:
@@ -120,14 +168,50 @@ class ExecutorchExporter(DynamoExporter):
         if prepare_for_backend is None:
             raise ValueError(f"Unsupported backend {config.backend} for ExecuTorch export")
 
-        model, sample_inputs, partitioner = prepare_for_backend(model, sample_inputs)
+        prepared = prepare_for_backend(model, sample_inputs, config)
+        plan = prepared if isinstance(prepared, BackendExportPlan) else BackendExportPlan(
+            method_set=OrderedDict(forward=GraphSpec(module=prepared[0], sample_inputs=prepared[1], mode="hf")),
+            partitioner=prepared[2],
+        )
 
+        # ── Backend-owns-lowering path (e.g. QNN) ──
+        # The graphs are pre-surgered + already-quantized (q/dq baked in). Trace each with PLAIN
+        # torch.export — byte-for-byte the backend's native trace — with NO HF op-patches and NO
+        # fx-fixes (either would rewrite the q/dq nodes). The backend's `lower` hook owns to_edge
+        # (it manages its own context, e.g. QnnManagerContext), then we serialise once.
+        if plan.lower is not None:
+            programs: "OrderedDict[str, ExportedProgram]" = OrderedDict()
+            for name, spec in plan.method_set.items():
+                if spec.role == "calibrate":
+                    continue  # consumed by the lower hook, never emitted
+                programs[name] = spec.exported_program if spec.exported_program is not None else (
+                    torch.export.export(
+                        spec.module, spec.sample_inputs, dynamic_shapes=spec.dynamic_shapes, strict=True
+                    )
+                )
+            edge_program_manager: EdgeProgramManager = plan.lower(programs, config)
+            return edge_program_manager.to_executorch(
+                *((plan.backend_config,) if plan.backend_config is not None else ())
+            )
+
+        # ── Generic HF path (xnnpack / cuda / multi-graph encoder-decoder) ──
+        # HF-aware tracing + fx-fixes + the generic to_edge, all under the transformers
+        # ExecuTorch patches (needed by both tracing and to_edge/to_executorch).
         with apply_patches("executorch"):
-            exported_program: ExportedProgram = super().export(model, sample_inputs, config=config)
-            apply_fx_program_fixes("executorch", exported_program)
-            apply_fx_node_fixes("executorch", exported_program.graph_module)
-            edge_program_manager: EdgeProgramManager = to_edge_transform_and_lower(
-                exported_program, partitioner=partitioner, compile_config=_get_edge_compile_config()
+            programs = OrderedDict()
+            for name, spec in plan.method_set.items():
+                if spec.role == "calibrate":
+                    continue
+                method_config = dataclasses.replace(config, dynamic_shapes=spec.dynamic_shapes)
+                ep = super().export(spec.module, spec.sample_inputs, config=method_config)
+                apply_fx_program_fixes("executorch", ep)
+                apply_fx_node_fixes("executorch", ep.graph_module)
+                programs[name] = ep
+            edge_program_manager = to_edge_transform_and_lower(
+                dict(programs) if len(programs) > 1 else next(iter(programs.values())),
+                partitioner=plan.partitioner,
+                constant_methods=plan.constant_methods or None,
+                compile_config=_get_edge_compile_config(),
             )
             executorch_programs_manager: ExecutorchProgramManager = edge_program_manager.to_executorch()
 
@@ -171,7 +255,7 @@ def _get_edge_compile_config() -> EdgeCompileConfig:
 # To add a new backend: implement _prepare_for_new_backend and add it to the _BACKEND_PREPARE table.
 
 
-def prepare_for_xnnpack(model: PreTrainedModel, sample_inputs: dict[str, Any]):
+def prepare_for_xnnpack(model: PreTrainedModel, sample_inputs: dict[str, Any], config: ExecutorchConfig = None):
     """CPU inference via XNNPACK. Moves the model to CPU and uses the default XnnpackPartitioner.
 
     XNNPACK's partitioner/lowering passes segfault on CUDA-typed EPs — the state and graph
@@ -191,7 +275,7 @@ def prepare_for_xnnpack(model: PreTrainedModel, sample_inputs: dict[str, Any]):
     return model, sample_inputs, partitioner
 
 
-def prepare_for_cuda(model: PreTrainedModel, sample_inputs: dict[str, Any]):
+def prepare_for_cuda(model: PreTrainedModel, sample_inputs: dict[str, Any], config: ExecutorchConfig = None):
     """GPU inference via the ExecuTorch CUDA backend.
 
     Moves the model to CUDA and upcasts to bfloat16 — required by the CUDA backend.
@@ -215,6 +299,23 @@ _BACKEND_PREPARE = {
     "xnnpack": prepare_for_xnnpack,
     "cuda": prepare_for_cuda,
 }
+
+
+def _register_optional_backends() -> None:
+    """Register backends whose prepare depends on optional ExecuTorch backend packages
+    (imported lazily so the module still imports without them). QNN returns a
+    ``BackendExportPlan`` (multi-method) from its prepare, like any other backend."""
+    if not is_executorch_available():
+        return
+    try:
+        from .exporter_executorch_qnn import prepare_for_qnn
+    except ImportError as exc:  # QNN backend package not built / SDK absent
+        logger.debug("QNN ExecuTorch backend unavailable, skipping registration: %s", exc)
+        return
+    _BACKEND_PREPARE["qnn"] = prepare_for_qnn
+
+
+_register_optional_backends()
 
 
 # ── Stage 2: Torch patches ────────────────────────────────────────────────────

--- a/src/transformers/exporters/exporter_executorch_qnn.py
+++ b/src/transformers/exporters/exporter_executorch_qnn.py
@@ -1,0 +1,106 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""QNN (Qualcomm AI Engine Direct / HTP) backend for the ExecuTorch exporter.
+
+A QNN decoder-LLM export is a multi-graph, cross-graph-quantized pipeline (static_llama surgery +
+fixed-shape CALIBRATE/PREFILL/DECODE graphs + 16a4w PT2E + encoding-override + per-KV requant). That
+"wet clay" work is owned by ExecuTorch's Qualcomm backend and reused here verbatim, via its
+return-not-write seam: ``export_llama(args, build_only=True)`` runs the surgery/quant/encoding-override
+and returns the converted deploy graphs as a ``QnnLLMGraphSet`` (before any lowering/serialize).
+
+``prepare_for_qnn`` turns that graph-set into a ``BackendExportPlan``; the generic exporter then
+traces each graph with plain ``torch.export`` (no HF fx-fixes — q/dq already present) and ``qnn_lower``
+runs the QNN transform + the generic ``to_edge_transform_and_lower`` (inside ``QnnManagerContext``).
+So the ``.pte`` is emitted by the HF exporter and is structurally identical to native ``export_llama``.
+
+Imported lazily so the exporter still works without the Qualcomm SDK/package.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from executorch.backends.qualcomm._passes.qnn_pass_manager import get_qnn_pass_manager_cls
+from executorch.backends.qualcomm.llm_export import build_qnn_llm_graphset
+from executorch.backends.qualcomm.partition.qnn_partitioner import QnnPartitioner
+from executorch.backends.qualcomm.utils.utils import (
+    QnnManagerContext,
+    flatbuffer_to_option,
+    generate_qnn_executorch_option,
+    qnn_edge_config,
+)
+from executorch.exir import to_edge_transform_and_lower
+
+from ..utils import logging
+from .exporter_executorch import BackendExportPlan, GraphSpec
+
+
+logger = logging.get_logger(__name__)
+
+
+def prepare_for_qnn(model, sample_inputs, config):
+    """Build the QNN ``BackendExportPlan`` from ExecuTorch's static_llama seam.
+
+    ① (surgery + 16a4w PT2E + encoding-override) is reused verbatim through the stable
+    ``executorch.backends.qualcomm.llm_export.build_qnn_llm_graphset`` API — no dependency on
+    ``executorch.examples``. It is model-driven (the HF model supplies the architecture) and returns
+    the converted deploy graphs; ②③④ (trace + QNN transform + generic to_edge) run in the HF
+    exporter / ``qnn_lower``.
+    """
+    options = config.backend_options or {}
+    logger.info("QNN prepare: building deploy graph-set via backends.qualcomm.build_qnn_llm_graphset")
+    gs = build_qnn_llm_graphset(
+        model,
+        decoder_model=options.get("decoder_model"),
+        soc_model=options.get("soc_model"),
+        model_mode=options.get("model_mode", "kv"),
+        prompt=options.get("prompt"),
+        calib_samples=options.get("calib_samples"),
+        artifact_dir=options.get("artifact_dir"),
+    )  # QnnLLMGraphSet — surgery+quant+encoding-override done
+
+    method_set: "OrderedDict[str, GraphSpec]" = OrderedDict()
+    for g in gs.modules:
+        method_set[g] = GraphSpec(
+            module=gs.modules[g], sample_inputs=gs.inputs[g], dynamic_shapes=None, role="deploy", mode="plain"
+        )
+
+    def qnn_lower(programs, cfg):
+        # ③④ — per-graph transform_for_export_pipeline + get_to_edge_transform_passes, then one
+        # generic to_edge_transform_and_lower inside QnnManagerContext (native lines 456-484).
+        aten_programs = {}
+        transform_passes = {}
+        qnn_partitioners = {
+            g: [QnnPartitioner(gs.compiler_specs[g], skip_node_op_set=gs.skip_node_op_set)]
+            for g in programs
+        }
+        for g, ep in programs.items():
+            option = generate_qnn_executorch_option(gs.compiler_specs[g])
+            backend_type = flatbuffer_to_option(option).backend_options.backend_type
+            pass_manager = get_qnn_pass_manager_cls(backend_type)()
+            aten_programs[g] = pass_manager.transform_for_export_pipeline(ep)
+            transform_passes[g] = pass_manager.get_to_edge_transform_passes(
+                ep, passes_job=gs.passes_job[g], dep_table=gs.dep_table[g],
+                compiler_specs=gs.compiler_specs[g], skip_node_op_set=gs.skip_node_op_set,
+            )
+        with QnnManagerContext(gs.compiler_specs):
+            return to_edge_transform_and_lower(
+                aten_programs, transform_passes=transform_passes, partitioner=qnn_partitioners,
+                constant_methods=gs.constant_methods or None, compile_config=qnn_edge_config(),
+            )
+
+    return BackendExportPlan(
+        method_set=method_set, partitioner=None, constant_methods=gs.constant_methods,
+        lower=qnn_lower, backend_config=gs.backend_config, lowering_context=None,
+    )


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47594)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47594)
<!-- ci-dashboard-badge:end -->

## What

Generalizes the `transformers` ExecuTorch exporter's single-graph assumption into **multi-method (multi-graph) export**, and adds **QNN (Qualcomm HTP)** as the first consumer — reusing ExecuTorch's `static_llama` LLM pipeline verbatim, with **no backend-specific fork**.

- `exporters/exporter_executorch.py` — generic core. A backend's prepare may return a `BackendExportPlan` declaring an ordered set of graphs (`GraphSpec`) instead of the single `(model, inputs, partitioner)` tuple. `export()` traces each graph and lowers them together via the already-multi-method-capable `to_edge_transform_and_lower`. A single-entry plan keeps XNNPACK/CUDA **byte-identical (N=1)**. A backend whose export is multi-graph + cross-graph-quantized supplies a `lower` hook and is traced plainly (no HF fx-fixes — its graphs are already surgered/quantized).
- `exporters/exporter_executorch_qnn.py` — QNN backend. `prepare_for_qnn` reuses ExecuTorch's static_llama build + 16a4w PT2E + encoding-override, and returns the converted decode/prefill graphs plus a `lower` hook running the QNN transform + generic `to_edge`.
- `exporters/configs.py` — `backend_options` passthrough.

## Why it's generic (not a QNN bolt-on)

Multi-method export is a real gap: encoder-decoder (Whisper) and multimodal (LLaVA) models are inherently multi-graph on **any** backend. QNN is just the first (hardest) consumer. There is **no `if backend == "qnn"`** in the core.

## What it proves

`.pte`s produced **through `ExecutorchExporter.export(backend="qnn")`** are **structurally identical** to the native `examples/qualcomm` `export_llama` output — same method set, same HTP delegation, **byte-exact size** — across five decoder models:

| model | methods (quant_attr) | delegated | size Δ vs native |
|---|---|---|---|
| smollm2-135M | 78 (60) | ✓ | 0 bytes |
| qwen2.5-0.5B | 66 (48) | ✓ | 0 bytes |
| qwen2.5-1.5B | 74 (56) | ✓ | 0 bytes |
| qwen3-0.6B | 74 (56) | ✓ | 0 bytes |
| gemma3-1B | 71 (52) | ✓ | 0 bytes |

## Experimental / open items

- **QNN ①** (static_llama build + PT2E + encoding-override) is currently reused by capturing native's converted graphs at the `to_edge_transform_and_lower_to_qnn` boundary. The upstream-clean version replaces this with a `HybridTextDecoder.compile()` **seam split** on the ExecuTorch side (follow-up) and a shipped `llm_export` package so it's importable without the `examples/` tree.
- Runs on pytorch/executorch **#20738 part-1** (transitional `QnnManagerContext` + `transform_passes`, isolated inside `qnn_lower`); collapses to a plain `to_edge_transform_and_lower(dict, QnnPartitioner)` at that series' end-state — no HF-core change.
- On-device A/B accuracy + perf validation (S23 / HTP v73) pending.

Authored with Claude.