### PR TITLE
CI: Log GitHub API diagnostics to stderr

### DIFF
--- a/tests/repo_utils/test_github_utils.py
+++ b/tests/repo_utils/test_github_utils.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import sys
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from unittest.mock import patch
 
 
@@ -257,6 +260,29 @@ class GithubRequestTest(unittest.TestCase):
         self.assertEqual(headers["Content-Type"], "application/json")
         self.assertEqual(mock.call_args.kwargs["method"], "POST")
         self.assertEqual(mock.call_args.kwargs["data"], b'{"body": "hi"}')
+
+
+def test_github_diagnostics_logger_uses_stream_handler_not_stdout():
+    assert any(
+        isinstance(handler, logging.StreamHandler) and getattr(handler, "stream", None) is not sys.stdout
+        for handler in gh.logger.handlers
+    )
+
+
+def test_github_request_diagnostics_are_logged_not_printed_to_stdout():
+    stdout = StringIO()
+    with (
+        patch.object(gh, "_log_token_status", return_value=None),
+        patch.object(gh, "_request", return_value=_response(200, {"X-RateLimit-Limit": "5000"}, '{"ok": true}')),
+        redirect_stdout(stdout),
+        unittest.TestCase().assertLogs(gh.logger, level="INFO") as logs,
+    ):
+        assert github_request("https://api.github.com/x", token="t") == {"ok": True}
+
+    assert stdout.getvalue() == ""
+    output = "\n".join(logs.output)
+    assert "[initial] GET https://api.github.com/x" in output
+    assert "GitHub rate-limit" in output
 
 
 if __name__ == "__main__":

--- a/utils/github_utils.py
+++ b/utils/github_utils.py
@@ -30,10 +30,22 @@ imported by GitHub Actions steps that run a bare Python with no third-party pack
 """
 
 import json
+import logging
 import os
 import time
 import urllib.error
 import urllib.request
+
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    # StreamHandler defaults to stderr, keeping diagnostics visible in CI logs without polluting stdout
+    # that some workflow steps capture as machine-readable output.
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
 
 
 def build_github_headers(token=None):
@@ -49,7 +61,7 @@ def build_github_headers(token=None):
 
 
 def _log_rate_limit_headers(response_headers, prefix=""):
-    """Print all GitHub rate-limit response headers for diagnostics."""
+    """Log all GitHub rate-limit response headers for diagnostics."""
     limit = response_headers.get("X-RateLimit-Limit", "n/a")
     used = response_headers.get("X-RateLimit-Used", "n/a")
     remaining = response_headers.get("X-RateLimit-Remaining", "n/a")
@@ -74,7 +86,7 @@ def _log_rate_limit_headers(response_headers, prefix=""):
         parts.append(f"Retry-After={retry_after}s")
 
     tag = f"[{prefix}] " if prefix else ""
-    print(f"{tag}GitHub rate-limit: {', '.join(parts)}")
+    logger.info("%sGitHub rate-limit: %s", tag, ", ".join(parts))
 
 
 _token_status_logged = False
@@ -106,7 +118,7 @@ def _log_token_status(token=None):
     try:
         status, response_headers, body = _request("https://api.github.com/rate_limit", build_github_headers(token))
     except urllib.error.URLError as e:
-        print(f"[token check] Could not reach GitHub API: {e}")
+        logger.info("[token check] Could not reach GitHub API: %s", e)
         return
 
     if status == 401:
@@ -122,7 +134,7 @@ def _log_token_status(token=None):
             )
 
     if status != 200:
-        print(f"[token check] Unexpected status {status} from /rate_limit: {body[:200]!r}")
+        logger.info("[token check] Unexpected status %s from /rate_limit: %r", status, body[:200])
         return
 
     # Parse the JSON body for richer quota info (headers only carry a subset).
@@ -145,7 +157,7 @@ def _log_token_status(token=None):
         reset_str = "n/a"
 
     auth_status = "AUTHENTICATED" if token else "UNAUTHENTICATED"
-    print(f"[token check] {auth_status} — limit={limit}, remaining={remaining}, reset={reset_str}")
+    logger.info("[token check] %s — limit=%s, remaining=%s, reset=%s", auth_status, limit, remaining, reset_str)
 
     if remaining == "0":
         msg = f"[token check] Rate-limit quota EXHAUSTED (remaining=0). Resets at {reset_str}."
@@ -252,7 +264,7 @@ def github_request(url, token=None, method="GET", payload=None, max_retries=8):
             # Network-level failure (DNS, connection reset, timeout): not a rate limit, so fail hard.
             raise RuntimeError(f"GitHub API request to {method} {url} failed: {error}") from error
 
-        print(f"[{label}] {method} {url} → HTTP {status}")
+        logger.info("[%s] %s %s → HTTP %s", label, method, url, status)
         # Rate-limit headers are absent on 401 (auth rejected before rate-limit machinery runs).
         if status != 401:
             _log_rate_limit_headers(response_headers, prefix=label)
@@ -260,7 +272,7 @@ def github_request(url, token=None, method="GET", payload=None, max_retries=8):
         wait = _rate_limit_wait(status, response_headers, body, attempt)
         if wait is not None:
             next_label = f"retry {attempt + 1}/{max_retries - 1}"
-            print(f"[{label}] Rate limited (HTTP {status}) — waiting {wait}s before {next_label}")
+            logger.info("[%s] Rate limited (HTTP %s) — waiting %ss before %s", label, status, wait, next_label)
             time.sleep(wait)
             continue
 


### PR DESCRIPTION
# What happened?

The "Check new failures / process bad commit reports" job in PR comment CI was broken by https://github.com/huggingface/transformers/pull/47474

That job captures stdout from `utils/process_bad_commit_report.py` into `REPORT_TEXT`, then embeds `REPORT_TEXT` into a Slack JSON payload. The GitHub API helper was printing token/rate-limit diagnostics to stdout, so `REPORT_TEXT` contained extra raw multi-line diagnostic text before the actual report.

When the workflow interpolated that into:

```
  "text": "${{ env.REPORT_TEXT }}"
```

The raw newlines made the Slack payload invalid JSON. The Slack action failed with:

```
passed in payload was invalid JSON
Error: Need to provide valid JSON payload
```

# What does this PR do?

Route GitHub API diagnostic messages through logging to stderr instead of stdout.

This keeps rate-limit/token diagnostics visible in CI logs while avoiding pollution of stdout values captured by workflow steps, such as Slack report payloads.