### PR TITLE
Potential fix for code scanning alert no. 265: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -201,7 +201,13 @@ jobs:
         env:
           ACCESS_TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
         run: |
-          echo "END_SHA=$(TOKEN="$ACCESS_TOKEN" python3 -c 'import os; from get_previous_daily_ci import get_last_daily_ci_run_commit; commit=get_last_daily_ci_run_commit(token=os.environ["TOKEN"], workflow_run_id=os.environ["PREV_WORKFLOW_RUN_ID"]); print(commit)')" >> $GITHUB_ENV
+          END_SHA_VALUE="$(TOKEN="$ACCESS_TOKEN" python3 -c 'import os; from get_previous_daily_ci import get_last_daily_ci_run_commit; commit=get_last_daily_ci_run_commit(token=os.environ["TOKEN"], workflow_run_id=os.environ["PREV_WORKFLOW_RUN_ID"]); print(commit)')"
+          DELIM="$(uuidgen)"
+          {
+            echo "END_SHA<<$DELIM"
+            echo "$END_SHA_VALUE"
+            echo "$DELIM"
+          } >> "$GITHUB_ENV"
 
       # However, for workflow runs triggered by `issue_comment` (for pull requests), we want to check against the
       # parent commit (on `main`) of the `merge_commit` (dynamically created by GitHub). In this case, the goal is to


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47600)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47600)
<!-- ci-dashboard-badge:end -->

Potential fix for [https://github.com/huggingface/transformers/security/code-scanning/265](https://github.com/huggingface/transformers/security/code-scanning/265)

Use GitHub Actions’ **multiline env-file format with a unique delimiter** instead of `KEY=VALUE` when assigning a value derived from runtime data. This prevents newline/env-injection because the value is bounded by explicit delimiter markers, not parsed as extra `KEY=VALUE` lines.

Best minimal fix (no functionality change):
- In `.github/workflows/check_failed_tests.yml`, update the `Get \`END_SHA\` from previous CI runs of the same workflow` step (`run:` block around lines 203–204).
- Capture Python output into a shell variable, generate a unique delimiter (e.g., `uuidgen`), and append:
  - `END_SHA<<$DELIM`
  - actual value
  - `$DELIM`
  to `$GITHUB_ENV`.

No new imports/dependencies are required; this is shell-only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._