### PR TITLE
Fix feature dtype mismatch in masked_scatter for seven multimodal models

### DIFF
--- a/src/transformers/models/audioflamingo3/modeling_audioflamingo3.py
+++ b/src/transformers/models/audioflamingo3/modeling_audioflamingo3.py
@@ -540,7 +540,9 @@ class AudioFlamingo3Model(AudioFlamingo3PreTrainedModel):
             special_audio_mask = self.get_placeholder_mask(
                 input_ids, inputs_embeds=inputs_embeds, audio_features=audio_embeds
             )
-            inputs_embeds = inputs_embeds.masked_scatter(special_audio_mask, audio_embeds.to(inputs_embeds.device))
+            inputs_embeds = inputs_embeds.masked_scatter(
+                special_audio_mask, audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            )
 
         outputs = self.language_model(
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/audioflamingo3/modular_audioflamingo3.py
+++ b/src/transformers/models/audioflamingo3/modular_audioflamingo3.py
@@ -247,7 +247,9 @@ class AudioFlamingo3Model(VoxtralModel):
             special_audio_mask = self.get_placeholder_mask(
                 input_ids, inputs_embeds=inputs_embeds, audio_features=audio_embeds
             )
-            inputs_embeds = inputs_embeds.masked_scatter(special_audio_mask, audio_embeds.to(inputs_embeds.device))
+            inputs_embeds = inputs_embeds.masked_scatter(
+                special_audio_mask, audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            )
 
         outputs = self.language_model(
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/glmasr/modeling_glmasr.py
+++ b/src/transformers/models/glmasr/modeling_glmasr.py
@@ -462,7 +462,9 @@ class GlmAsrModel(GlmAsrPreTrainedModel):
             special_audio_mask = self.get_placeholder_mask(
                 input_ids, inputs_embeds=inputs_embeds, audio_features=audio_embeds
             )
-            inputs_embeds = inputs_embeds.masked_scatter(special_audio_mask, audio_embeds.to(inputs_embeds.device))
+            inputs_embeds = inputs_embeds.masked_scatter(
+                special_audio_mask, audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            )
 
         outputs = self.language_model(
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/musicflamingo/modeling_musicflamingo.py
+++ b/src/transformers/models/musicflamingo/modeling_musicflamingo.py
@@ -308,7 +308,9 @@ class MusicFlamingoModel(MusicFlamingoPreTrainedModel):
             special_audio_mask = self.get_placeholder_mask(
                 input_ids, inputs_embeds=inputs_embeds, audio_features=audio_embeds
             )
-            inputs_embeds = inputs_embeds.masked_scatter(special_audio_mask, audio_embeds.to(inputs_embeds.device))
+            inputs_embeds = inputs_embeds.masked_scatter(
+                special_audio_mask, audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            )
 
         outputs = self.language_model(
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/musicflamingo/modular_musicflamingo.py
+++ b/src/transformers/models/musicflamingo/modular_musicflamingo.py
@@ -371,7 +371,9 @@ class MusicFlamingoModel(AudioFlamingo3Model):
             special_audio_mask = self.get_placeholder_mask(
                 input_ids, inputs_embeds=inputs_embeds, audio_features=audio_embeds
             )
-            inputs_embeds = inputs_embeds.masked_scatter(special_audio_mask, audio_embeds.to(inputs_embeds.device))
+            inputs_embeds = inputs_embeds.masked_scatter(
+                special_audio_mask, audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            )
 
         outputs = self.language_model(
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/pi0/modeling_pi0.py
+++ b/src/transformers/models/pi0/modeling_pi0.py
@@ -132,7 +132,9 @@ class PI0Model(PI0PreTrainedModel):
         special_image_mask = (
             (input_ids == self.config.vlm_config.image_token_id).unsqueeze(-1).to(inputs_embeds.device)
         )
-        inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, total_image_features)
+        inputs_embeds = inputs_embeds.masked_scatter(
+            special_image_mask, total_image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+        )
 
         return inputs_embeds
 

--- a/src/transformers/models/pi0/modular_pi0.py
+++ b/src/transformers/models/pi0/modular_pi0.py
@@ -413,7 +413,9 @@ class PI0Model(PI0PreTrainedModel):
         special_image_mask = (
             (input_ids == self.config.vlm_config.image_token_id).unsqueeze(-1).to(inputs_embeds.device)
         )
-        inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, total_image_features)
+        inputs_embeds = inputs_embeds.masked_scatter(
+            special_image_mask, total_image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+        )
 
         return inputs_embeds
 

--- a/src/transformers/models/qwen3_asr/modeling_qwen3_asr.py
+++ b/src/transformers/models/qwen3_asr/modeling_qwen3_asr.py
@@ -554,7 +554,9 @@ class Qwen3ASRModel(Qwen3ASRPreTrainedModel):
             special_audio_mask = self.get_placeholder_mask(
                 input_ids, inputs_embeds=inputs_embeds, audio_features=audio_embeds
             )
-            inputs_embeds = inputs_embeds.masked_scatter(special_audio_mask, audio_embeds.to(inputs_embeds.device))
+            inputs_embeds = inputs_embeds.masked_scatter(
+                special_audio_mask, audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            )
 
         outputs = self.language_model(
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/vibevoice_asr/modeling_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/modeling_vibevoice_asr.py
@@ -422,7 +422,7 @@ class VibeVoiceAsrModel(VibeVoiceAsrPreTrainedModel):
 
             audio_token_mask = (input_ids == self.config.audio_token_id).unsqueeze(-1)
             inputs_embeds = inputs_embeds.masked_scatter(
-                audio_token_mask.to(inputs_embeds.device), audio_embeds.to(inputs_embeds.device)
+                audio_token_mask.to(inputs_embeds.device), audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
             )
 
         outputs = self.language_model(

--- a/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
@@ -360,7 +360,7 @@ class VibeVoiceAsrModel(VibeVoiceAsrPreTrainedModel):
 
             audio_token_mask = (input_ids == self.config.audio_token_id).unsqueeze(-1)
             inputs_embeds = inputs_embeds.masked_scatter(
-                audio_token_mask.to(inputs_embeds.device), audio_embeds.to(inputs_embeds.device)
+                audio_token_mask.to(inputs_embeds.device), audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
             )
 
         outputs = self.language_model(

--- a/src/transformers/models/voxtral/modeling_voxtral.py
+++ b/src/transformers/models/voxtral/modeling_voxtral.py
@@ -460,7 +460,9 @@ class VoxtralModel(VoxtralPreTrainedModel):
             special_audio_mask = self.get_placeholder_mask(
                 input_ids, inputs_embeds=inputs_embeds, audio_features=audio_embeds
             )
-            inputs_embeds = inputs_embeds.masked_scatter(special_audio_mask, audio_embeds.to(inputs_embeds.device))
+            inputs_embeds = inputs_embeds.masked_scatter(
+                special_audio_mask, audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            )
 
         outputs: BaseModelOutputWithPast = self.language_model(
             attention_mask=attention_mask,

--- a/src/transformers/models/voxtral/modular_voxtral.py
+++ b/src/transformers/models/voxtral/modular_voxtral.py
@@ -230,7 +230,9 @@ class VoxtralModel(VoxtralPreTrainedModel):
             special_audio_mask = self.get_placeholder_mask(
                 input_ids, inputs_embeds=inputs_embeds, audio_features=audio_embeds
             )
-            inputs_embeds = inputs_embeds.masked_scatter(special_audio_mask, audio_embeds.to(inputs_embeds.device))
+            inputs_embeds = inputs_embeds.masked_scatter(
+                special_audio_mask, audio_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            )
 
         outputs: BaseModelOutputWithPast = self.language_model(
             attention_mask=attention_mask,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47673)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47673)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Seven multimodal models scatter their encoder output into the text embeddings while moving it to the right device but not to the right dtype:

```python
inputs_embeds = inputs_embeds.masked_scatter(special_audio_mask, audio_embeds.to(inputs_embeds.device))
```

`masked_scatter` requires `self` and `source` to share a dtype, so this raises as soon as the encoder and the text residual stream diverge. Under `torch.autocast`, which is what `Trainer(bf16=True)` and Accelerate mixed precision set up, they always do: `nn.Embedding` is not on autocast's cast list so `inputs_embeds` stays float32, while the encoder's final projection is an `nn.Linear` and returns bfloat16.

```
RuntimeError: masked_scatter: expected self and source to have same dtypes but gotFloat and BFloat16
```

This is the same defect #47482 fixed for Gemma 4 a week ago, and this PR makes the same one-line change.

## Scope

Rather than guess which models were affected, I listed every `masked_scatter` call site under `src/transformers/models/*/modeling_*.py` and split them by whether the scattered source is aligned to the destination dtype anywhere in the enclosing block: 104 of 121 align it, 17 do not. I then ran each of those 17 models through the same `torch.autocast("cpu", dtype=torch.bfloat16)` forward, built from the model's own `ModelTester` config, no pretrained weights:

| model | before | after |
|---|---|---|
| `voxtral` | `RuntimeError` | ok |
| `audioflamingo3` | `RuntimeError` | ok |
| `musicflamingo` | `RuntimeError` | ok |
| `vibevoice_asr` | `RuntimeError` | ok |
| `glmasr` | `RuntimeError` | ok |
| `qwen3_asr` | `RuntimeError` | ok |
| `pi0` | `RuntimeError` | ok |
| `chameleon` | ok | ok |
| `emu3` | ok | ok |
| `higgs_audio_v2` | ok | ok |
| `gemma4` (control, fixed in #47482) | ok | ok |
| `gemma3` (control) | ok | ok |

The three unaligned ones that already pass do so because their scattered tensor comes from an embedding table or from a norm applied to `hidden_states` in the same module, so it is already in the residual stream's dtype. I left them alone. The remaining unaligned sites are a different shape and are not touched either: `glm_image:1298` scatters token ids into `input_ids` (both int64), `blt:851` packs a tensor into a `zeros_like` of itself, and `qwen2_5_omni:3852,3861,3870` scatter a tensor built with `dtype=embeds_to_talker.dtype`.

Standalone repro for `voxtral` (CPU, no weights, a few seconds) is in the linked issue.

## Modular

Five of the seven are modular edit sites and were changed there: `voxtral`, `audioflamingo3`, `musicflamingo`, `vibevoice_asr`, `pi0`. `glmasr` and `qwen3_asr` inherit `AudioFlamingo3Model.forward` and have no `masked_scatter` of their own, so `modular_conversion --fix` propagated the change into their generated files without a separate edit. No `# Copied from` block references this code.

## Tests

```
tests/models/{voxtral,audioflamingo3,musicflamingo,vibevoice_asr,glmasr,qwen3_asr,pi0}

main    17 failed, 1026 passed, 1063 skipped
branch  17 failed, 1026 passed, 1063 skipped
```

The 17 failures are identical on both sides and pre-existing in my environment (processor tests needing audio decoding backends, plus two `torch.compile` tests); none are in the modeling paths this PR touches.

`ruff check` and `ruff format --check` are clean on all 12 changed files with the pinned 0.14.10.

No regression test is added here, matching #47482, since the change only brings these models in line with the dtype handling the rest of the library already has. Happy to add one if you would prefer it, either per model or as a shared check.

Fixes #47672

Disclosure: this fix was implemented with the assistance of a code agent, and reviewed and validated by me.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue? https://github.com/huggingface/transformers/issues/47672
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@eustlb @Rocketknight1