### PR TITLE
Fix sliding window cache index off-by-one on wraparound

### DIFF
--- a/src/transformers/generation/continuous_batching/cache_manager.py
+++ b/src/transformers/generation/continuous_batching/cache_manager.py
@@ -504,9 +504,10 @@ class SlidingAttentionCacheAllocator(CacheAllocator):
         block_table = self.block_table.get(request_id)
         if block_table is None:
             raise ValueError(f"No block table found for request {request_id}")
-        # Apply sliding window
-        start_index = 0 if past_length < self.sliding_window else past_length % self.sliding_window
+        # Apply sliding window: read the `cache_length` most recent tokens, which start at logical position
+        # `past_length - cache_length` and thus at that position's slot in the rolling buffer
         cache_length = min(past_length, self.sliding_window - 1)
+        start_index = (past_length - cache_length) % self.sliding_window
         # Compute the physical indices
         physical_indices = []
         for i in range(start_index, start_index + cache_length):
@@ -525,10 +526,11 @@ class SlidingAttentionCacheAllocator(CacheAllocator):
         block_table = self.block_table.get(request_id)
         if block_table is None:
             raise ValueError(f"No block table found for request {request_id}")
-        # Apply sliding window
-        start_index = past_length % self.sliding_window
+        # Apply sliding window: only the last `sliding_window` query tokens are kept, the earlier ones go to the trash
+        # slot. The first kept token is at logical position `past_length + padding_length`, hence the start index
         cache_length = min(query_length, self.sliding_window)
         padding_length = query_length - cache_length
+        start_index = (past_length + padding_length) % self.sliding_window
         # Compute the physical indices
         physical_indices = []
         for i in range(start_index, start_index + cache_length):

--- a/src/transformers/generation/continuous_batching/cache_manager.py
+++ b/src/transformers/generation/continuous_batching/cache_manager.py
@@ -526,7 +526,7 @@ class SlidingAttentionCacheAllocator(CacheAllocator):
         block_table = self.block_table.get(request_id)
         if block_table is None:
             raise ValueError(f"No block table found for request {request_id}")
-        # Apply sliding window: only the last `sliding_window` query tokens are kept, the earlier ones go to the trash
+        # Apply sliding window: only the last `sliding_window` query tokens are written, the earlier ones go to the trash
         # slot. The first kept token is at logical position `past_length + padding_length`, hence the start index
         cache_length = min(query_length, self.sliding_window)
         padding_length = query_length - cache_length

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -538,10 +538,11 @@ class ContinuousBatchingNoAcceleratorTest(unittest.TestCase):
         )
         allocator.block_table["req"] = block_table
 
-        # Read indices: cache positions followed by one sentinel per query token
-        read_start = 0 if past_length < sliding_window else past_length % sliding_window
+        # Read indices: the (at most) `sliding_window - 1` most recent cached tokens, in chronological order,
+        # followed by one sentinel per query token. The most recent cached token is the one at logical position
+        # `past_length - 1`, and it must be part of the read.
         read_cache_length = min(past_length, sliding_window - 1)
-        expected_read = [to_physical(i) for i in range(read_start, read_start + read_cache_length)]
+        expected_read = [to_physical(i) for i in range(past_length - read_cache_length, past_length)]
         expected_read += [sentinel_index] * query_length
         read = allocator.get_read_indices("req", past_length, query_length)
 
@@ -555,11 +556,10 @@ class ContinuousBatchingNoAcceleratorTest(unittest.TestCase):
 
         # Write indices: one slot per query token, left-padded with the write trash index when the query overflows the
         # window
-        write_start = past_length % sliding_window
         write_cache_length = min(query_length, sliding_window)
         padding_length = query_length - write_cache_length
         expected_write = [write_trash_index] * padding_length
-        expected_write += [to_physical(i) for i in range(write_start, write_start + write_cache_length)]
+        expected_write += [to_physical(i) for i in range(past_length + padding_length, past_length + query_length)]
         write = allocator.get_write_indices("req", past_length, query_length)
 
         # Main check
@@ -569,6 +569,63 @@ class ContinuousBatchingNoAcceleratorTest(unittest.TestCase):
         # Cache writes land in allocated blocks
         for idx in write[padding_length:]:
             self.assertIn(idx // block_size, block_table)
+
+    @parameterized.expand(
+        [
+            # (block_size, sliding_window, block_table, query_lengths)
+            # Prefill shorter than the window, then decode past the wrap-around
+            (4, 8, [0, 1], [3] + [1] * 16),
+            # Prefill exactly the size of the window, then decode
+            (4, 8, [0, 1], [8] + [1] * 16),
+            # Prefill longer than the window, then decode
+            (4, 8, [3, 5], [11] + [1] * 16),
+            # Chunked prefill, with chunks smaller and larger than the window
+            (4, 8, [0, 1], [3, 5, 4, 10, 2] + [1] * 8),
+            # Single-block window
+            (4, 4, [7], [1] * 12),
+            # Larger block size
+            (16, 32, [0, 1], [5] + [1] * 40),
+        ]
+    )
+    def test_sliding_attention_read_write_round_trip(
+        self,
+        block_size: int,
+        sliding_window: int,
+        block_table: list[int],
+        query_lengths: list[int],
+    ) -> None:
+        """Replays a sequence of prefill/decode steps through the rolling buffer, tracking which logical token each
+        physical slot holds, and checks that every read returns the `sliding_window - 1` most recent tokens in
+        chronological order. Reads and writes are only consistent with each other if both agree on where a given
+        logical position lives, so this catches off-by-one errors that the two index computations would otherwise hide
+        from each other."""
+        allocator = SlidingAttentionCacheAllocator(
+            index=0,
+            block_size=block_size,
+            sliding_window=sliding_window,
+            sentinel_index=-1,
+            write_trash_index=-2,
+        )
+        allocator.block_table["req"] = block_table
+
+        slot_to_token: dict[int, int] = {}  # physical slot -> logical position currently stored there
+        past_length = 0
+        for query_length in query_lengths:
+            # Reads happen before writes, and only when there is cache to read from
+            if past_length > 0:
+                read = allocator.get_read_indices("req", past_length, query_length)
+                self.assertEqual(read[-query_length:], [allocator.sentinel_index] * query_length)
+                cached_tokens = [slot_to_token[idx] for idx in read[:-query_length]]
+                expected_tokens = list(range(max(0, past_length - sliding_window + 1), past_length))
+                self.assertEqual(
+                    cached_tokens,
+                    expected_tokens,
+                    f"Wrong cache read at {past_length = } for {sliding_window = }, {block_size = }",
+                )
+            for offset, idx in enumerate(allocator.get_write_indices("req", past_length, query_length)):
+                if idx != allocator.write_trash_index:
+                    slot_to_token[idx] = past_length + offset
+            past_length += query_length
 
     @slow
     def test_continuous_batching_no_accelerators(self) -> None:

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -540,7 +540,7 @@ class ContinuousBatchingNoAcceleratorTest(unittest.TestCase):
 
         # Read indices: the (at most) `sliding_window - 1` most recent cached tokens, in chronological order,
         # followed by one sentinel per query token. The most recent cached token is the one at logical position
-        # `past_length - 1`, and it must be part of the read.
+        # `past_length - 1`, and will be read as long as sliding_window > 1 (should always be the case)
         read_cache_length = min(past_length, sliding_window - 1)
         expected_read = [to_physical(i) for i in range(past_length - read_cache_length, past_length)]
         expected_read += [sentinel_index] * query_length


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47708)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47708)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This PR fixes an off by one bug in `SlidingAttentionCacheAllocator` inside continuous batching's cache manager.

The read and write index computations used `past_length % sliding_window` as the start of the range to read or write in the rolling buffer. That formula only points at the correct slot when the cache already holds a full window of tokens (`sliding_window - 1` entries). When the cache holds fewer tokens than that, for example right after a short prefill or right after the buffer wraps around, the start index no longer matches where the kept tokens actually begin. This causes reads to return tokens out of order and writes to land in the wrong slots, corrupting the sliding window cache during generation.

The fix computes the start index from where the kept range actually begins instead of from `past_length` alone. For reads it is `past_length - cache_length`, and for writes it is `past_length + padding_length`, both taken modulo `sliding_window`.

I also added `test_sliding_attention_read_write_round_trip`, which replays a sequence of prefill and decode steps through the allocator, tracks which logical token each physical slot holds, and checks that every read returns the right tokens in chronological order. The existing tests checked read and write shapes on their own, so they did not catch this bug since a matching offset error on both sides can look consistent in isolation.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Acknowledgement
I came up with the logic myself but want to acknowledge that I used AI Agents to optimize it, write test cases and draft this PR.

## Who can review?

@Rocketknight1 @ArthurZucker