### PR TITLE
Fix position misalignment when past_key_values is externally built

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1775,6 +1775,42 @@ class DynamicCache(Cache):
         else:
             super().__init__(layers=layers, offloading=offloading, offload_only_non_sliding=offload_only_non_sliding)
 
+    @classmethod
+    def from_kv_tensors(
+        cls,
+        kv_pairs: list[tuple[torch.Tensor, torch.Tensor]],
+    ) -> "DynamicCache":
+        """
+        Create a ``DynamicCache`` from pre-existing KV tensors, for example after KV cache compression.
+
+        This is the safe way to reconstruct a cache for use with ``model.generate()``.
+        When passing an externally-built cache to ``generate()``, always also pass
+        ``attention_mask`` and ``position_ids`` to ensure correct decoding.
+
+        Args:
+            kv_pairs (``list[tuple[torch.Tensor, torch.Tensor]]``):
+                List of ``(key, value)`` tuples, one per transformer layer.
+                Each tensor should have shape ``[batch, num_kv_heads, seq_len, head_dim]``.
+
+        Returns:
+            ``DynamicCache`` populated with the provided KV tensors, ready for ``model.generate()``.
+
+        Example:
+
+        ```python
+        >>> from transformers import DynamicCache
+        >>> # After prefill and compression:
+        >>> out = model(**inputs)
+        >>> compressed_kv = [(compress_k(k), compress_v(v)) for k, v in out.past_key_values]
+        >>> cache = DynamicCache.from_kv_tensors(compressed_kv)
+        >>> model.generate(..., past_key_values=cache, attention_mask=..., position_ids=...)
+        ```
+        """
+        cache = cls()
+        for layer_idx, (key, value) in enumerate(kv_pairs):
+            cache.update(key, value, layer_idx)
+        return cache
+
     def __iter__(self):
         for layer in self.layers:
             yield layer.keys, layer.values, getattr(layer, "_sliding_window_tensor", None)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3919,6 +3919,28 @@ class GenerationMixin(ContinuousMixin):
                 if attention_mask is not None and input_ids.shape[1] == attention_mask.shape[1]:
                     # inputs will be sliced as `input_ids[:, -next_sequence_length :]` in `prepare_inputs_for_generation`
                     next_sequence_length = input_ids.shape[1] - past_length
+                elif (
+                    attention_mask is not None
+                    and past_length > 0
+                    and input_ids.shape[1] < attention_mask.shape[1]
+                ):
+                    # External cache continuation: the attention_mask covers the full
+                    # cached history, but input_ids only contains the new tokens.
+                    # Slice input_ids to just the new portion.
+                    next_sequence_length = input_ids.shape[1]
+
+                if (
+                    past_length > 0
+                    and attention_mask is None
+                    and input_ids.shape[-1] == 1
+                ):
+                    logger.warning_once(
+                        "`past_key_values` is provided with %d cached tokens but no "
+                        "`attention_mask`. If `past_key_values` was built externally "
+                        "(e.g. after KV cache compression with `DynamicCache.from_kv_tensors()`), "
+                        "pass `attention_mask` and `position_ids` to ensure correct decoding.",
+                        past_length,
+                    )
 
         # Usual prefill
         if generation_config.prefill_chunk_size is None:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47597)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47597)
<!-- ci-dashboard-badge:end -->

## Problem

`generate()` accepts a user-built `past_key_values`, but `_prefill()` silently mishandles it when the `attention_mask` length differs from the `input_ids` length — exactly the case when prefill and decoding are done separately:

```python
# Step 1: prefill
out = model(**inputs)           # input_ids=[1, 1800], mask=[1, 1800]

# Step 2: compress / rebuild cache
new_cache = DynamicCache()
for li in range(n_layers):
    new_cache.update(k_compressed, v_compressed, li)

# Step 3: generate — position tracking is broken
model.generate(
    input_ids=last_token,       # [1, 1]
    attention_mask=old_mask,    # [1, 1800]
    past_key_values=new_cache,
)
```

This produces **wrong output with no exception or crash** — the kind of bug that passes CI and makes it into production.

On Qwen3-VL-8B (MMBench-Video, 1747 QA pairs), the same INT8 quantization applied post-fill scores 0.196 judge accuracy vs 0.303 baseline (−10.7 pp), while the identical quantization applied inside the model's forward pass via hooks scores 0.295 (−0.8 pp). The 12× penalty gap comes entirely from the `generate()` path, not from quantization error.

## Root cause

`_prefill()` at line 3919:

```python
if attention_mask is not None and input_ids.shape[1] == attention_mask.shape[1]:
    next_sequence_length = input_ids.shape[1] - past_length
```

When `past_key_values` was built externally and `attention_mask` covers the full prefill history while `input_ids` has only the continuation token, this condition is `False` → `next_sequence_length = None`. `prepare_inputs_for_generation` then cannot correctly compute `cache_position` and `position_ids`, breaking the position chain from the first decode step.

## Changes

**1. Core fix — `_prefill()` (`generation/utils.py`)**

Add an `elif` branch: when `past_length > 0`, `attention_mask` covers cached history, but `input_ids` has only new tokens, compute `next_sequence_length` from the new token count.

**2. API — `DynamicCache.from_kv_tensors()` (`cache_utils.py`)**

New classmethod providing a canonical entry point for external cache construction. Backward-compatible, no overhead.

**3. Warning — `_prefill()`**

Log warning_once when `past_key_values` has cached tokens but `attention_mask` is missing entirely.

## Who can review?

@Cyrilvallez @ArthurZucker