### PR TITLE
Post the model linter's first pass as a PR review

### DIFF
--- a/.github/workflows/mlinter-review.yml
+++ b/.github/workflows/mlinter-review.yml
@@ -1,0 +1,52 @@
+name: Post Model Lint Review
+
+on:
+  workflow_run:
+    workflows: ["Model Lint"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  post-review:
+    name: Post the linter's first pass
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Download findings from the lint run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" --name mlinter-findings --dir . || {
+            echo "No findings artifact; nothing to post."
+            exit 0
+          }
+          ls -la
+
+      # Fetched by ref rather than checked out, so no PR code is ever placed in this workspace.
+      - name: Download the review script
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SCRIPT_REF: ${{ github.workflow_sha }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github.raw" \
+            "/repos/${GITHUB_REPOSITORY}/contents/utils/post_mlinter_review.py?ref=${SCRIPT_REF}" \
+            > post_mlinter_review.py
+
+      - name: Post the review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ ! -f mlinter-findings.json ]; then
+            echo "No findings file; nothing to post."
+            exit 0
+          fi
+          PR_NUMBER="$(cat mlinter-pr-number.txt 2>/dev/null || true)"
+          export PR_NUMBER
+          python3 post_mlinter_review.py

--- a/.github/workflows/mlinter.yml
+++ b/.github/workflows/mlinter.yml
@@ -1,0 +1,50 @@
+name: Model Lint
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    paths:
+      - 'src/transformers/models/**'
+      - 'tests/models/**/test_tokenization_*.py'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint changed model files
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # The linter diffs against the base ref, so it needs both sides of the branch point.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install the model linter
+        run: python -m pip install --upgrade "transformers-mlinter>=0.1.2"
+
+      - name: Collect findings
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch --no-tags origin "$BASE_REF"
+          python utils/collect_mlinter_findings.py --base-ref "origin/$BASE_REF"
+
+      - name: Record the PR number
+        run: echo "${{ github.event.pull_request.number }}" > mlinter-pr-number.txt
+
+      # The review is posted by a separate workflow_run job: this job runs untrusted PR code and
+      # therefore has no write access to the pull request.
+      - uses: actions/upload-artifact@v5
+        with:
+          name: mlinter-findings
+          path: |
+            mlinter-findings.json
+            mlinter-pr-number.txt
+          if-no-files-found: warn
+          retention-days: 3

--- a/tests/utils/test_post_mlinter_review.py
+++ b/tests/utils/test_post_mlinter_review.py
@@ -1,0 +1,108 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_poster():
+    """`utils/` is not an importable package, so load the script by path."""
+    path = REPO_ROOT / "utils" / "post_mlinter_review.py"
+    spec = importlib.util.spec_from_file_location("post_mlinter_review", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+poster = _load_poster()
+
+FINDINGS = [
+    {
+        "path": "src/transformers/models/acme/modeling_acme.py",
+        "line": 10,
+        "rule": "TRF023",
+        "message": "`nn.Linear` is built with the hardcoded dimension(s) 768.",
+    },
+    {
+        "path": "src/transformers/models/acme/modeling_acme.py",
+        "line": 16,
+        "rule": "TRF026",
+        "message": "bare `assert` in a model file.",
+    },
+]
+RULES = {
+    "TRF023": {
+        "description": "Layer dimensions must come from the config.",
+        "why_bad": "A hardcoded width pins the module to one checkpoint size.",
+        "diff": "-nn.Linear(768, 768)\n+nn.Linear(config.hidden_size, config.hidden_size)",
+    },
+    "TRF026": {"description": "No bare assert.", "why_bad": "`python -O` strips asserts.", "diff": ""},
+}
+
+
+class CommentableLinesTest(unittest.TestCase):
+    def test_counts_added_and_context_lines_only(self):
+        patch = "@@ -1,3 +1,6 @@\n context1\n+added2\n+added3\n-deleted\n context4\n"
+        self.assertEqual(poster.commentable_lines(patch), {1, 2, 3, 4})
+
+    def test_restarts_at_each_hunk_header(self):
+        patch = "@@ -1,1 +1,1 @@\n c1\n@@ -20,2 +30,3 @@\n c30\n+a31\n"
+        self.assertEqual(poster.commentable_lines(patch), {1, 30, 31})
+
+    def test_handles_single_line_hunk_header_without_count(self):
+        self.assertEqual(poster.commentable_lines("@@ -1 +7 @@\n+added7\n"), {7})
+
+    def test_handles_missing_and_malformed_patches(self):
+        self.assertEqual(poster.commentable_lines(None), set())
+        self.assertEqual(poster.commentable_lines(""), set())
+        self.assertEqual(poster.commentable_lines("@@ garbage @@\n+line\n"), set())
+
+
+class RenderingTest(unittest.TestCase):
+    def test_review_body_carries_marker_and_rule_table(self):
+        body = poster.review_body(FINDINGS, RULES, inline_count=2, skipped=[], version="0.1.2")
+        self.assertIn(poster.MARKER, body)
+        self.assertIn("TRF023", body)
+        self.assertIn("TRF026", body)
+        self.assertIn("2 item(s)", body)
+        self.assertNotIn("point at lines outside this diff", body)
+
+    def test_review_body_lists_findings_it_could_not_anchor(self):
+        body = poster.review_body(FINDINGS, RULES, inline_count=1, skipped=FINDINGS[1:], version="0.1.2")
+        self.assertIn("1 item(s) point at lines outside this diff", body)
+        self.assertIn("modeling_acme.py:16", body)
+
+    def test_review_body_escapes_pipes_in_descriptions(self):
+        rules = {"TRF023": {"description": "a | b", "why_bad": "", "diff": ""}}
+        body = poster.review_body(FINDINGS[:1], rules, inline_count=0, skipped=[], version="0.1.2")
+        self.assertIn("a \\| b", body)
+
+    def test_comment_body_includes_rationale_and_the_escape_hatch(self):
+        body = poster.comment_body(FINDINGS[0], RULES)
+        self.assertIn("**TRF023**", body)
+        self.assertIn("pins the module to one checkpoint size", body)
+        self.assertIn("```diff", body)
+        self.assertIn("# trf-ignore: TRF023", body)
+
+    def test_comment_body_without_a_rule_spec_is_still_valid(self):
+        body = poster.comment_body({"rule": "TRF999", "message": "something"}, {})
+        self.assertIn("**TRF999**", body)
+        self.assertNotIn("<details>", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/collect_mlinter_findings.py
+++ b/utils/collect_mlinter_findings.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright 2026 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run the model linter over the files a PR touches and write the findings to JSON.
+
+Runs in the untrusted `pull_request` job, so it only reads the working tree and writes a file. The
+companion `post_mlinter_review.py` runs separately with write access and turns this JSON into a review.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-ref", default="origin/main", help="Base ref to diff against.")
+    parser.add_argument("--output", type=Path, default=Path("mlinter-findings.json"))
+    args = parser.parse_args()
+
+    try:
+        from mlinter import (
+            DEFAULT_ENABLED_TRF_RULES,
+            TRF_RULE_SPECS,
+            __version__,
+            analyze_file,
+            get_changed_modeling_files,
+        )
+    except ImportError:
+        print("transformers-mlinter is not installed; nothing to do.", file=sys.stderr)
+        return 0
+
+    changed = sorted(get_changed_modeling_files(args.base_ref))
+    findings = []
+    for path in changed:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            violations = analyze_file(path, text, enabled_rules=set(DEFAULT_ENABLED_TRF_RULES))
+        except Exception as exc:  # a parse error is the PR's problem, not the linter's
+            print(f"skipped {path}: {exc}", file=sys.stderr)
+            continue
+        for violation in violations:
+            findings.append(
+                {
+                    "path": str(violation.file_path),
+                    "line": violation.line_number,
+                    "rule": violation.rule_id,
+                    # The rule id is already the first token of the message; the review renders it
+                    # separately, so strip it here rather than in the poster.
+                    "message": violation.message.split(": ", 1)[-1],
+                }
+            )
+
+    rules_used = sorted({finding["rule"] for finding in findings if finding["rule"]})
+    payload = {
+        "mlinter_version": __version__,
+        "changed_files": [str(path) for path in changed],
+        "findings": findings,
+        "rules": {
+            rule: {
+                "description": TRF_RULE_SPECS[rule]["description"],
+                "why_bad": TRF_RULE_SPECS[rule]["explanation"]["why_bad"],
+                "diff": TRF_RULE_SPECS[rule]["explanation"]["diff"],
+            }
+            for rule in rules_used
+            if rule in TRF_RULE_SPECS
+        },
+    }
+    args.output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"{len(findings)} finding(s) across {len(changed)} changed model file(s) -> {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/post_mlinter_review.py
+++ b/utils/post_mlinter_review.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# Copyright 2026 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Post the model linter's findings on a PR as a single review with inline comments.
+
+Reads the JSON that `collect_mlinter_findings.py` produced in the untrusted job. Never checks out or
+executes PR code: it only talks to the GitHub API.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+GITHUB_API_URL = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+RULES_DOC_URL = "https://github.com/huggingface/transformers-mlinter#rules"
+# Lets a re-run recognise its own previous review instead of stacking duplicates.
+MARKER = "<!-- mlinter-review -->"
+MAX_INLINE_COMMENTS = 40
+
+
+def request_json(url, token, method="GET", payload=None):
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+    request.add_header("User-Agent", "transformers-mlinter-review")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(request, timeout=60) as response:
+        body = response.read().decode("utf-8")
+    return json.loads(body) if body.strip() else {}
+
+
+def paginate(url, token):
+    items = []
+    page = 1
+    while page <= 20:
+        separator = "&" if "?" in url else "?"
+        batch = request_json(f"{url}{separator}per_page=100&page={page}", token)
+        if not isinstance(batch, list) or not batch:
+            break
+        items.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return items
+
+
+def commentable_lines(patch):
+    """Line numbers on the head side of a file that a review comment can anchor to.
+
+    GitHub rejects a comment whose line is not part of the diff, so added and context lines are the
+    only valid anchors. Deleted lines never appear on the head side.
+    """
+    lines = set()
+    head_line = 0
+    for raw in (patch or "").splitlines():
+        if raw.startswith("@@"):
+            # @@ -old,+count +new,+count @@
+            try:
+                head_line = int(raw.split("+", 1)[1].split(",", 1)[0].split(" ", 1)[0])
+            except (IndexError, ValueError):
+                head_line = 0
+            continue
+        if raw.startswith("-"):
+            continue
+        if raw.startswith("+") or raw.startswith(" "):
+            if head_line:
+                lines.add(head_line)
+                head_line += 1
+    return lines
+
+
+def comment_body(finding, rules):
+    rule = finding["rule"]
+    spec = rules.get(rule, {})
+    lines = [f"**{rule}** — {finding['message']}"]
+    why = (spec.get("why_bad") or "").strip()
+    diff = (spec.get("diff") or "").strip()
+    if why or diff:
+        lines.append("")
+        lines.append("<details><summary>Why this matters</summary>")
+        lines.append("")
+        if why:
+            lines.append(why)
+            lines.append("")
+        if diff:
+            lines.append("```diff")
+            lines.append(diff)
+            lines.append("```")
+            lines.append("")
+        lines.append(f"If this model genuinely needs to deviate, add `# trf-ignore: {rule}` above the line.")
+        lines.append("")
+        lines.append("</details>")
+    return "\n".join(lines)
+
+
+def review_body(findings, rules, inline_count, skipped, version):
+    counts = Counter(finding["rule"] for finding in findings)
+    lines = [
+        MARKER,
+        "## Model linter — first pass",
+        "",
+        f"`transformers-mlinter` {version} found **{len(findings)} item(s)** in the model files this PR touches. "
+        "These are the structural conventions a maintainer would otherwise flag by hand, so getting them out of "
+        "the way first makes the human review shorter.",
+        "",
+        "This is automated and advisory. It does not block merging, and a maintainer may well tell you to ignore "
+        "some of it.",
+        "",
+        "| rule | count | what it checks |",
+        "| --- | --- | --- |",
+    ]
+    for rule, count in counts.most_common():
+        description = (rules.get(rule, {}).get("description") or "").replace("|", "\\|")
+        lines.append(f"| [`{rule}`]({RULES_DOC_URL}) | {count} | {description} |")
+    lines.append("")
+    if inline_count:
+        lines.append(f"{inline_count} of these are attached inline below.")
+    if skipped:
+        lines.append("")
+        lines.append(f"<details><summary>{len(skipped)} item(s) point at lines outside this diff</summary>")
+        lines.append("")
+        for finding in skipped:
+            lines.append(f"- `{finding['path']}:{finding['line']}` — **{finding['rule']}** {finding['message']}")
+        lines.append("")
+        lines.append("</details>")
+    lines.append("")
+    lines.append(
+        "Run it locally with `pip install transformers-mlinter && mlinter --changed-only`, or see one rule in "
+        "detail with `mlinter --rule TRF001`. Suppress a single line with `# trf-ignore: TRFxxx`."
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN is not set.", file=sys.stderr)
+        return 1
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    findings_path = Path(os.environ.get("MLINTER_FINDINGS", "mlinter-findings.json"))
+    pr_number = os.environ.get("PR_NUMBER", "").strip()
+
+    if not pr_number:
+        print("No PR number available; nothing to post.")
+        return 0
+    if not findings_path.exists():
+        print(f"{findings_path} is missing; the lint job produced nothing.")
+        return 0
+
+    payload = json.loads(findings_path.read_text(encoding="utf-8"))
+    findings = payload.get("findings") or []
+    rules = payload.get("rules") or {}
+    version = payload.get("mlinter_version", "")
+
+    if not findings:
+        print("No findings; not posting a review.")
+        return 0
+
+    pulls_url = f"{GITHUB_API_URL}/repos/{repository}/pulls/{pr_number}"
+
+    # Already reviewed this PR once? The point is a first pass, not a comment on every push.
+    for review in paginate(f"{pulls_url}/reviews", token):
+        if MARKER in (review.get("body") or ""):
+            print(f"Already posted review {review.get('id')}; leaving it alone.")
+            return 0
+
+    anchors = {}
+    for entry in paginate(f"{pulls_url}/files", token):
+        anchors[entry["filename"]] = commentable_lines(entry.get("patch"))
+
+    comments = []
+    skipped = []
+    per_file = defaultdict(int)
+    for finding in findings:
+        path, line = finding["path"], finding["line"]
+        # Cap per file so one noisy file cannot bury the rest of the review.
+        if line in anchors.get(path, set()) and len(comments) < MAX_INLINE_COMMENTS and per_file[path] < 10:
+            comments.append({"path": path, "line": line, "side": "RIGHT", "body": comment_body(finding, rules)})
+            per_file[path] += 1
+        else:
+            skipped.append(finding)
+
+    body = review_body(findings, rules, len(comments), skipped, version)
+    try:
+        review = request_json(
+            f"{pulls_url}/reviews",
+            token,
+            method="POST",
+            payload={"event": "COMMENT", "body": body, "comments": comments},
+        )
+        print(f"Posted review {review.get('id')} with {len(comments)} inline comment(s).")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:500]
+        print(f"Review with inline comments failed ({exc.code}): {detail}", file=sys.stderr)
+        # An anchor can still be rejected (force-push races, renamed files). A summary-only review keeps
+        # the feedback rather than losing the whole run.
+        body = review_body(findings, rules, 0, findings, version)
+        review = request_json(f"{pulls_url}/reviews", token, method="POST", payload={"event": "COMMENT", "body": body})
+        print(f"Posted summary-only review {review.get('id')}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47760)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47760)
<!-- ci-dashboard-badge:end -->

## What this does

Runs `transformers-mlinter` on the model files a PR touches and posts the result as **one review with inline comments**, so the mechanical pass is already done when a human starts reading.

Each inline comment carries the rule id, what to change, a collapsed rationale with an example diff, and the `# trf-ignore: TRFxxx` escape hatch. The review body opens with a per-rule table and a plain statement that it is automated and advisory.

Here is the actual output, generated locally against a synthetic new model:

> ## Model linter — first pass
>
> `transformers-mlinter` 0.1.2 found **7 item(s)** in the model files this PR touches. These are the structural conventions a maintainer would otherwise flag by hand, so getting them out of the way first makes the human review shorter.
>
> This is automated and advisory. It does not block merging, and a maintainer may well tell you to ignore some of it.
>
> | rule | count | what it checks |
> | --- | --- | --- |
> | `TRF023` | 2 | Layer dimensions must come from the config, not from an integer literal in the modeling file. |
> | `TRF025` | 1 | A module whose forward only delegates to its single submodule adds nothing; inline it. |
> | `TRF026` | 1 | Model files must raise explicit errors instead of using bare `assert`. |
> | `TRF027` | 1 | Model files must carry the Apache 2.0 license header. |
> | `TRF028` | 1 | A module taking `config` must not also take arguments that live on the config. |
> | `TRF031` | 1 | Masked positions must be filled with torch.finfo(dtype).min, not a magic negative number. |

…and one of the inline comments:

> **TRF026** — bare `assert` in a model file. Raise a ValueError with an actionable message instead; asserts vanish under `python -O`.
>
> <details><summary>Why this matters</summary>
>
> `python -O` strips assert statements, so a shape or config check written as an assert silently disappears in optimised runs. An assert also gives the user a bare AssertionError with no guidance, where a ValueError can name the offending value and what to do about it.
>
> ```diff
> def forward(self, hidden_states):
> -    assert hidden_states.dim() == 3
> +    if hidden_states.dim() != 3:
> +        raise ValueError(f"Expected a 3D tensor, got shape {tuple(hidden_states.shape)}.")
> ```
>
> If this model genuinely needs to deviate, add `# trf-ignore: TRF026` above the line.
>
> </details>

## Why

New model PRs get their structural conventions taught by hand, one line comment at a time, across several rounds. Across the 52 PRs in this repo that drew more than 100 review comments, *reuse an existing model* appears in 50 of them, *config hygiene* in 51, *naming* in 51, *tests* in 52 — and one reviewer carries 40% of that labour. The linter already knows most of it; nobody sees its output until a maintainer runs it.

## Triggering

`opened` and `reopened` only, and the poster refuses to post twice on the same PR (it looks for its own marker in existing reviews). This is a first pass, not a bot that comments on every push.

## Security

Split across two workflows, following `pr-ci-post-dashboard-link.yml`:

- **`mlinter.yml`** — `pull_request`, `contents: read`. Runs the linter over untrusted PR code and only uploads an artifact. No token that can write anything.
- **`mlinter-review.yml`** — `workflow_run`, holds `pull-requests: write`, never checks out PR code. It downloads the artifact and fetches the review script by `github.workflow_sha` rather than from the PR branch, so a PR cannot alter the script that runs with write access.

No `pull_request_target` and no checkout of a fork's head in a privileged context.

## Robustness

- Comments are anchored only to lines that are actually in the diff (the patch is parsed to find them); anything else goes into a collapsed "points at lines outside this diff" list rather than 422-ing the whole review.
- Capped at 40 inline comments and 10 per file, so one noisy file cannot bury the review.
- If the API rejects the anchors anyway (force-push race, renamed file), it falls back to a summary-only review instead of losing the run.
- A missing artifact, missing PR number or zero findings all exit cleanly without posting.

## Testing

`tests/utils/test_post_mlinter_review.py` — 9 tests over the diff parser (hunk headers with and without counts, deletions excluded, malformed patches) and the rendering. I also ran the collector end-to-end against a synthetic new model in a real checkout to produce the output quoted above.

One note: my first attempt to test this planted a violation in `modeling_llama.py` and got zero findings — llama predates the rules' `cutoff_date`, so it is exempt. Worth knowing if you test this by hand: use a new model directory.

## Depends on

The rules quoted above (`TRF023`, `TRF025`–`TRF031`) are in flight in huggingface/transformers-mlinter#15, #16, #18 and #19. This PR works with whatever is released — it reads `DEFAULT_ENABLED_TRF_RULES` at runtime — but it pins `transformers-mlinter>=0.1.2`, which today ships `TRF001`–`TRF021`. Bump that floor once the new rules are released if you want them included.