### PR TITLE
Build Llama pipeline from the reference SentencePiece normalizer

### DIFF
--- a/src/transformers/models/llama/tokenization_llama.py
+++ b/src/transformers/models/llama/tokenization_llama.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tokenizers import Tokenizer, decoders, pre_tokenizers
+from tokenizers import Tokenizer, decoders, normalizers
 from tokenizers.models import BPE
 
-from ...tokenization_utils_base import _get_prepend_scheme
 from ...tokenization_utils_tokenizers import TokenizersBackend
 from ...utils import logging
 
@@ -116,10 +115,11 @@ class LlamaTokenizer(TokenizersBackend):
         self._tokenizer = Tokenizer(
             BPE(vocab=self._vocab, merges=self._merges, fuse_unk=True, byte_fallback=True, dropout=None)
         )
-        self._tokenizer.normalizer = None
-        self._tokenizer.pre_tokenizer = pre_tokenizers.Metaspace(
-            replacement="▁", prepend_scheme=_get_prepend_scheme(self.add_prefix_space, self), split=False
-        )
+        normalizer_sequence = []
+        if self.add_prefix_space:
+            normalizer_sequence.append(normalizers.Prepend(prepend="▁"))
+        normalizer_sequence.append(normalizers.Replace(pattern=" ", content="▁"))
+        self._tokenizer.normalizer = normalizers.Sequence(normalizer_sequence)
 
         sequence = [
             decoders.Replace("▁", " "),

--- a/tests/models/llama/test_tokenization_llama.py
+++ b/tests/models/llama/test_tokenization_llama.py
@@ -12,25 +12,23 @@ from transformers.testing_utils import (
 @require_tokenizers
 class LlamaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     from_pretrained_id = [
-        "hf-internal-testing/llama-tokenizer",
         "meta-llama/Llama-2-7b-hf",
+        "hf-internal-testing/llama-tokenizer",
         "meta-llama/Meta-Llama-3-8B",
     ]
     tokenizer_class = LlamaTokenizer
     from_pretrained_kwargs = {}
 
     # Integration test data - expected outputs for the default input string
-    integration_expected_tokens = ["▁This", "▁is", "▁a", "▁test", "▁", "<0xF0>", "<0x9F>", "<0x98>", "<0x8A>", "<0x0A>", "I", "▁was", "▁born", "▁in", "▁", "9", "2", "0", "0", "0", ",", "▁and", "▁this", "▁is", "▁f", "als", "é", ".", "<0x0A>", "生", "活", "的", "真", "<0xE8>", "<0xB0>", "<0x9B>", "是", "<0x0A>", "Hi", "▁", "▁Hello", "<0x0A>", "Hi", "▁▁", "▁Hello", "<0x0A>", "<0x0A>", "▁", "<0x0A>", "▁▁", "<0x0A>", "▁Hello", "<0x0A>", "<s>", "<0x0A>", "hi", "<s>", "there", "<0x0A>", "The", "▁following", "▁string", "▁should", "▁be", "▁properly", "▁encoded", ":", "▁Hello", ".", "<0x0A>", "But", "▁", "ird", "▁and", "▁", "ป", "ี", "▁▁▁", "ird", "▁▁▁", "ด", "<0x0A>", "H", "ey", "▁how", "▁are", "▁you", "▁doing"]  # fmt: skip
-    integration_expected_token_ids = [910, 338, 263, 1243, 29871, 243, 162, 155, 141, 13, 29902, 471, 6345, 297, 29871, 29929, 29906, 29900, 29900, 29900, 29892, 322, 445, 338, 285, 1338, 29948, 29889, 13, 30486, 31704, 30210, 30848, 235, 179, 158, 30392, 13, 18567, 29871, 15043, 13, 18567, 259, 15043, 13, 13, 29871, 13, 259, 13, 15043, 13, 1, 13, 2918, 1, 12711, 13, 1576, 1494, 1347, 881, 367, 6284, 18511, 29901, 15043, 29889, 13, 6246, 29871, 1823, 322, 29871, 31010, 30691, 1678, 1823, 1678, 30718, 13, 29950, 1032, 920, 526, 366, 2599]  # fmt: skip
-    integration_expected_decoded_text = "This is a test 😊\nI was born in 92000, and this is falsé.\n生活的真谛是\nHi  Hello\nHi   Hello\n\n \n  \n Hello\n<s>\nhi<s>there\nThe following string should be properly encoded: Hello.\nBut ird and ปี   ird   ด\nHey how are you doing"
+    integration_expected_tokens = ["▁This", "▁is", "▁a", "▁test", "▁", "<0xF0>", "<0x9F>", "<0x98>", "<0x8A>", "<0x0A>", "I", "▁was", "▁born", "▁in", "▁", "9", "2", "0", "0", "0", ",", "▁and", "▁this", "▁is", "▁f", "als", "é", ".", "<0x0A>", "生", "活", "的", "真", "<0xE8>", "<0xB0>", "<0x9B>", "是", "<0x0A>", "Hi", "▁", "▁Hello", "<0x0A>", "Hi", "▁▁", "▁Hello", "<0x0A>", "<0x0A>", "▁", "<0x0A>", "▁▁", "<0x0A>", "▁Hello", "<0x0A>", "<s>", "▁", "<0x0A>", "hi", "<s>", "▁there", "<0x0A>", "The", "▁following", "▁string", "▁should", "▁be", "▁properly", "▁encoded", ":", "▁Hello", ".", "<0x0A>", "But", "▁", "ird", "▁and", "▁", "ป", "ี", "▁▁▁", "ird", "▁▁▁", "ด", "<0x0A>", "H", "ey", "▁how", "▁are", "▁you", "▁doing"]  # fmt: skip
+    integration_expected_token_ids = [910, 338, 263, 1243, 29871, 243, 162, 155, 141, 13, 29902, 471, 6345, 297, 29871, 29929, 29906, 29900, 29900, 29900, 29892, 322, 445, 338, 285, 1338, 29948, 29889, 13, 30486, 31704, 30210, 30848, 235, 179, 158, 30392, 13, 18567, 29871, 15043, 13, 18567, 259, 15043, 13, 13, 29871, 13, 259, 13, 15043, 13, 1, 29871, 13, 2918, 1, 727, 13, 1576, 1494, 1347, 881, 367, 6284, 18511, 29901, 15043, 29889, 13, 6246, 29871, 1823, 322, 29871, 31010, 30691, 1678, 1823, 1678, 30718, 13, 29950, 1032, 920, 526, 366, 2599]  # fmt: skip
+    integration_expected_decoded_text = "This is a test 😊\nI was born in 92000, and this is falsé.\n生活的真谛是\nHi  Hello\nHi   Hello\n\n \n  \n Hello\n<s> \nhi<s> there\nThe following string should be properly encoded: Hello.\nBut ird and ปี   ird   ด\nHey how are you doing"
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
-        from_pretrained_id = "hf-internal-testing/llama-tokenizer"
-
-        tokenizer = LlamaTokenizer.from_pretrained(from_pretrained_id)
+        tokenizer = LlamaTokenizer.from_pretrained(cls.from_pretrained_id[0])
         tokenizer.pad_token = tokenizer.eos_token
         tokenizer.save_pretrained(cls.tmpdirname)
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47700)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47700)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Follow-up to #47488, which fixed the same bug for CodeLlama.

`LlamaTokenizer` builds its pipeline with a `Metaspace(prepend_scheme="first")` pre-tokenizer (via `_get_prepend_scheme` with the default `legacy=False`). Metaspace runs `replace(" ", "▁")` before its guarded prepend, so a real leading space becomes `▁` and the prepend is then skipped, which fuses a user-provided leading space into the synthetic prefix at encode time. `" hello"` and `"hello"` encode to the same ids, the leading space is gone before decode runs, and the ids diverge from the pipeline the checkpoint ships in `tokenizer.json`.

This builds the pipeline from the `Prepend("▁") + Replace(" ", "▁")` normalizer with no pre-tokenizer, which is what `meta-llama/Llama-2-7b-hf` ships in its `tokenizer.json`. It is the same fix that landed for CodeLlama in #47488, applied to the sibling. Leading whitespace now round-trips exactly, including a single leading space, tabs, newlines, and real code with nested indentation, and encode matches the reference `tokenizer.json`.

Note: I wanted to check the intent before going further, since Llama is more widely used than CodeLlama and `LlamaTokenizer` still carries a real `legacy` flag (CodeLlama had dropped it), so if there is a reason Llama-1/2 is meant to stay on Metaspace, this may be scoped differently. Given the "code llama is llama2, pre-metaspace" point from #47488, the same reasoning seems to apply to Llama-1/2. Llama-3 is byte-level and is unaffected.

This PR updates the integration test expectations to the reference tokenization (`<s>` is followed by `▁`), and changes `setUpClass` to save `from_pretrained_id[0]` rather than a hardcoded fixture. The `hf-internal-testing/llama-tokenizer` fixture marks `<s>` as `normalized=True`, which splits it under the normalizer, whereas the published `meta-llama/Llama-2-7b-hf` checkpoint uses `normalized=False`, so the test now runs against the real checkpoint (mirroring what #47488 did for CodeLlama). The remaining checkpoints in `from_pretrained_id` are gated, so the full suite needs `meta-llama` access to run locally, but it passes in that setup.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@ArthurZucker @itazap