### PR TITLE
Fix TDT loss failing on torch below 2.8

### DIFF
--- a/src/transformers/loss/loss_tdt.py
+++ b/src/transformers/loss/loss_tdt.py
@@ -80,7 +80,9 @@ def tdt_loss(
     blank_log_probs = token_log_probs[:, :, :, blank_token_id]
 
     if max_u > 1:
-        targets_expanded = targets.unsqueeze(1).expand(-1, max_t, -1)  # (batch, T, U_labels)
+        # torch.gather only accepts an int64 index before torch 2.8, and callers
+        # legitimately pass int32 targets (ParakeetForTDTLoss casts to int32 itself).
+        targets_expanded = targets.long().unsqueeze(1).expand(-1, max_t, -1)  # (batch, T, U_labels)
         label_log_probs = torch.gather(
             token_log_probs[:, :, : max_u - 1, :],  # (batch, T, U-1, vocab)
             dim=3,

--- a/src/transformers/loss/loss_tdt.py
+++ b/src/transformers/loss/loss_tdt.py
@@ -80,8 +80,8 @@ def tdt_loss(
     blank_log_probs = token_log_probs[:, :, :, blank_token_id]
 
     if max_u > 1:
-        # torch.gather only accepts an int64 index before torch 2.8, and callers
-        # legitimately pass int32 targets (ParakeetForTDTLoss casts to int32 itself).
+        # torch.gather only accepts an int64 index before torch 2.8, and targets can
+        # legitimately arrive as int32 from a caller of tdt_loss.
         targets_expanded = targets.long().unsqueeze(1).expand(-1, max_t, -1)  # (batch, T, U_labels)
         label_log_probs = torch.gather(
             token_log_probs[:, :, : max_u - 1, :],  # (batch, T, U-1, vocab)
@@ -185,7 +185,7 @@ def ParakeetForTDTLoss(
     return tdt_loss(
         token_logits=token_logits,
         duration_logits=duration_logits,
-        targets=labels.to(device).int(),
+        targets=labels.to(device),
         logit_lengths=logit_lengths.to(device).int(),
         target_lengths=label_lengths.to(device).int(),
         blank_token_id=blank_token_id,

--- a/tests/models/parakeet/test_modeling_parakeet.py
+++ b/tests/models/parakeet/test_modeling_parakeet.py
@@ -43,7 +43,7 @@ if is_torch_available():
         ParakeetTDTConfig,
     )
     from transformers.loss.loss_rnnt import rnnt_loss
-    from transformers.loss.loss_tdt import tdt_loss
+    from transformers.loss.loss_tdt import ParakeetForTDTLoss, tdt_loss
 
 
 FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures/parakeet"
@@ -125,26 +125,38 @@ class TDTLossTest(unittest.TestCase):
         self.assertFalse(torch.all(inputs["token_logits"].grad == 0))
         self.assertFalse(torch.all(inputs["duration_logits"].grad == 0))
 
-    def test_tdt_loss_accepts_int32_targets(self):
-        # ParakeetForTDTLoss casts the targets to int32, which torch.gather only started accepting in torch 2.8.
-        from transformers.loss.loss_tdt import ParakeetForTDTLoss
-
+    def test_tdt_loss_accepts_int32_and_int64_targets(self):
+        # Anything reaching the gather as int32 used to raise below torch 2.8, so cover both entry
+        # points (the model's labels= path and a direct tdt_loss call) and both integer dtypes.
         batch, max_t, max_u, vocab = 2, 6, 4, 8
         durations = [0, 1, 2]
         token_logits = torch.randn(batch, max_t, max_u, vocab + 1)
         duration_logits = torch.randn(batch, max_t, max_u, len(durations))
-        labels = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.int32)
+        targets = torch.tensor([[1, 2, 3], [4, 5, 6]])
 
-        loss = ParakeetForTDTLoss(
-            token_logits=token_logits,
-            duration_logits=duration_logits,
-            labels=labels,
-            logit_lengths=torch.tensor([max_t, max_t]),
-            label_lengths=torch.tensor([3, 3]),
-            blank_token_id=vocab,
-            durations=durations,
-        )
-        self.assertTrue(torch.isfinite(loss))
+        for dtype in (torch.int32, torch.int64):
+            with self.subTest(dtype=dtype):
+                loss = ParakeetForTDTLoss(
+                    token_logits=token_logits,
+                    duration_logits=duration_logits,
+                    labels=targets.to(dtype),
+                    logit_lengths=torch.tensor([max_t, max_t]),
+                    label_lengths=torch.tensor([3, 3]),
+                    blank_token_id=vocab,
+                    durations=durations,
+                )
+                self.assertTrue(torch.isfinite(loss))
+
+                loss = tdt_loss(
+                    token_logits=token_logits,
+                    duration_logits=duration_logits,
+                    targets=targets.to(dtype),
+                    logit_lengths=torch.tensor([max_t, max_t]),
+                    target_lengths=torch.tensor([3, 3]),
+                    blank_token_id=vocab,
+                    durations=durations,
+                )
+                self.assertTrue(torch.isfinite(loss))
 
 
 @require_torch

--- a/tests/models/parakeet/test_modeling_parakeet.py
+++ b/tests/models/parakeet/test_modeling_parakeet.py
@@ -125,6 +125,27 @@ class TDTLossTest(unittest.TestCase):
         self.assertFalse(torch.all(inputs["token_logits"].grad == 0))
         self.assertFalse(torch.all(inputs["duration_logits"].grad == 0))
 
+    def test_tdt_loss_accepts_int32_targets(self):
+        # ParakeetForTDTLoss casts the targets to int32, which torch.gather only started accepting in torch 2.8.
+        from transformers.loss.loss_tdt import ParakeetForTDTLoss
+
+        batch, max_t, max_u, vocab = 2, 6, 4, 8
+        durations = [0, 1, 2]
+        token_logits = torch.randn(batch, max_t, max_u, vocab + 1)
+        duration_logits = torch.randn(batch, max_t, max_u, len(durations))
+        labels = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.int32)
+
+        loss = ParakeetForTDTLoss(
+            token_logits=token_logits,
+            duration_logits=duration_logits,
+            labels=labels,
+            logit_lengths=torch.tensor([max_t, max_t]),
+            label_lengths=torch.tensor([3, 3]),
+            blank_token_id=vocab,
+            durations=durations,
+        )
+        self.assertTrue(torch.isfinite(loss))
+
 
 @require_torch
 @require_torchaudio


### PR DESCRIPTION
## What does this PR do?

On torch below 2.8, `ParakeetForTDT.forward(..., labels=...)` raises before it can return a loss, for every label dtype:

```
RuntimeError: gather(): Expected dtype int64 for index
```

Two things combine. `ParakeetForTDTLoss` casts the targets with `.int()` unconditionally, and `tdt_loss` then passes them as the `index` argument of `torch.gather`. `gather` only accepted int64 indices until pytorch/pytorch#151822 relaxed the check to accept int32 as well, which shipped in torch 2.8. `setup.py` declares `torch>=2.5`, so on 2.5, 2.6 and 2.7 the documented `labels=` training path fails on the first step, on any input. On 2.8 and later it happens to work.

That `.int()` looks carried over from `ParakeetForRNNTLoss`, where it is load bearing: `torchaudio.functional.rnnt_loss` requires int32. `tdt_loss` is pure torch and has no such requirement, so this PR drops it. The int64 cast at the gather stays, so that a direct `tdt_loss` call with int32 targets works too. Measured on torch 2.5.1, against this branch's base commit:

| | base | dropping `.int()` only | this PR |
|---|---|---|---|
| `ParakeetForTDTLoss`, int64 labels | raises | ok | ok |
| `ParakeetForTDTLoss`, int32 labels | raises | raises | ok |
| `tdt_loss`, int64 targets | ok | ok | ok |
| `tdt_loss`, int32 targets | raises | raises | ok |

The `.int()` casts on `logit_lengths` and `label_lengths` are left alone, since those tensors are only used for arithmetic and advanced indexing, and both accept int32 on torch 2.5. Happy to drop them as well if you would rather see the casts gone entirely.

Minimal reproduction, run on the base commit with torch 2.5.1:

```python
import torch
from transformers.loss.loss_tdt import ParakeetForTDTLoss

batch, max_t, max_u, vocab = 2, 6, 4, 8
durations = [0, 1, 2]

ParakeetForTDTLoss(
    token_logits=torch.randn(batch, max_t, max_u, vocab + 1),
    duration_logits=torch.randn(batch, max_t, max_u, len(durations)),
    labels=torch.tensor([[1, 2, 3], [4, 5, 6]]),
    logit_lengths=torch.tensor([max_t, max_t]),
    label_lengths=torch.tensor([3, 3]),
    blank_token_id=vocab,
    durations=durations,
)
```

The same happens through the model, since `ParakeetForTDT.forward` routes `labels` into this function.

One caveat about the test. Because torch 2.8 accepts int32 gather indices, it passes with and without the fix on a recent torch, so it will not turn CI red here. It fails on torch 2.5 through 2.7. I kept it because it pins down the target dtype contract of the loss, but I am happy to drop it if you would rather not carry a test CI cannot enforce.

I hit this while attaching a second head to `parakeet-tdt-0.6b-v3` and training the transducer jointly with it.

## Before submitting

- [ ] This PR fixes a typo or improves the docs.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [ ] Was this discussed via a GitHub issue? I did not open one, since the failure is deterministic and the fix is small. Happy to file one if you prefer.
- [ ] Did you make sure to update the documentation? Not applicable, no public API change.
- [x] Did you write any new necessary tests? Widened the TDT loss tests to cover both entry points, the model's `labels=` path and a direct `tdt_loss` call, with int32 and int64 targets. See the caveat above about which torch versions it can fail on.

## Who can review?

@nithinraok, since you added Parakeet, and @eustlb as the audio maintainer who last touched `loss_tdt.py`.
