### PR TITLE
fix(tokenization): decode byte-fallback tokens in SentencePieceBackend.convert_tokens_to_string

### DIFF
--- a/src/transformers/tokenization_utils_sentencepiece.py
+++ b/src/transformers/tokenization_utils_sentencepiece.py
@@ -230,9 +230,29 @@ class SentencePieceBackend(PreTrainedTokenizer):
         return token
 
     def convert_tokens_to_string(self, tokens: list[str]) -> str:
-        """Converts a sequence of tokens (string) in a single string."""
-        out_string = "".join(tokens).replace(SPIECE_UNDERLINE, " ").strip()
-        return out_string
+        """Converts a sequence of tokens (string) in a single string.
+
+        Byte-fallback tokens (e.g. ``<0x0A>``, ``<0xF0>``) produced by
+        SentencePiece models with ``byte_fallback=True`` are decoded correctly
+        by passing them through ``sp_model.decode`` rather than a simple string
+        join.  Special tokens are kept as-is and not fed to the SP model.
+        """
+        all_special_tokens = set(self.all_special_tokens)
+        current_sub_tokens: list[str] = []
+        out_string = ""
+        prev_is_special = False
+        for token in tokens:
+            if token in all_special_tokens:
+                if not prev_is_special:
+                    out_string += " "
+                out_string += self.sp_model.decode(current_sub_tokens) + token
+                prev_is_special = True
+                current_sub_tokens = []
+            else:
+                current_sub_tokens.append(token)
+                prev_is_special = False
+        out_string += self.sp_model.decode(current_sub_tokens)
+        return out_string.strip()
 
     def save_vocabulary(self, save_directory: str, filename_prefix: str | None = None) -> tuple[str]:
         """

--- a/tests/test_sentencepiece_backend_mixin.py
+++ b/tests/test_sentencepiece_backend_mixin.py
@@ -1,11 +1,13 @@
 # Sentencepiece backend layer tests
 
+import os
 import shutil
 import tempfile
 from typing import TYPE_CHECKING
 
 from transformers import AutoTokenizer, PythonBackend, TokenizersBackend
 from transformers.tokenization_python import AddedToken
+from transformers.tokenization_utils_sentencepiece import SentencePieceBackend
 
 
 if TYPE_CHECKING:
@@ -105,6 +107,29 @@ class SentencePieceBackendTesterMixin:
             slow_decoded = tokenizer.decode(slow_ids)
             fast_decoded = rust_tokenizer.decode(slow_ids)
             self.assertEqual(slow_decoded, fast_decoded)
+
+    def test_convert_tokens_to_string_byte_fallback(self):
+        """Regression test for https://github.com/huggingface/transformers/issues/47473.
+
+        SentencePieceBackend.convert_tokens_to_string previously did a simple
+        string join, so byte-fallback tokens like <0xF0><0x9F>... were returned
+        as literal strings instead of being decoded back to UTF-8.
+        """
+        vocab_file = os.path.join(os.path.dirname(__file__), "fixtures", "test_sentencepiece_with_bytefallback.model")
+        if not os.path.isfile(vocab_file):
+            self.skipTest(reason="byte-fallback fixture model not found")
+
+        tokenizer = SentencePieceBackend(vocab_file=vocab_file)
+
+        # Emoji is encoded as a sequence of byte-fallback tokens <0xF0><0x9F><0xA4><0x97>.
+        # Before the fix, convert_tokens_to_string returned the literal token strings.
+        text = "foo \U0001f917 bar"
+        ids = tokenizer.encode(text, add_special_tokens=False)
+        tokens = tokenizer.convert_ids_to_tokens(ids)
+        # Ensure at least one byte-fallback token is present in the tokenisation
+        self.assertTrue(any(t.startswith("<0x") for t in tokens), f"Expected byte-fallback tokens in {tokens}")
+        decoded = tokenizer.convert_tokens_to_string(tokens)
+        self.assertEqual(decoded, text, f"Byte-fallback tokens not decoded to UTF-8, got: {decoded!r}")
 
     def test_save_sentencepiece_tokenizer(self) -> None:
         text = "This is text to test the tokenizer."


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47740)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47740)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Fixes #47473

`SentencePieceBackend.convert_tokens_to_string` was joining tokens with simple string concatenation, leaving byte-fallback tokens like `<0xF0><0x9F><0xA4><0x97>` as literal strings instead of decoding them to UTF-8 (🤗).

## Before

```python
tokenizer.decode(tokenizer('foo 🤗 bar').input_ids)
# 'foo <0xF0><0x9F><0xA4><0x97> bar'  <- broken
```

## After

```python
tokenizer.decode(tokenizer('foo 🤗 bar').input_ids)
# 'foo 🤗 bar'  <- correct
```

## How was it fixed?

Replaced the simple join with the same `sp_model.decode()` pattern already used by `SiglipTokenizer.convert_tokens_to_string` — special tokens are kept verbatim, non-special tokens are passed through the SP model which handles byte-fallback natively.

## Tests

Added `test_convert_tokens_to_string_byte_fallback` to `test_sentencepiece_backend_mixin.py` using the existing `test_sentencepiece_with_bytefallback.model` fixture.

Implemented with Claude Code assistance. All changed lines reviewed manually.