### PR TITLE
Fix DBRX MoE hidden size and expert GLU transposes

### DIFF
--- a/src/transformers/models/dbrx/configuration_dbrx.py
+++ b/src/transformers/models/dbrx/configuration_dbrx.py
@@ -74,9 +74,9 @@ class DbrxFFNConfig(PreTrainedConfig):
     ffn_hidden_size: int = 3584
     moe_num_experts: int = 4
     moe_top_k: int = 1
-    moe_jitter_eps: float | None = None
-    moe_loss_weight: float = 0.01
-    moe_normalize_expert_weights: float | None = 1.0
+    moe_jitter_eps: float | int | None = None
+    moe_loss_weight: float | int = 0.01
+    moe_normalize_expert_weights: float | int | None = 1.0
 
     def __post_init__(self, **kwargs):
         if self.ffn_act_fn is None:
@@ -162,6 +162,10 @@ class DbrxConfig(PreTrainedConfig):
             self.ffn_config = DbrxFFNConfig()
         elif isinstance(self.ffn_config, dict):
             self.ffn_config = DbrxFFNConfig(**self.ffn_config)
+
+        # The experts read/write hidden states, so `ffn_config.hidden_size` must mirror the model's
+        # `hidden_size`. Checkpoints do not store it, hence we always propagate it from `d_model`.
+        self.ffn_config.hidden_size = self.d_model
 
         self.num_key_value_heads = self.attn_config.kv_n_heads
         super().__post_init__(**kwargs)

--- a/src/transformers/models/dbrx/configuration_dbrx.py
+++ b/src/transformers/models/dbrx/configuration_dbrx.py
@@ -75,7 +75,7 @@ class DbrxFFNConfig(PreTrainedConfig):
     moe_num_experts: int = 4
     moe_top_k: int = 1
     moe_jitter_eps: float | int | None = None
-    moe_loss_weight: float= 0.01
+    moe_loss_weight: float = 0.01
     moe_normalize_expert_weights: float | None = 1.0
 
     def __post_init__(self, **kwargs):

--- a/src/transformers/models/dbrx/configuration_dbrx.py
+++ b/src/transformers/models/dbrx/configuration_dbrx.py
@@ -163,8 +163,7 @@ class DbrxConfig(PreTrainedConfig):
         elif isinstance(self.ffn_config, dict):
             self.ffn_config = DbrxFFNConfig(**self.ffn_config)
 
-        # The experts read/write hidden states, so `ffn_config.hidden_size` must mirror the model's
-        # `hidden_size`. Checkpoints do not store it, hence we always propagate it from `d_model`.
+        # The experts read/write hidden states, so `ffn_config.hidden_size` must mirror the model's `hidden_size`.
         self.ffn_config.hidden_size = self.d_model
 
         self.num_key_value_heads = self.attn_config.kv_n_heads

--- a/src/transformers/models/dbrx/configuration_dbrx.py
+++ b/src/transformers/models/dbrx/configuration_dbrx.py
@@ -75,8 +75,8 @@ class DbrxFFNConfig(PreTrainedConfig):
     moe_num_experts: int = 4
     moe_top_k: int = 1
     moe_jitter_eps: float | int | None = None
-    moe_loss_weight: float | int = 0.01
-    moe_normalize_expert_weights: float | int | None = 1.0
+    moe_loss_weight: float= 0.01
+    moe_normalize_expert_weights: float | None = 1.0
 
     def __post_init__(self, **kwargs):
         if self.ffn_act_fn is None:

--- a/src/transformers/models/dbrx/modeling_dbrx.py
+++ b/src/transformers/models/dbrx/modeling_dbrx.py
@@ -278,8 +278,8 @@ class DbrxExpertGLU(nn.Module):
     def forward(
         self, x: torch.Tensor, expert_w1: torch.Tensor, expert_v1: torch.Tensor, expert_w2: torch.Tensor
     ) -> torch.Tensor:
-        gate_proj = x.matmul(expert_w1.t())
-        up_proj = x.matmul(expert_v1.t())
+        gate_proj = x.matmul(expert_w1.T)
+        up_proj = x.matmul(expert_v1.T)
         gate_proj = self.activation_fn(gate_proj)
         intermediate_states = gate_proj * up_proj
         down_proj = intermediate_states.matmul(expert_w2)

--- a/src/transformers/models/dbrx/modeling_dbrx.py
+++ b/src/transformers/models/dbrx/modeling_dbrx.py
@@ -278,11 +278,11 @@ class DbrxExpertGLU(nn.Module):
     def forward(
         self, x: torch.Tensor, expert_w1: torch.Tensor, expert_v1: torch.Tensor, expert_w2: torch.Tensor
     ) -> torch.Tensor:
-        gate_proj = x.matmul(expert_w1)
-        up_proj = x.matmul(expert_v1)
+        gate_proj = x.matmul(expert_w1.t())
+        up_proj = x.matmul(expert_v1.t())
         gate_proj = self.activation_fn(gate_proj)
         intermediate_states = gate_proj * up_proj
-        down_proj = intermediate_states.matmul(expert_w2.t())
+        down_proj = intermediate_states.matmul(expert_w2)
         return down_proj
 
 
@@ -301,7 +301,7 @@ class DbrxExperts(nn.Module):
         top_k_weights: torch.Tensor,
     ) -> torch.Tensor:
         batch_size = hidden_states.shape[0]
-        hidden_states = hidden_states.reshape(-1, self.ffn_hidden_size)
+        hidden_states = hidden_states.reshape(-1, self.hidden_size)
 
         next_states = torch.zeros_like(hidden_states, dtype=hidden_states.dtype, device=hidden_states.device)
         with torch.no_grad():
@@ -318,17 +318,17 @@ class DbrxExperts(nn.Module):
             w1 = self.mlp.w1.view(split_expert_shape)[expert_idx]
             w2 = self.mlp.w2.view(split_expert_shape)[expert_idx]
             states = self.mlp(hidden_states[token_idx], w1, v1, w2)
-            states = states.view(-1, self.ffn_hidden_size) * top_k_weights[token_idx, idx, None]
+            states = states.view(-1, self.hidden_size) * top_k_weights[token_idx, idx, None]
             next_states.index_add_(0, token_idx, states)
 
-        next_states = next_states.view(batch_size, -1, self.ffn_hidden_size)
+        next_states = next_states.view(batch_size, -1, self.hidden_size)
         return next_states
 
 
 class DbrxRouter(nn.Module):
     def __init__(self, config):
         super().__init__()
-        self.hidden_size = config.ffn_hidden_size
+        self.hidden_size = config.hidden_size
         self.moe_jitter_eps = config.moe_jitter_eps
         self.layer = nn.Linear(self.hidden_size, config.moe_num_experts, bias=False)
 

--- a/src/transformers/models/dbrx/modular_dbrx.py
+++ b/src/transformers/models/dbrx/modular_dbrx.py
@@ -148,11 +148,11 @@ class DbrxExpertGLU(nn.Module):
     def forward(
         self, x: torch.Tensor, expert_w1: torch.Tensor, expert_v1: torch.Tensor, expert_w2: torch.Tensor
     ) -> torch.Tensor:
-        gate_proj = x.matmul(expert_w1)
-        up_proj = x.matmul(expert_v1)
+        gate_proj = x.matmul(expert_w1.t())
+        up_proj = x.matmul(expert_v1.t())
         gate_proj = self.activation_fn(gate_proj)
         intermediate_states = gate_proj * up_proj
-        down_proj = intermediate_states.matmul(expert_w2.t())
+        down_proj = intermediate_states.matmul(expert_w2)
         return down_proj
 
 
@@ -171,7 +171,7 @@ class DbrxExperts(nn.Module):
         top_k_weights: torch.Tensor,
     ) -> torch.Tensor:
         batch_size = hidden_states.shape[0]
-        hidden_states = hidden_states.reshape(-1, self.ffn_hidden_size)
+        hidden_states = hidden_states.reshape(-1, self.hidden_size)
 
         next_states = torch.zeros_like(hidden_states, dtype=hidden_states.dtype, device=hidden_states.device)
         with torch.no_grad():
@@ -188,17 +188,17 @@ class DbrxExperts(nn.Module):
             w1 = self.mlp.w1.view(split_expert_shape)[expert_idx]
             w2 = self.mlp.w2.view(split_expert_shape)[expert_idx]
             states = self.mlp(hidden_states[token_idx], w1, v1, w2)
-            states = states.view(-1, self.ffn_hidden_size) * top_k_weights[token_idx, idx, None]
+            states = states.view(-1, self.hidden_size) * top_k_weights[token_idx, idx, None]
             next_states.index_add_(0, token_idx, states)
 
-        next_states = next_states.view(batch_size, -1, self.ffn_hidden_size)
+        next_states = next_states.view(batch_size, -1, self.hidden_size)
         return next_states
 
 
 class DbrxRouter(nn.Module):
     def __init__(self, config):
         super().__init__()
-        self.hidden_size = config.ffn_hidden_size
+        self.hidden_size = config.hidden_size
         self.moe_jitter_eps = config.moe_jitter_eps
         self.layer = nn.Linear(self.hidden_size, config.moe_num_experts, bias=False)
 

--- a/src/transformers/models/dbrx/modular_dbrx.py
+++ b/src/transformers/models/dbrx/modular_dbrx.py
@@ -148,8 +148,8 @@ class DbrxExpertGLU(nn.Module):
     def forward(
         self, x: torch.Tensor, expert_w1: torch.Tensor, expert_v1: torch.Tensor, expert_w2: torch.Tensor
     ) -> torch.Tensor:
-        gate_proj = x.matmul(expert_w1.t())
-        up_proj = x.matmul(expert_v1.t())
+        gate_proj = x.matmul(expert_w1.T)
+        up_proj = x.matmul(expert_v1.T)
         gate_proj = self.activation_fn(gate_proj)
         intermediate_states = gate_proj * up_proj
         down_proj = intermediate_states.matmul(expert_w2)

--- a/tests/models/dbrx/test_modeling_dbrx.py
+++ b/tests/models/dbrx/test_modeling_dbrx.py
@@ -61,11 +61,10 @@ class DbrxModelTester(CausalLMModelTester):
         self.clip_qkv = clip_qkv
 
         # DBRX takes sub-configurations for the FFN and attention layers, so we need to set that correctly here.
-        # `ffn_config.hidden_size` must mirror the model's `hidden_size` (the experts read/write hidden
-        # states), while `ffn_config.ffn_hidden_size` is the larger MoE intermediate size.
+        # `ffn_config.hidden_size` is not set here on purpose: it always mirrors the model's `hidden_size` and
+        # is propagated by `DbrxConfig`. `ffn_config.ffn_hidden_size` is the larger MoE intermediate size.
         self.ffn_config = {
             "ffn_hidden_size": 2 * self.hidden_size,
-            "hidden_size": self.hidden_size,
             "moe_jitter_eps": moe_jitter_eps,
             "moe_loss_weight": moe_loss_weight,
             "moe_num_experts": moe_num_experts,
@@ -113,7 +112,7 @@ class DbrxModelTest(CausalLMModelTest, unittest.TestCase):
 class DbrxModelIntegrationTest(unittest.TestCase):
     @slow
     def test_tiny_model_logits(self):
-        model = DbrxForCausalLM.from_pretrained("Rocketknight1/dbrx-tiny-random")
+        model = DbrxForCausalLM.from_pretrained("Rocketknight1/dbrx-tiny-random", dtype=torch.float32)
         input_ids = torch.tensor([[0, 1, 2, 3, 4, 5]])
         output = model(input_ids)[0]
         vocab_size = model.vocab_size

--- a/tests/models/dbrx/test_modeling_dbrx.py
+++ b/tests/models/dbrx/test_modeling_dbrx.py
@@ -62,7 +62,7 @@ class DbrxModelTester(CausalLMModelTester):
 
         # DBRX takes sub-configurations for the FFN and attention layers, so we need to set that correctly here.
         # `ffn_config.hidden_size` is not set here on purpose: it always mirrors the model's `hidden_size` and
-        # is propagated by `DbrxConfig`. `ffn_config.ffn_hidden_size` is the larger MoE intermediate size.
+        # is propagated by `DbrxConfig`.
         self.ffn_config = {
             "ffn_hidden_size": 2 * self.hidden_size,
             "moe_jitter_eps": moe_jitter_eps,

--- a/tests/models/dbrx/test_modeling_dbrx.py
+++ b/tests/models/dbrx/test_modeling_dbrx.py
@@ -60,10 +60,12 @@ class DbrxModelTester(CausalLMModelTester):
         # Set DBRX's unusual params
         self.clip_qkv = clip_qkv
 
-        # DBRX takes sub-configurations for the FFN and attention layers, so we need to set that correctly here
+        # DBRX takes sub-configurations for the FFN and attention layers, so we need to set that correctly here.
+        # `ffn_config.hidden_size` must mirror the model's `hidden_size` (the experts read/write hidden
+        # states), while `ffn_config.ffn_hidden_size` is the larger MoE intermediate size.
         self.ffn_config = {
-            "ffn_hidden_size": self.hidden_size,
-            "hidden_size": 2 * self.hidden_size,
+            "ffn_hidden_size": 2 * self.hidden_size,
+            "hidden_size": self.hidden_size,
             "moe_jitter_eps": moe_jitter_eps,
             "moe_loss_weight": moe_loss_weight,
             "moe_num_experts": moe_num_experts,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47671)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47671)
<!-- ci-dashboard-badge:end -->

`DbrxRouter`/`DbrxExperts` are built from `config.ffn_config`, where `hidden_size` is the model hidden size and `ffn_hidden_size` the expert intermediate size, but the two were mixed up: the router linear used `ffn_hidden_size` inputs, `DbrxExperts.forward` reshaped hidden states with `ffn_hidden_size`, and the three matmuls in `DbrxExpertGLU.forward` had their transposes inverted. Any DBRX checkpoint fails in the MoE block on any device. This should be a regression introduced in https://github.com/huggingface/transformers/pull/40132 (commit 7938e91) when the DBRX MoE modules were rewritten to read dims from config

`DbrxModelTester` also swapped the two sizes in `ffn_config`, which made the wrong lookups resolve to the right value and hid the bug; fixed as well.

 @ArthurZucker @Cyrilvallez @vasqu pls help review, thx!