### PR TITLE
docs(serve): note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/source/en/serve-cli/serving.md
+++ b/docs/source/en/serve-cli/serving.md
@@ -46,6 +46,8 @@ transformers serve
 
 The `v1/chat/completions` API is based on the [Chat Completions API](https://platform.openai.com/docs/api-reference/chat). It supports text, image, audio, and video requests for LLMs, VLMs, and multimodal models. Use it with `curl`, the [`~huggingface_hub.InferenceClient`], or the [OpenAI](https://platform.openai.com/docs/quickstart) client.
 
+The same OpenAI client `base_url` pattern works with any OpenAI-compatible multi-model gateway when you are not running `transformers serve` locally — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1` (set a real `api_key`).
+
 ### Text-based completions
 
 <hfoptions id="chat-completion-http">


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47719)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47719)
<!-- ci-dashboard-badge:end -->

## Summary

The `transformers serve` docs already show the OpenAI Python client via `base_url`.

This PR adds a short tip that the same client pattern works with OpenAI-compatible multi-model gateways when not running `transformers serve` locally, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Serve CLI docs render
- [ ] Local client examples unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>