### PR TITLE
config: raise on missing local config file instead of silently falling back to defaults

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -701,6 +701,15 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin, Heterogeneous
         kwargs["revision"] = revision
 
         config_dict, kwargs = cls.get_config_dict(pretrained_model_name_or_path, **kwargs)
+        if not config_dict and os.path.isdir(pretrained_model_name_or_path):
+            # Local directory without a config file: raise instead of silently building the class
+            # default config. Hub ids are intentionally left to their existing handling (AutoConfig
+            # raises its own ValueError for config-less repos).
+            raise OSError(
+                f"It looks like the config file at '{pretrained_model_name_or_path}' was not found. "
+                "Make sure the directory contains a `config.json` file (for example the one saved "
+                "with `save_pretrained`)."
+            )
         if cls.base_config_key and cls.base_config_key in config_dict:
             config_dict = config_dict[cls.base_config_key]
 

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -175,6 +175,23 @@ class ConfigTestUtils(unittest.TestCase):
         config = BertConfig.from_pretrained("hf-internal-testing/tiny-random-bert-subfolder", subfolder="bert")
         self.assertIsNotNone(config)
 
+    def test_from_pretrained_missing_config_raises(self):
+        # A local directory without a config file must not silently fall back to the default config
+        # of the requested class — it has to raise, pointing at the missing config. Hub ids are out
+        # of scope: AutoConfig already fails on them with its own ValueError.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            for config_class in (BertConfig, PreTrainedConfig):
+                with self.assertRaises(OSError) as ctx:
+                    config_class.from_pretrained(tmp_dir)
+                self.assertIn("config", str(ctx.exception).lower())
+
+    def test_get_config_dict_missing_config_returns_empty(self):
+        # get_config_dict stays non-raising for callers that probe for a config (e.g. backbone loading);
+        # the failure surfaces in from_pretrained instead.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_dict, _ = BertConfig.get_config_dict(tmp_dir)
+            self.assertEqual(config_dict, {})
+
     def test_cached_files_are_used_when_internet_is_down(self):
         # A mock response for an HTTP head request to emulate server down
         response_mock = mock.Mock()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47712)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47712)
<!-- ci-dashboard-badge:end -->

## What

`PreTrainedConfig.from_pretrained()` previously returned the class **default config** when given a **local directory** that contains no `config.json`:

- `_get_config_dict()` maps a missing local file to `None`,
- `get_config_dict()` turns that into `{}`,
- `from_pretrained()` then builds `cls.from_dict({})` — a fully default-initialized config with **no warning**.

The miss is invisible until much later: a model instantiated from such a config gets the *class default* hidden sizes / layer counts / vocab size, so failures surface at runtime as shape mismatches far from the actual cause.

Reproducer:

```python
from transformers import BertConfig
import tempfile

with tempfile.TemporaryDirectory() as d:
    # empty directory, no config.json
    cfg = BertConfig.from_pretrained(d)
    print(cfg.hidden_size)  # before: 768 (bert default) — silent. after: OSError
```

This also masked a real bug in our own tooling: a path-resolution slip (`config_path.parent` instead of the checkpoint dir) made us load the *default* 43-layer/129k-vocab DeepSeek-V4 config instead of the tiny test config, and nothing complained.

## Change

- Raise `OSError` in `PreTrainedConfig.from_pretrained()` when the resolved config dict is empty **and the input is a local directory**, pointing at the missing file.
- Hub ids keep their existing handling (`AutoConfig.from_pretrained()` already raises its own `ValueError` for config-less repos), so nothing changes for hub paths — first revision of this PR raised for hub ids too and it broke tokenizer/generation tests that rely on that `ValueError`; scope narrowed accordingly.
- `get_config_dict()` keeps returning `{}` (non-raising) so callers that *probe* for a config (e.g. backbone loading in `backbone_utils.py`) are unaffected.

## Tests

- `test_from_pretrained_missing_config_raises` (new): a config-less local directory raises `OSError` for `BertConfig` / `PreTrainedConfig`.
- `test_get_config_dict_missing_config_returns_empty` (new): `get_config_dict()` stays non-raising.

`tests/utils/test_configuration_utils.py` and `tests/models/auto/test_configuration_auto.py` fully green.