### PR TITLE
squad_metrics: use precompiled regex for article removal

### DIFF
--- a/src/transformers/data/metrics/squad_metrics.py
+++ b/src/transformers/data/metrics/squad_metrics.py
@@ -32,13 +32,16 @@ from ...utils import logging
 
 logger = logging.get_logger(__name__)
 
+# Compiled once at import time instead of on every `normalize_answer` call, since this function
+# is called per gold/predicted answer for every example during SQuAD evaluation.
+_ARTICLES_REGEX = re.compile(r"\b(a|an|the)\b", re.UNICODE)
+
 
 def normalize_answer(s):
     """Lower text and remove punctuation, articles and extra whitespace."""
 
     def remove_articles(text):
-        regex = re.compile(r"\b(a|an|the)\b", re.UNICODE)
-        return re.sub(regex, " ", text)
+        return re.sub(_ARTICLES_REGEX, " ", text)
 
     def white_space_fix(text):
         return " ".join(text.split())


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47715)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47715)
<!-- ci-dashboard-badge:end -->

Replaced inline regex for article removal with a precompiled regex for efficiency.

in `normalize_answer()` in `src/transformers/data/metrics/squad_metrics.py` recompiled

 i saw that same regex (`\b(a|an|the)\b`) on every call via `re.compile()` inside the nested
`remove_articles()` function. Since `normalize_answer` runs once per gold/predicted
answer for every example during SQuAD evaluation, this meant the identical pattern
was being so i  recompiled tens of thousands of times on a full eval run.

This PR moves the `re.compile()`  call to module level so the regex is compiled once and also at import time instead of on every call. Output is unchanged  is verified against the original implementation across empty strings, unicode, punctuation-only, and
word-boundary edge cases (e.g. "Anthem", "Athens", to confirm \b doesn't
accidentally match inside those words). and that's it.