### PR TITLE
Refresh MiniMax context window defaults to match official checkpoints

### DIFF
--- a/src/transformers/models/minimax_m2/configuration_minimax_m2.py
+++ b/src/transformers/models/minimax_m2/configuration_minimax_m2.py
@@ -81,7 +81,7 @@ class MiniMaxM2Config(PreTrainedConfig):
     num_key_value_heads: int = 8
     head_dim: int = 128
     hidden_act: str = "silu"
-    max_position_embeddings: int = 196608
+    max_position_embeddings: int = 204800
     initializer_range: float = 0.02
     rms_norm_eps: float = 1e-06
     use_cache: bool = True

--- a/src/transformers/models/minimax_m2/modular_minimax_m2.py
+++ b/src/transformers/models/minimax_m2/modular_minimax_m2.py
@@ -100,7 +100,7 @@ class MiniMaxM2Config(PreTrainedConfig):
     num_key_value_heads: int = 8
     head_dim: int = 128
     hidden_act: str = "silu"
-    max_position_embeddings: int = 196608
+    max_position_embeddings: int = 204800
     initializer_range: float = 0.02
     rms_norm_eps: float = 1e-06
     use_cache: bool = True

--- a/src/transformers/models/minimax_m3_vl/configuration_minimax_m3_vl.py
+++ b/src/transformers/models/minimax_m3_vl/configuration_minimax_m3_vl.py
@@ -89,7 +89,7 @@ class MiniMaxM3VLTextConfig(PreTrainedConfig):
     num_key_value_heads: int = 4
     head_dim: int = 128
     hidden_act: str = "silu"
-    max_position_embeddings: int = 524288
+    max_position_embeddings: int = 1000000
     initializer_range: float = 0.02
     rms_norm_eps: float = 1e-06
     use_cache: bool = True

--- a/src/transformers/models/minimax_m3_vl/modular_minimax_m3_vl.py
+++ b/src/transformers/models/minimax_m3_vl/modular_minimax_m3_vl.py
@@ -104,7 +104,7 @@ class MiniMaxM3VLTextConfig(MiniMaxM2Config):
     num_attention_heads: int = 64
     num_key_value_heads: int = 4
     head_dim: int = 128
-    max_position_embeddings: int = 524288
+    max_position_embeddings: int = 1000000
     vocab_size: int = 200064
     rms_norm_eps: float = 1e-06
     num_local_experts: int = 128


### PR DESCRIPTION
Reason: Refresh MiniMax model configuration defaults so the text context window matches the official MiniMax-M3 and MiniMax-M2.7 checkpoints.

This updates the default `max_position_embeddings` for the MiniMax-M3 and MiniMax-M2 text configuration classes (both the generated configuration and the modular source) so the defaults reflect the officially declared context windows:

- `minimax_m3_vl` text config: 524288 -> 1000000
- `minimax_m2` config: 196608 -> 204800

Files changed:
- `src/transformers/models/minimax_m3_vl/configuration_minimax_m3_vl.py`
- `src/transformers/models/minimax_m3_vl/modular_minimax_m3_vl.py`
- `src/transformers/models/minimax_m2/configuration_minimax_m2.py`
- `src/transformers/models/minimax_m2/modular_minimax_m2.py`

Checks:
- `python3 -m py_compile` on all four modified files (syntax OK).
