### PR TITLE
Fix missing github_utils.py download in PR CI dashboard workflow

### DIFF
--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -25,6 +25,10 @@ jobs:
             -H "Accept: application/vnd.github.raw" \
             "/repos/${GITHUB_REPOSITORY}/contents/utils/update_pr_ci_dashboard_recap.py?ref=${SCRIPT_REF}" \
             > update_pr_ci_dashboard_recap.py
+          gh api \
+            -H "Accept: application/vnd.github.raw" \
+            "/repos/${GITHUB_REPOSITORY}/contents/utils/github_utils.py?ref=${SCRIPT_REF}" \
+            > github_utils.py
 
       - name: Update PR CI recap
         env:


### PR DESCRIPTION
## Summary

- `update_pr_ci_dashboard_recap.py` imports `github_request` from `github_utils`, but the workflow only downloaded the main script, causing `ModuleNotFoundError: No module named 'github_utils'`
- Now both `update_pr_ci_dashboard_recap.py` and `github_utils.py` are fetched from the same `SCRIPT_REF` (the workflow's commit SHA on `main`)

## Test plan
- [ ] Re-run the failed workflow after merging — should no longer error on import
