### PR TITLE
fix: correct typos in source and tests

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1475,7 +1475,7 @@ class Cache:
     def get_max_length(self, layer_idx: int | None = None) -> int:
         """
         Returns the maximum length of the cache. If `layer_idx` is not provided (default), this returns the maximum
-        accross all layers. Otherwise, return the maximum supported value for the given layer.
+        across all layers. Otherwise, return the maximum supported value for the given layer.
         A value of `-1` means no maximum, or undefined maximum, e.g. for dynamic attention layers that can grow indefinitely,
         or linear attention layer that do not have a sequence length dimension.
         """

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1990,7 +1990,7 @@ class PreTrainedModel(
     def _can_set_attn_implementation(cls) -> bool:
         """Detect whether the class supports setting its attention implementation dynamically. Inspects the module
         source as a heuristic, which avoids maintaining yet another property flag. Instead, the flag is set dynamically
-        on the first succesful call.
+        on the first successful call.
         """
         # Early return if there is a cached value
         cached_value = getattr(cls, "_can_set_attn_implementation_cached_value", None)
@@ -2019,7 +2019,7 @@ class PreTrainedModel(
     def _can_set_experts_implementation(cls) -> bool:
         """Detect whether the class supports setting its experts implementation dynamically. Inspects the module source
         as a heuristic, which avoids maintaining yet another property flag. Instead, the flag is set dynamically
-        on the first succesful call.
+        on the first successful call.
         """
         # Early return if there is a cached value
         cached_value = getattr(cls, "_can_set_experts_implementation_cached_value", None)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1594,7 +1594,7 @@ class ModelTesterMixin(ExportTesterMixin):
         self,
     ):
         """
-        Tests that the model can run forward pass when config is intialized without common attributes.
+        Tests that the model can run forward pass when config is initialized without common attributes.
         We expect that these attributes have a default value and will not cause errors. See #41541
         where the attributes were removed from `PreTrainedConfig` and moved to each model's config
         class.

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -3173,7 +3173,7 @@ class TestAttentionImplementation(unittest.TestCase):
         # Simulate the "module cleared from sys.modules" case (test cleanup, REPL).
         from transformers.models.llama.modeling_llama import LlamaModel
 
-        # The method _can_set_attn_implementation caches the result on a succesful call, so we need to clear the cache
+        # The method _can_set_attn_implementation caches the result on a successful call, so we need to clear the cache
         if hasattr(LlamaModel, "_can_set_attn_implementation_cached_value"):
             delattr(LlamaModel, "_can_set_attn_implementation_cached_value")
 


### PR DESCRIPTION
- succesful → successful (3x)
- intialized → initialized
- accross → across