### PR TITLE
[generate] Stop setting the static cache as an attribute to save memory

### DIFF
--- a/src/transformers/_typing.py
+++ b/src/transformers/_typing.py
@@ -24,8 +24,6 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
 if TYPE_CHECKING:
     import torch
 
-    from .cache_utils import Cache
-
 
 # A few helpful type aliases
 Level: TypeAlias = int
@@ -150,7 +148,7 @@ class GenerativePreTrainedModel(Protocol):
     hf_quantizer: Any
     encoder: Any
     hf_device_map: dict[str, Any]
-    _cache: Cache
+    _previous_max_cache_length: int
 
     generation_config: Any  # GenerationConfig
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1853,65 +1853,45 @@ class GenerationMixin(ContinuousMixin):
         model_kwargs,
     ) -> Cache:
         """
-        Sets a cache for `generate`, that will persist across calls. A new cache will only be initialized a
-        new `generate` call requires a larger cache or uses a different batch size.
-
-        Returns the resulting cache object.
+        Create a static cache for `generate`. To avoid recompilation, the new cache will use the maximum between the current
+        `max_cache_len` and the potential previous value of `max_cache_len`, if there was some previous `generate` calls with
+        static cache.
         """
         offload_cache = "offloaded" in cache_implementation
+        previous_max_len = getattr(self, "_previous_max_cache_length", -1)
+        effective_length = max(max_cache_len, previous_max_len)
 
-        cache_to_check: StaticCache | None = None
-        if hasattr(self, "_cache"):
-            if isinstance(self._cache, EncoderDecoderCache):
-                cache_to_check = self._cache.self_attention_cache
-            elif isinstance(self._cache, StaticCache):
-                cache_to_check = self._cache
-
-        need_new_cache = (
-            cache_to_check is None
-            or cache_to_check.offloading != offload_cache
-            or cache_to_check.batch_size != batch_size
-            or cache_to_check.get_max_length() < max_cache_len
-        )
-
-        encoder_decoder_cache = getattr(self, "_cache", None)
-        if isinstance(encoder_decoder_cache, EncoderDecoderCache):
-            need_new_cache = (
-                need_new_cache
-                or encoder_decoder_cache.cross_attention_cache.get_max_length()
-                != model_kwargs["encoder_outputs"][0].shape[1]
-            )
-
-        if need_new_cache:
-            self_attention_cache_kwargs = {
+        self_attention_cache_kwargs = {
+            "config": self.config.get_text_config(decoder=True),
+            "max_cache_len": effective_length,
+            "offloading": offload_cache,
+        }
+        cache = StaticCache(**self_attention_cache_kwargs)
+        if self.config.is_encoder_decoder:
+            cross_attention_cache_kwargs = {
                 "config": self.config.get_text_config(decoder=True),
-                "max_cache_len": max_cache_len,
+                "max_cache_len": model_kwargs["encoder_outputs"][0].shape[1],
                 "offloading": offload_cache,
             }
-            self._cache = StaticCache(**self_attention_cache_kwargs)
-            if self.config.is_encoder_decoder:
-                cross_attention_cache_kwargs = {
-                    "config": self.config.get_text_config(decoder=True),
-                    "max_cache_len": model_kwargs["encoder_outputs"][0].shape[1],
-                    "offloading": offload_cache,
-                }
-                self._cache = EncoderDecoderCache(self._cache, StaticCache(**cross_attention_cache_kwargs))
-            elif prefill_chunk_size is not None:
-                # Chunked prefill compiles the prefill, so eagerly init the fresh cache to avoid a recompile next call
-                # (#46421). Skipped (-> lazy init) when it can't be initialized on a single device.
-                init_shape = self._get_static_cache_init_shape()
-                if init_shape is not None:
-                    num_heads, head_dim = init_shape
-                    self._cache.early_initialization(
-                        batch_size=batch_size,
-                        num_heads=num_heads,
-                        head_dim=head_dim,
-                        dtype=self.dtype,
-                        device=self.device,
-                    )
-        else:
-            self._cache.reset()
-        return self._cache
+            cache = EncoderDecoderCache(cache, StaticCache(**cross_attention_cache_kwargs))
+        elif prefill_chunk_size is not None:
+            # Chunked prefill compiles the prefill, so eagerly init the fresh cache to avoid a recompile next call
+            # (#46421). Skipped (-> lazy init) when it can't be initialized on a single device.
+            init_shape = self._get_static_cache_init_shape()
+            if init_shape is not None:
+                num_heads, head_dim = init_shape
+                cache.early_initialization(
+                    batch_size=batch_size,
+                    num_heads=num_heads,
+                    head_dim=head_dim,
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+
+        # Set the current length on the current model, to avoid recompilation later if we can
+        self._previous_max_cache_length = effective_length
+
+        return cache
 
     @classmethod
     def _supports_default_dynamic_cache(cls: type["GenerativePreTrainedModel"]) -> bool:

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1797,6 +1797,62 @@ class GenerationTesterMixin(ExportGenerateTesterMixin):
             self._check_generate_outputs(output_generate, model.config, use_cache=True)
 
     @pytest.mark.generate
+    @pytest.mark.torch_compile_test
+    def test_static_cache_no_recompile_with_smaller_length(self):
+        """
+        Tests that 2 subsequent calls to `generate` does not recompile when using a smaller length, i.e. we recreate a cache
+        of the correct previous shape.
+        """
+        for model_class in self.all_generative_model_classes:
+            if not model_class._can_compile_fullgraph:
+                self.skipTest("This model doesn't support compilation without graph breaks")
+
+            config, inputs_dict = self.prepare_config_and_inputs_for_generate()
+            set_config_for_less_flaky_test(config)
+            model = model_class(config).to(torch_device)
+            set_model_for_less_flaky_test(model)
+            model.eval()
+
+            if "blip" in model.__class__.__name__.lower():
+                self.skipTest("Blip overwrite `generate` for some reason making it interact weirdly")
+
+            compile_config = CompileConfig()
+            compile_config._compile_all_devices = True  # force compilation (e.g. fast CI, CPU)
+            generation_kwargs = {
+                "use_cache": True,
+                "do_sample": False,
+                "compile_config": compile_config,
+                "cache_implementation": "static",
+            }
+
+            # prevent cached compilation from being used in the test
+            torch.compiler.reset()
+
+            # Perform a first `generate` call to trigger compilation
+            _ = model.generate(**inputs_dict, **generation_kwargs, max_new_tokens=5)
+            # Sanity checks
+            self.assertTrue(hasattr(model, "_compiled_call"))
+
+            # Uses a context manager to catch recompilation logs. If there is any recompilation, this test fails.
+            # Try/Finally is used to ensure that the log options are reset even if an error is raised.
+            try:
+                torch._logging.set_logs(recompiles_verbose=True)
+                logger = logging.get_logger("torch._dynamo.guards")
+                with CaptureLogger(logger) as cl:
+                    # 2nd call to `generate` with a smaller total size -> should use size of previous cache and not recompile
+                    _ = model.generate(**inputs_dict, **generation_kwargs, max_new_tokens=2)
+                    self.assertTrue(hasattr(model, "_compiled_call"))
+            finally:
+                torch._logging.set_logs()
+
+            has_recompilation = "Recompiling" in cl.out or ("guard" in cl.out and "failure" in cl.out)
+            if has_recompilation:
+                raise RuntimeError(
+                    f"`torch.compile` recompiled part of the forward pass in {model.__class__.__name__}. "
+                    "See the test logs for more details."
+                )
+
+    @pytest.mark.generate
     def test_generate_methods_with_logits_to_keep(self):
         for model_class in self.all_generative_model_classes:
             if "logits_to_keep" not in set(inspect.signature(model_class.forward).parameters.keys()):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47731)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47731)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

As per the title. Keeping the cache as an attribute `self._cache` inside `generate` is a very bad idea in general, because it will keep a big memory footprint without the user noticing, which can be very surprising and unwanted if we want to make 1 call to generate with static cache, and then use the model for something else.
It was previously done to avoid recompilation if we were making several calls to `generate` with several lengths, but simply keeping the old `max_cache_len` as attribute and re-using that later is enough to avoid recompilation.

The following snippet illustrates the issue:

```python
import torch
from transformers import AutoModelForCausalLM

model_id = "meta-llama/Llama-3.2-1B-instruct"
device = 0
model = AutoModelForCausalLM.from_pretrained(model_id, device_map=device)
print(f"Memory reserved before call to generate: {torch.cuda.memory_allocated(device) / 1024**3:.2f} GiB")

foo = model.generate(torch.randint(100, 200, (10, 8192), device=device), max_new_tokens=100, cache_implementation="static")
print(f"Memory reserved after call to generate: {torch.cuda.memory_allocated(device) / 1024**3:.2f} GiB")
```

Before this PR, it prints:
```sh
Memory reserved before call to generate: 2.30 GiB
Memory reserved after call to generate: 4.83 GiB
```

After this PR:
```sh
Memory reserved before call to generate: 2.30 GiB
Memory reserved after call to generate: 2.30 GiB
```

which makes a HUGE difference as can be easily seen.

Note that this does not incur any additional recompilation, since we still check the max size of the cache. This can be checked with the following snippet for example:

```python
import os
os.environ["TORCH_LOGS"] = "recompiles"
import torch
from transformers import AutoModelForCausalLM

model_id = "meta-llama/Llama-3.2-1B-instruct"
device = 0
model = AutoModelForCausalLM.from_pretrained(model_id, device_map=device)

foo = model.generate(torch.randint(100, 200, (10, 8192), device=device), max_new_tokens=100, cache_implementation="static")
# smaller size should not trigger any recompilation
foo = model.generate(torch.randint(100, 200, (10, 8000), device=device), max_new_tokens=100, cache_implementation="static")
```