### PR TITLE
Forward loss kwargs to self.loss_function so gradient accumulation normalizes correctly

### DIFF
--- a/src/transformers/modeling_layers.py
+++ b/src/transformers/modeling_layers.py
@@ -178,7 +178,9 @@ class GenericForSequenceClassification:
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config)
+            loss = self.loss_function(
+                logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config, **kwargs
+            )
 
         return SequenceClassifierOutputWithPast(
             loss=loss,
@@ -303,7 +305,7 @@ class GenericForTokenClassification:
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, self.config)
+            loss = self.loss_function(logits, labels, self.config, **kwargs)
 
         return TokenClassifierOutput(
             loss=loss,

--- a/src/transformers/models/beit/modeling_beit.py
+++ b/src/transformers/models/beit/modeling_beit.py
@@ -712,7 +712,7 @@ class BeitForImageClassification(BeitPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,
@@ -1071,6 +1071,7 @@ class BeitForSemanticSegmentation(BeitPreTrainedModel):
                 ignore_index=self.config.semantic_loss_ignore_index,
                 auxiliary_logits=auxiliary_logits,
                 auxiliary_loss_weight=self.config.auxiliary_loss_weight,
+                **kwargs,
             )
         return SemanticSegmenterOutput(
             loss=loss,

--- a/src/transformers/models/beit/modular_beit.py
+++ b/src/transformers/models/beit/modular_beit.py
@@ -519,7 +519,7 @@ class BeitForImageClassification(BeitPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,
@@ -870,6 +870,7 @@ class BeitForSemanticSegmentation(BeitPreTrainedModel):
                 ignore_index=self.config.semantic_loss_ignore_index,
                 auxiliary_logits=auxiliary_logits,
                 auxiliary_loss_weight=self.config.auxiliary_loss_weight,
+                **kwargs,
             )
         return SemanticSegmenterOutput(
             loss=loss,

--- a/src/transformers/models/bit/modeling_bit.py
+++ b/src/transformers/models/bit/modeling_bit.py
@@ -734,7 +734,7 @@ class BitForImageClassification(BitPreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -1009,7 +1009,7 @@ class CLIPForImageClassification(CLIPPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/conditional_detr/modeling_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modeling_conditional_detr.py
@@ -1507,6 +1507,8 @@ def inverse_sigmoid(x, eps=1e-5):
     """
 )
 class ConditionalDetrForObjectDetection(ConditionalDetrPreTrainedModel):
+    accepts_loss_kwargs = False
+
     def __init__(self, config: ConditionalDetrConfig):
         super().__init__(config)
 
@@ -1653,6 +1655,8 @@ class ConditionalDetrForObjectDetection(ConditionalDetrPreTrainedModel):
     """
 )
 class ConditionalDetrForSegmentation(ConditionalDetrPreTrainedModel):
+    accepts_loss_kwargs = False
+
     def __init__(self, config: ConditionalDetrConfig):
         super().__init__(config)
 

--- a/src/transformers/models/conditional_detr/modular_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modular_conditional_detr.py
@@ -1021,6 +1021,8 @@ class ConditionalDetrModel(DetrModel):
 
 
 class ConditionalDetrForObjectDetection(DetrForObjectDetection):
+    accepts_loss_kwargs = False
+
     def __init__(self, config: ConditionalDetrConfig):
         super().__init__(config)
         self.class_labels_classifier = nn.Linear(config.d_model, config.num_labels)
@@ -1152,7 +1154,7 @@ class ConditionalDetrForObjectDetection(DetrForObjectDetection):
 
 
 class ConditionalDetrForSegmentation(DetrForSegmentation):
-    pass
+    accepts_loss_kwargs = False
 
 
 __all__ = [

--- a/src/transformers/models/dab_detr/modeling_dab_detr.py
+++ b/src/transformers/models/dab_detr/modeling_dab_detr.py
@@ -1414,6 +1414,8 @@ class DabDetrMHAttentionMap(nn.Module):
 )
 class DabDetrForObjectDetection(DabDetrPreTrainedModel):
     # When using clones, all layers > 0 will be clones, but layer 0 *is* required
+    accepts_loss_kwargs = False
+
     _tied_weights_keys = {"model.decoder.bbox_embed": "bbox_predictor"}
 
     def __init__(self, config: DabDetrConfig):

--- a/src/transformers/models/data2vec/modeling_data2vec_vision.py
+++ b/src/transformers/models/data2vec/modeling_data2vec_vision.py
@@ -817,7 +817,7 @@ class Data2VecVisionForImageClassification(Data2VecVisionPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -1541,6 +1541,8 @@ class DeformableDetrMLPPredictionHead(nn.Module):
 class DeformableDetrForObjectDetection(DeformableDetrPreTrainedModel):
     # When using clones, all layers > 0 will be clones, but layer 0 *is* required
     # We can't initialize the model on meta device as some weights are modified during the initialization
+    accepts_loss_kwargs = False
+
     _no_split_modules = None
     _tied_weights_keys = {
         r"bbox_embed.(?![0])\d+": "bbox_embed.0",

--- a/src/transformers/models/deformable_detr/modular_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modular_deformable_detr.py
@@ -1368,6 +1368,8 @@ class DeformableDetrMLPPredictionHead(DetrMLPPredictionHead):
 class DeformableDetrForObjectDetection(DeformableDetrPreTrainedModel):
     # When using clones, all layers > 0 will be clones, but layer 0 *is* required
     # We can't initialize the model on meta device as some weights are modified during the initialization
+    accepts_loss_kwargs = False
+
     _no_split_modules = None
     _tied_weights_keys = {
         r"bbox_embed.(?![0])\d+": "bbox_embed.0",

--- a/src/transformers/models/detr/modeling_detr.py
+++ b/src/transformers/models/detr/modeling_detr.py
@@ -1307,6 +1307,8 @@ class DetrMLPPredictionHead(nn.Module):
     """
 )
 class DetrForObjectDetection(DetrPreTrainedModel):
+    accepts_loss_kwargs = False
+
     def __init__(self, config: DetrConfig):
         super().__init__(config)
 
@@ -1444,6 +1446,8 @@ class DetrForObjectDetection(DetrPreTrainedModel):
     """
 )
 class DetrForSegmentation(DetrPreTrainedModel):
+    accepts_loss_kwargs = False
+
     def __init__(self, config: DetrConfig):
         super().__init__(config)
 

--- a/src/transformers/models/dinat/modeling_dinat.py
+++ b/src/transformers/models/dinat/modeling_dinat.py
@@ -667,7 +667,7 @@ class DinatForImageClassification(DinatPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/donut/modeling_donut_swin.py
+++ b/src/transformers/models/donut/modeling_donut_swin.py
@@ -926,7 +926,7 @@ class DonutSwinForImageClassification(DonutSwinPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/efficientnet/modeling_efficientnet.py
+++ b/src/transformers/models/efficientnet/modeling_efficientnet.py
@@ -551,7 +551,7 @@ class EfficientNetForImageClassification(EfficientNetPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/focalnet/modeling_focalnet.py
+++ b/src/transformers/models/focalnet/modeling_focalnet.py
@@ -831,7 +831,7 @@ class FocalNetForImageClassification(FocalNetPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -547,7 +547,9 @@ class GPTNeoXForSequenceClassification(GPTNeoXPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config)
+            loss = self.loss_function(
+                logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config, **kwargs
+            )
 
         return SequenceClassifierOutputWithPast(
             loss=loss,
@@ -607,7 +609,7 @@ class GPTNeoXForTokenClassification(GPTNeoXPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, self.config)
+            loss = self.loss_function(logits, labels, self.config, **kwargs)
 
         return TokenClassifierOutput(
             loss=loss,
@@ -658,7 +660,7 @@ class GPTNeoXForQuestionAnswering(GPTNeoXPreTrainedModel):
 
         loss = None
         if start_positions is not None and end_positions is not None:
-            loss = self.loss_function(start_logits, end_logits, start_positions, end_positions)
+            loss = self.loss_function(start_logits, end_logits, start_positions, end_positions, **kwargs)
 
         return QuestionAnsweringModelOutput(
             loss=loss,

--- a/src/transformers/models/gpt_neox/modular_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modular_gpt_neox.py
@@ -487,7 +487,9 @@ class GPTNeoXForSequenceClassification(GPTNeoXPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config)
+            loss = self.loss_function(
+                logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config, **kwargs
+            )
 
         return SequenceClassifierOutputWithPast(
             loss=loss,
@@ -547,7 +549,7 @@ class GPTNeoXForTokenClassification(GPTNeoXPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, self.config)
+            loss = self.loss_function(logits, labels, self.config, **kwargs)
 
         return TokenClassifierOutput(
             loss=loss,
@@ -598,7 +600,7 @@ class GPTNeoXForQuestionAnswering(GPTNeoXPreTrainedModel):
 
         loss = None
         if start_positions is not None and end_positions is not None:
-            loss = self.loss_function(start_logits, end_logits, start_positions, end_positions)
+            loss = self.loss_function(start_logits, end_logits, start_positions, end_positions, **kwargs)
 
         return QuestionAnsweringModelOutput(
             loss=loss,

--- a/src/transformers/models/grounding_dino/modeling_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/modeling_grounding_dino.py
@@ -2376,6 +2376,8 @@ def build_text_mask(logits, attention_mask):
 class GroundingDinoForObjectDetection(GroundingDinoPreTrainedModel):
     # When using clones, all layers > 0 will be clones, but layer 0 *is* required
     # the bbox_embed in the decoder are all clones though
+    accepts_loss_kwargs = False
+
     _tied_weights_keys = {
         r"bbox_embed.(?![0])\d+": "bbox_embed.0",
         "model.decoder.bbox_embed": "bbox_embed",

--- a/src/transformers/models/hgnet_v2/modeling_hgnet_v2.py
+++ b/src/transformers/models/hgnet_v2/modeling_hgnet_v2.py
@@ -482,7 +482,7 @@ class HGNetV2ForImageClassification(HGNetV2PreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/hgnet_v2/modular_hgnet_v2.py
+++ b/src/transformers/models/hgnet_v2/modular_hgnet_v2.py
@@ -571,7 +571,7 @@ class HGNetV2ForImageClassification(HGNetV2PreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/hiera/modeling_hiera.py
+++ b/src/transformers/models/hiera/modeling_hiera.py
@@ -1256,7 +1256,7 @@ class HieraForImageClassification(HieraPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/imagegpt/modeling_imagegpt.py
+++ b/src/transformers/models/imagegpt/modeling_imagegpt.py
@@ -803,7 +803,7 @@ class ImageGPTForImageClassification(ImageGPTPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + transformer_outputs[1:]

--- a/src/transformers/models/levit/modeling_levit.py
+++ b/src/transformers/models/levit/modeling_levit.py
@@ -585,7 +585,7 @@ class LevitForImageClassification(LevitPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/lw_detr/modeling_lw_detr.py
+++ b/src/transformers/models/lw_detr/modeling_lw_detr.py
@@ -1536,6 +1536,8 @@ class LwDetrObjectDetectionOutput(ModelOutput):
 class LwDetrForObjectDetection(LwDetrPreTrainedModel):
     # When using clones, all layers > 0 will be clones, but layer 0 *is* required
     # We can't initialize the model on meta device as some weights are modified during the initialization
+    accepts_loss_kwargs = False
+
     _no_split_modules = None
     _tied_weights_keys = None
 

--- a/src/transformers/models/metaclip_2/modeling_metaclip_2.py
+++ b/src/transformers/models/metaclip_2/modeling_metaclip_2.py
@@ -1164,7 +1164,7 @@ class MetaClip2ForImageClassification(MetaClip2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/minicpmv4_6/modeling_minicpmv4_6.py
+++ b/src/transformers/models/minicpmv4_6/modeling_minicpmv4_6.py
@@ -617,7 +617,7 @@ class MiniCPMV4_6Model(MiniCPMV4_6PreTrainedModel):
             When set to `"4x"` the intermediate `vit_merger` is skipped so that each image keeps
             `4×` more visual tokens. Default `"16x"` mode applies the full merge pipeline.
         """
-        downsample_mode = downsample_mode if downsample_mode else self.config.downsample_mode
+        downsample_mode = downsample_mode or self.config.downsample_mode
         use_vit_merger = downsample_mode != "4x"
         pixel_values = pixel_values.to(dtype=self.vision_tower.dtype)
 
@@ -818,7 +818,9 @@ class MiniCPMV4_6ForConditionalGeneration(MiniCPMV4_6PreTrainedModel, Generation
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return CausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/minicpmv4_6/modular_minicpmv4_6.py
+++ b/src/transformers/models/minicpmv4_6/modular_minicpmv4_6.py
@@ -764,7 +764,9 @@ class MiniCPMV4_6ForConditionalGeneration(MiniCPMV4_6PreTrainedModel, Generation
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return CausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/minimax_m3_vl/modeling_minimax_m3_vl.py
+++ b/src/transformers/models/minimax_m3_vl/modeling_minimax_m3_vl.py
@@ -1523,7 +1523,9 @@ class MiniMaxM3SparseForConditionalGeneration(MiniMaxM3VLPreTrainedModel, Genera
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return MiniMaxM3VLCausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/minimax_m3_vl/modular_minimax_m3_vl.py
+++ b/src/transformers/models/minimax_m3_vl/modular_minimax_m3_vl.py
@@ -1190,7 +1190,9 @@ class MiniMaxM3SparseForConditionalGeneration(LlavaForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return MiniMaxM3VLCausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/mm_grounding_dino/modeling_mm_grounding_dino.py
+++ b/src/transformers/models/mm_grounding_dino/modeling_mm_grounding_dino.py
@@ -2352,6 +2352,8 @@ def build_text_mask(logits, attention_mask):
     """
 )
 class MMGroundingDinoForObjectDetection(MMGroundingDinoPreTrainedModel):
+    accepts_loss_kwargs = False
+
     _tied_weights_keys = {
         r"bbox_embed.(?![0])\d+": r"bbox_embed.0",
         r"class_embed.(?![0])\d+": r"^class_embed.0",

--- a/src/transformers/models/mm_grounding_dino/modular_mm_grounding_dino.py
+++ b/src/transformers/models/mm_grounding_dino/modular_mm_grounding_dino.py
@@ -262,6 +262,8 @@ class MMGroundingDinoMLPPredictionHead(GroundingDinoMLPPredictionHead):
 
 
 class MMGroundingDinoForObjectDetection(GroundingDinoForObjectDetection, MMGroundingDinoPreTrainedModel):
+    accepts_loss_kwargs = False
+
     _tied_weights_keys = {
         r"bbox_embed.(?![0])\d+": r"bbox_embed.0",
         r"class_embed.(?![0])\d+": r"^class_embed.0",

--- a/src/transformers/models/mobilenet_v1/modeling_mobilenet_v1.py
+++ b/src/transformers/models/mobilenet_v1/modeling_mobilenet_v1.py
@@ -276,7 +276,7 @@ class MobileNetV1ForImageClassification(MobileNetV1PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/mobilenet_v2/modeling_mobilenet_v2.py
+++ b/src/transformers/models/mobilenet_v2/modeling_mobilenet_v2.py
@@ -412,7 +412,7 @@ class MobileNetV2ForImageClassification(MobileNetV2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/mobilevit/modeling_mobilevit.py
+++ b/src/transformers/models/mobilevit/modeling_mobilevit.py
@@ -733,7 +733,7 @@ class MobileViTForImageClassification(MobileViTPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/mobilevitv2/modeling_mobilevitv2.py
+++ b/src/transformers/models/mobilevitv2/modeling_mobilevitv2.py
@@ -709,7 +709,7 @@ class MobileViTV2ForImageClassification(MobileViTV2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/nemotron3_5_asr/modeling_nemotron3_5_asr.py
+++ b/src/transformers/models/nemotron3_5_asr/modeling_nemotron3_5_asr.py
@@ -206,6 +206,7 @@ class Nemotron3_5AsrForRNNT(Nemotron3_5AsrPreTrainedModel, Nemotron3_5AsrGenerat
     config: Nemotron3_5AsrConfig
     _no_split_modules = ["Nemotron3_5AsrRNNTDecoder"]
     _supported_generation_modes = [GenerationMode.GREEDY_SEARCH]
+    accepts_loss_kwargs = False
 
     def __init__(self, config: Nemotron3_5AsrConfig):
         super().__init__(config)

--- a/src/transformers/models/nemotron3_5_asr/modular_nemotron3_5_asr.py
+++ b/src/transformers/models/nemotron3_5_asr/modular_nemotron3_5_asr.py
@@ -365,6 +365,8 @@ class Nemotron3_5AsrPromptProjector(nn.Module):
     """
 )
 class Nemotron3_5AsrForRNNT(NemotronAsrStreamingForRNNT, Nemotron3_5AsrGenerationMixin):
+    accepts_loss_kwargs = False
+
     def __init__(self, config: Nemotron3_5AsrConfig):
         super().__init__(config)
         self.prompt_projector = Nemotron3_5AsrPromptProjector(config)

--- a/src/transformers/models/nemotron_asr_streaming/modeling_nemotron_asr_streaming.py
+++ b/src/transformers/models/nemotron_asr_streaming/modeling_nemotron_asr_streaming.py
@@ -1144,6 +1144,7 @@ class NemotronAsrStreamingForRNNT(NemotronAsrStreamingPreTrainedModel, NemotronA
     config: NemotronAsrStreamingConfig
     _no_split_modules = ["NemotronAsrStreamingRNNTDecoder"]
     _supported_generation_modes = [GenerationMode.GREEDY_SEARCH]
+    accepts_loss_kwargs = False
 
     def __init__(self, config: NemotronAsrStreamingConfig):
         super().__init__(config)

--- a/src/transformers/models/nemotron_asr_streaming/modular_nemotron_asr_streaming.py
+++ b/src/transformers/models/nemotron_asr_streaming/modular_nemotron_asr_streaming.py
@@ -983,6 +983,8 @@ class NemotronAsrStreamingRNNTJointNetwork(ParakeetRNNTJointNetwork):
 class NemotronAsrStreamingForRNNT(
     ParakeetForRNNT, NemotronAsrStreamingPreTrainedModel, NemotronAsrStreamingGenerationMixin
 ):
+    accepts_loss_kwargs = False
+
     config: NemotronAsrStreamingConfig
 
     def __init__(self, config: NemotronAsrStreamingConfig):

--- a/src/transformers/models/perceiver/modeling_perceiver.py
+++ b/src/transformers/models/perceiver/modeling_perceiver.py
@@ -1160,7 +1160,7 @@ class PerceiverForImageClassificationLearned(PerceiverPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]
@@ -1283,7 +1283,7 @@ class PerceiverForImageClassificationFourier(PerceiverPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]
@@ -1407,7 +1407,7 @@ class PerceiverForImageClassificationConvProcessing(PerceiverPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/phi4_multimodal/modeling_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/modeling_phi4_multimodal.py
@@ -1680,7 +1680,7 @@ class Phi4MultimodalForCausalLM(Phi4MultimodalPreTrainedModel, GenerationMixin):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, self.vocab_size)
+            loss = self.loss_function(logits, labels, self.vocab_size, **kwargs)
 
         return CausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/phi4_multimodal/modular_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/modular_phi4_multimodal.py
@@ -1456,7 +1456,7 @@ class Phi4MultimodalForCausalLM(Phi3ForCausalLM):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, self.vocab_size)
+            loss = self.loss_function(logits, labels, self.vocab_size, **kwargs)
 
         return CausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/poolformer/modeling_poolformer.py
+++ b/src/transformers/models/poolformer/modeling_poolformer.py
@@ -364,7 +364,7 @@ class PoolFormerForImageClassification(PoolFormerPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/pvt/modeling_pvt.py
+++ b/src/transformers/models/pvt/modeling_pvt.py
@@ -526,7 +526,7 @@ class PvtForImageClassification(PvtPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[1:]

--- a/src/transformers/models/pvt_v2/modeling_pvt_v2.py
+++ b/src/transformers/models/pvt_v2/modeling_pvt_v2.py
@@ -484,7 +484,7 @@ class PvtV2ForImageClassification(PvtV2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[1:]

--- a/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
@@ -2031,7 +2031,7 @@ class Qwen2_5OmniThinkerForConditionalGeneration(Qwen2_5OmniPreTrainedModelForCo
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.get_text_config().vocab_size
+                logits=logits, labels=labels, vocab_size=self.config.get_text_config().vocab_size, **kwargs
             )
 
         return Qwen2_5OmniThinkerCausalLMOutputWithPast(

--- a/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
@@ -2024,7 +2024,7 @@ class Qwen2_5OmniThinkerForConditionalGeneration(Qwen2_5OmniPreTrainedModelForCo
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.get_text_config().vocab_size
+                logits=logits, labels=labels, vocab_size=self.config.get_text_config().vocab_size, **kwargs
             )
 
         return Qwen2_5OmniThinkerCausalLMOutputWithPast(

--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -2194,7 +2194,7 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.get_text_config().vocab_size
+                logits=logits, labels=labels, vocab_size=self.config.get_text_config().vocab_size, **kwargs
             )
 
         aux_loss = None

--- a/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
@@ -1414,7 +1414,7 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(Qwen2_5OmniThinkerForCondition
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.get_text_config().vocab_size
+                logits=logits, labels=labels, vocab_size=self.config.get_text_config().vocab_size, **kwargs
             )
 
         aux_loss = None

--- a/src/transformers/models/regnet/modeling_regnet.py
+++ b/src/transformers/models/regnet/modeling_regnet.py
@@ -367,7 +367,7 @@ class RegNetForImageClassification(RegNetPreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/resnet/modeling_resnet.py
+++ b/src/transformers/models/resnet/modeling_resnet.py
@@ -375,7 +375,7 @@ class ResNetForImageClassification(ResNetPreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/rf_detr/modeling_rf_detr.py
+++ b/src/transformers/models/rf_detr/modeling_rf_detr.py
@@ -1733,6 +1733,8 @@ class RfDetrObjectDetectionOutput(ModelOutput):
 class RfDetrForObjectDetection(RfDetrPreTrainedModel):
     # When using clones, all layers > 0 will be clones, but layer 0 *is* required
     # We can't initialize the model on meta device as some weights are modified during the initialization
+    accepts_loss_kwargs = False
+
     _no_split_modules = None
     _tied_weights_keys = None
 
@@ -1999,6 +2001,8 @@ class RfDetrSegmentationMLPBlock(nn.Module):
 class RfDetrForInstanceSegmentation(RfDetrPreTrainedModel):
     # When using clones, all layers > 0 will be clones, but layer 0 *is* required
     # We can't initialize the model on meta device as some weights are modified during the initialization
+    accepts_loss_kwargs = False
+
     _no_split_modules = None
 
     def __init__(self, config: RfDetrConfig):

--- a/src/transformers/models/rf_detr/modular_rf_detr.py
+++ b/src/transformers/models/rf_detr/modular_rf_detr.py
@@ -1377,6 +1377,8 @@ class RfDetrSegmentationMLPBlock(nn.Module):
 class RfDetrForInstanceSegmentation(RfDetrPreTrainedModel):
     # When using clones, all layers > 0 will be clones, but layer 0 *is* required
     # We can't initialize the model on meta device as some weights are modified during the initialization
+    accepts_loss_kwargs = False
+
     _no_split_modules = None
 
     def __init__(self, config: RfDetrConfig):

--- a/src/transformers/models/sapiens2/modeling_sapiens2.py
+++ b/src/transformers/models/sapiens2/modeling_sapiens2.py
@@ -1079,7 +1079,7 @@ class Sapiens2ForSemanticSegmentation(Sapiens2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, ignore_index=self.config.semantic_loss_ignore_index)
+            loss = self.loss_function(logits, labels, ignore_index=self.config.semantic_loss_ignore_index, **kwargs)
 
         return SemanticSegmenterOutput(
             loss=loss,

--- a/src/transformers/models/sapiens2/modular_sapiens2.py
+++ b/src/transformers/models/sapiens2/modular_sapiens2.py
@@ -1630,7 +1630,7 @@ class Sapiens2ForSemanticSegmentation(Sapiens2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, ignore_index=self.config.semantic_loss_ignore_index)
+            loss = self.loss_function(logits, labels, ignore_index=self.config.semantic_loss_ignore_index, **kwargs)
 
         return SemanticSegmenterOutput(
             loss=loss,

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -915,7 +915,7 @@ class SiglipForImageClassification(SiglipPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/siglip2/modeling_siglip2.py
+++ b/src/transformers/models/siglip2/modeling_siglip2.py
@@ -1007,7 +1007,7 @@ class Siglip2ForImageClassification(Siglip2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/siglip2/modular_siglip2.py
+++ b/src/transformers/models/siglip2/modular_siglip2.py
@@ -571,7 +571,7 @@ class Siglip2ForImageClassification(SiglipForImageClassification):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/swiftformer/modeling_swiftformer.py
+++ b/src/transformers/models/swiftformer/modeling_swiftformer.py
@@ -499,7 +499,7 @@ class SwiftFormerForImageClassification(SwiftFormerPreTrainedModel):
         # calculate loss
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[1:]

--- a/src/transformers/models/swinv2/modeling_swinv2.py
+++ b/src/transformers/models/swinv2/modeling_swinv2.py
@@ -1152,7 +1152,7 @@ class Swinv2ForImageClassification(Swinv2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/t5gemma/modeling_t5gemma.py
+++ b/src/transformers/models/t5gemma/modeling_t5gemma.py
@@ -1242,7 +1242,9 @@ class T5GemmaForSequenceClassification(T5GemmaPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config)
+            loss = self.loss_function(
+                logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config, **kwargs
+            )
 
         return SequenceClassifierOutput(
             loss=loss,
@@ -1357,7 +1359,7 @@ class T5GemmaForTokenClassification(T5GemmaPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, self.config)
+            loss = self.loss_function(logits, labels, self.config, **kwargs)
 
         return TokenClassifierOutput(
             loss=loss,

--- a/src/transformers/models/t5gemma/modular_t5gemma.py
+++ b/src/transformers/models/t5gemma/modular_t5gemma.py
@@ -1090,7 +1090,9 @@ class T5GemmaForSequenceClassification(T5GemmaPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config)
+            loss = self.loss_function(
+                logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config, **kwargs
+            )
 
         return SequenceClassifierOutput(
             loss=loss,
@@ -1205,7 +1207,7 @@ class T5GemmaForTokenClassification(T5GemmaPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, self.config)
+            loss = self.loss_function(logits, labels, self.config, **kwargs)
 
         return TokenClassifierOutput(
             loss=loss,

--- a/src/transformers/models/t5gemma2/modeling_t5gemma2.py
+++ b/src/transformers/models/t5gemma2/modeling_t5gemma2.py
@@ -1459,7 +1459,9 @@ class T5Gemma2ForSequenceClassification(T5Gemma2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config)
+            loss = self.loss_function(
+                logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config, **kwargs
+            )
 
         return SequenceClassifierOutput(
             loss=loss,
@@ -1548,7 +1550,7 @@ class T5Gemma2ForTokenClassification(T5Gemma2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, self.config)
+            loss = self.loss_function(logits, labels, self.config, **kwargs)
 
         return TokenClassifierOutput(
             loss=loss,

--- a/src/transformers/models/t5gemma2/modular_t5gemma2.py
+++ b/src/transformers/models/t5gemma2/modular_t5gemma2.py
@@ -1244,7 +1244,9 @@ class T5Gemma2ForSequenceClassification(T5Gemma2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config)
+            loss = self.loss_function(
+                logits=logits, labels=labels, pooled_logits=pooled_logits, config=self.config, **kwargs
+            )
 
         return SequenceClassifierOutput(
             loss=loss,
@@ -1333,7 +1335,7 @@ class T5Gemma2ForTokenClassification(T5Gemma2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, self.config)
+            loss = self.loss_function(logits, labels, self.config, **kwargs)
 
         return TokenClassifierOutput(
             loss=loss,

--- a/src/transformers/models/table_transformer/modeling_table_transformer.py
+++ b/src/transformers/models/table_transformer/modeling_table_transformer.py
@@ -1135,6 +1135,8 @@ class TableTransformerModel(TableTransformerPreTrainedModel):
 )
 class TableTransformerForObjectDetection(TableTransformerPreTrainedModel):
     # TODO: use modular - Copied from transformers.models.detr.modeling_detr.DetrForObjectDetection.__init__ with Detr->TableTransformer
+    accepts_loss_kwargs = False
+
     def __init__(self, config: TableTransformerConfig):
         super().__init__(config)
 

--- a/src/transformers/models/textnet/modeling_textnet.py
+++ b/src/transformers/models/textnet/modeling_textnet.py
@@ -329,7 +329,7 @@ class TextNetForImageClassification(TextNetPreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/tipsv2_dpt/modeling_tipsv2_dpt.py
+++ b/src/transformers/models/tipsv2_dpt/modeling_tipsv2_dpt.py
@@ -695,6 +695,7 @@ class Tipsv2DptForSemanticSegmentation(Tipsv2DptPreTrainedModel):
                 upsampled_logits,
                 labels,
                 ignore_index=self.config.semantic_loss_ignore_index,
+                **kwargs,
             )
 
         return SemanticSegmenterOutput(

--- a/src/transformers/models/tipsv2_dpt/modular_tipsv2_dpt.py
+++ b/src/transformers/models/tipsv2_dpt/modular_tipsv2_dpt.py
@@ -723,6 +723,7 @@ class Tipsv2DptForSemanticSegmentation(Tipsv2DptPreTrainedModel):
                 upsampled_logits,
                 labels,
                 ignore_index=self.config.semantic_loss_ignore_index,
+                **kwargs,
             )
 
         return SemanticSegmenterOutput(

--- a/src/transformers/models/vipllava/modeling_vipllava.py
+++ b/src/transformers/models/vipllava/modeling_vipllava.py
@@ -372,7 +372,9 @@ class VipLlavaForConditionalGeneration(VipLlavaPreTrainedModel, GenerationMixin)
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **lm_kwargs
+            )
 
         return VipLlavaCausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/vipllava/modular_vipllava.py
+++ b/src/transformers/models/vipllava/modular_vipllava.py
@@ -264,7 +264,9 @@ class VipLlavaForConditionalGeneration(LlavaForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **lm_kwargs
+            )
 
         return VipLlavaCausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/vjepa2/modeling_vjepa2.py
+++ b/src/transformers/models/vjepa2/modeling_vjepa2.py
@@ -1042,7 +1042,7 @@ class VJEPA2ForVideoClassification(VJEPA2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(pooled_logits=logits, labels=labels, config=self.config)
+            loss = self.loss_function(pooled_logits=logits, labels=labels, config=self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/xglm/modeling_xglm.py
+++ b/src/transformers/models/xglm/modeling_xglm.py
@@ -562,6 +562,7 @@ class XGLMForCausalLM(XGLMPreTrainedModel, GenerationMixin):
                 labels,
                 vocab_size=self.config.vocab_size,
                 pad_token_id=self.config.pad_token_id,
+                **kwargs,
             )
 
         return CausalLMOutputWithCrossAttentions(

--- a/src/transformers/models/yolos/modeling_yolos.py
+++ b/src/transformers/models/yolos/modeling_yolos.py
@@ -542,6 +542,8 @@ class YolosMLPPredictionHead(nn.Module):
     """
 )
 class YolosForObjectDetection(YolosPreTrainedModel):
+    accepts_loss_kwargs = False
+
     def __init__(self, config: YolosConfig):
         super().__init__(config)
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1880,6 +1880,67 @@ class ModelTesterMixin(ExportTesterMixin):
             loss = model(**inputs).loss
             loss.backward()
 
+    def test_loss_kwargs_are_forwarded_to_loss_function(self):
+        """
+        `Trainer` decides whether the loss still needs to be divided by `gradient_accumulation_steps` from
+        `model.accepts_loss_kwargs`, which defaults to "does `forward` declare `**kwargs`?". When it decides the model
+        handles it, `Trainer.compute_loss` injects `num_items_in_batch` into `forward` and skips its own
+        normalization. A head that declares `**kwargs` but drops `num_items_in_batch` before reaching
+        `self.loss_function` therefore trains with a loss inflated by roughly `gradient_accumulation_steps`.
+
+        Heads that do not route their loss through `self.loss_function` are skipped: the probe never fires for them.
+        """
+        num_items_in_batch = 7
+
+        for model_class in self.all_model_classes:
+            if model_class.__name__ in [
+                *get_values(MODEL_MAPPING_NAMES),
+                *get_values(MODEL_FOR_BACKBONE_MAPPING_NAMES),
+            ]:
+                continue
+            if getattr(model_class, "accepts_loss_kwargs", True) is False:
+                continue
+            forward_params = inspect.signature(model_class.forward).parameters
+            if not any(param.kind == inspect.Parameter.VAR_KEYWORD for param in forward_params.values()):
+                continue
+
+            if hasattr(self.model_tester, "prepare_config_and_inputs_for_model_class"):
+                config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_model_class(model_class)
+            else:
+                config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
+            if set(inputs) == set(self._prepare_for_class(inputs_dict, model_class)):
+                # no labels for this class, so `Trainer` would never compute `num_items_in_batch` for it
+                continue
+
+            model = model_class(config)
+            model.to(torch_device)
+            model.eval()
+
+            observed = {}
+            wrapped_loss_function = model.loss_function
+
+            def spy(*args, _observed=observed, _wrapped=wrapped_loss_function, **kwargs):
+                _observed["num_items_in_batch"] = kwargs.get("num_items_in_batch", "<not forwarded>")
+                return _wrapped(*args, **kwargs)
+
+            model.loss_function = spy
+            with torch.no_grad():
+                model(**inputs, num_items_in_batch=num_items_in_batch)
+
+            if not observed:
+                # this head does not compute its loss through `self.loss_function`, nothing to assert
+                continue
+
+            self.assertEqual(
+                observed["num_items_in_batch"],
+                num_items_in_batch,
+                f"`{model_class.__name__}.forward` declares `**kwargs`, so `Trainer` assumes it consumes "
+                "`num_items_in_batch` and skips the gradient accumulation normalization, but the value never "
+                "reaches `self.loss_function`. Either forward the variadic keyword arguments to "
+                "`self.loss_function(...)`, or set `accepts_loss_kwargs = False` on the class.",
+            )
+
     def test_training_gradient_checkpointing(self):
         # Scenario - 1 default behaviour
         self.check_training_gradient_checkpointing()


### PR DESCRIPTION
# What does this PR do?

Fixes #47688

`Trainer` decides whether the loss still needs the `/ gradient_accumulation_steps` normalization from `model.accepts_loss_kwargs`, which falls back to "does `forward` declare `**kwargs`?". When it decides the model handles it, `compute_loss` injects `num_items_in_batch` into `forward` and `training_step` skips the division. A head that declares `**kwargs` but never passes them to `self.loss_function` does neither normalization, so the backward loss is inflated by roughly `gradient_accumulation_steps`.

65 head classes were in that state. They fall into two groups, and the PR applies the remedy that already exists in the codebase for each.

**Group 1, 50 classes whose loss function does consume `num_items_in_batch`: forward the variadic keyword arguments.**

```diff
- loss = self.loss_function(labels, logits, self.config)
+ loss = self.loss_function(labels, logits, self.config, **kwargs)
```

This is what `ViTForImageClassification`, `SwinForImageClassification`, `Dinov2ForImageClassification`, `SegformerForImageClassification`, `VideoMAEForVideoClassification`, `ASTForAudioClassification`, `LlavaForConditionalGeneration` and `GenericForQuestionAnswering` already do.

Two of the 50 are `GenericForSequenceClassification` and `GenericForTokenClassification` in `modeling_layers.py`, which covers every model that reuses the shared heads. `GenericForQuestionAnswering`, right next to them in the same file, was already correct.

**Group 2, 15 classes whose loss function has no notion of an item count: `accepts_loss_kwargs = False`.**

`ForObjectDetectionLoss` builds its own `HungarianMatcher` and `ImageLoss` criterion and never reads `num_items_in_batch`; the RNNT losses are the same. Forwarding the kwargs there would be a no-op and would leave the loss inflated, so these opt out instead and let `Trainer` do the division, following #40746 (ConvNext), #41006 (ESM) and #35257 (TimmWrapper). This covers the DETR family, yolos, rf_detr, table_transformer and the two Nemotron RNNT heads.

`BloomForCausalLM` is deliberately untouched: it already passes `num_items_in_batch=kwargs.get("num_items_in_batch")` explicitly, and adding `**kwargs` there would raise `TypeError: got multiple values for keyword argument`.

Edits were made at the `modular_*.py` source wherever one exists; `metaclip_2` and `regnet` are fully derived from `clip` and `resnet` and only carry regenerated output. One incidental line in `minicpmv4_6/modeling_minicpmv4_6.py` (`x if x else y` to `x or y`) comes from `make fix-repo` regenerating a file that had drifted from its modular source; it is unrelated to the fix but required for the modular conversion check to pass.

## How it was verified

Numeric repro on CPU with tiny random configs, before and after. The invariant is `loss * n`, the raw summed loss, which must not depend on `n`:

```
BEFORE
SwinForImageClassification (control)      n=4 -> 1.094149  n=8 -> 0.547074   raw sum: 4.376595 / 4.376595   honours num_items: True
Swinv2ForImageClassification (subject)    n=4 -> 1.094382  n=8 -> 1.094382   raw sum: 4.377528 / 8.755056   honours num_items: False
GPTNeoXForCausalLM (control)              n=4 -> 32.144936 n=8 -> 16.072468  raw sum: 128.579742 / 128.579742  honours num_items: True
GPTNeoXForTokenClassification (subject)   n=4 -> 1.107692  n=8 -> 1.107692   raw sum: 4.430769 / 8.861538   honours num_items: False

AFTER
SwinForImageClassification (control)      n=4 -> 1.094149  n=8 -> 0.547074   raw sum: 4.376595 / 4.376595   honours num_items: True
Swinv2ForImageClassification (subject)    n=4 -> 1.094382  n=8 -> 0.547191   raw sum: 4.377528 / 4.377528   honours num_items: True
GPTNeoXForCausalLM (control)              n=4 -> 32.144936 n=8 -> 16.072468  raw sum: 128.579742 / 128.579742  honours num_items: True
GPTNeoXForTokenClassification (subject)   n=4 -> 8.861538  n=8 -> 4.430769   raw sum: 35.446152 / 35.446152  honours num_items: True
```

New regression test, repo wide:

```
pytest tests/models -k test_loss_kwargs_are_forwarded_to_loss_function
605 passed, 5 skipped in 93.02s
```

Full test suites of every touched model, plus llama and mistral as unaffected controls, run on the same machine before and after the change:

```
pytest tests/models/{55 affected test_modeling_*.py} tests/models/llama tests/models/mistral
before: 27 failed, 6821 passed, 9227 skipped, 673 xfailed, 32 xpassed
after:  27 failed, 6894 passed, 9228 skipped, 673 xfailed, 32 xpassed
```

The 27 failures are identical in both runs and unrelated to this change (`test_generate_compile_model_forward_fullgraph`, `test_generate_compilation_all_outputs`, `test_backbone_selection`, `test_fsdp2_plan_vs_ddp_*`, `test_mask_*_prob_ctc` on a CPU-only Windows box). The 73 extra passes are the new test.

Repository consistency:

```
python utils/checkers.py modular_conversion, copies --fix   # no further changes
ruff check / ruff format --check on all touched files       # clean
```

## About the test

`tests/test_modeling_common.py` gains `test_loss_kwargs_are_forwarded_to_loss_function`. It wraps `self.loss_function` and asserts that `num_items_in_batch` reaches it, rather than asserting on loss values. That keeps it model agnostic and free of allowlists:

- a head that does not route its loss through `self.loss_function` never fires the probe and is skipped, which covers the many heads that still build an `nn.CrossEntropyLoss()` inline;
- classes in `MODEL_MAPPING_NAMES` / `MODEL_FOR_BACKBONE_MAPPING_NAMES`, and classes for which `_prepare_for_class` produces no labels, are skipped because `Trainer` would never compute `num_items_in_batch` for them;
- the failure message names both accepted remedies, so the next contributor to hit it knows which one applies.

## On the file count

`security-gate` flags this PR because it touches 75 files, above the 50 file threshold for automatic CI approval. The count comes from the shape of the change rather than its size: it is one line per class across 55 model directories, and every model with a `modular_*.py` contributes two files, the edited source and its regenerated output. The whole diff is +198 / -66, and the only lines that are neither `**kwargs` nor `accepts_loss_kwargs = False` are the new test and one incidental regeneration in `minicpmv4_6`.

I kept it as a single PR because the regression test asserts the invariant across all of them at once, so any split leaves the test red until every part has landed. If you would rather review it in pieces, the natural cut is 36 files for the vision, video and segmentation group and 39 for the rest plus the test, and I am happy to reopen it that way.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. — #47688
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [X] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@SunMarc @molbap

---

Disclosure per CONTRIBUTING.md: AI tools were used while producing this change. Coordination link is #47688, which also records the sweep that produced the class list. I checked for overlapping work before opening (`gh pr list --search "accepts_loss_kwargs"`, `"loss_function kwargs gradient accumulation"`, `gh issue list --search "num_items_in_batch"`) and found none. The test commands and their results are quoted verbatim above; I reviewed every changed line and ran the suites on my own machine.


