### PR TITLE
Fix HuBERT positional conv embedding padding sensitivity when conv_pos_batch_norm=True (#47739)

### DIFF
--- a/src/transformers/models/hubert/modeling_hubert.py
+++ b/src/transformers/models/hubert/modeling_hubert.py
@@ -80,10 +80,12 @@ class HubertPositionalConvEmbedding(nn.Module):
         self.padding = HubertSamePadLayer(config.num_conv_pos_embeddings)
         self.activation = ACT2FN[config.feat_extract_activation]
 
-    def forward(self, hidden_states):
+    def forward(self, hidden_states, attention_mask=None):
         hidden_states = hidden_states.transpose(1, 2)
         if self.batch_norm is not None:
             hidden_states = self.batch_norm(hidden_states)
+            if attention_mask is not None:
+                hidden_states = hidden_states * attention_mask.unsqueeze(1)
         hidden_states = self.conv(hidden_states)
         hidden_states = self.padding(hidden_states)
         hidden_states = self.activation(hidden_states)
@@ -430,13 +432,14 @@ class HubertEncoder(nn.Module):
             expand_attention_mask = attention_mask.unsqueeze(-1).repeat(1, 1, hidden_states.shape[2])
             hidden_states[~expand_attention_mask] = 0
 
+        position_embeddings = self.pos_conv_embed(hidden_states, attention_mask=attention_mask)
+
         attention_mask = create_bidirectional_mask(
             config=self.config,
             inputs_embeds=hidden_states,
             attention_mask=attention_mask,
         )
 
-        position_embeddings = self.pos_conv_embed(hidden_states)
         hidden_states = hidden_states + position_embeddings.to(hidden_states.device)
         hidden_states = self.layer_norm(hidden_states)
         hidden_states = self.dropout(hidden_states)
@@ -575,13 +578,14 @@ class HubertEncoderStableLayerNorm(nn.Module):
             expand_attention_mask = attention_mask.unsqueeze(-1).repeat(1, 1, hidden_states.shape[2])
             hidden_states[~expand_attention_mask] = 0
 
+        position_embeddings = self.pos_conv_embed(hidden_states, attention_mask=attention_mask)
+
         attention_mask = create_bidirectional_mask(
             config=self.config,
             inputs_embeds=hidden_states,
             attention_mask=attention_mask,
         )
 
-        position_embeddings = self.pos_conv_embed(hidden_states)
         hidden_states = hidden_states + position_embeddings
         hidden_states = self.dropout(hidden_states)
 

--- a/src/transformers/models/hubert/modeling_hubert.py
+++ b/src/transformers/models/hubert/modeling_hubert.py
@@ -18,25 +18,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Callable
-
-import numpy as np
 import torch
 import torch.nn as nn
-from torch.nn import CrossEntropyLoss
 
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...integrations.deepspeed import is_deepspeed_zero3_enabled
 from ...integrations.fsdp import is_fsdp_managed_module
 from ...masking_utils import create_bidirectional_mask
+from ...modeling_outputs import BaseModelOutput
+from ...modeling_utils import PreTrainedModel
+from ...utils import auto_docstring
+from .configuration_hubert import HubertConfig
+from collections.abc import Callable
+
+import numpy as np
+from torch.nn import CrossEntropyLoss
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import GradientCheckpointingLayer
-from ...modeling_outputs import BaseModelOutput, CausalLMOutput, SequenceClassifierOutput
-from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel, get_torch_context_manager_or_global_device
+from ...modeling_outputs import (
+    CausalLMOutput, SequenceClassifierOutput)
+from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, get_torch_context_manager_or_global_device
 from ...processing_utils import Unpack
-from ...utils import TransformersKwargs, auto_docstring, logging
-from .configuration_hubert import HubertConfig
+from ...utils import (
+    TransformersKwargs, logging)
 
 
 logger = logging.get_logger(__name__)
@@ -188,7 +193,9 @@ class HubertFeatureEncoder(nn.Module):
                 HubertNoLayerNormConvLayer(config, layer_id=i + 1) for i in range(config.num_feat_extract_layers - 1)
             ]
         elif config.feat_extract_norm == "layer":
-            conv_layers = [HubertLayerNormConvLayer(config, layer_id=i) for i in range(config.num_feat_extract_layers)]
+            conv_layers = [
+                HubertLayerNormConvLayer(config, layer_id=i) for i in range(config.num_feat_extract_layers)
+            ]
         else:
             raise ValueError(
                 f"`config.feat_extract_norm` is {config.feat_extract_norm}, but has to be one of ['group', 'layer']"
@@ -231,6 +238,7 @@ class HubertFeatureProjection(nn.Module):
         hidden_states = self.projection(hidden_states)
         hidden_states = self.dropout(hidden_states)
         return hidden_states
+
 
 
 def eager_attention_forward(
@@ -418,7 +426,7 @@ class HubertEncoder(nn.Module):
 
     def forward(
         self,
-        hidden_states: torch.tensor,
+        hidden_states: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         output_attentions: bool = False,
         output_hidden_states: bool = False,
@@ -432,6 +440,11 @@ class HubertEncoder(nn.Module):
             expand_attention_mask = attention_mask.unsqueeze(-1).repeat(1, 1, hidden_states.shape[2])
             hidden_states[~expand_attention_mask] = 0
 
+        # Pass the 2-D bool mask to pos_conv_embed *before* it is converted to a
+        # 4-D additive float mask by create_bidirectional_mask.  When
+        # conv_pos_batch_norm=True, HubertPositionalConvEmbedding uses this mask
+        # to zero-out padded positions after BatchNorm1d so that padding does not
+        # contaminate the batch statistics.
         position_embeddings = self.pos_conv_embed(hidden_states, attention_mask=attention_mask)
 
         attention_mask = create_bidirectional_mask(
@@ -564,11 +577,11 @@ class HubertEncoderStableLayerNorm(nn.Module):
 
     def forward(
         self,
-        hidden_states,
-        attention_mask=None,
-        output_attentions=False,
-        output_hidden_states=False,
-        return_dict=True,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        return_dict: bool = True,
     ):
         all_hidden_states = () if output_hidden_states else None
         all_self_attentions = () if output_attentions else None
@@ -578,6 +591,7 @@ class HubertEncoderStableLayerNorm(nn.Module):
             expand_attention_mask = attention_mask.unsqueeze(-1).repeat(1, 1, hidden_states.shape[2])
             hidden_states[~expand_attention_mask] = 0
 
+        # Pass the 2-D bool mask before it becomes a 4-D additive float mask.
         position_embeddings = self.pos_conv_embed(hidden_states, attention_mask=attention_mask)
 
         attention_mask = create_bidirectional_mask(
@@ -595,13 +609,10 @@ class HubertEncoderStableLayerNorm(nn.Module):
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)
 
-            # add LayerDrop (see https://huggingface.co/papers/1909.11556 for description)
             dropout_probability = torch.rand([])
 
             skip_the_layer = self.training and dropout_probability < self.config.layerdrop
             if not skip_the_layer or synced_gpus:
-                # under fsdp or deepspeed zero3 all gpus must run in sync
-                # XXX: could optimize this like synced_gpus in generate_utils but not sure if it's worth the code complication
                 layer_outputs = layer(
                     hidden_states, attention_mask=attention_mask, output_attentions=output_attentions
                 )

--- a/src/transformers/models/hubert/modular_hubert.py
+++ b/src/transformers/models/hubert/modular_hubert.py
@@ -19,6 +19,8 @@ import torch.nn as nn
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...integrations.deepspeed import is_deepspeed_zero3_enabled
+from ...integrations.fsdp import is_fsdp_managed_module
+from ...masking_utils import create_bidirectional_mask
 from ...modeling_outputs import BaseModelOutput
 from ...modeling_utils import PreTrainedModel
 from ...utils import auto_docstring
@@ -116,11 +118,136 @@ class HubertFeatureProjection(nn.Module):
 
 
 class HubertEncoder(Wav2Vec2Encoder):
-    pass
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        return_dict: bool = True,
+    ):
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attentions = () if output_attentions else None
+
+        if attention_mask is not None:
+            # make sure padded tokens output 0
+            expand_attention_mask = attention_mask.unsqueeze(-1).repeat(1, 1, hidden_states.shape[2])
+            hidden_states[~expand_attention_mask] = 0
+
+        # Pass the 2-D bool mask to pos_conv_embed *before* it is converted to a
+        # 4-D additive float mask by create_bidirectional_mask.  When
+        # conv_pos_batch_norm=True, HubertPositionalConvEmbedding uses this mask
+        # to zero-out padded positions after BatchNorm1d so that padding does not
+        # contaminate the batch statistics.
+        position_embeddings = self.pos_conv_embed(hidden_states, attention_mask=attention_mask)
+
+        attention_mask = create_bidirectional_mask(
+            config=self.config,
+            inputs_embeds=hidden_states,
+            attention_mask=attention_mask,
+        )
+
+        hidden_states = hidden_states + position_embeddings.to(hidden_states.device)
+        hidden_states = self.layer_norm(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+
+        synced_gpus = is_deepspeed_zero3_enabled() or is_fsdp_managed_module(self)
+
+        for layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states = all_hidden_states + (hidden_states,)
+
+            # add LayerDrop (see https://huggingface.co/papers/1909.11556 for description)
+            dropout_probability = torch.rand([])
+
+            skip_the_layer = self.training and dropout_probability < self.config.layerdrop
+            if not skip_the_layer or synced_gpus:
+                # under fsdp or deepspeed zero3 all gpus must run in sync
+                layer_outputs = layer(
+                    hidden_states, attention_mask=attention_mask, output_attentions=output_attentions
+                )
+                hidden_states = layer_outputs[0]
+
+            if skip_the_layer:
+                layer_outputs = (None, None)
+
+            if output_attentions:
+                all_self_attentions = all_self_attentions + (layer_outputs[1],)
+
+        if output_hidden_states:
+            all_hidden_states = all_hidden_states + (hidden_states,)
+
+        if not return_dict:
+            return tuple(v for v in [hidden_states, all_hidden_states, all_self_attentions] if v is not None)
+        return BaseModelOutput(
+            last_hidden_state=hidden_states,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attentions,
+        )
 
 
 class HubertEncoderStableLayerNorm(Wav2Vec2EncoderStableLayerNorm):
-    pass
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        return_dict: bool = True,
+    ):
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attentions = () if output_attentions else None
+
+        if attention_mask is not None:
+            # make sure padded tokens output 0
+            expand_attention_mask = attention_mask.unsqueeze(-1).repeat(1, 1, hidden_states.shape[2])
+            hidden_states[~expand_attention_mask] = 0
+
+        # Pass the 2-D bool mask before it becomes a 4-D additive float mask.
+        position_embeddings = self.pos_conv_embed(hidden_states, attention_mask=attention_mask)
+
+        attention_mask = create_bidirectional_mask(
+            config=self.config,
+            inputs_embeds=hidden_states,
+            attention_mask=attention_mask,
+        )
+
+        hidden_states = hidden_states + position_embeddings
+        hidden_states = self.dropout(hidden_states)
+
+        synced_gpus = is_deepspeed_zero3_enabled() or is_fsdp_managed_module(self)
+
+        for layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states = all_hidden_states + (hidden_states,)
+
+            dropout_probability = torch.rand([])
+
+            skip_the_layer = self.training and dropout_probability < self.config.layerdrop
+            if not skip_the_layer or synced_gpus:
+                layer_outputs = layer(
+                    hidden_states, attention_mask=attention_mask, output_attentions=output_attentions
+                )
+                hidden_states = layer_outputs[0]
+
+            if skip_the_layer:
+                layer_outputs = (None, None)
+
+            if output_attentions:
+                all_self_attentions = all_self_attentions + (layer_outputs[1],)
+
+        hidden_states = self.layer_norm(hidden_states)
+
+        if output_hidden_states:
+            all_hidden_states = all_hidden_states + (hidden_states,)
+
+        if not return_dict:
+            return tuple(v for v in [hidden_states, all_hidden_states, all_self_attentions] if v is not None)
+        return BaseModelOutput(
+            last_hidden_state=hidden_states,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attentions,
+        )
 
 
 @auto_docstring

--- a/src/transformers/models/hubert/modular_hubert.py
+++ b/src/transformers/models/hubert/modular_hubert.py
@@ -75,10 +75,12 @@ class HubertPositionalConvEmbedding(nn.Module):
         self.padding = HubertSamePadLayer(config.num_conv_pos_embeddings)
         self.activation = ACT2FN[config.feat_extract_activation]
 
-    def forward(self, hidden_states):
+    def forward(self, hidden_states, attention_mask=None):
         hidden_states = hidden_states.transpose(1, 2)
         if self.batch_norm is not None:
             hidden_states = self.batch_norm(hidden_states)
+            if attention_mask is not None:
+                hidden_states = hidden_states * attention_mask.unsqueeze(1)
         hidden_states = self.conv(hidden_states)
         hidden_states = self.padding(hidden_states)
         hidden_states = self.activation(hidden_states)

--- a/tests/models/hubert/test_modeling_hubert.py
+++ b/tests/models/hubert/test_modeling_hubert.py
@@ -338,6 +338,32 @@ class HubertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.check_labels_out_of_vocab(*config_and_inputs)
 
+    def test_positional_conv_embedding_batch_norm_padding(self):
+        from transformers.models.hubert.modeling_hubert import HubertPositionalConvEmbedding
+
+        config = HubertConfig(
+            hidden_size=16,
+            num_conv_pos_embeddings=128,
+            num_conv_pos_embedding_groups=16,
+            feat_extract_activation="gelu",
+            conv_pos_batch_norm=True,
+        )
+        layer = HubertPositionalConvEmbedding(config).eval()
+
+        sz1, sz2 = 40, 80
+        s1 = torch.randn(1, sz1, 16)
+        s2 = torch.randn(1, sz2, 16)
+        s1_padded = torch.cat([s1, torch.zeros(1, sz2 - sz1, 16)], dim=1)
+        batch = torch.cat([s1_padded, s2], dim=0)
+
+        mask = torch.ones(2, sz2, dtype=torch.long)
+        mask[0, sz1:] = 0
+
+        out_alone = layer(s1, attention_mask=mask[0:1, :sz1])
+        out_batched = layer(batch, attention_mask=mask)[0:1, :sz1]
+
+        torch.testing.assert_close(out_alone, out_batched, rtol=1e-5, atol=1e-5)
+
     @unittest.skip(reason="Hubert has no inputs_embeds")
     def test_inputs_embeds(self):
         pass


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47763)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47763)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47739.

When `conv_pos_batch_norm=True`, `HubertPositionalConvEmbedding` applies `BatchNorm1d` on hidden states without zeroing out padded positions. `BatchNorm1d` shifts 0-padded tokens by bias, converting padding positions to non-zero values. The subsequent convolution layer then convolves valid boundary tokens with non-zero padding, causing outputs for a given sample to depend on batch padding lengths.

This PR:
1. Passes `attention_mask` into `HubertPositionalConvEmbedding.forward` in both `modeling_hubert.py` and `modular_hubert.py`.
2. Zeros out padding positions after `BatchNorm1d` before convolution when `attention_mask` is provided.
3. Updates `HubertEncoder` and `HubertEncoderStableLayerNorm` to pass 2D `attention_mask` into `self.pos_conv_embed` before 4D mask conversion.
4. Adds a regression unit test `test_positional_conv_embedding_batch_norm_padding` in `test_modeling_hubert.py`.

## Proof of Fix

- **Before fix** (unbatched vs batched output for same sample):
  Max output difference: `1.535166`
- **After fix** (unbatched vs batched output for same sample):
  Max output difference: `0.0` (exact match down to floating point precision).