### PR TITLE
Update daily CI Docker image to torch 2.13.0 / CUDA 13.0

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -86,6 +86,7 @@ jobs:
           context: ./docker/transformers-all-latest-gpu
           build-args: |
             REF=main
+            CUDA=cu126
             PYTORCH=2.8.0
             TORCHCODEC=0.7.0
             FLASH_ATTN=yes

--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.0-cudnn-devel-ubuntu22.04
+FROM nvidia/cuda:13.0.3-cudnn-devel-ubuntu22.04
 LABEL maintainer="Hugging Face"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -9,12 +9,12 @@ SHELL ["sh", "-lc"]
 # The following `ARG` are mainly used to specify the versions explicitly & directly in this docker file, and not meant
 # to be used as arguments for docker build (so far).
 
-ARG PYTORCH='2.11.0'
+ARG PYTORCH='2.13.0'
 # Example: `cu102`, `cu113`, etc.
-ARG CUDA='cu126'
+ARG CUDA='cu130'
 
 # This needs to be compatible with the above `PYTORCH`.
-ARG TORCHCODEC='0.11.0'
+ARG TORCHCODEC='0.15.0'
 
 ARG FLASH_ATTN='false'
 
@@ -32,12 +32,22 @@ RUN python3 -m pip install --no-cache-dir -e ./transformers[dev]
 # 2. For `torchcodec`, use `cpu` as we don't have `libnvcuvid.so` on the host runner. See https://github.com/meta-pytorch/torchcodec/issues/912
 #    **Important**: We need to specify `torchcodec` version if the torch version is not the latest stable one.
 # 3. `set -e` means "exit immediately if any command fails".
+# 4. Warning: torchaudio only publishes wheels for the CUDA version it was released with (e.g. 2.11.0
+#    only has a cu130 build). If torch is installed with a different CUDA suffix (e.g. cu132), pip
+#    will keep the torchaudio installed in the previous step and torchaudio will raise a RuntimeError on import due to the
+#    CUDA version mismatch. When upgrading CUDA, make sure torchaudio has a wheel for the new version.
 RUN set -e; \
     # Determine torch version
     if [ ${#PYTORCH} -gt 0 ] && [ "$PYTORCH" != "pre" ]; then \
         VERSION="torch==${PYTORCH}.*"; \
-        TORCHAUDIO_VERSION="torchaudio==${PYTORCH}.*"; \
         TORCHCODEC_VERSION="torchcodec==${TORCHCODEC}.*"; \
+        # torchaudio is in maintenance mode: 2.11 is the final release, compatible with torch 2.11+
+        # (no need to upgrade it with torch; it does not pin torch to a specific version)
+        if printf '%s\n' "2.11.0" "${PYTORCH}" | sort -V | head -1 | grep -qx "2.11.0"; then \
+            TORCHAUDIO_VERSION="torchaudio==2.11.0"; \
+        else \
+            TORCHAUDIO_VERSION="torchaudio==${PYTORCH}.*"; \
+        fi; \
     else \
         VERSION="torch"; \
         TORCHAUDIO_VERSION="torchaudio"; \


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47738)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47738)
<!-- ci-dashboard-badge:end -->

## Summary

- Bumps the `transformers-all-latest-gpu` Docker image from torch 2.11.0 / CUDA 12.6 to **torch 2.13.0 / CUDA 13.0**
- Updates `TORCHCODEC` from `0.11.0` → `0.15.0` to match
- Pins `torchaudio==2.11.0` for torch >= 2.11.0: torchaudio is in maintenance mode and 2.11 is its final release — it is compatible with torch 2.11+ and does not pin torch to a specific version
- Adds a warning comment explaining that torchaudio only publishes wheels for the CUDA version it was released with (e.g. 2.11.0 only has a cu130 build); installing torch with a different CUDA suffix would silently keep the mismatched torchaudio build and cause a `RuntimeError` at import time
- Adds explicit `CUDA=cu126` build-arg to the existing torch 2.8.0 CI job in `build-docker-images.yml` so it continues to work now that the Dockerfile default changed

## Notes

- **Why cu130 and not cu132?** torchaudio 2.11.0 only has a cu130 wheel — there is no cu132 build. Installing torch+cu132 alongside torchaudio+cu130 causes `torchaudio._check_cuda_version()` to raise a `RuntimeError` on import, which propagates through the transformers lazy-module system and surfaces as a misleading `ModuleNotFoundError: Could not import module 'is_clearml_available'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)