### PR TITLE
Remove unused DPT fusion residual parameters

### DIFF
--- a/src/transformers/models/dpt/convert_dinov2_depth_to_hf.py
+++ b/src/transformers/models/dpt/convert_dinov2_depth_to_hf.py
@@ -296,10 +296,7 @@ def convert_dpt_checkpoint(model_name, pytorch_dump_folder_path, push_to_hub, ve
     missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
     print("Missing keys:", missing_keys)
     print("Unexpected keys:", unexpected_keys)
-    assert missing_keys == [
-        "neck.fusion_stage.layers.0.residual_layer1.convolution1.weight",
-        "neck.fusion_stage.layers.0.residual_layer1.convolution2.weight",
-    ]
+    assert missing_keys == []
     model.eval()
 
     # Verify image processor

--- a/src/transformers/models/dpt/convert_dpt_beit_to_hf.py
+++ b/src/transformers/models/dpt/convert_dpt_beit_to_hf.py
@@ -194,6 +194,11 @@ def convert_dpt_checkpoint(model_name, pytorch_dump_folder_path, push_to_hub):
     rename_keys = create_rename_keys(config)
     for src, dest in rename_keys:
         rename_key(state_dict, src, dest)
+    # The first fusion layer never consumes a residual, so its source checkpoint parameters are intentionally unused.
+    first_fusion_residual_prefix = "neck.fusion_stage.layers.0.residual_layer1."
+    for key in tuple(state_dict):
+        if key.startswith(first_fusion_residual_prefix):
+            state_dict.pop(key)
     # read in qkv matrices
     read_in_q_k_v(state_dict, config)
 

--- a/src/transformers/models/dpt/convert_dpt_hybrid_to_pytorch.py
+++ b/src/transformers/models/dpt/convert_dpt_hybrid_to_pytorch.py
@@ -234,6 +234,11 @@ def convert_dpt_checkpoint(checkpoint_url, pytorch_dump_folder_path, push_to_hub
     for key in state_dict.copy():
         val = state_dict.pop(key)
         state_dict[rename_key(key)] = val
+    # The first fusion layer never consumes a residual, so its source checkpoint parameters are intentionally unused.
+    first_fusion_residual_prefix = "neck.fusion_stage.layers.0.residual_layer1."
+    for key in tuple(state_dict):
+        if key.startswith(first_fusion_residual_prefix):
+            state_dict.pop(key)
     # read in qkv matrices
     read_in_q_k_v(state_dict, config)
 

--- a/src/transformers/models/dpt/convert_dpt_swinv2_to_hf.py
+++ b/src/transformers/models/dpt/convert_dpt_swinv2_to_hf.py
@@ -210,6 +210,11 @@ def convert_dpt_checkpoint(model_name, pytorch_dump_folder_path, verify_logits, 
     rename_keys = create_rename_keys(config)
     for src, dest in rename_keys:
         rename_key(state_dict, src, dest)
+    # The first fusion layer never consumes a residual, so its source checkpoint parameters are intentionally unused.
+    first_fusion_residual_prefix = "neck.fusion_stage.layers.0.residual_layer1."
+    for key in tuple(state_dict):
+        if key.startswith(first_fusion_residual_prefix):
+            state_dict.pop(key)
     # read in qkv matrices
     read_in_q_k_v(state_dict, config, model)
 

--- a/src/transformers/models/dpt/convert_dpt_to_pytorch.py
+++ b/src/transformers/models/dpt/convert_dpt_to_pytorch.py
@@ -201,6 +201,11 @@ def convert_dpt_checkpoint(checkpoint_url, pytorch_dump_folder_path, push_to_hub
     for key in state_dict.copy():
         val = state_dict.pop(key)
         state_dict[rename_key(key)] = val
+    # The first fusion layer never consumes a residual, so its source checkpoint parameters are intentionally unused.
+    first_fusion_residual_prefix = "neck.fusion_stage.layers.0.residual_layer1."
+    for key in tuple(state_dict):
+        if key.startswith(first_fusion_residual_prefix):
+            state_dict.pop(key)
     # read in qkv matrices
     read_in_q_k_v(state_dict, config)
 

--- a/src/transformers/models/dpt/modeling_dpt.py
+++ b/src/transformers/models/dpt/modeling_dpt.py
@@ -714,6 +714,7 @@ class DPTPreTrainedModel(PreTrainedModel):
     base_model_prefix = "dpt"
     main_input_name = "pixel_values"
     input_modalities = ("image",)
+    _keys_to_ignore_on_load_unexpected = [r"neck\.fusion_stage\.layers\.0\.residual_layer1\..*"]
     supports_gradient_checkpointing = True
     _supports_sdpa = True
     _supports_flash_attn = True
@@ -939,6 +940,10 @@ class DPTForDepthEstimation(DPTPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
+        # The first fusion layer never receives a residual. Remove its dead parameters after initialization so the
+        # initialization order of all remaining parameters stays unchanged.
+        self.neck.fusion_stage.layers[0].residual_layer1 = None
+
     @can_return_tuple
     @auto_docstring
     def forward(
@@ -1091,6 +1096,10 @@ class DPTForSemanticSegmentation(DPTPreTrainedModel):
 
         # Initialize weights and apply final processing
         self.post_init()
+
+        # The first fusion layer never receives a residual. Remove its dead parameters after initialization so the
+        # initialization order of all remaining parameters stays unchanged.
+        self.neck.fusion_stage.layers[0].residual_layer1 = None
 
     @can_return_tuple
     @auto_docstring

--- a/tests/models/dpt/test_modeling_dpt.py
+++ b/tests/models/dpt/test_modeling_dpt.py
@@ -191,6 +191,55 @@ class DPTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, nn.Linear))
 
+    def test_first_fusion_layer_has_no_unused_residual_parameters(self):
+        """The first fusion layer never receives a residual, so it should not expose checkpoint parameters for one."""
+        first_residual_prefix = "neck.fusion_stage.layers.0.residual_layer1."
+        second_residual_prefix = "neck.fusion_stage.layers.1.residual_layer1."
+
+        for model_class in (DPTForDepthEstimation, DPTForSemanticSegmentation):
+            with self.subTest(model_class=model_class.__name__):
+                model = model_class(self.model_tester.get_config())
+                state_dict_keys = model.state_dict().keys()
+
+                self.assertIsNone(model.neck.fusion_stage.layers[0].residual_layer1)
+                self.assertIsNotNone(model.neck.fusion_stage.layers[1].residual_layer1)
+                self.assertFalse(any(key.startswith(first_residual_prefix) for key in state_dict_keys))
+                self.assertTrue(any(key.startswith(second_residual_prefix) for key in state_dict_keys))
+
+    def test_load_legacy_first_fusion_residual_parameters(self):
+        first_residual_prefix = "neck.fusion_stage.layers.0.residual_layer1."
+        second_residual_prefix = "neck.fusion_stage.layers.1.residual_layer1."
+        unrelated_key = "unrelated.weight"
+
+        for model_class in (DPTForDepthEstimation, DPTForSemanticSegmentation):
+            for use_batch_norm in (False, True):
+                with self.subTest(model_class=model_class.__name__, use_batch_norm=use_batch_norm):
+                    config = self.model_tester.get_config()
+                    config.use_batch_norm_in_fusion_residual = use_batch_norm
+                    model = model_class(config)
+                    legacy_state_dict = model.state_dict()
+
+                    legacy_keys = []
+                    for key, value in list(legacy_state_dict.items()):
+                        if key.startswith(second_residual_prefix):
+                            legacy_key = key.replace(second_residual_prefix, first_residual_prefix, 1)
+                            legacy_state_dict[legacy_key] = value.clone()
+                            legacy_keys.append(legacy_key)
+                    legacy_state_dict[unrelated_key] = torch.zeros(1)
+
+                    _, loading_info = model_class.from_pretrained(
+                        None,
+                        config=config,
+                        state_dict=legacy_state_dict,
+                        output_loading_info=True,
+                        local_files_only=True,
+                    )
+
+                    self.assertGreater(len(legacy_keys), 0)
+                    self.assertEqual(loading_info["missing_keys"], set())
+                    self.assertEqual(loading_info["unexpected_keys"], {unrelated_key})
+                    self.assertEqual(loading_info["error_msgs"], [])
+
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47699)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47699)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

The first DPT feature-fusion layer is always called without a residual input, but it still registers a `residual_layer1` module. Those parameters are therefore unreachable. Checkpoints that follow the original DPT layout omit them, which produces a misleading warning that the weights were newly initialized.

This PR:

- removes the unused first residual module from the DPT depth-estimation and semantic-segmentation heads after `post_init()`, preserving the initialization order and RNG state of every retained parameter;
- ignores the corresponding legacy checkpoint keys during `from_pretrained` loading;
- updates the DPT conversion scripts so converted state dictionaries match the corrected model structure;
- adds regression coverage for both task heads and for legacy checkpoints with and without fusion BatchNorm.

The retained parameters and outputs of both task heads are bit-for-bit identical before and after this change. This addresses the maintainer-identified random-initialization warning in #28292; it does not change depth-map normalization or post-processing behavior.

Fixes #28292

## AI-assisted contribution disclosure

I used Codex to assist with repository exploration, implementation, and local test execution. I reviewed every changed line and validated the behavior locally before submission.

- Coordination and maintainer diagnosis: #28292, which is labeled `Good Second Issue`
- Existing work: I found no open pull request addressing the unused first DPT fusion residual parameters before publishing this branch
- Scope control: copied DPT fusion implementations in ZoeDepth and DepthAnything are intentionally unchanged to avoid altering their checkpoint schemas

## Validation

```text
python -m pytest -q tests/models/dpt/test_modeling_dpt.py
102 passed, 122 skipped, 2145 subtests passed
```

Additional checks:

- targeted legacy-loading coverage: 2 tests passed, 6 subtests passed
- Ruff lint and format checks passed for all 7 changed files
- copied-code consistency and import ordering checks passed
- changed-only modeling-structure check passed
- synthetic converter checks covered both the 4-key non-BatchNorm and 12-key BatchNorm legacy subtrees

Large real-world checkpoint conversion scripts were not run end to end because they require downloading their source checkpoints; their key mapping and strict-loading behavior were validated with synthetic state dictionaries.

## Code Agent Policy

Not applicable to the first-time-contributor checkbox: I am not a first-time Transformers contributor.

## Before submitting

- [ ] This PR fixes a typo or improves the docs
- [x] I read the contributor guidelines and PR checks
- [x] This change follows the diagnosis and invitation to contribute in #28292
- [x] No documentation update is required because this does not change a public API
- [x] I added and ran the necessary tests