### PR TITLE
Allow bnb_4bit_compute_dtype override for pre-quantized bnb checkpoints

### DIFF
--- a/src/transformers/quantizers/auto.py
+++ b/src/transformers/quantizers/auto.py
@@ -138,6 +138,7 @@ LOADING_ATTRIBUTES_CONFIG_TYPES = (
     Mxfp4Config,
     MetalConfig,
     FineGrainedFP8Config,
+    BitsAndBytesConfig,
 )
 
 logger = logging.get_logger(__name__)

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -569,6 +569,9 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
         else:
             return None
 
+    def get_loading_attributes(self):
+        return {"bnb_4bit_compute_dtype": self.bnb_4bit_compute_dtype}
+
     def to_dict(self) -> dict[str, Any]:
         """
         Serializes this instance to a Python dictionary. Returns:

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -836,6 +836,7 @@ class Bnb4BitTestBasicConfigTest(unittest.TestCase):
 
     def test_bnb_4bit_compute_dtype_override(self):
         from transformers.quantizers.auto import AutoHfQuantizer
+
         saved_config = BitsAndBytesConfig(
             load_in_4bit=True,
             bnb_4bit_compute_dtype=torch.bfloat16,
@@ -844,10 +845,35 @@ class Bnb4BitTestBasicConfigTest(unittest.TestCase):
             load_in_4bit=True,
             bnb_4bit_compute_dtype=torch.float16,
         )
-        merged = AutoHfQuantizer.merge_quantization_configs(
-            saved_config, requested_config
-        )
+        merged = AutoHfQuantizer.merge_quantization_configs(saved_config, requested_config)
         self.assertEqual(merged.bnb_4bit_compute_dtype, torch.float16)
+
+    def test_bnb_4bit_compute_dtype_override_on_module(self):
+        import bitsandbytes as bnb
+        import torch.nn as nn
+
+        from transformers.integrations.bitsandbytes import replace_with_bnb_linear
+
+        class TinyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fc = nn.Linear(16, 16)
+
+        saved_config = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_compute_dtype=torch.bfloat16)
+        requested_config = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_compute_dtype=torch.float16)
+
+        from transformers.quantizers.auto import AutoHfQuantizer
+
+        merged_config = AutoHfQuantizer.merge_quantization_configs(saved_config, requested_config)
+
+        model = TinyModel()
+        model = replace_with_bnb_linear(model, quantization_config=merged_config)
+
+        linear4bit_modules = [m for m in model.modules() if isinstance(m, bnb.nn.Linear4bit)]
+        self.assertTrue(len(linear4bit_modules) > 0)
+        for m in linear4bit_modules:
+            self.assertEqual(m.compute_dtype, torch.float16)
+
 
 @require_bitsandbytes
 @require_accelerate

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -834,6 +834,20 @@ class Bnb4BitTestBasicConfigTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "load_in_4bit and load_in_8bit are both True"):
             quantization_config.load_in_8bit = True
 
+    def test_bnb_4bit_compute_dtype_override(self):
+        from transformers.quantizers.auto import AutoHfQuantizer
+        saved_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_compute_dtype=torch.bfloat16,
+        )
+        requested_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_compute_dtype=torch.float16,
+        )
+        merged = AutoHfQuantizer.merge_quantization_configs(
+            saved_config, requested_config
+        )
+        self.assertEqual(merged.bnb_4bit_compute_dtype, torch.float16)
 
 @require_bitsandbytes
 @require_accelerate


### PR DESCRIPTION
# What does this PR do?

Fixes #47378

When loading a pre-quantized bitsandbytes checkpoint, a user-passed
`bnb_4bit_compute_dtype` was silently ignored — the checkpoint's saved
value always won, with no way to override it at load time.

## Root cause

`BitsAndBytesConfig` had no `get_loading_attributes()` method and
wasn't included in `LOADING_ATTRIBUTES_CONFIG_TYPES` in
`quantizers/auto.py`. That's the mechanism `merge_quantization_configs()`
uses to decide which fields can be overridden for a pre-quantized
checkpoint — GPTQConfig and AwqConfig already support this, bnb didn't.

## Fix

- Added `get_loading_attributes()` to `BitsAndBytesConfig`, returning
  `bnb_4bit_compute_dtype`.
- Added `BitsAndBytesConfig` to `LOADING_ATTRIBUTES_CONFIG_TYPES`.

Only `bnb_4bit_compute_dtype` is overridable; other bnb settings stay
locked to the saved checkpoint.

## Testing

Added two tests to `test_4bit.py`, both passing locally:
- `test_bnb_4bit_compute_dtype_override` — checks the merged config
  picks up the requested dtype.
- `test_bnb_4bit_compute_dtype_override_on_module` — checks the real
  `Linear4bit.compute_dtype` reflects it after module construction.

Discussed with the original reporter on #47378 before opening this —
see the comment thread there.

## Before submitting
- [x] Read the contributor guideline and PR checks
- [x] Discussed/approved via GitHub issue: https://github.com/huggingface/transformers/issues/47378
- [x] Wrote new tests

## Who can review?
@SunMarc