### PR TITLE
[CI - Debug] Skip /transformers-dependent steps for CPU runner

### DIFF
--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -71,6 +71,7 @@ jobs:
       image: ${{ github.event.inputs.docker_image }}
     steps:
       - name: Update clone
+        if: ${{ github.event.inputs.runner_type != 'cpu' }}
         working-directory: /transformers
         env:
           commit_sha: ${{ github.sha }}
@@ -78,6 +79,7 @@ jobs:
           git fetch && git checkout "$commit_sha"
 
       - name: Cleanup
+        if: ${{ github.event.inputs.runner_type != 'cpu' }}
         working-directory: /transformers
         run: |
           rm -rf tests/__pycache__
@@ -85,6 +87,7 @@ jobs:
           rm -rf reports
 
       - name: Show installed libraries and their versions
+        if: ${{ github.event.inputs.runner_type != 'cpu' }}
         working-directory: /transformers
         run: pip freeze
 
@@ -104,12 +107,14 @@ jobs:
           pip install psutil --break-system-packages
 
       - name: Download memory monitor script
+        if: ${{ github.event.inputs.runner_type != 'cpu' }}
         working-directory: /transformers
         run: |
           apt-get update && apt-get install -y curl
           curl -o memory_monitor.py https://raw.githubusercontent.com/huggingface/transformers/refs/heads/utility_scripts/utils/memory_monitor.py
 
       - name: Start memory monitor
+        if: ${{ github.event.inputs.runner_type != 'cpu' }}
         working-directory: /transformers
         continue-on-error: true  # Don't fail workflow if monitor has issues
         run: |


### PR DESCRIPTION
## Summary

The a10 Docker images have the repo pre-cloned at `/transformers`, but CPU images don't — causing the workflow to fail immediately on `cd: can't cd to /transformers`.

Steps that assume `/transformers` exists are now skipped for `runner_type=cpu`:
- **Update clone** (`working-directory: /transformers`)
- **Cleanup** (`working-directory: /transformers`)
- **Show installed libraries** (`working-directory: /transformers`)
- **Download memory monitor script** (`working-directory: /transformers`)
- **Start memory monitor** (`working-directory: /transformers`)

This allows a clean Tailscale SSH session into the CPU runner to explore its actual directory structure, after which we can decide whether to replicate the same setup steps (e.g. clone the repo) for CPU.