### PR TITLE
Fix ImportError in transformers.exporters on torch < 2.8

### DIFF
--- a/src/transformers/exporters/exporter_executorch.py
+++ b/src/transformers/exporters/exporter_executorch.py
@@ -60,7 +60,6 @@ from .utils import (
 if is_torch_available():
     import torch
     from torch.export import ExportedProgram
-    from torch.fx.experimental.symbolic_shapes import guard_or_true
     from torch.nn.attention import SDPBackend, sdpa_kernel
     from torch.utils._sympy.numbers import IntInfinity
     from torch.utils._sympy.value_ranges import ValueRanges
@@ -494,6 +493,7 @@ def _patch_remove_empty_tensors_from_cat(_original):
     inputs conservatively (the pass is purely an optimisation).
     """
     from executorch.exir.dialects._ops import ops as exir_ops
+    from torch.fx.experimental.symbolic_shapes import guard_or_true
 
     def patch(self, graph_module, cat_node):
         pruned = [arg for arg in cat_node.args[0] if guard_or_true(arg.meta["val"].numel() != 0)]

--- a/tests/exporters/test_utils.py
+++ b/tests/exporters/test_utils.py
@@ -132,20 +132,6 @@ class AutoHfExporterTest(unittest.TestCase):
             AutoHfExporter.from_config({})
 
 
-class ImportSurfaceTest(unittest.TestCase):
-    """`auto.py` imports every exporter module eagerly, so a symbol that only exists on a newer
-    torch than `setup.py` declares (`torch>=2.5`) takes the whole `transformers.exporters` package
-    down when imported at module scope — ONNX and Dynamo included. Version-gated symbols belong
-    inside the function that uses it."""
-
-    @require_torch
-    def test_guard_or_true_is_not_imported_at_module_scope(self):
-        from transformers.exporters import exporter_executorch
-
-        # `guard_or_true` landed in torch 2.8.
-        self.assertNotIn("guard_or_true", vars(exporter_executorch))
-
-
 class RegistrationTest(unittest.TestCase):
     """Cover the edge cases of `register_exporter` / `register_export_config` that normal
     registrations at module load don't hit — the type-check rejection paths. The mappings are

--- a/tests/exporters/test_utils.py
+++ b/tests/exporters/test_utils.py
@@ -132,6 +132,20 @@ class AutoHfExporterTest(unittest.TestCase):
             AutoHfExporter.from_config({})
 
 
+class ImportSurfaceTest(unittest.TestCase):
+    """`auto.py` imports every exporter module eagerly, so a symbol that only exists on a newer
+    torch than `setup.py` declares (`torch>=2.5`) takes the whole `transformers.exporters` package
+    down when imported at module scope — ONNX and Dynamo included. Version-gated symbols belong
+    inside the function that uses it."""
+
+    @require_torch
+    def test_guard_or_true_is_not_imported_at_module_scope(self):
+        from transformers.exporters import exporter_executorch
+
+        # `guard_or_true` landed in torch 2.8.
+        self.assertNotIn("guard_or_true", vars(exporter_executorch))
+
+
 class RegistrationTest(unittest.TestCase):
     """Cover the edge cases of `register_exporter` / `register_export_config` that normal
     registrations at module load don't hit — the type-check rejection paths. The mappings are


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47711)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47711)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47710.

`import transformers.exporters` raises `ImportError` on torch 2.5, 2.6 and 2.7, all inside the
declared `torch>=2.5` support range. `exporter_executorch.py` imports `guard_or_true` at module
scope, and that symbol was added in torch 2.8 where it replaced `definitely_true`.
`is_torch_available()` checks that torch is installed, not which version, so the import runs and
fails. Because `exporters/auto.py` imports the ExecuTorch exporter eagerly, the ONNX and Dynamo
exporters become unreachable too, on torch versions neither of them needs.

First bad commit is `fde2b96b5` (#41992), found with `git log -S guard_or_true`.

## The change

One line moves. That is the whole diff.

`guard_or_true` moves into `_patch_remove_empty_tensors_from_cat`, the only function that uses it.
The sibling patch handler in the same file, `_patch_dim_order_from_stride`, already imports
`guard_or_false, guard_or_true` function-locally, so this follows existing convention.

No `min_versions` entry is added. An earlier revision of this PR declared
`min_versions = {"torch": "2.8.0"}` on `ExecutorchExporter`; that was wrong and has been dropped.
`min_versions` is a plain class attribute, so `ExecutorchExporter` already inherits
`{"torch": "2.11.0"}` from `DynamoExporter`, and declaring `2.8.0` here overrode it downward. That
would have let users past `validate_environment` on torch 2.8 to 2.10 and into a later failure
inside `DynamoExporter.export`. Thanks to the Copilot review for catching it. The inherited
`torch>=2.11.0` floor already covers `guard_or_true` by a wide margin, so this file needs no gate
of its own.

An earlier revision also added `tests/exporters/test_utils.py::ImportSurfaceTest`, asserting
`guard_or_true` is not a module global of `exporter_executorch`. Removed at @IlyasMoutawwakil's
request.

No new helper, no new dependency, no behavior change on torch >= 2.8.

## Verification on torch 2.6.0

| | before | after |
|---|---|---|
| `import transformers.exporters` | ImportError | OK |
| `from transformers.exporters import AutoHfExporter` | ImportError | OK |
| `AUTO_EXPORTER_MAPPING` | unreachable | `['dynamo', 'executorch', 'onnx']` |
| `python utils/checkers.py imports, repo` | FAILED | OK |
| `pytest tests/exporters/test_utils.py` | collection error, 0 run | 13 passed, 2 skipped, 1 failed |

The fix was verified against the bug: restoring the module-scope import makes the whole test file
fail collection on torch 2.6.

The one remaining failure, `test_from_config_dispatches_dynamo`, is
`DynamoExporter requires newer versions of: torch>=2.11.0 (found 2.6.0+cu124)`. That comes from
`DynamoExporter.min_versions` and my local torch, not from this change. It failed before this PR
too, silently, because nothing in the suite could be collected.

`ruff check` and `ruff format` are clean.

## Before submitting

- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing)?
- [x] Was this discussed via a GitHub issue? #47710.
- [x] Did you write any new necessary tests? No, per reviewer request.

I used AI tooling to investigate this, and I have reviewed and verified every changed line and run
the tests and checks above myself.

## Who can review?

@IlyasMoutawwakil, since you authored #41992. Review, and merge if it looks right to you. Happy to
switch to raising the declared torch floor instead if you prefer that route.
