### PR TITLE
Fix SDPA logit corruption for left-padded generation in multimodal models (#47651)

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -532,6 +532,13 @@ def sdpa_mask(
             "Please update your torch version or use `use_vmap=False` with index-based masks."
         )
 
+    # Attend to all tokens in masked rows from the causal_mask, for example the relevant first rows when
+    # using left padding. This is required by F.scaled_dot_product_attention memory-efficient attention path.
+    # Details: https://github.com/pytorch/pytorch/issues/110213
+    if attention_mask is not None and not is_tracing(attention_mask) and attention_mask.device.type in ["cuda", "xpu"]:
+        unattended = ~attention_mask.any(dim=-1, keepdim=True)
+        attention_mask = attention_mask | unattended
+
     return attention_mask
 
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47678)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47678)
<!-- ci-dashboard-badge:end -->

This PR fixes the massive logit shift observed during left-padded generation with SDPA in gemma4 and other models utilizing the new masking API (masking_utils.py).

### Root Cause
When the mask is built via lockwise_overlay and left-padded (	otal_padded_length % 32 == 1), the padded query positions are entirely masked out, leading to a fully-False row in the SDPA boolean mask. PyTorch's F.scaled_dot_product_attention converts False to -inf, leading to NaNs and corrupted outputs. 

The previous masking architecture (modeling_attn_mask_utils.py) avoided this by explicitly checking for and unmasking unattended rows for CUDA/XPU. This workaround was dropped in masking_utils.py.

### Fix
This PR restores the unmask unattended rows workaround directly in sdpa_mask() for cuda and xpu devices to prevent PyTorch from breaking. This resolves issue #47651.