### PR TITLE
Do not modify caller-provided tensors in place during forward

### DIFF
--- a/src/transformers/models/blip/modeling_blip_text.py
+++ b/src/transformers/models/blip/modeling_blip_text.py
@@ -84,7 +84,7 @@ class BlipTextEmbeddings(nn.Module):
         embeddings = inputs_embeds
 
         position_embeddings = self.position_embeddings(position_ids)
-        embeddings += position_embeddings
+        embeddings = embeddings + position_embeddings
 
         embeddings = self.LayerNorm(embeddings)
         embeddings = self.dropout(embeddings)

--- a/src/transformers/models/canine/modeling_canine.py
+++ b/src/transformers/models/canine/modeling_canine.py
@@ -1333,8 +1333,8 @@ class CanineForQuestionAnswering(CaninePreTrainedModel):
                 end_positions = end_positions.squeeze(-1)
             # sometimes the start/end positions are outside our model inputs, we ignore these terms
             ignored_index = start_logits.size(1)
-            start_positions.clamp_(0, ignored_index)
-            end_positions.clamp_(0, ignored_index)
+            start_positions = start_positions.clamp(0, ignored_index)
+            end_positions = end_positions.clamp(0, ignored_index)
 
             loss_fct = CrossEntropyLoss(ignore_index=ignored_index)
             start_loss = loss_fct(start_logits, start_positions)

--- a/src/transformers/models/ctrl/modeling_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_ctrl.py
@@ -311,7 +311,7 @@ class CTRLModel(CTRLPreTrainedModel):
             position_ids=position_ids,
         )
 
-        inputs_embeds *= np.sqrt(self.d_model_size)
+        inputs_embeds = inputs_embeds * np.sqrt(self.d_model_size)
 
         # `self.pos_encoding` won't be sent to the correct device and dtype along the model, so we do it manually.
         self.pos_encoding = self.pos_encoding.to(device=device, dtype=inputs_embeds.dtype)

--- a/src/transformers/models/flava/modeling_flava.py
+++ b/src/transformers/models/flava/modeling_flava.py
@@ -1730,7 +1730,7 @@ class FlavaForPreTraining(FlavaPreTrainedModel):
             if mim_labels is not None:
                 mim_labels = self._resize_to_2d(mim_labels)
                 bool_masked_pos = self._resize_to_2d(bool_masked_pos)
-                mim_labels[bool_masked_pos.ne(True)] = self.ce_ignore_index
+                mim_labels = mim_labels.masked_fill(bool_masked_pos.ne(True), self.ce_ignore_index)
 
                 sequence_for_image = sequence_for_image[:, -mim_labels.size(1) :, :]
                 masked_tokens = mim_labels.ne(self.ce_ignore_index)
@@ -1794,7 +1794,7 @@ class FlavaForPreTraining(FlavaPreTrainedModel):
             if mim_labels is not None:
                 mim_labels = self._resize_to_2d(mim_labels)
                 bool_masked_pos = self._resize_to_2d(bool_masked_pos)
-                mim_labels[bool_masked_pos.ne(True)] = self.ce_ignore_index
+                mim_labels = mim_labels.masked_fill(bool_masked_pos.ne(True), self.ce_ignore_index)
 
                 masked_tokens = mim_labels.ne(self.ce_ignore_index)
                 mim_labels_filtered = mim_labels[masked_tokens]

--- a/src/transformers/models/git/modeling_git.py
+++ b/src/transformers/models/git/modeling_git.py
@@ -108,7 +108,7 @@ class GitEmbeddings(nn.Module):
             embeddings = inputs_embeds
 
         position_embeddings = self.position_embeddings(position_ids)
-        embeddings += position_embeddings
+        embeddings = embeddings + position_embeddings
 
         embeddings = self.LayerNorm(embeddings)
         embeddings = self.dropout(embeddings)

--- a/src/transformers/models/kosmos2/modeling_kosmos2.py
+++ b/src/transformers/models/kosmos2/modeling_kosmos2.py
@@ -950,6 +950,7 @@ class Kosmos2TextTransformer(Kosmos2PreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if image_embeds is not None:
+            inputs_embeds = inputs_embeds.clone()
             inputs_embeds[img_input_mask.to(dtype=torch.bool)] = image_embeds.to(
                 inputs_embeds.device, inputs_embeds.dtype
             ).view(-1, image_embeds.size(-1))

--- a/src/transformers/models/luke/modeling_luke.py
+++ b/src/transformers/models/luke/modeling_luke.py
@@ -1898,8 +1898,8 @@ class LukeForQuestionAnswering(LukePreTrainedModel):
                 end_positions = end_positions.squeeze(-1)
             # sometimes the start/end positions are outside our model inputs, we ignore these terms
             ignored_index = start_logits.size(1)
-            start_positions.clamp_(0, ignored_index)
-            end_positions.clamp_(0, ignored_index)
+            start_positions = start_positions.clamp(0, ignored_index)
+            end_positions = end_positions.clamp(0, ignored_index)
 
             loss_fct = CrossEntropyLoss(ignore_index=ignored_index)
             start_loss = loss_fct(start_logits, start_positions)

--- a/src/transformers/models/markuplm/modeling_markuplm.py
+++ b/src/transformers/models/markuplm/modeling_markuplm.py
@@ -686,8 +686,8 @@ class MarkupLMForQuestionAnswering(MarkupLMPreTrainedModel):
                 end_positions = end_positions.squeeze(-1)
             # sometimes the start/end positions are outside our model inputs, we ignore these terms
             ignored_index = start_logits.size(1)
-            start_positions.clamp_(0, ignored_index)
-            end_positions.clamp_(0, ignored_index)
+            start_positions = start_positions.clamp(0, ignored_index)
+            end_positions = end_positions.clamp(0, ignored_index)
 
             loss_fct = CrossEntropyLoss(ignore_index=ignored_index)
             start_loss = loss_fct(start_logits, start_positions)

--- a/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
@@ -825,7 +825,7 @@ class MoonshineStreamingDecoder(MoonshineStreamingPreTrainedModel):
         position_embeddings = self.pos_emb(
             torch.arange(encoder_hidden_states.shape[1], device=encoder_hidden_states.device)
         )
-        encoder_hidden_states += position_embeddings.to(encoder_hidden_states.device)
+        encoder_hidden_states = encoder_hidden_states + position_embeddings.to(encoder_hidden_states.device)
         encoder_hidden_states = self.proj(encoder_hidden_states)
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")

--- a/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
@@ -385,7 +385,7 @@ class MoonshineStreamingDecoder(MoonshineDecoder):
         position_embeddings = self.pos_emb(
             torch.arange(encoder_hidden_states.shape[1], device=encoder_hidden_states.device)
         )
-        encoder_hidden_states += position_embeddings.to(encoder_hidden_states.device)
+        encoder_hidden_states = encoder_hidden_states + position_embeddings.to(encoder_hidden_states.device)
         encoder_hidden_states = self.proj(encoder_hidden_states)
 
         return super().forward(

--- a/src/transformers/models/moshi/modeling_moshi.py
+++ b/src/transformers/models/moshi/modeling_moshi.py
@@ -734,7 +734,7 @@ class MoshiDepthDecoder(MoshiPreTrainedModel, GenerationMixin):
 
             inputs_embeds = torch.cat(inputs_embeds, dim=1)
 
-        inputs_embeds += self.input_projections(last_hidden_state, codebook_idx)
+        inputs_embeds = inputs_embeds + self.input_projections(last_hidden_state, codebook_idx)
 
         causal_mask = None
         if attention_mask is not None:

--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -1299,7 +1299,7 @@ class Pix2StructForConditionalGeneration(Pix2StructPreTrainedModel, GenerationMi
             # get decoder inputs from shifting lm labels to the right
             decoder_input_ids = self._shift_right(labels)
             decoder_attention_mask = (
-                decoder_attention_mask
+                decoder_attention_mask.clone()
                 if decoder_attention_mask is not None
                 else decoder_input_ids.ne(self.config.pad_token_id).float()
             )

--- a/src/transformers/models/rembert/modeling_rembert.py
+++ b/src/transformers/models/rembert/modeling_rembert.py
@@ -1109,8 +1109,8 @@ class RemBertForQuestionAnswering(RemBertPreTrainedModel):
                 end_positions = end_positions.squeeze(-1)
             # sometimes the start/end positions are outside our model inputs, we ignore these terms
             ignored_index = start_logits.size(1)
-            start_positions.clamp_(0, ignored_index)
-            end_positions.clamp_(0, ignored_index)
+            start_positions = start_positions.clamp(0, ignored_index)
+            end_positions = end_positions.clamp(0, ignored_index)
 
             loss_fct = CrossEntropyLoss(ignore_index=ignored_index)
             start_loss = loss_fct(start_logits, start_positions)

--- a/src/transformers/models/splinter/modeling_splinter.py
+++ b/src/transformers/models/splinter/modeling_splinter.py
@@ -547,8 +547,8 @@ class SplinterForQuestionAnswering(SplinterPreTrainedModel):
                 end_positions = end_positions.squeeze(-1)
             # sometimes the start/end positions are outside our model inputs, we ignore these terms
             ignored_index = start_logits.size(1)
-            start_positions.clamp_(0, ignored_index)
-            end_positions.clamp_(0, ignored_index)
+            start_positions = start_positions.clamp(0, ignored_index)
+            end_positions = end_positions.clamp(0, ignored_index)
 
             loss_fct = CrossEntropyLoss(ignore_index=ignored_index)
             start_loss = loss_fct(start_logits, start_positions)
@@ -693,8 +693,8 @@ class SplinterForPreTraining(SplinterPreTrainedModel):
         # [batch_size, num_questions, sequence_length]
         if start_positions is not None and end_positions is not None:
             # sometimes the start/end positions are outside our model inputs, we ignore these terms
-            start_positions.clamp_(0, max(0, sequence_length - 1))
-            end_positions.clamp_(0, max(0, sequence_length - 1))
+            start_positions = start_positions.clamp(0, max(0, sequence_length - 1))
+            end_positions = end_positions.clamp(0, max(0, sequence_length - 1))
 
             # Ignore zero positions in the loss. Splinter never predicts zero
             # during pretraining and zero is used for padding question

--- a/src/transformers/models/tvp/modeling_tvp.py
+++ b/src/transformers/models/tvp/modeling_tvp.py
@@ -568,7 +568,7 @@ class TvpFrameDownPadPrompter(nn.Module):
                 [self.max_img_size, self.max_img_size], dtype=pixel_values.dtype, device=pixel_values.device
             )
             visual_prompt_mask[self.max_img_size - self.visual_prompt_size : self.max_img_size, :] = 0.0
-            pixel_values *= visual_prompt_mask
+            pixel_values = pixel_values * visual_prompt_mask
         if self.visual_prompter_apply != "remove":
             prompt = torch.zeros(
                 [pixel_values.shape[0], pixel_values.shape[1], 3, self.max_img_size, self.max_img_size],
@@ -576,7 +576,7 @@ class TvpFrameDownPadPrompter(nn.Module):
             )
             start_point = self.max_img_size - self.visual_prompt_size
             prompt[:, :, :, start_point : self.max_img_size, :] = self.pad_down
-            pixel_values += prompt.to(pixel_values.dtype)
+            pixel_values = pixel_values + prompt.to(pixel_values.dtype)
         return pixel_values
 
 
@@ -657,7 +657,7 @@ class TvpFramePadPrompter(nn.Module):
             raise ValueError(f"Invalid visual_prompter_apply value {self.visual_prompter_apply}")
         if self.visual_prompter_apply in ("replace", "remove"):
             visual_prompt_mask = torch.ones([height, width], dtype=pixel_values.dtype, device=pixel_values.device)
-            pixel_values *= visual_prompt_mask
+            pixel_values = pixel_values * visual_prompt_mask
         if self.visual_prompter_apply in ("replace", "add"):
             base = torch.zeros(1, self.num_frames, 3, self.base_size, self.base_size, device=pixel_values.device)
 

--- a/src/transformers/models/udop/modeling_udop.py
+++ b/src/transformers/models/udop/modeling_udop.py
@@ -203,7 +203,7 @@ def combine_image_text_embeddings(
         image_embeddings, 1, ocr_points.unsqueeze(-1).repeat(1, 1, image_embeddings.size(-1))
     )
     repeated_vision_embeds[target_seg] = 0.0
-    inputs_embeds += repeated_vision_embeds
+    inputs_embeds = inputs_embeds + repeated_vision_embeds
 
     patch_inds = torch.full_like(image_embeddings[:, :, 0], True).bool()
     ind = torch.cat(
@@ -1159,7 +1159,7 @@ class UdopStack(UdopPreTrainedModel):
             input_shape = inputs_embeds.size()[:-1]
 
         if not self.is_decoder and bbox is not None:
-            inputs_embeds += self.cell_2d_embedding(bbox)
+            inputs_embeds = inputs_embeds + self.cell_2d_embedding(bbox)
 
         batch_size, seq_length = input_shape
 

--- a/src/transformers/models/voxtral_realtime/modeling_voxtral_realtime.py
+++ b/src/transformers/models/voxtral_realtime/modeling_voxtral_realtime.py
@@ -980,7 +980,7 @@ class VoxtralRealtimeModel(VoxtralRealtimePreTrainedModel):
                 return_dict=True,
             )
             audio_embeds = audio_outputs.pooler_output
-            inputs_embeds += audio_embeds.to(inputs_embeds.device)
+            inputs_embeds = inputs_embeds + audio_embeds.to(inputs_embeds.device)
 
         if num_delay_tokens is None:
             num_delay_tokens = self.config.default_num_delay_tokens

--- a/src/transformers/models/voxtral_realtime/modular_voxtral_realtime.py
+++ b/src/transformers/models/voxtral_realtime/modular_voxtral_realtime.py
@@ -591,7 +591,7 @@ class VoxtralRealtimeModel(VoxtralRealtimePreTrainedModel):
                 return_dict=True,
             )
             audio_embeds = audio_outputs.pooler_output
-            inputs_embeds += audio_embeds.to(inputs_embeds.device)
+            inputs_embeds = inputs_embeds + audio_embeds.to(inputs_embeds.device)
 
         if num_delay_tokens is None:
             num_delay_tokens = self.config.default_num_delay_tokens

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1859,6 +1859,50 @@ class ModelTesterMixin(ExportTesterMixin):
                     ),
                 )
 
+    def test_forward_does_not_mutate_inputs(self):
+        """`forward` must not write into the tensors it is handed.
+
+        Callers keep their own reference to `inputs_embeds`, `pixel_values`, labels and masks and reuse
+        them: to run the same batch twice, to take gradients with respect to an embedding, or simply to
+        read the labels back afterwards. An in-place write corrupts all three.
+
+        The oracle is the tensor version counter rather than the values, because several of these writes
+        happen to be numerically inert on the inputs a `ModelTester` produces (`clamp_` on labels that are
+        already in range, a multiply by an all-ones mask) while still bumping the version, breaking autograd
+        and corrupting the caller's tensor for inputs that are not.
+        """
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            with self.subTest(model_class.__name__):
+                class_config, class_inputs_dict = config, inputs_dict
+                if hasattr(self.model_tester, "prepare_config_and_inputs_for_model_class"):
+                    class_config, class_inputs_dict = self.model_tester.prepare_config_and_inputs_for_model_class(
+                        model_class
+                    )
+                model = model_class(copy.deepcopy(class_config)).to(torch_device).eval()
+
+                return_labels = model_class.__name__ not in [
+                    *get_values(MODEL_MAPPING_NAMES),
+                    *get_values(MODEL_FOR_BACKBONE_MAPPING_NAMES),
+                ]
+                inputs = self._prepare_for_class(class_inputs_dict, model_class, return_labels=return_labels)
+
+                with torch.no_grad():
+                    self.assert_inputs_untouched(model, inputs)
+
+    def assert_inputs_untouched(self, model, inputs):
+        """Call `model`, assert it did not write into any tensor in `inputs`, and return its output."""
+        versions = {k: v._version for k, v in inputs.items() if isinstance(v, torch.Tensor)}
+        outputs = model(**inputs)
+        for name, version in versions.items():
+            self.assertEqual(
+                inputs[name]._version,
+                version,
+                msg=f"{model.__class__.__name__} wrote into the caller's `{name}` tensor in place",
+            )
+        return outputs
+
     def test_training(self):
         if not self.model_tester.is_training:
             self.skipTest(reason="ModelTester is not configured to run training tests")
@@ -2942,7 +2986,9 @@ class ModelTesterMixin(ExportTesterMixin):
                 inputs["decoder_inputs_embeds"] = wte(decoder_input_ids)
 
             with torch.no_grad():
-                model(**inputs)[0]
+                # `inputs_embeds` is routinely kept and reused by the caller (gradient attribution, soft
+                # prompts), so the model must not write into it.
+                self.assert_inputs_untouched(model, inputs)[0]
 
     def test_inputs_embeds_matches_input_ids(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47742)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47742)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47741

Sixteen models write into a tensor the caller passed to `forward` instead of producing a new one. The
caller still holds a reference, so the write escapes the model, with three consequences:

- calling a model twice with the same `inputs_embeds` returns a different result the second time;
- passing an embedding with `requires_grad=True` raises `a leaf Variable that requires grad is being
  used in an in-place operation`, which rules out gradient attribution;
- a label tensor comes back rewritten, silently changing anything the caller computes from that batch
  after the forward pass.

The linked issue has a CPU-only, download-free reproducer for all three.

## Scope

I did not pick the models by name. I added the common test below, ran it over every model directory,
and took the failures as the list. Sixteen models write into a caller-owned tensor:

| Input | Models |
| --- | --- |
| `inputs_embeds` | blip, ctrl, git, kosmos2, moshi, udop, voxtral_realtime |
| `start_positions` / `end_positions` | canine, luke, markuplm, rembert, splinter |
| `mim_labels` | flava |
| `pixel_values` | tvp |
| `encoder_hidden_states` | moonshine_streaming |
| `decoder_attention_mask` | pix2struct |

Not included, and why:

| Excluded | Reason |
| --- | --- |
| csm, florence2, longformer, idefics, musicgen_melody, ovis2, speecht5, nemotron_asr_streaming | the write is guarded by `if <arg> is None:` or follows an out-of-place rebind, so the tensor is a fresh local, never the caller's |
| mixtral, phimoe, minimax, emu3, janus, gemma4 audio, maskformer FPN | the mutated `hidden_states` is an intermediate produced by the model itself, not an argument the caller owns |
| wav2vec2 / wavlm / unispeech / sew families | same: SpecAugment writes into the encoder's own hidden states |
| rt_detr, d_fine, deimv2, pp_doclayout | their `inputs_embeds` is the backbone's own feature-map list, built inside the model |
| sam, sam2, sam_hq, sam3_tracker, edgetam | `point_embeddings` is created by the prompt encoder, not passed in by the user |

## The fix

Every site becomes its out-of-place equivalent, which is what the rest of the library already does:

- 53 question-answering heads (bert, bart, roberta, electra, …) use
  `start_positions = start_positions.clamp(0, ignored_index)`; the five here used `clamp_`.
- In `modeling_tvp.py`, `TvpFramePadPrompter` already adds its prompt out of place a few lines below a
  sibling prompter that does not.

The replacements are numerically identical, so the change is a no-op wherever the tensor happened to be
a fresh local, and only allocates one extra tensor where it was not. `pix2struct` and `kosmos2` keep
their index assignment and clone first, since rewriting those as `masked_scatter` would be a larger
change than the bug warrants.

## Tests

`ModelTesterMixin.test_forward_does_not_mutate_inputs` calls each model with the inputs its
`ModelTester` produces, including labels, and asserts no input tensor was written to. `test_inputs_embeds`
gets the same assertion, which is what catches the `inputs_embeds` group.

Both compare the tensor **version counter**, not the values. A first version compared values and passed
on `main`: `clamp_` on labels that are already in range and a multiply by an all-ones mask change nothing
numerically on generated test inputs, while still bumping the version, breaking autograd, and corrupting
the caller's tensor for inputs that are not so lucky. The version counter makes the test fail on `main`
for all sixteen models and pass here.

Verified locally on CPU:

- `pytest tests/models -k "test_forward_does_not_mutate_inputs or test_inputs_embeds"` — 25 failures on
  `main`, 0 after this change (two unrelated failures on my box come from a missing `torchaudio`, and hit
  untouched tests the same way).
- Full test files of all sixteen touched models: 2682 passed, 0 failed, no change from `main`.
- `python utils/checkers.py modular_conversion,copies` clean; `ruff check` / `ruff format --check` clean
  on the changed files.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. — #47741
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@zucchini-nlp @Cyrilvallez

Disclosure: this fix was implemented with the assistance of a code agent, per my proposal in the linked issue, and reviewed and validated by me.