### PR TITLE
Follow the hidden states dtype in MaskFormerSwin's shifted-window attention mask

### DIFF
--- a/src/transformers/models/maskformer/image_processing_maskformer.py
+++ b/src/transformers/models/maskformer/image_processing_maskformer.py
@@ -33,6 +33,7 @@ from ...image_utils import (
     PILImageResampling,
     SizeDict,
     get_image_size_for_max_height_width,
+    get_max_height_width,
 )
 from ...processing_utils import ImagesKwargs, Unpack
 from ...utils import TensorType, auto_docstring, logging
@@ -442,8 +443,6 @@ class MaskFormerImageProcessor(TorchvisionBackend):
         return_tensors: str | TensorType | None,
         **kwargs,
     ) -> BatchFeature:
-        from ...image_utils import get_max_height_width
-
         if segmentation_maps is not None and len(images) != len(segmentation_maps):
             raise ValueError("Images and segmentation maps must have the same length.")
 

--- a/src/transformers/models/maskformer/modeling_maskformer_swin.py
+++ b/src/transformers/models/maskformer/modeling_maskformer_swin.py
@@ -457,7 +457,7 @@ class MaskFormerSwinLayer(nn.Module):
         self.intermediate = MaskFormerSwinIntermediate(config, dim)
         self.output = MaskFormerSwinOutput(config, dim)
 
-    def get_attn_mask(self, input_resolution):
+    def get_attn_mask(self, input_resolution, dtype):
         """Build the cyclic-shift attention mask for shifted-window MSA; returns None when shift_size is 0.
 
         Each (h, w) position belongs to one of 9 cyclic-shift regions (3 along each axis), encoded
@@ -476,7 +476,7 @@ class MaskFormerSwinLayer(nn.Module):
         w_idx = torch.arange(width)
         h_region = (h_idx >= height - self.window_size).long() + (h_idx >= height - self.shift_size).long()
         w_region = (w_idx >= width - self.window_size).long() + (w_idx >= width - self.shift_size).long()
-        img_mask = (h_region[None, :, None, None] * 3 + w_region[None, None, :, None]).float()
+        img_mask = (h_region[None, :, None, None] * 3 + w_region[None, None, :, None]).to(dtype)
         mask_windows = window_partition(img_mask, self.window_size)
         mask_windows = mask_windows.view(-1, self.window_size * self.window_size)
         attn_mask = mask_windows.unsqueeze(1) - mask_windows.unsqueeze(2)
@@ -511,7 +511,7 @@ class MaskFormerSwinLayer(nn.Module):
         # partition windows
         hidden_states_windows = window_partition(shifted_hidden_states, self.window_size)
         hidden_states_windows = hidden_states_windows.view(-1, self.window_size * self.window_size, channels)
-        attn_mask = self.get_attn_mask((height_pad, width_pad))
+        attn_mask = self.get_attn_mask((height_pad, width_pad), dtype=hidden_states.dtype)
         if attn_mask is not None:
             attn_mask = attn_mask.to(hidden_states_windows.device)
 

--- a/tests/models/maskformer/test_modeling_maskformer_swin.py
+++ b/tests/models/maskformer/test_modeling_maskformer_swin.py
@@ -17,7 +17,13 @@ import collections
 import unittest
 
 from transformers import MaskFormerSwinConfig
-from transformers.testing_utils import require_torch, require_torch_multi_gpu, torch_device
+from transformers.testing_utils import (
+    is_torch_bf16_available_on_device,
+    is_torch_fp16_available_on_device,
+    require_torch,
+    require_torch_multi_gpu,
+    torch_device,
+)
 from transformers.utils import is_torch_available
 
 from ...test_backbone_common import BackboneTesterMixin
@@ -207,6 +213,23 @@ class MaskFormerSwinModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Te
     def test_backbone(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_backbone(*config_and_inputs)
+
+    def test_shifted_window_attention_mask_dtype(self):
+        # The shifted-window attention mask must follow the hidden states' dtype, otherwise a
+        # half-precision model mixes a float32 mask into float16/bfloat16 scores and the matmul
+        # against the value states raises. See #18803, which fixed the same thing for Swin.
+        config, pixel_values, _ = self.model_tester.prepare_config_and_inputs()
+        for dtype, is_available in (
+            (torch.float16, is_torch_fp16_available_on_device),
+            (torch.bfloat16, is_torch_bf16_available_on_device),
+        ):
+            if not is_available(torch_device):
+                continue
+            with self.subTest(dtype=str(dtype)):
+                model = MaskFormerSwinModel(config).to(torch_device).to(dtype).eval()
+                with torch.no_grad():
+                    outputs = model(pixel_values.to(torch_device).to(dtype))
+                self.assertEqual(outputs.last_hidden_state.dtype, dtype)
 
     @unittest.skip(reason="Swin does not use inputs_embeds")
     def test_inputs_embeds(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47744)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47744)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47743

`MaskFormerSwinLayer.get_attn_mask` builds the cyclic-shift attention mask with a hardcoded
`.float()`, and the call site aligns only its device. In a half-precision model the float32 mask is
added to the float16/bfloat16 attention scores, which promotes the scores back to float32, and the
following matmul against the value states raises:

```
RuntimeError: expected m1 and m2 to have the same dtype, but got: float != struct c10::BFloat16
```

So `MaskFormerSwinModel`, and therefore `MaskFormerModel` and `MaskFormerForInstanceSegmentation`
on any `facebook/maskformer-swin-*` checkpoint, cannot be loaded with `dtype=torch.float16` or
`torch.bfloat16`. The linked issue has a CPU-only, download-free reproducer.

This is the same fix as commit
[`7320d95d98`](https://github.com/huggingface/transformers/commit/7320d95d98f51ba056cbfe58f08146420c7ec8af)
— *"[Swin, Swinv2] Fix attn_mask dtype (#18803)"* — which added a `dtype` argument to `get_attn_mask`
in `swin`, `swinv2` and `donut_swin` in 2022 and did not reach `maskformer_swin`. With this change
every `get_attn_mask` in the library takes a dtype again (`swin`, `swinv2`, `donut_swin`, `swin2sr`,
`clap`).

## About the second file

`image_processing_maskformer.py` is not related to the bug, but the PR cannot be green without it.
`_preprocess` imports `get_max_height_width` locally. When the modular converter generates
`mask2former/image_processing_mask2former.py` it drops that local import and keeps the blank line
that followed, so the generated file gains a blank line at the start of a function body that
`ruff format` then removes. The two checks contradict each other, and because `mask2former`'s
modular file depends on `maskformer`, **any** change under `models/maskformer/` on `main` today
makes `Check repository consistency` fail. Reproducible on a clean `main`:

```
$ echo "# probe" >> src/transformers/models/maskformer/modeling_maskformer_swin.py
$ python utils/check_modular_conversion.py --fix_and_overwrite
Overwritten src/transformers/models/mask2former/image_processing_mask2former.py with the generated content.
$ git diff --stat src/transformers/models/mask2former/
 .../mask2former/image_processing_mask2former.py | 1 +
```

Moving the import into the module-level `image_utils` block it already belongs to removes the
artifact, and both checks pass. Happy to split it out if you would rather fix the converter instead.

## Tests

`MaskFormerSwinModelTest.test_shifted_window_attention_mask_dtype` runs the model in float16 and
bfloat16 and asserts the output dtype, skipping either dtype the device does not support via the
existing `is_torch_fp16_available_on_device` / `is_torch_bf16_available_on_device` helpers. It fails
on `main` with `expected scalar type Float but found Half` and `... found BFloat16`, and passes here.

Verified locally on CPU:

- `pytest tests/models/maskformer` — 181 passed, 0 failed, unchanged from `main`.
- `pytest tests/models/mask2former tests/models/oneformer` — no new failures
  (`oneformer::test_batching_equivalence` already fails on a clean `main` on this box).
- `python utils/checkers.py modular_conversion,copies` clean; `ruff check` / `ruff format --check`
  clean on the changed files.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. — #47743
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@NielsRogge @molbap

Disclosure: this fix was implemented with the assistance of a code agent, per my proposal in the linked issue, and reviewed and validated by me.