### PR TITLE
fix(distributed): gate torch.distributed.checkpoint imports on _torch_distributed_available

### DIFF
--- a/src/transformers/distributed/utils.py
+++ b/src/transformers/distributed/utils.py
@@ -29,7 +29,7 @@ if is_torch_available():
 else:
     _torch_distributed_available = False
 
-if is_torch_available() and is_torch_greater_or_equal("2.7"):
+if _torch_distributed_available and is_torch_greater_or_equal("2.7"):
     import torch.distributed.checkpoint as dcp
     from torch.distributed.checkpoint.hf_storage import HuggingFaceStorageWriter
     from torch.distributed.checkpoint.state_dict import (


### PR DESCRIPTION
Gates torch.distributed.checkpoint module imports in src/transformers/distributed/utils.py on _torch_distributed_available rather than solely checking is_torch_available(). Prevents ModuleNotFoundError when importing transformers components (such as AutoImageProcessor) under PyTorch builds compiled without C10d / torch.distributed support (fixes #47603).