### PR TITLE
Don't warn about class defaults when diffing a config

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -1019,8 +1019,14 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin, Heterogeneous
         # Get the default config dict (from a fresh PreTrainedConfig instance)
         default_config_dict = PreTrainedConfig().to_dict()
 
-        # get class specific config dict
-        class_config_dict = self.__class__().to_dict() if not self.has_no_defaults_at_init else {}
+        # get class specific config dict. The instance is only used to diff against, so we silence the
+        # validation warnings it triggers: they are about the class defaults, not about `self`
+        verbosity = logging.get_verbosity()
+        logging.set_verbosity_error()
+        try:
+            class_config_dict = self.__class__().to_dict() if not self.has_no_defaults_at_init else {}
+        finally:
+            logging.set_verbosity(verbosity)
 
         serializable_config_dict = {}
 

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -22,10 +22,19 @@ import warnings
 from pathlib import Path
 
 import httpx
+from huggingface_hub.dataclasses import strict
 
 from transformers import AutoConfig, BertConfig, Florence2Config, GPT2Config
 from transformers.configuration_utils import PreTrainedConfig
-from transformers.testing_utils import TOKEN, TemporaryHubRepo, is_staging_test, require_torch
+from transformers.testing_utils import (
+    TOKEN,
+    CaptureLogger,
+    LoggingLevel,
+    TemporaryHubRepo,
+    is_staging_test,
+    require_torch,
+)
+from transformers.utils import logging
 
 
 sys.path.append(str(Path(__file__).parent.parent.parent / "utils"))
@@ -260,6 +269,23 @@ class ConfigTestUtils(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             PreTrainedConfig.from_pretrained("bert-base-uncased")
+
+    def test_to_diff_dict_does_not_warn_about_class_defaults(self):
+        """Regression test for https://github.com/huggingface/transformers/issues/47612."""
+
+        @strict
+        class DefaultsOutOfVocabConfig(PreTrainedConfig):
+            vocab_size: int = 17
+            bos_token_id: int | None = 4242
+
+        # The special tokens of the config are valid, only the class defaults are not: the diff should be
+        # computed without warning about token ids that the config doesn't hold
+        config = DefaultsOutOfVocabConfig(vocab_size=9999)
+        logger = logging.get_logger("transformers.configuration_utils")
+        with LoggingLevel(logging.WARNING):
+            with CaptureLogger(logger) as cl:
+                config.to_diff_dict()
+        self.assertNotIn("bos_token_id", cl.out)
 
     def test_get_text_config(self):
         """Tests the `get_text_config` method."""


### PR DESCRIPTION
Fixes #47612

`to_diff_dict` instantiates `self.__class__()` to diff against, and `@strict` runs the class validators on that throwaway object. So `validate_token_ids` warns about the *class defaults*, not about the config the user actually loaded. `Siglip2TextConfig` defaults to `vocab_size=32000` with CLIP's `bos_token_id=49406` / `eos_token_id=49407`, hence the message about "between 0 and 31999" on a checkpoint whose real vocab is 256000.

It reaches users on a plain `AutoConfig.from_pretrained` because `huggingface_hub.dataclasses` validates `text_config: dict | PreTrainedConfig | None` by trying `dict` first, and its error message is built eagerly with `repr(value)` before the union falls through to the branch that matches. `PreTrainedConfig.__repr__` calls `to_diff_dict()`, so the discarded message triggers a full default-config build.

The patch silences transformers logging while that reference instance is built. Warnings about the user's own config are untouched: they are emitted when the config itself is constructed. `google/siglip-base-patch16-224`, which genuinely stores out-of-range special tokens, still warns.

Verified on Python 3.10 / torch 2.9.0, CPU only (config code, no accelerator involved):

- The repro from the issue is silent now and still reports `vocab_size=256000 bos=49406 eos=49407`.
- Serialization is unchanged: `to_json_string(use_diff=True)` for all 680 default-constructible classes in `CONFIG_MAPPING` is byte-identical before and after.
- New regression test in `tests/utils/test_configuration_utils.py` fails without the patch and passes with it.
- `tests/utils/test_configuration_utils.py`, `tests/models/auto/test_configuration_auto.py`, and the siglip / siglip2 modeling tests pass.

Two things I did not verify. I could not run `make style` in full (the `ty` / mlinter toolchain is not installed here), only pinned ruff check and format on the touched files. And the suppression lowers verbosity process-wide for the duration of the call, so it is not thread safe and it seeds `warning_once`'s cache: a later, byte-identical warning from a different config would be swallowed. In practice that means loading siglip2 then siglip in one process hides siglip's warning. Happy to switch to another mechanism if you prefer.

Separately, and not addressed here: the siglip / siglip2 text config defaults are wrong data on their own. Siglip's tokenizer has no 49406 / 49407 and no BOS at all, so those defaults are CLIP leftovers. About 15 config classes have similarly inconsistent defaults, which is why I fixed the reporting path instead of one model's numbers. Let me know if you want a follow-up.

Thanks to @willxxy for the clear report and minimal repro.