### PR TITLE
Align image feature dtype in kosmos2 and kosmos2_5 embedding merge

### DIFF
--- a/src/transformers/models/kosmos2/modeling_kosmos2.py
+++ b/src/transformers/models/kosmos2/modeling_kosmos2.py
@@ -950,9 +950,9 @@ class Kosmos2TextTransformer(Kosmos2PreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if image_embeds is not None:
-            inputs_embeds[img_input_mask.to(dtype=torch.bool)] = image_embeds.to(inputs_embeds.device).view(
-                -1, image_embeds.size(-1)
-            )
+            inputs_embeds[img_input_mask.to(dtype=torch.bool)] = image_embeds.to(
+                inputs_embeds.device, inputs_embeds.dtype
+            ).view(-1, image_embeds.size(-1))
 
         inputs_embeds = inputs_embeds * self.embed_scale
 

--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -937,9 +937,9 @@ class Kosmos2_5TextTransformer(Kosmos2_5PreTrainedModel):
         # Ignore copy
         if image_embeds is not None:
             inputs_embeds = inputs_embeds.clone()
-            inputs_embeds[image_embeds_position_mask == 1] = image_embeds.to(inputs_embeds.device).view(
-                -1, image_embeds.shape[-1]
-            )
+            inputs_embeds[image_embeds_position_mask == 1] = image_embeds.to(
+                inputs_embeds.device, inputs_embeds.dtype
+            ).view(-1, image_embeds.shape[-1])
 
         inputs_embeds = inputs_embeds * self.embed_scale
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47691)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47691)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47689

`Kosmos2TextTransformer.forward_embedding` and `Kosmos2_5TextTransformer.forward` move the vision features to the text device but not to the text dtype before merging them into `inputs_embeds`. Under `torch.autocast`, `inputs_embeds` comes from `nn.Embedding`, which is not on autocast's cast list and stays float32, while `image_embeds` comes from a projection ending in `nn.Linear` and is cast to bfloat16. The merge is an advanced index assignment, which lowers to `index_put_`, and that operator does not type promote:

```
RuntimeError: Index put requires the source and destination dtypes match,
got Float for the destination and BFloat16 for the source.
```

Passing the dtype alongside the device is what `idefics2`, `idefics3` and `modernvbert` already do at the same merge point.

This is the same root cause as #47672 / #47673, but a different operator: that sweep covered `masked_scatter`, and these two models use an advanced index assignment instead, so they were not in its scope. `smolvlm` has the same defect in `modular_smolvlm.py`, but #41485 is already open against that file and is deliberately left alone here.

## How it was verified

Both models were driven through a bfloat16 autocast forward pass on CPU, built from their existing `ModelTester`s, before and after the change:

```
BEFORE
kosmos2      RuntimeError: Index put requires the source and destination dtypes match, got Float for the destination and BFloat16 for the source.
kosmos2_5    RuntimeError: Index put requires the source and destination dtypes match, got Float for the destination and BFloat16 for the source.

AFTER
kosmos2      ok under bfloat16 autocast
kosmos2_5    ok under bfloat16 autocast
```

```
pytest tests/models/kosmos2/test_modeling_kosmos2.py tests/models/kosmos2_5/test_modeling_kosmos2_5.py
228 passed, 315 skipped, 3368 subtests passed in 36.90s
```

```
python utils/checkers.py modular_conversion, copies --fix   # no changes
ruff check / ruff format --check on both files              # clean
```

No test is added, matching #47673, which fixed the same class of bug across seven models without one. There is no reusable autocast helper under `tests/` to extend. I have a CPU-only bfloat16 forward test built on `Kosmos2ModelTester` and `Kosmos2_5ModelTester` ready if you would like it included.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. — #47689
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@zucchini-nlp

---

Disclosure per CONTRIBUTING.md: AI tools were used while producing this change. Coordination link is #47689. I checked for overlapping work before opening (`gh pr list --search "kosmos2"`, `"index_put dtype autocast"`, `gh issue list --search "kosmos"`) and found none; #41485 covers smolvlm only and is excluded above. The commands and their output are quoted verbatim; I reviewed both changed lines and ran the tests on my own machine.