### PR TITLE
Fix text-generation pipeline not forwarding tokenizer to generate

### DIFF
--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -400,6 +400,9 @@ class TextGenerationPipeline(Pipeline):
         if "generation_config" not in generate_kwargs:
             generate_kwargs["generation_config"] = self.generation_config
 
+        # The pipeline holds a tokenizer; forward it so `generate` can use it (e.g. for `stop_strings`).
+        generate_kwargs.setdefault("tokenizer", self.tokenizer)
+
         output = self.model.generate(input_ids=input_ids, attention_mask=attention_mask, **generate_kwargs)
 
         if isinstance(output, ModelOutput):

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -370,6 +370,17 @@ class TextGenerationPipelineTests(unittest.TestCase):
         output = text_generator(prompt, stop_sequence=" fe")
         self.assertEqual(output, [{"generated_text": "Hello I believe in fe"}])
 
+    def test_stop_strings_from_generation_config(self):
+        # `stop_strings` set on the pipeline's generation config requires the tokenizer to be forwarded to
+        # `generate`; otherwise it raises a ValueError. See https://github.com/huggingface/transformers/issues/34571
+        prompt = """Hello I believe in"""
+        text_generator = pipeline(
+            "text-generation", model="hf-internal-testing/tiny-random-gpt2", max_new_tokens=5, do_sample=False
+        )
+        text_generator.generation_config.stop_strings = [" fe"]
+        output = text_generator(prompt)
+        self.assertEqual(output, [{"generated_text": "Hello I believe in fe"}])
+
     def run_pipeline_test(self, text_generator, _):
         model = text_generator.model
         tokenizer = text_generator.tokenizer


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47702)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47702)
<!-- ci-dashboard-badge:end -->

## What

When `stop_strings` is set on the pipeline's generation config, `generate` needs the tokenizer to decode the stop strings. The text-generation pipeline wasn't forwarding its tokenizer, so this raised a `ValueError`.

This adds `generate_kwargs.setdefault("tokenizer", self.tokenizer)` before the `generate` call, so the pipeline's tokenizer is forwarded while explicit user-passed tokenizers still win.

This covers the pipeline half of #34571, as suggested by @qgallouedec.

## Test

Added `test_stop_strings_from_generation_config`, which sets `stop_strings` on the pipeline's generation config and checks the output stops correctly. It fails without the fix and passes with it.

`make style` and `make fix-repo` pass. The only local test failures in this file are pre-existing ones that need access to the gated `google/gemma-3-270m-it` model.