### PR TITLE
clean up reverse_op fixme in compressed_tensors

### DIFF
--- a/src/transformers/integrations/compressed_tensors.py
+++ b/src/transformers/integrations/compressed_tensors.py
@@ -16,7 +16,7 @@
 import torch
 from torch import nn
 
-from ..core_model_loading import ConversionOps
+from ..core_model_loading import ConversionOps, _IdentityOp
 from ..utils import logging
 from ..utils.import_utils import is_torch_greater_or_equal
 
@@ -166,7 +166,7 @@ class DecompressExperts(ConversionOps):
 
     @property
     def reverse_op(self) -> "ConversionOps":
-        return None  # FIXME
+        return _IdentityOp()
 
 
 _FP8_DTYPE = torch.float8_e4m3fn

--- a/src/transformers/integrations/compressed_tensors.py
+++ b/src/transformers/integrations/compressed_tensors.py
@@ -16,7 +16,7 @@
 import torch
 from torch import nn
 
-from ..core_model_loading import ConversionOps
+from ..core_model_loading import ConversionOps, _IdentityOp
 from ..utils import logging
 from ..utils.import_utils import is_torch_greater_or_equal
 
@@ -171,7 +171,7 @@ class DecompressExperts(ConversionOps):
 
     @property
     def reverse_op(self) -> "ConversionOps":
-        return None  # FIXME
+        return _IdentityOp()
 
 
 _FP8_DTYPE = torch.float8_e4m3fn


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47701)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47701)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

just cleaning up a lingering FIXME in `compressed_tensors.py` where `reverse_op` was returning `None`. changed it to return `_IdentityOp()` instead.