### PR TITLE
Fix fp8_linear compilability 

### DIFF
--- a/src/transformers/integrations/deepgemm.py
+++ b/src/transformers/integrations/deepgemm.py
@@ -141,38 +141,28 @@ def _get_nvcc_version() -> tuple[int, int] | None:
     return None
 
 
-_IS_SM100: bool | None = None
-
-
-@torch._dynamo.allow_in_graph
-def _is_sm100() -> None:
-    """Resolve whether the current CUDA device is Blackwell (SM100+) into the `_IS_SM100` module global.
-
-    `@allow_in_graph` keeps the untraceable `torch.cuda.get_device_capability()` pybind out of the graph
-    (opaque node) and must return `None` (proxyable) — the same populate-a-global double-hop the kernel
-    loaders use. Re-queries each call rather than caching, so a faked capability in tests is honoured and
-    there is no stale global to reset.
-    """
-    global _IS_SM100
-    _IS_SM100 = torch.cuda.get_device_capability()[0] >= 10
-
-
+@torch._dynamo.assume_constant_result
 def is_sm100() -> bool:
-    """Whether the current CUDA device is Blackwell (SM100+). Reads the `_IS_SM100` global that the
-    `@allow_in_graph` `_is_sm100` populates, so it folds to a constant under `torch.compile` — the
-    branches on it (SF layout, cast kwargs, psum layout, and the arch guards) stay compile-safe without
-    the capability pybind ever entering the traced graph.
+    """Whether the current CUDA device is Blackwell (SM100+). `@assume_constant_result` makes dynamo
+    evaluate it once at trace time and inline the bool — keeping the untraceable
+    `torch.cuda.get_device_capability()` pybind out of the graph — so the branches on it (SF layout, cast
+    kwargs, psum layout, and the arch guards) stay compile-safe. Re-queries each eager call, so a faked
+    capability in tests is honoured.
     """
-    _is_sm100()
-    return _IS_SM100
+    return torch.cuda.get_device_capability()[0] >= 10
 
 
+@torch._dynamo.assume_constant_result
 def is_deepgemm_loadable(raise_error: bool = False) -> bool:
     """Whether the DeepGEMM kernel can be loaded in this environment: `kernels` installed, a CUDA GPU on a
     supported arch (Hopper SM90 or Blackwell SM100), and a CUDA toolkit/nvcc new enough to JIT-compile it.
     A one-glance gate for callers — including external stacks — deciding whether to dispatch to DeepGEMM.
     With `raise_error=True` (used by the loader) it re-raises the specific `ImportError` explaining what's
     missing instead of returning `False`.
+
+    `@assume_constant_result` makes dynamo evaluate this once at trace time and inline the bool (its probe
+    is untraceable — an `lru_cache`'d import check + the `get_device_capability` pybind + nvcc lookup), so
+    the check can sit in a compiled dispatch gate (e.g. `fp8_linear`) without breaking the graph.
 
     FP4 / Mega MoE additionally need Blackwell (SM100); the relevant forwards enforce that via
     `_assert_sm100_requirements` / `is_sm100()`, since this env check can't see which dtype path the
@@ -327,7 +317,7 @@ def _assert_sm100_requirements(weight: torch.Tensor, scale: torch.Tensor) -> Non
         loader normalizes even float32-container checkpoints like dsv4-flash-base), so a ``float32`` scale
         on SM100 means a genuine non-UE8M0 checkpoint.
 
-    Uses `is_sm100()` (the compile-safe double-hop), so the whole guard folds to a constant under
+    Uses `is_sm100()` (compile-safe via `assume_constant_result`), so the whole guard folds to a constant under
     ``torch.compile``: the valid case compiles away to nothing, while an unsupported combo fails loud
     rather than letting the hot path silently corrupt (unlike an ``is_compiling`` skip, which would miss a
     model compiled from cold with no eager warmup). Both raise ``NotImplementedError``, which

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -33,6 +33,7 @@ from .deepgemm import (
     deepgemm_fp8_fp4_linear,
     deepgemm_fp8_fp4_megamoe_experts_forward,
     is_deepgemm_loadable,
+    is_sm100,
 )
 from .hub_kernels import _MISSING_KERNELS_MESSAGE, lazy_load_kernel
 from .moe import ExpertsInterface, use_experts_implementation
@@ -243,17 +244,20 @@ def fp8_linear(
             to a single CUDA context and produce garbage across devices (see the multi-device guard
             in ``quantizer_finegrained_fp8.py``).
     """
-    # DeepGEMM is CUDA-only, dynamic-only, SM90+ only, FP4/FP8-block-128-only.
-    # ``TRANSFORMERS_DISABLE_DEEPGEMM_LINEAR=1`` forces the Triton fallback for this single
-    # dispatcher (the experts ``"deepgemm"`` impl is unaffected — use ``set_experts_implementation``
-    # for that). Used by the FP8 MoE batched_mm / grouped_mm paths to avoid a still-unexplained
-    # DeepGEMM-vs-Triton interaction that degrades end-to-end generation on B200 (per-row kernel
-    # outputs still measure bit-perfect, but final tokens drift; not reproducible with the
-    # DeepGEMM linear off).
+    # DeepGEMM is CUDA-only, dynamic-only, SM90+ only, FP4/FP8-block-128-only. On SM100 its FP8 GEMM only
+    # consumes UE8M0 scales; float32 scales would be ceil-rounded to UE8M0 without requantizing and
+    # silently corrupt the output (#47030), so we skip DeepGEMM up front for that combo rather than
+    # attempt-then-fall-back every call — `_assert_sm100_requirements` still guards it as a backstop.
+    # ``TRANSFORMERS_DISABLE_DEEPGEMM_LINEAR=1`` forces the Triton fallback for this single dispatcher (the
+    # experts ``"deepgemm"`` impl is unaffected — use ``set_experts_implementation`` for that). Used by the
+    # FP8 MoE batched_mm / grouped_mm paths to avoid a still-unexplained DeepGEMM-vs-Triton interaction that
+    # degrades end-to-end generation on B200 (per-row kernel outputs still measure bit-perfect, but final
+    # tokens drift; not reproducible with the DeepGEMM linear off).
     deepgemm_preferred = (
         allow_deepgemm
         and is_deepgemm_loadable()
         and activation_scale is None
+        and not (is_sm100() and weight_scale_inv.dtype == torch.float32)
         and (weight.dtype == torch.int8 or (block_size is not None and block_size[0] == block_size[1] == 128))
         and os.environ.get("TRANSFORMERS_DISABLE_DEEPGEMM_LINEAR", "0") != "1"
     )

--- a/src/transformers/integrations/sonicmoe.py
+++ b/src/transformers/integrations/sonicmoe.py
@@ -43,12 +43,17 @@ ACT_MAP = {"silu": "swiglu", "gelu": "geglu", "relu": "reglu"}
 SONICMOE_DEPENDENCIES = {"nvidia-cutlass-dsl": "4.5.2", "apache-tvm-ffi": "0.1.9"}
 
 
+@torch._dynamo.assume_constant_result
 def is_sonicmoe_loadable(raise_error: bool = False) -> bool:
     """Whether the sonic-moe kernel can be loaded in this environment: `kernels` installed, a CUDA GPU on
     Hopper (SM90) or newer, and `nvidia-cutlass-dsl` / `apache-tvm-ffi` no newer than the versions the
     kernel was validated against (`SONICMOE_DEPENDENCIES`) — newer releases may break its CuteDSL / TVM
     FFI dispatch. A one-glance gate for callers, including external stacks. With `raise_error=True` (used
     by the loader) it re-raises the specific `ImportError` instead of returning `False`.
+
+    `@assume_constant_result` makes dynamo evaluate this once at trace time and inline the bool (its probe
+    is untraceable — an `lru_cache`'d import check, the `get_device_capability` pybind, and
+    `importlib.metadata` version lookups), so it stays compile-safe if called from a compiled region.
     """
     if not is_kernels_available():
         return maybe_import_error(

--- a/tests/kernels/test_deepgemm.py
+++ b/tests/kernels/test_deepgemm.py
@@ -424,21 +424,6 @@ class DeepGemmForwardTest(unittest.TestCase):
                 dg._assert_sm100_requirements(fp8_w, f32_sf)  # no float32 SF path on Blackwell
             dg._assert_sm100_requirements(int8_w, ue8m0_sf)  # UE8M0 on SM100 -> no raise
 
-    @require_torch_greater_or_equal("2.7")  # torch.float8_e8m0fnu (UE8M0) landed in 2.7
-    def test_linear_fp8_sm100_rejects_float32_scales(self):
-        # Regression for #47030: FP8 weights + float32 block scales on SM100 (e.g. Qwen3-4B-FP8) must NOT
-        # reach the kernel. DeepGEMM's SM100 GEMM only takes UE8M0 SFs, and ceil-rounding float32 SFs to
-        # UE8M0 without requantizing the payload silently corrupts the output (finite, warning-free, wrong).
-        # The forward must raise before loading — `fp8_linear` turns that into a Triton fallback — so no
-        # kernel op runs.
-        input = torch.randn(4, 128, dtype=torch.bfloat16, device=torch_device)
-        weight = torch.randn(256, 128, device=torch_device).to(torch.float8_e4m3fn)
-        weight_scale = torch.ones(2, 1, dtype=torch.float32, device=torch_device)  # (N/128, K/128), float32
-        with self._bundle(is_sm100=True) as captured:
-            with self.assertRaisesRegex(NotImplementedError, "float32 scale-factor path"):
-                deepgemm_fp8_fp4_linear(input, weight, weight_scale, block_size=(128, 128))
-        self.assertEqual(captured, {})  # raised before load — the corrupting cast/matmul never ran
-
     def test_linear_adds_bias_and_ignores_deprecated_output_dtype(self):
         input = torch.randn(4, 128, dtype=torch.bfloat16, device=torch_device)
         weight = torch.randn(16, 128, device=torch_device).to(torch.float8_e4m3fn)

--- a/tests/kernels/test_deepgemm.py
+++ b/tests/kernels/test_deepgemm.py
@@ -426,8 +426,9 @@ class DeepGemmForwardTest(unittest.TestCase):
 
     def test_linear_rejects_float32_scales_on_sm100(self):
         # Regression for #47030: rounding a checkpoint's float32 scales up to UE8M0 without requantizing
-        # silently corrupts the output on SM100. The forward must reject them before the kernel runs (so
-        # `fp8_linear` falls back to Triton) — no kernel op should execute.
+        # silently corrupts the output on SM100. `fp8_linear` skips DeepGEMM up front for this combo, but
+        # this guards the backstop inside the forward itself (which also protects the experts / megamoe
+        # paths, that have no such gate): the forward must reject float32 scales before any kernel op runs.
         input = torch.randn(4, 128, dtype=torch.bfloat16, device=torch_device)
         weight = torch.randn(256, 128, device=torch_device).to(torch.float8_e4m3fn)
         weight_scale = torch.ones(2, 1, dtype=torch.float32, device=torch_device)

--- a/tests/kernels/test_deepgemm.py
+++ b/tests/kernels/test_deepgemm.py
@@ -424,6 +424,18 @@ class DeepGemmForwardTest(unittest.TestCase):
                 dg._assert_sm100_requirements(fp8_w, f32_sf)  # no float32 SF path on Blackwell
             dg._assert_sm100_requirements(int8_w, ue8m0_sf)  # UE8M0 on SM100 -> no raise
 
+    def test_linear_rejects_float32_scales_on_sm100(self):
+        # Regression for #47030: rounding a checkpoint's float32 scales up to UE8M0 without requantizing
+        # silently corrupts the output on SM100. The forward must reject them before the kernel runs (so
+        # `fp8_linear` falls back to Triton) — no kernel op should execute.
+        input = torch.randn(4, 128, dtype=torch.bfloat16, device=torch_device)
+        weight = torch.randn(256, 128, device=torch_device).to(torch.float8_e4m3fn)
+        weight_scale = torch.ones(2, 1, dtype=torch.float32, device=torch_device)
+        with self._bundle(is_sm100=True) as captured:
+            with self.assertRaisesRegex(NotImplementedError, "float32 scale-factor path"):
+                deepgemm_fp8_fp4_linear(input, weight, weight_scale, block_size=(128, 128))
+        self.assertEqual(captured, {})  # raised before the kernel ran
+
     def test_linear_adds_bias_and_ignores_deprecated_output_dtype(self):
         input = torch.randn(4, 128, dtype=torch.bfloat16, device=torch_device)
         weight = torch.randn(16, 128, device=torch_device).to(torch.float8_e4m3fn)

--- a/tests/kernels/test_deepgemm.py
+++ b/tests/kernels/test_deepgemm.py
@@ -218,6 +218,17 @@ class DeepGemmLoaderTest(unittest.TestCase):
             out = run(torch.zeros(3, device=torch_device))
         self.assertTrue(torch.equal(out, torch.ones(3, device=torch_device)))
 
+    def test_is_deepgemm_loadable_is_compile_safe(self):
+        # Regression guard: `is_deepgemm_loadable` sits in the compiled `fp8_linear` gate, so it must fold
+        # to a constant (via `@assume_constant_result`); tracing its env probe would break the graph.
+        torch.compiler.reset()
+
+        @torch.compile(fullgraph=True)
+        def run(x):
+            return x + 1 if dg.is_deepgemm_loadable() else x - 1
+
+        run(torch.zeros(3, device=torch_device))  # a graph break / traced probe would raise here
+
 
 # ── Capturing fake DeepGEMM bundle ─────────────────────────────────────────────
 #
@@ -412,6 +423,21 @@ class DeepGemmForwardTest(unittest.TestCase):
             with self.assertRaisesRegex(NotImplementedError, "float32 scale-factor path"):
                 dg._assert_sm100_requirements(fp8_w, f32_sf)  # no float32 SF path on Blackwell
             dg._assert_sm100_requirements(int8_w, ue8m0_sf)  # UE8M0 on SM100 -> no raise
+
+    @require_torch_greater_or_equal("2.7")  # torch.float8_e8m0fnu (UE8M0) landed in 2.7
+    def test_linear_fp8_sm100_rejects_float32_scales(self):
+        # Regression for #47030: FP8 weights + float32 block scales on SM100 (e.g. Qwen3-4B-FP8) must NOT
+        # reach the kernel. DeepGEMM's SM100 GEMM only takes UE8M0 SFs, and ceil-rounding float32 SFs to
+        # UE8M0 without requantizing the payload silently corrupts the output (finite, warning-free, wrong).
+        # The forward must raise before loading — `fp8_linear` turns that into a Triton fallback — so no
+        # kernel op runs.
+        input = torch.randn(4, 128, dtype=torch.bfloat16, device=torch_device)
+        weight = torch.randn(256, 128, device=torch_device).to(torch.float8_e4m3fn)
+        weight_scale = torch.ones(2, 1, dtype=torch.float32, device=torch_device)  # (N/128, K/128), float32
+        with self._bundle(is_sm100=True) as captured:
+            with self.assertRaisesRegex(NotImplementedError, "float32 scale-factor path"):
+                deepgemm_fp8_fp4_linear(input, weight, weight_scale, block_size=(128, 128))
+        self.assertEqual(captured, {})  # raised before load — the corrupting cast/matmul never ran
 
     def test_linear_adds_bias_and_ignores_deprecated_output_dtype(self):
         input = torch.randn(4, 128, dtype=torch.bfloat16, device=torch_device)

--- a/tests/kernels/test_sonicmoe.py
+++ b/tests/kernels/test_sonicmoe.py
@@ -206,6 +206,17 @@ class SonicMoeLoaderTest(unittest.TestCase):
             out = run(torch.zeros(6, 8, dtype=torch.bfloat16, device=torch_device))
         self.assertEqual(out.shape, (6, 8))
 
+    def test_is_sonicmoe_loadable_is_compile_safe(self):
+        # `is_sonicmoe_loadable` must fold to a constant (via `@assume_constant_result`); tracing its env
+        # probe would break the graph.
+        torch.compiler.reset()
+
+        @torch.compile(fullgraph=True)
+        def run(x):
+            return x + 1 if sm.is_sonicmoe_loadable() else x - 1
+
+        run(torch.zeros(3, device=torch_device))  # a graph break / traced probe would raise here
+
 
 @require_torch
 class SonicMoeForwardTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

is_deepgemm_loadable does not use the double hop allow_in_graph nor assume_constant_result because i thought i only used it in the already protected loader utils, but it's also used in the fp8_linear path which makes it break it during compilation. In this PR i tag every util that returns a trace time python constant with assume_constant_result and add regression tests.

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.

Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
for reviewers and other users and will almost certainly get you blocked.

For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @molbap @guarin
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
