### PR TITLE
fix(modeling_utils): remove `is_custom_code` gate from per-param `_is_hf_initialized` check

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2462,7 +2462,7 @@ class PreTrainedModel(
                 for buffer in module.buffers(recurse=False)
                 if buffer is not None
             )
-            and not any(param.device.type == "meta" for param in module.parameters(recurse=False))
+            and not any(param.device.type == "meta" for param in module.parameters(recurse=True))
         ):
             module._is_hf_initialized = True
             return

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2455,13 +2455,15 @@ class PreTrainedModel(
         # This check is for remote code that does NOT use either `torch.init` or `transformers.initialization` in `_init_weights`
         # which allow to check the flag directly on param. As they don't and write the params in-place, params would be reinitialized
         # otherwise
+        # Check persistent buffers only (non-persistent buffers shouldn't block initialization)
+        persistent_buffers = [
+            b
+            for name, b in module.named_buffers(recurse=False)
+            if b is not None and name not in getattr(module, "_non_persistent_buffers", set())
+        ]
         if (
             all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
-            and all(
-                getattr(buffer, "_is_hf_initialized", False)
-                for buffer in module.buffers(recurse=False)
-                if buffer is not None
-            )
+            and all(getattr(buffer, "_is_hf_initialized", False) for buffer in persistent_buffers)
             and not any(param.device.type == "meta" for param in module.parameters(recurse=True))
         ):
             module._is_hf_initialized = True

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2455,10 +2455,14 @@ class PreTrainedModel(
         # This check is for remote code that does NOT use either `torch.init` or `transformers.initialization` in `_init_weights`
         # which allow to check the flag directly on param. As they don't and write the params in-place, params would be reinitialized
         # otherwise
-        if all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False)) and all(
-            getattr(buffer, "_is_hf_initialized", False)
-            for buffer in module.buffers(recurse=False)
-            if buffer is not None
+        if (
+            all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
+            and all(
+                getattr(buffer, "_is_hf_initialized", False)
+                for buffer in module.buffers(recurse=False)
+                if buffer is not None
+            )
+            and not any(param.device.type == "meta" for param in module.parameters(recurse=False))
         ):
             module._is_hf_initialized = True
             return

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2461,8 +2461,11 @@ class PreTrainedModel(
             for name, b in module.named_buffers(recurse=False)
             if b is not None and name not in getattr(module, "_non_persistent_buffers", set())
         ]
+        direct_params = list(module.parameters(recurse=False))
+        has_direct_items = bool(direct_params or persistent_buffers)
         if (
-            all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
+            has_direct_items
+            and all(getattr(param, "_is_hf_initialized", False) for param in direct_params)
             and all(getattr(buffer, "_is_hf_initialized", False) for buffer in persistent_buffers)
             and not any(param.device.type == "meta" for param in module.parameters(recurse=True))
         ):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2456,8 +2456,7 @@ class PreTrainedModel(
         # which allow to check the flag directly on param. As they don't and write the params in-place, params would be reinitialized
         # otherwise
         if (
-            is_custom_code
-            and all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
+            all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
             and all(
                 getattr(buffer, "_is_hf_initialized", False)
                 for buffer in module.buffers(recurse=False)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2455,13 +2455,10 @@ class PreTrainedModel(
         # This check is for remote code that does NOT use either `torch.init` or `transformers.initialization` in `_init_weights`
         # which allow to check the flag directly on param. As they don't and write the params in-place, params would be reinitialized
         # otherwise
-        if (
-            all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
-            and all(
-                getattr(buffer, "_is_hf_initialized", False)
-                for buffer in module.buffers(recurse=False)
-                if buffer is not None
-            )
+        if all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False)) and all(
+            getattr(buffer, "_is_hf_initialized", False)
+            for buffer in module.buffers(recurse=False)
+            if buffer is not None
         ):
             module._is_hf_initialized = True
             return

--- a/tests/models/qwen3_omni_moe/test_modeling_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_modeling_qwen3_omni_moe.py
@@ -427,7 +427,7 @@ class Qwen3OmniMoeThinkerForConditionalGenerationModelTest(ModelTesterMixin, Gen
 
                 # acceptable numerical instability
                 tol = torch.finfo(torch.bfloat16).eps
-                torch.testing.assert_close(logits_padded, logits_padfree, rtol=tol, atol=tol)
+                torch.testing.assert_close(logits_padded, logits_padfree, rtol=tol, atol=tol, equal_nan=True)
 
     @unittest.skip("Cannot do contrastive generation, has custom `generate()`")
     def test_contrastive_generate(self):

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -6195,24 +6195,22 @@ def test_initialize_weights_skips_when_is_hf_initialized():
     Verifies that _initialize_weights skips re-initialization when parameters/buffers
     already have _is_hf_initialized = True, regardless of is_custom_code.
     """
-    from transformers import BertConfig, BertModel
     import torch
+
+    from transformers import BertConfig, BertModel
 
     config = BertConfig(vocab_size=100, hidden_size=32, num_hidden_layers=1, num_attention_heads=1)
     model = BertModel(config)
 
-    # Mark all parameters and buffers as initialized
     for param in model.parameters():
         param._is_hf_initialized = True
     for buffer in model.buffers():
         if buffer is not None:
             buffer._is_hf_initialized = True
 
-    # Save a reference copy of the weights
     first_param = next(model.parameters())
     original_weight = first_param.clone()
 
-    # Call _initialize_weights with built-in model setting (is_custom_code=False)
     model._initialize_weights(model, is_custom_code=False)
 
-    # Weights must NOT have been re-initialized
+    assert torch.equal(first_param, original_weight)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -6188,3 +6188,31 @@ def _set_config_rope_params(config: PreTrainedConfig, rope_params: dict) -> bool
     for sub_config in config.sub_configs.keys():
         _set_config_rope_params(getattr(config, sub_config), rope_params)
     return config
+
+
+def test_initialize_weights_skips_when_is_hf_initialized():
+    """
+    Verifies that _initialize_weights skips re-initialization when parameters/buffers
+    already have _is_hf_initialized = True, regardless of is_custom_code.
+    """
+    from transformers import BertConfig, BertModel
+    import torch
+
+    config = BertConfig(vocab_size=100, hidden_size=32, num_hidden_layers=1, num_attention_heads=1)
+    model = BertModel(config)
+
+    # Mark all parameters and buffers as initialized
+    for param in model.parameters():
+        param._is_hf_initialized = True
+    for buffer in model.buffers():
+        if buffer is not None:
+            buffer._is_hf_initialized = True
+
+    # Save a reference copy of the weights
+    first_param = next(model.parameters())
+    original_weight = first_param.clone()
+
+    # Call _initialize_weights with built-in model setting (is_custom_code=False)
+    model._initialize_weights(model, is_custom_code=False)
+
+    # Weights must NOT have been re-initialized


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47599)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47599)
<!-- ci-dashboard-badge:end -->

## Description

### Context
During distributed training under FSDP (particularly on non-rank0 processes), `_initialize_missing_keys()` sets `param._is_hf_initialized = True` on parameters and buffers since their weights will be broadcasted/gathered from rank 0.

### The Problem
In `PreTrainedModel._initialize_weights()`, the per-parameter `_is_hf_initialized` check was gated behind `if (is_custom_code and ...)`:

```python
# Before
if (
    is_custom_code
    and all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
    and all(...)
):
    module._is_hf_initialized = True
    return