### PR TITLE
Gate eager distributed imports on torch.distributed.is_available()

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -41,6 +41,9 @@ from .utils.logging import get_logger, tqdm
 
 if _torch_distributed_available:
     from torch.distributed.tensor import DTensor
+else:
+    # torch built with `USE_DISTRIBUTED=0`: `isinstance(x, ())` is always False, so the DTensor branches are skipped
+    DTensor = ()
 
 if TYPE_CHECKING:
     from .integrations.tensor_parallel import TensorParallelLayer

--- a/src/transformers/distributed/fsdp.py
+++ b/src/transformers/distributed/fsdp.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 if is_torch_available():
     import torch
 
-if is_torch_available() and is_torch_greater_or_equal("2.6"):
+if _torch_distributed_available and is_torch_greater_or_equal("2.6"):
     from torch.distributed._composable.fsdp import fully_shard
     from torch.distributed.fsdp import CPUOffloadPolicy, MixedPrecisionPolicy
 

--- a/src/transformers/distributed/sharding_utils.py
+++ b/src/transformers/distributed/sharding_utils.py
@@ -17,6 +17,7 @@ import math
 from typing import TYPE_CHECKING
 
 from ..utils import is_torch_available
+from .utils import _torch_distributed_available
 
 
 if TYPE_CHECKING:
@@ -25,6 +26,8 @@ if TYPE_CHECKING:
 
 if is_torch_available():
     import torch
+
+if _torch_distributed_available:
     from torch.distributed.tensor import DTensor
     from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
     from torch.distributed.tensor.placement_types import Shard

--- a/src/transformers/distributed/utils.py
+++ b/src/transformers/distributed/utils.py
@@ -29,7 +29,7 @@ if is_torch_available():
 else:
     _torch_distributed_available = False
 
-if is_torch_available() and is_torch_greater_or_equal("2.7"):
+if _torch_distributed_available and is_torch_greater_or_equal("2.7"):
     import torch.distributed.checkpoint as dcp
     from torch.distributed.checkpoint.hf_storage import HuggingFaceStorageWriter
     from torch.distributed.checkpoint.state_dict import (

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -255,3 +255,49 @@ def test_broken_torchaudio_does_not_break_import():
             pass
         else:
             raise AssertionError("rnnt_loss must raise ImportError when torchaudio is unavailable")
+
+
+@run_test_using_subprocess
+def test_import_without_torch_distributed():
+    """A torch build without distributed support (`USE_DISTRIBUTED=0`, e.g. the ROCm 7.2.1 Windows wheels) must still
+    be able to import transformers and load a model: distributed-only imports have to be gated on
+    `torch.distributed.is_available()`, not just on the torch version. See #47603.
+
+    Runs in a subprocess because transformers must be imported *after* the patching below, and the parent pytest
+    process has already imported it.
+    """
+    import tempfile
+
+    import torch
+
+    # Emulate `USE_DISTRIBUTED=0`: `torch.distributed` exists, but `is_available()` is False and every submodule
+    # needing c10d raises `ModuleNotFoundError` on import (which is what a `None` entry in `sys.modules` does).
+    blocked = dict.fromkeys(
+        [
+            "torch.distributed.tensor",
+            "torch.distributed.checkpoint",
+            "torch.distributed.fsdp",
+            "torch.distributed._composable",
+        ]
+    )
+
+    # `patch.dict` snapshots `sys.modules`, so both the blocking and the reimport below are undone on exit.
+    with patch.dict(sys.modules, blocked), patch.object(torch.distributed, "is_available", lambda: False):
+        for name in list(sys.modules):
+            if name == "transformers" or name.startswith("transformers."):
+                del sys.modules[name]
+
+        from transformers import AutoImageProcessor, LlamaConfig, LlamaForCausalLM  # noqa: F401
+
+        # Loading a checkpoint must not reach the (now undefined) `DTensor` either.
+        config = LlamaConfig(
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            intermediate_size=64,
+            vocab_size=128,
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            LlamaForCausalLM(config).save_pretrained(tmp_dir)
+            LlamaForCausalLM.from_pretrained(tmp_dir)


### PR DESCRIPTION
Fixes #47603

Three module-level blocks that are reached eagerly from `import transformers` gate their `torch.distributed` submodule imports on `is_torch_available()` and the torch version, but never on `torch.distributed.is_available()`. On a torch built with `USE_DISTRIBUTED=0` (the reporter hit this with the ROCm 7.2.1 Windows wheels) `import torch` works but `torch.distributed.tensor` raises `ModuleNotFoundError: No module named 'torch._C._distributed_c10d'`, so `sharding_utils.py` kills the whole import chain behind `AutoImageProcessor`.

Changes, all switching to the `_torch_distributed_available` flag the codebase already uses for this in `core_model_loading.py`, `integrations/tensor_parallel.py` and `pytorch_utils.py`:

- `distributed/sharding_utils.py`: gate the DTensor imports. Plain `import torch` is split out so it still runs.
- `distributed/utils.py`: gate the `torch.distributed.checkpoint` imports.
- `distributed/fsdp.py`: gate the `_composable.fsdp` / `fsdp` imports.
- `core_model_loading.py`: add a `DTensor = ()` fallback. Without it the import now succeeds but `from_pretrained` dies with `NameError: name 'DTensor' is not defined` at the `isinstance(empty_param, DTensor)` check. `isinstance(x, ())` is always False, so those branches are just skipped.

Each of the four sites was found by following the next traceback, not by grepping.

### Verification

I have no `USE_DISTRIBUTED=0` build, so the new test in `tests/utils/test_import_utils.py` simulates one in a fresh subprocess: `torch.distributed.is_available()` patched to False plus a `sys.meta_path` finder that raises the reporter's exact `ModuleNotFoundError` for the c10d-dependent submodules. It has to be a subprocess because the blocking must happen before `transformers` is imported. The test imports `AutoImageProcessor` and does a tiny `save_pretrained` / `from_pretrained` round trip. It fails on main with the reporter's traceback and passes with this patch.

Ran on Linux, python 3.10, torch 2.9.0+cu126, CPU. `tests/utils/test_import_utils.py`, `tests/utils/test_distributed_sharding_utils.py` and `tests/utils/test_core_model_loading.py` show the same 4 pre-existing environment failures (torch 2.9 strided-shard API, and an fp8 test needing sm_89+) before and after. `ruff` clean.

Not verified: a real `USE_DISTRIBUTED=0` or ROCm build, Windows, and anything beyond import plus checkpoint load. Distributed features themselves still cannot run on such a build, they are just no longer imported.

Thanks to @hlky for the report and the diagnosis, including pointing at the DTensor import as the trigger.