### PR TITLE
Fix Starcoder2 default bos/eos token ids falling outside the vocabulary

### DIFF
--- a/src/transformers/models/starcoder2/configuration_starcoder2.py
+++ b/src/transformers/models/starcoder2/configuration_starcoder2.py
@@ -69,8 +69,10 @@ class Starcoder2Config(PreTrainedConfig):
     initializer_range: float = 0.018042
     norm_epsilon: float = 1e-5
     use_cache: bool = True
-    bos_token_id: int | None = 50256
-    eos_token_id: int | list[int] | None = 50256
+    # `50256` was inherited from GPT-2 and falls outside `vocab_size`; the released
+    # Starcoder2 checkpoints all use `0` (`<|endoftext|>`) for both.
+    bos_token_id: int | None = 0
+    eos_token_id: int | list[int] | None = 0
     pad_token_id: int | None = None
     rope_parameters: RopeParameters | dict | None = None
     sliding_window: int | None = None

--- a/tests/models/starcoder2/test_modeling_starcoder2.py
+++ b/tests/models/starcoder2/test_modeling_starcoder2.py
@@ -17,7 +17,7 @@ import unittest
 
 import pytest
 
-from transformers import BitsAndBytesConfig, is_torch_available
+from transformers import BitsAndBytesConfig, Starcoder2Config, is_torch_available
 from transformers.testing_utils import (
     Expectations,
     require_bitsandbytes,
@@ -53,6 +53,15 @@ class Starcoder2ModelTest(CausalLMModelTest, unittest.TestCase):
     @unittest.skip("Float8 quantization + TP numerical noise exceeds match threshold")
     def test_tp_generation_quantized(self):
         pass
+
+    def test_default_special_token_ids_within_vocab(self):
+        # The defaults used to be GPT-2's `50256`, which is outside `vocab_size` (49152): building a
+        # model from a default config and calling `generate()` without a prompt raised an `IndexError`
+        # when `bos_token_id` was used as the decoder start token.
+        config = Starcoder2Config()
+        for name in ("bos_token_id", "eos_token_id"):
+            token_id = getattr(config, name)
+            self.assertTrue(0 <= token_id < config.vocab_size, f"{name}={token_id} is outside the vocabulary")
 
 
 @slow


### PR DESCRIPTION
# What does this PR do?

`Starcoder2Config` defaults `bos_token_id` and `eos_token_id` to `50256` — GPT-2's `<|endoftext|>` — while its own default `vocab_size` is `49152`. Both ids are therefore outside the vocabulary, and they contradict every released checkpoint: `bigcode/starcoder2-3b`, `-7b` and `-15b` all ship `vocab_size=49152, bos_token_id=0, eos_token_id=0`. `bigcode/starcoder2-7b` is the checkpoint this config's `@auto_docstring` already points at.

This is not only cosmetic. A model built from a default config crashes in the embedding lookup as soon as `bos_token_id` is used as the decoder start token:

```python
from transformers import Starcoder2Config, Starcoder2ForCausalLM

# small, but keeps the default vocab_size / bos_token_id / eos_token_id
config = Starcoder2Config(
    num_hidden_layers=1, hidden_size=32, num_attention_heads=2,
    num_key_value_heads=2, intermediate_size=64, max_position_embeddings=32,
)
model = Starcoder2ForCausalLM(config).eval()
model.generate(max_new_tokens=2, do_sample=False)
```

```
IndexError: index out of range in self
```

And because `eos_token_id=50256 >= vocab_size`, EOS can never be sampled, so generation from a scratch-initialised model can never stop on EOS and always runs to `max_length`.

Anyone loading a released checkpoint is unaffected — the checkpoint's own `config.json` overrides both values. What breaks is building Starcoder2 from a config, which is what pretraining-from-scratch and most testing paths do.

## Fix

Point both defaults at `0`, matching the reference checkpoints, and add a regression test asserting the defaults stay inside the vocabulary.

## How was it tested?

Verified on this branch, CPU only (config/generation code, no accelerator involved):

- The repro above raises `IndexError` on `main` and runs cleanly after the patch.
- The new `test_default_special_token_ids_within_vocab` fails on `main` (`bos_token_id=50256 is outside the vocabulary`) and passes with the patch.
- `ruff check` and `ruff format --check` clean on both touched files.

One thing I could not verify locally: the full `tests/models/starcoder2` suite. `pytest` will not start inside the repo on my Windows box (it aborts during startup with no output, and the `--doctest-glob='**/*.md'` addopts hangs collection), so I ran the new test's assertions through `unittest` directly instead. I would appreciate CI confirming the rest of the model suite.

## How I found it

Not from a bug report — I swept every config in `CONFIG_MAPPING`, instantiated it with defaults, and flagged each `*_token_id` falling outside that config's own `vocab_size`. Most hits are legitimate: configs with more than one vocabulary, where the id indexes a different space than `vocab_size` (Musicgen's codebook BOS, CSM, Qwen2.5-Omni's talker, Kyutai). Starcoder2 is a genuine single-vocabulary mismatch, which is why it is the only model changed here.

Two related hits I deliberately left out of this PR, happy to follow up on either if you want them:

- **SigLIP / SigLIP2** — `bos_token_id=49406`, `eos_token_id=49407` are CLIP leftovers with `vocab_size=32000`; SigLIP's tokenizer has no BOS at all and uses `</s>`=1, SigLIP2's Gemma tokenizer uses `pad`=0/`eos`=1/`bos`=2. This is the data behind #47612, and #47613 already notes it as separate follow-up work, so I have stayed off it.
- **Arcee** — `bos_token_id=128000`/`eos_token_id=128001` (Llama-3 ids) with `vocab_size=32000` (Llama-2 vocab). Here it is ambiguous whether the `vocab_size` default or the token ids are the wrong half — `arcee-ai/AFM-4.5B` is `vocab_size=128005, bos=128000, eos=128003` — so it needs a maintainer call rather than a guess.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests)?
- [x] Did you write any new necessary tests?

## Who can review?

@Cyrilvallez @ArthurZucker

## AI assistance disclosure

Written with Claude Code. The finding, the sweep, the repro and the verification above are mine and I have reviewed every line; I am not a first-time contributor here (#46807 and #20436 in executorch merged, #47478 in review).
