### PR TITLE
Transform paths and repeat joining for response parsing

### DIFF
--- a/docs/source/en/chat_response_parsing.md
+++ b/docs/source/en/chat_response_parsing.md
@@ -255,6 +255,7 @@ Each field supports several keys. We can divide these into two types. First, the
 | `close`         | str or list[str]   | Literal string (or list of strings) that closes this region. Omit to run to end-of-stream.    |
 | `close_pattern` | str (regex)        | Regex alternative to `close`. Named groups become capture variables available to `transform`. |
 | `repeats`       | bool               | If true, the field is a list and each match appends. Default `false`.                         |
+| `join`          | str                | With `repeats`, concatenate matches into one string with this separator instead of a list.    |
 | `optional`      | bool               | If false and the region never matches, we raise an error. Default `true`.                     |
 
 A field should have **either** `open` or `open_pattern`, but not both, and the same is true for `close` and `close_pattern`.
@@ -274,6 +275,20 @@ multiple tool calls simultaneously:
 '<tool_call>{"name": "a", ...}</tool_call><tool_call>{"name": "b", ...}</tool_call>'
 # Returns `"tool_calls": [{... "a" ...}, {... "b" ...}]` in a template with repeats: true
 ```
+
+Not every repeated field should become a list, though. Some models emit several `thinking` or `content`
+blocks in a single message, and the natural output for those is one concatenated string. Setting `join`
+(a separator string, often just `""`) switches a `repeats` field from collecting a list to concatenating
+its matches:
+
+```python
+field = {"thinking": {"open": "<think>", "close": "</think>", "repeats": True, "join": "\n"}}
+input = "<think>first</think>...<think>second</think>"
+# Returns: {"thinking": "first\nsecond"}
+```
+
+Each match of a `join` field must parse to a string. When streaming, `region_close` still carries each
+block's own value; the separator only appears in the final message dict.
 
 Finally, you can specify `optional: false` for fields that must be present. If such a field is missing,
 we raise an error instead of just returning a message dict without it.
@@ -461,6 +476,23 @@ becomes (note `repeats: True` makes `tool_calls` a list):
 A whole-string placeholder like `"{content}"` returns the looked-up value with its type preserved — so above, the
 parsed JSON dict slots in directly as the value of `function`. A placeholder must be the entire string: mixing
 text and placeholders (`"abc {name} def"`) is not permitted. They're not f-strings!
+
+Placeholders can also take a dotted path like `"{content.args}"`, which looks up `content` and then descends into
+the `args` key of the parsed dict. This is how you reshape tool-call bodies whose key names don't match our
+standard format. For example, a model that emits `{"name": ..., "args": ...}` needs `args` renamed to `arguments`:
+
+```python
+"tool_calls": {
+    "open": "<tool>",
+    "close": "</tool>",
+    "repeats": True,
+    "content": "json",
+    "transform": {"type": "function", "function": {"name": "{content.name}", "arguments": "{content.args}"}},
+},
+```
+
+A path that doesn't resolve (here, a tool call whose body lacks `args`) raises an error rather than emitting a
+malformed tool call.
 
 `transform` is quite versatile, which becomes necessary when the model output has a wildly different format
 to our standard API. GPT-OSS is a good example - it embeds the function name in the channel header rather than in

--- a/src/transformers/utils/chat_parsing/content_parsers.py
+++ b/src/transformers/utils/chat_parsing/content_parsers.py
@@ -159,12 +159,13 @@ def parse_content(text: str, name: str, args: dict) -> Any:
     return CONTENT_PARSERS[name](text, args)
 
 
-_PLACEHOLDER = re.compile(r"\{(\w+)\}")
+_PLACEHOLDER = re.compile(r"\{(\w+(?:\.\w+)*)\}")
 
 
 def _apply_transform(transform: Any, scope: dict) -> Any:
     """Recursively walk a transform template, which is used to restructure
-    parsed output into the actual shape we want."""
+    parsed output into the actual shape we want. A dotted placeholder like
+    `{content.args}` descends into keys of the looked-up value."""
     if isinstance(transform, dict):
         return {k: _apply_transform(v, scope) for k, v in transform.items()}
     if isinstance(transform, list):
@@ -174,10 +175,18 @@ def _apply_transform(transform: Any, scope: dict) -> Any:
     whole = _PLACEHOLDER.fullmatch(transform)
     if not whole:
         return transform
-    key = whole.group(1)
-    if key not in scope:
-        raise KeyError(f"transform placeholder '{{{key}}}' is not defined. Available: {sorted(scope)}")
-    return scope[key]
+    path = whole.group(1)
+    root, *keys = path.split(".")
+    if root not in scope:
+        raise KeyError(f"transform placeholder '{{{path}}}' is not defined. Available: {sorted(scope)}")
+    value = scope[root]
+    for key in keys:
+        if not isinstance(value, dict):
+            raise ValueError(f"transform placeholder '{{{path}}}' cannot index into {type(value).__name__} at '{key}'")
+        if key not in value:
+            raise ValueError(f"transform placeholder '{{{path}}}' is missing key '{key}'. Available: {sorted(value)}")
+        value = value[key]
+    return value
 
 
 def validate_transform_strings(scope: str, transform: Any) -> None:

--- a/src/transformers/utils/chat_parsing/response_parser.py
+++ b/src/transformers/utils/chat_parsing/response_parser.py
@@ -359,7 +359,15 @@ class ResponseParser:
         value = process_field(self._body, field, self._captures)
         if self._tool_params:
             value = self._coerce_tool_calls(value)
-        if field.repeats:
+        if field.join is not None:
+            if not isinstance(value, str):
+                raise ValueError(
+                    f"Field '{field.name}': 'join' requires each match to parse to a string, "
+                    f"got {type(value).__name__}."
+                )
+            previous = self._output.get(self._current)
+            self._output[self._current] = value if previous is None else previous + field.join + value
+        elif field.repeats:
             self._output.setdefault(self._current, []).append(value)
         else:
             self._output[self._current] = value

--- a/src/transformers/utils/chat_parsing/response_templates.py
+++ b/src/transformers/utils/chat_parsing/response_templates.py
@@ -39,6 +39,7 @@ class ResponseTemplateField:
     content: str
     content_args: dict
     repeats: bool
+    join: str | None
     optional: bool
     transform: Any
     transform_each: bool
@@ -147,6 +148,7 @@ def _build_field(name: str, field: dict) -> ResponseTemplateField:
         "content",
         "content_args",
         "repeats",
+        "join",
         "optional",
         "transform",
         "transform_each",
@@ -161,6 +163,11 @@ def _build_field(name: str, field: dict) -> ResponseTemplateField:
         raise ValueError(f"{scope}: unknown content parser '{content}'. Available: {sorted(CONTENT_PARSERS)}")
     open_re, open_literals, open_literal_can_extend = _compile_anchor(scope, field, "open", "open_pattern")
     close_re, close_literals, close_literal_can_extend = _compile_anchor(scope, field, "close", "close_pattern")
+    join = field.get("join")
+    if join is not None and not isinstance(join, str):
+        raise ValueError(f"{scope}: 'join' must be a string, got {type(join).__name__}")
+    if join is not None and not field.get("repeats", False):
+        raise ValueError(f"{scope}: 'join' requires 'repeats': true")
     transform = field.get("transform")
     transform_each = field.get("transform_each", False)
     if not isinstance(transform_each, bool):
@@ -195,6 +202,7 @@ def _build_field(name: str, field: dict) -> ResponseTemplateField:
         content=content,
         content_args=field.get("content_args", {}),
         repeats=field.get("repeats", False),
+        join=join,
         optional=field.get("optional", True),
         transform=transform,
         transform_each=transform_each,

--- a/tests/utils/test_chat_parsing.py
+++ b/tests/utils/test_chat_parsing.py
@@ -174,6 +174,37 @@ gemma4_template = {
 }
 
 
+# Inkling (TMLv0) frames every block as <|message_model|>[author-name]<|content_KIND|>body<|end_message|>;
+# the generation prompt pre-writes the first <|message_model|>, so each open treats the header as optional.
+inkling_template = {
+    "defaults": {"role": "assistant"},
+    "start_anchor": "<|message_model|>",
+    "fields": {
+        "thinking": {
+            "open_pattern": r"(?:<\|message_model\|>)?[^<]*<\|content_thinking\|>",
+            "close": "<|end_message|>",
+            "repeats": True,
+            "join": "",
+            "content_args": {"strip": False},
+        },
+        "content": {
+            "open_pattern": r"(?:<\|message_model\|>)?[^<]*<\|content_text\|>",
+            "close": "<|end_message|>",
+            "repeats": True,
+            "join": "",
+            "content_args": {"strip": False},
+        },
+        "tool_calls": {
+            "open_pattern": r"(?:<\|message_model\|>)?[^<]*<\|content_invoke_tool_json\|>",
+            "close": "<|end_message|>",
+            "repeats": True,
+            "content": "json",
+            "transform": {"type": "function", "function": {"name": "{content.name}", "arguments": "{content.args}"}},
+        },
+    },
+}
+
+
 class ChatResponseTemplateParserTest(unittest.TestCase):
     def test_response_template_save_load(self):
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
@@ -578,6 +609,133 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             },
         )
 
+    def test_inkling_multi_block_message(self):
+        model_out = (
+            "<|content_thinking|>Consider the weather.<|end_message|>"
+            "<|message_model|><|content_thinking|> Tokyo, probably.<|end_message|>"
+            "<|message_model|><|content_text|>Checking the weather now.<|end_message|>"
+            "<|message_model|>get_weather<|content_invoke_tool_json|>"
+            '{"name":"get_weather","args":{"city":"Tokyo","units":"C"}}<|end_message|>'
+            "<|content_model_end_sampling|>"
+        )
+        prefix = "<|message_system|><|content_text|>Thinking effort level: 0.9<|end_message|><|message_model|>"
+        self.assertEqual(
+            parse_response(model_out, inkling_template, prefix=prefix),
+            {
+                "role": "assistant",
+                "thinking": "Consider the weather. Tokyo, probably.",
+                "content": "Checking the weather now.",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": {"city": "Tokyo", "units": "C"}},
+                    }
+                ],
+            },
+        )
+
+    def test_transform_dotted_paths(self):
+        template_spec = {
+            "defaults": {"role": "assistant"},
+            "start_anchor": "<|assistant|>",
+            "fields": {
+                "tool_calls": {
+                    "open": "<tool>",
+                    "close": "</tool>",
+                    "repeats": True,
+                    "content": "json",
+                    "transform": {
+                        "type": "function",
+                        "function": {"name": "{content.name}", "arguments": "{content.args}"},
+                    },
+                },
+            },
+        }
+        model_out = '<tool>{"name": "get_weather", "args": {"city": {"id": 7}}}</tool>'
+        self.assertEqual(
+            parse_response(model_out, template_spec, prefix="")["tool_calls"],
+            [{"type": "function", "function": {"name": "get_weather", "arguments": {"city": {"id": 7}}}}],
+        )
+
+    def test_transform_dotted_paths_with_transform_each(self):
+        template_spec = {
+            "defaults": {"role": "assistant"},
+            "start_anchor": "<|assistant|>",
+            "fields": {
+                "tool_calls": {
+                    "open": "<actions>",
+                    "close": "</actions>",
+                    "content": "json",
+                    "transform_each": True,
+                    "transform": {"type": "function", "function": {"name": "{fn.name}", "arguments": "{fn.args}"}},
+                },
+            },
+        }
+        model_out = '<actions>[{"fn": {"name": "a", "args": {"x": 1}}}, {"fn": {"name": "b", "args": {}}}]</actions>'
+        self.assertEqual(
+            parse_response(model_out, template_spec, prefix="")["tool_calls"],
+            [
+                {"type": "function", "function": {"name": "a", "arguments": {"x": 1}}},
+                {"type": "function", "function": {"name": "b", "arguments": {}}},
+            ],
+        )
+
+    def test_transform_dotted_path_errors(self):
+        def spec_with(transform):
+            return {
+                "start_anchor": "<|assistant|>",
+                "fields": {"x": {"open": "<x>", "close": "</x>", "content": "json", "transform": transform}},
+            }
+
+        with self.assertRaisesRegex(ValueError, "missing key 'args'"):
+            parse_response('<x>{"name": "n"}</x>', spec_with({"a": "{content.args}"}), prefix="")
+        with self.assertRaisesRegex(ValueError, "cannot index into str"):
+            parse_response('<x>{"name": "n"}</x>', spec_with({"a": "{content.name.x}"}), prefix="")
+        with self.assertRaises(KeyError):
+            parse_response("<x>{}</x>", spec_with({"a": "{missing}"}), prefix="")
+
+    def test_transform_dotted_mixed_string_rejected(self):
+        template_spec = {
+            "start_anchor": "<|assistant|>",
+            "fields": {"x": {"open": "<x>", "close": "</x>", "transform": {"v": "pre {content.args}"}}},
+        }
+        with self.assertRaisesRegex(ValueError, "mixes"):
+            parse_response("", template_spec, prefix="")
+
+    def test_join_concatenates_repeated_matches(self):
+        template_spec = {
+            "defaults": {"role": "assistant"},
+            "start_anchor": "<|assistant|>",
+            "fields": {
+                "thinking": {"open": "<think>", "close": "</think>", "repeats": True, "join": " "},
+                "content": {"repeats": True, "join": " "},
+            },
+        }
+        self.assertEqual(
+            parse_response("<think>first</think>middle<think>second</think>done", template_spec, prefix=""),
+            {"role": "assistant", "thinking": "first second", "content": "middle done"},
+        )
+        self.assertEqual(
+            parse_response("<think>only</think>", template_spec, prefix=""),
+            {"role": "assistant", "thinking": "only"},
+        )
+
+    def test_join_validation(self):
+        no_repeats = {"start_anchor": "a", "fields": {"x": {"open": "<x>", "close": "</x>", "join": ""}}}
+        with self.assertRaisesRegex(ValueError, "requires 'repeats'"):
+            parse_response("", no_repeats, prefix="")
+        bad_type = {"start_anchor": "a", "fields": {"x": {"open": "<x>", "close": "</x>", "repeats": True, "join": 7}}}
+        with self.assertRaisesRegex(ValueError, "must be a string"):
+            parse_response("", bad_type, prefix="")
+
+    def test_join_requires_string_matches(self):
+        template_spec = {
+            "start_anchor": "a",
+            "fields": {"x": {"open": "<x>", "close": "</x>", "repeats": True, "join": "", "content": "json"}},
+        }
+        with self.assertRaisesRegex(ValueError, "parse to a string"):
+            parse_response("<x>{}</x>", template_spec, prefix="")
+
     def test_optional_false_raises_when_missing(self):
         template_spec = {
             "defaults": {"role": "assistant"},
@@ -840,6 +998,19 @@ _STREAMING_FIXTURES = [
         "gemma4",
         gemma4_template,
         '<|channel>thought\nhi<channel|><|tool_call>call:foo{a:1,b:<|"|>bar<|"|>}<tool_call|>',
+    ),
+    (
+        # Exercises `join` fields (two thinking blocks) and dotted transform paths.
+        "inkling",
+        inkling_template,
+        (
+            "<|content_thinking|>Consider the weather.<|end_message|>"
+            "<|message_model|><|content_thinking|> Tokyo, probably.<|end_message|>"
+            "<|message_model|><|content_text|>Checking now.<|end_message|>"
+            "<|message_model|>get_weather<|content_invoke_tool_json|>"
+            '{"name":"get_weather","args":{"city":"Tokyo"}}<|end_message|>'
+            "<|content_model_end_sampling|>"
+        ),
     ),
 ]
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47648)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47648)
<!-- ci-dashboard-badge:end -->

Two smallish features for the response parser that shouldn't break backward compatibility! This is based on PR #47529 though - it shouldn't be merged until that one is in, and we'll need a rebase. The diff will be very messy until then too, so reviews should probably wait.

Edit: #47529 merged, rebase done