### PR TITLE
[CI] Add CPU runner support to ssh-runner workflow

### DIFF
--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -4,14 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       runner_type:
-        description: 'Type of runner to test (a10)'
+        description: 'Type of runner to test (a10, cpu)'
         required: true
       docker_image:
         description: 'Name of the Docker image'
         required: true
       num_gpus:
-        description: 'Type of the number of gpus to use (`single` or `multi`)'
-        required: true
+        description: 'Number of GPUs to use (`single` or `multi`; not needed for cpu runner)'
+        required: false
+        default: 'none'
 
 env:
   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
@@ -39,10 +40,18 @@ jobs:
           NUM_GPUS: ${{ github.event.inputs.num_gpus }}
           RUNNER_TYPE: ${{ github.event.inputs.runner_type }}
         run: |
-          if [[ "$NUM_GPUS" == "single" && "$RUNNER_TYPE" == "a10" ]]; then
-            echo "RUNNER=aws-g5-4xlarge-cache-ssh" >> $GITHUB_ENV
-          elif [[ "$NUM_GPUS" == "multi" && "$RUNNER_TYPE" == "a10" ]]; then
-            echo "RUNNER=aws-g5-12xlarge-cache-ssh" >> $GITHUB_ENV
+          if [[ "$RUNNER_TYPE" == "a10" ]]; then
+            if [[ "$NUM_GPUS" != "single" && "$NUM_GPUS" != "multi" ]]; then
+              echo "WARNING: num_gpus not set or invalid for a10 runner, defaulting to 'single'"
+              NUM_GPUS="single"
+            fi
+            if [[ "$NUM_GPUS" == "single" ]]; then
+              echo "RUNNER=aws-g5-4xlarge-cache-ssh" >> $GITHUB_ENV
+            else
+              echo "RUNNER=aws-g5-12xlarge-cache-ssh" >> $GITHUB_ENV
+            fi
+          elif [[ "$RUNNER_TYPE" == "cpu" ]]; then
+            echo "RUNNER=aws-m8i-l-cache" >> $GITHUB_ENV
           else
             echo "RUNNER=" >> $GITHUB_ENV
           fi
@@ -80,6 +89,7 @@ jobs:
         run: pip freeze
 
       - name: NVIDIA-SMI
+        if: ${{ github.event.inputs.runner_type != 'cpu' }}
         run: |
           nvidia-smi
 


### PR DESCRIPTION
## Summary

- Adds `cpu` as a valid `runner_type` option, mapping to `aws-m8i-l-cache`
- Makes `num_gpus` optional (defaults to `none`) since CPU runners don't need it
- If `runner_type=a10` is selected without a valid `num_gpus`, prints a warning and falls back to `single`
- Skips the NVIDIA-SMI step for CPU runners