### PR TITLE
Fix auto_docstrings for recent models

### DIFF
--- a/src/transformers/models/cosmos3_edge/modeling_cosmos3_edge.py
+++ b/src/transformers/models/cosmos3_edge/modeling_cosmos3_edge.py
@@ -720,9 +720,8 @@ class Cosmos3EdgeTextModel(Cosmos3EdgePreTrainedModel):
         return BaseModelOutputWithPast(last_hidden_state=hidden_states, past_key_values=past_key_values)
 
 
+@auto_docstring(custom_intro="Packed variable-resolution SigLIP2 vision tower used by Cosmos3 Edge.")
 class Cosmos3EdgeVisionModel(Cosmos3EdgePreTrainedModel):
-    """Packed variable-resolution SigLIP2 vision tower used by Cosmos3 Edge."""
-
     config_class = Cosmos3EdgeVisionConfig
     main_input_name = "pixel_values"
     input_modalities = ("image", "video")
@@ -1147,6 +1146,7 @@ class Cosmos3EdgeModel(Cosmos3EdgePreTrainedModel):
         )
 
 
+@auto_docstring
 class Cosmos3EdgeForConditionalGeneration(Cosmos3EdgePreTrainedModel, GenerationMixin):
     _tied_weights_keys = {}
     config_class = Cosmos3EdgeConfig

--- a/src/transformers/models/cosmos3_edge/modular_cosmos3_edge.py
+++ b/src/transformers/models/cosmos3_edge/modular_cosmos3_edge.py
@@ -566,9 +566,8 @@ class Cosmos3EdgeTextModel(LlamaModel, Cosmos3EdgePreTrainedModel):
         return BaseModelOutputWithPast(last_hidden_state=hidden_states, past_key_values=past_key_values)
 
 
+@auto_docstring(custom_intro="Packed variable-resolution SigLIP2 vision tower used by Cosmos3 Edge.")
 class Cosmos3EdgeVisionModel(Cosmos3EdgePreTrainedModel):
-    """Packed variable-resolution SigLIP2 vision tower used by Cosmos3 Edge."""
-
     config_class = Cosmos3EdgeVisionConfig
     main_input_name = "pixel_values"
     input_modalities = ("image", "video")
@@ -762,6 +761,7 @@ class Cosmos3EdgeModel(Qwen2VLModel, Cosmos3EdgePreTrainedModel):
         )
 
 
+@auto_docstring
 class Cosmos3EdgeForConditionalGeneration(Qwen2VLForConditionalGeneration, Cosmos3EdgePreTrainedModel):
     config_class = Cosmos3EdgeConfig
     _tied_weights_keys = {}

--- a/src/transformers/models/dinov3_convnext/modeling_dinov3_convnext.py
+++ b/src/transformers/models/dinov3_convnext/modeling_dinov3_convnext.py
@@ -202,6 +202,7 @@ class DINOv3ConvNextEncoder(DINOv3ConvNextPreTrainedModel):
 
     @merge_with_config_defaults
     @capture_outputs(tie_last_hidden_states=False)
+    @auto_docstring
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/src/transformers/models/dinov3_vit/modeling_dinov3_vit.py
+++ b/src/transformers/models/dinov3_vit/modeling_dinov3_vit.py
@@ -491,6 +491,7 @@ class DINOv3ViTEncoder(DINOv3ViTPreTrainedModel):
 
     @merge_with_config_defaults
     @capture_outputs(tie_last_hidden_states=False)
+    @auto_docstring
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/src/transformers/models/dinov3_vit/modular_dinov3_vit.py
+++ b/src/transformers/models/dinov3_vit/modular_dinov3_vit.py
@@ -393,6 +393,7 @@ class DINOv3ViTEncoder(DINOv3ViTPreTrainedModel):
 
     @merge_with_config_defaults
     @capture_outputs(tie_last_hidden_states=False)
+    @auto_docstring
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
@@ -84,6 +84,7 @@ def smart_resize(
 
 
 @requires(backends=("vision", "torchvision"))
+@auto_docstring
 class HunYuanVLImageProcessorPil(PilBackend):
     do_resize = True
     resample = PILImageResampling.BICUBIC

--- a/src/transformers/models/hunyuan_vl/modeling_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modeling_hunyuan_vl.py
@@ -50,6 +50,7 @@ from ...vision_utils import get_vision_attention_seqlens
 from .configuration_hunyuan_vl import HunYuanVLConfig, HunYuanVLTextConfig, HunYuanVLVisionConfig
 
 
+@auto_docstring
 @dataclass
 class HunYuanVLModelOutputWithPast(BaseModelOutputWithPast):
     r"""
@@ -1149,12 +1150,19 @@ class HunYuanVLForConditionalGeneration(HunYuanVLPreTrainedModel, GenerationMixi
         self.vocab_size = config.text_config.vocab_size
         self.post_init()
 
+    @auto_docstring
     def get_image_features(
         self,
         pixel_values: torch.FloatTensor,
         image_grid_thw: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | BaseModelOutputWithPooling:
+        r"""
+        pixel_values (`torch.FloatTensor`):
+            Flat per-patch pixel features produced by the image processor.
+        image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
+            The temporal, height and width of feature shape of each image in LLM.
+        """
         return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
     @can_return_tuple

--- a/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
@@ -65,6 +65,7 @@ from ..qwen2_vl.modeling_qwen2_vl import Qwen2VLModel
 from ..siglip.modeling_siglip import SiglipEncoderLayer, SiglipMLP
 
 
+@auto_docstring
 @dataclass
 class HunYuanVLModelOutputWithPast(BaseModelOutputWithPast):
     r"""
@@ -441,6 +442,7 @@ class HunYuanVLImageProcessor(Qwen2VLImageProcessor):
 
 
 @requires(backends=("vision", "torchvision"))
+@auto_docstring
 class HunYuanVLImageProcessorPil(Qwen2VLImageProcessorPil):
     size = {"shortest_edge": 512 * 512, "longest_edge": 2048 * 2048}
     patch_size = 16
@@ -1330,12 +1332,19 @@ class HunYuanVLForConditionalGeneration(HunYuanVLPreTrainedModel, GenerationMixi
         self.vocab_size = config.text_config.vocab_size
         self.post_init()
 
+    @auto_docstring
     def get_image_features(
         self,
         pixel_values: torch.FloatTensor,
         image_grid_thw: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | BaseModelOutputWithPooling:
+        r"""
+        pixel_values (`torch.FloatTensor`):
+            Flat per-patch pixel features produced by the image processor.
+        image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
+            The temporal, height and width of feature shape of each image in LLM.
+        """
         return self.model.get_image_features(pixel_values, image_grid_thw, **kwargs)
 
     @can_return_tuple

--- a/src/transformers/models/inkling/configuration_inkling.py
+++ b/src/transformers/models/inkling/configuration_inkling.py
@@ -22,10 +22,57 @@
 from huggingface_hub.dataclasses import strict
 
 from ...configuration_utils import PreTrainedConfig
+from ...utils import auto_docstring
 
 
+@auto_docstring
 @strict
 class InklingTextConfig(PreTrainedConfig):
+    r"""
+    unpadded_vocab_size (`int`, *optional*, defaults to `None`):
+        Number of rows the checkpoint's unembedding matrix actually holds when the head is not padded to
+        `vocab_size`. Logits beyond it are dropped. If `None`, the head is not padded.
+    swa_num_attention_heads (`int`, *optional*, defaults to 64):
+        Number of attention heads in the sliding-window layers.
+    swa_num_key_value_heads (`int`, *optional*, defaults to 16):
+        Number of key/value heads in the sliding-window layers.
+    swa_head_dim (`int`, *optional*, defaults to 128):
+        Dimension of query and key heads in the sliding-window layers.
+    sliding_window_size (`int`, *optional*, defaults to 512):
+        Size of the sliding attention window used by layers whose `layer_types` entry is `"hybrid_sliding"`.
+    d_rel (`int`, *optional*, defaults to 16):
+        Per-head dimension of the relative states that are mixed into the relative position bias.
+    rel_extent (`int`, *optional*, defaults to 1024):
+        Backward distance, in tokens, over which the relative position bias is applied. The bias is zero beyond it.
+    log_scaling_n_floor (`int`, *optional*, defaults to `None`):
+        Position from which logits start being scaled up logarithmically in the full-attention layers. If `None`,
+        the scaling is disabled.
+    log_scaling_alpha (`float`, *optional*, defaults to 0.1):
+        Strength of the logarithmic logit scaling controlled by `log_scaling_n_floor`.
+    local_layer_ids (`list[int]`, *optional*, defaults to `None`):
+        Indices of the layers using sliding window attention. Used to derive `layer_types` when it is not provided.
+        If `None`, every layer whose index is not a multiple of 6 uses sliding window attention.
+    mlp_layer_types (`list[str]`, *optional*, defaults to `None`):
+        MLP type pattern for each layer (`"dense"` or `"sparse"`). If `None`, every layer is sparse.
+    shared_expert_sink (`bool`, *optional*, defaults to `True`):
+        Whether the router scores the shared experts alongside the routed ones, so that they act as a sink in the
+        softmax over expert weights.
+    logits_mup_width_multiplier (`float`, *optional*, defaults to 24.0):
+        muP width multiplier the final hidden states are divided by before the language modeling head.
+    rms_norm_eps_moe_gate (`float`, *optional*, defaults to 1e-6):
+        Epsilon of the RMS normalization applied inside the mixture-of-experts router.
+    num_mtp_layers (`int`, *optional*, defaults to `None`):
+        Number of multi-token-prediction layers. If `None`, multi-token prediction is disabled.
+    chain_hidden_post_norm (`bool`, *optional*, defaults to `False`):
+        Whether the hidden states chained between multi-token-prediction layers are normalized after each layer.
+    mtp_hidden_states_first (`bool`, *optional*, defaults to `True`):
+        Whether the hidden states come before the token embeddings when the two are concatenated as the input of a
+        multi-token-prediction layer.
+    mtp_local_layer_ids (`list[int]`, *optional*, defaults to `None`):
+        Indices of the multi-token-prediction layers using sliding window attention. If `None`, every
+        multi-token-prediction layer uses full attention.
+    """
+
     model_type = "inkling_text"
     base_config_key = "text_config"
     base_model_tp_plan = {
@@ -149,8 +196,18 @@ class InklingTextConfig(PreTrainedConfig):
         return None
 
 
+@auto_docstring
 @strict
 class InklingAudioConfig(PreTrainedConfig):
+    r"""
+    n_mel_bins (`int`, *optional*, defaults to 80):
+        Number of mel-frequency bins per audio frame.
+    mel_vocab_size (`int`, *optional*, defaults to 256):
+        Number of discrete bins each mel value is quantized into before being embedded.
+    text_hidden_size (`int`, *optional*, defaults to 6144):
+        Dimensionality the audio embeddings are projected to, matching the text backbone.
+    """
+
     model_type = "inkling_audio"
     base_config_key = "audio_config"
     attribute_map = {
@@ -166,8 +223,14 @@ class InklingAudioConfig(PreTrainedConfig):
     initializer_range: float = 0.02
 
 
+@auto_docstring
 @strict
 class InklingVisionConfig(PreTrainedConfig):
+    r"""
+    text_hidden_size (`int`, *optional*, defaults to 6144):
+        Dimensionality the vision features are projected to by the last encoder layer, matching the text backbone.
+    """
+
     model_type = "inkling_vision"
     base_config_key = "vision_config"
     attribute_map = {"num_hidden_layers": "n_layers"}
@@ -183,9 +246,15 @@ class InklingVisionConfig(PreTrainedConfig):
     initializer_range: float = 0.02
 
 
+@auto_docstring(custom_intro="Top-level multimodal config (`InklingMMConfig` in the SGLang source).")
 @strict
 class InklingConfig(PreTrainedConfig):
-    """Top-level multimodal config (`InklingMMConfig` in the SGLang source)."""
+    r"""
+    image_bos_token_id (`int`, *optional*, defaults to 200005):
+        The beginning-of-image token index used to mark the start of image spans.
+    audio_bos_token_id (`int`, *optional*, defaults to 200020):
+        The beginning-of-audio token index used to mark the start of audio spans.
+    """
 
     model_type = "inkling_mm_model"
     sub_configs = {

--- a/src/transformers/models/inkling/image_processing_inkling.py
+++ b/src/transformers/models/inkling/image_processing_inkling.py
@@ -109,6 +109,7 @@ class InklingImageProcessor(TorchvisionBackend):
             resample=resample,
         )
 
+    @auto_docstring
     def preprocess(
         self,
         images: ImageInput,

--- a/src/transformers/models/inkling/modeling_inkling.py
+++ b/src/transformers/models/inkling/modeling_inkling.py
@@ -811,13 +811,19 @@ class InklingAudioModelEmbeddings(nn.Module):
         return inputs_embeds
 
 
+@auto_docstring
 class InklingAudioModel(InklingPreTrainedModel):
     def __init__(self, config: InklingAudioConfig):
         super().__init__(config)
         self.embed_audio_tokens = InklingAudioModelEmbeddings(config)
         self.norm = InklingRMSNorm(config.text_hidden_size, eps=1e-6)
 
-    def forward(self, audio_input_ids: torch.Tensor, **kwargs) -> torch.Tensor:
+    @auto_docstring
+    def forward(self, audio_input_ids: torch.Tensor, **kwargs) -> BaseModelOutputWithPooling:
+        r"""
+        audio_input_ids (`torch.Tensor` of shape `(num_audios, max_num_frames, n_mel_bins)`):
+            Mel-spectrogram frames of the input audios.
+        """
         hidden_states = self.embed_audio_tokens(audio_input_ids)
         hidden_states = self.norm(hidden_states)
         return BaseModelOutputWithPooling(
@@ -942,6 +948,7 @@ def plan_out_scales(
     return scales[idxs]
 
 
+@auto_docstring
 class InklingVisionModel(InklingPreTrainedModel):
     def __init__(self, config: InklingVisionConfig):
         super().__init__(config)
@@ -974,7 +981,8 @@ class InklingVisionModel(InklingPreTrainedModel):
         self.final_norm = InklingRMSNorm(config.text_hidden_size)
         self.post_init()
 
-    def forward(self, pixel_values: torch.Tensor, **kwargs: Unpack[TransformersKwargs]) -> torch.Tensor:
+    @auto_docstring
+    def forward(self, pixel_values: torch.Tensor, **kwargs: Unpack[TransformersKwargs]) -> BaseModelOutputWithPooling:
         num_patches = pixel_values.shape[0]
         hidden_states = pixel_values
         for layer in self.encoder_layers:

--- a/src/transformers/models/inkling/modular_inkling.py
+++ b/src/transformers/models/inkling/modular_inkling.py
@@ -57,8 +57,54 @@ from ..qwen3_next.modeling_qwen3_next import apply_mask_to_padding_states
 logger = logging.get_logger(__name__)
 
 
+@auto_docstring
 @strict
 class InklingTextConfig(PreTrainedConfig):
+    r"""
+    unpadded_vocab_size (`int`, *optional*, defaults to `None`):
+        Number of rows the checkpoint's unembedding matrix actually holds when the head is not padded to
+        `vocab_size`. Logits beyond it are dropped. If `None`, the head is not padded.
+    swa_num_attention_heads (`int`, *optional*, defaults to 64):
+        Number of attention heads in the sliding-window layers.
+    swa_num_key_value_heads (`int`, *optional*, defaults to 16):
+        Number of key/value heads in the sliding-window layers.
+    swa_head_dim (`int`, *optional*, defaults to 128):
+        Dimension of query and key heads in the sliding-window layers.
+    sliding_window_size (`int`, *optional*, defaults to 512):
+        Size of the sliding attention window used by layers whose `layer_types` entry is `"hybrid_sliding"`.
+    d_rel (`int`, *optional*, defaults to 16):
+        Per-head dimension of the relative states that are mixed into the relative position bias.
+    rel_extent (`int`, *optional*, defaults to 1024):
+        Backward distance, in tokens, over which the relative position bias is applied. The bias is zero beyond it.
+    log_scaling_n_floor (`int`, *optional*, defaults to `None`):
+        Position from which logits start being scaled up logarithmically in the full-attention layers. If `None`,
+        the scaling is disabled.
+    log_scaling_alpha (`float`, *optional*, defaults to 0.1):
+        Strength of the logarithmic logit scaling controlled by `log_scaling_n_floor`.
+    local_layer_ids (`list[int]`, *optional*, defaults to `None`):
+        Indices of the layers using sliding window attention. Used to derive `layer_types` when it is not provided.
+        If `None`, every layer whose index is not a multiple of 6 uses sliding window attention.
+    mlp_layer_types (`list[str]`, *optional*, defaults to `None`):
+        MLP type pattern for each layer (`"dense"` or `"sparse"`). If `None`, every layer is sparse.
+    shared_expert_sink (`bool`, *optional*, defaults to `True`):
+        Whether the router scores the shared experts alongside the routed ones, so that they act as a sink in the
+        softmax over expert weights.
+    logits_mup_width_multiplier (`float`, *optional*, defaults to 24.0):
+        muP width multiplier the final hidden states are divided by before the language modeling head.
+    rms_norm_eps_moe_gate (`float`, *optional*, defaults to 1e-6):
+        Epsilon of the RMS normalization applied inside the mixture-of-experts router.
+    num_mtp_layers (`int`, *optional*, defaults to `None`):
+        Number of multi-token-prediction layers. If `None`, multi-token prediction is disabled.
+    chain_hidden_post_norm (`bool`, *optional*, defaults to `False`):
+        Whether the hidden states chained between multi-token-prediction layers are normalized after each layer.
+    mtp_hidden_states_first (`bool`, *optional*, defaults to `True`):
+        Whether the hidden states come before the token embeddings when the two are concatenated as the input of a
+        multi-token-prediction layer.
+    mtp_local_layer_ids (`list[int]`, *optional*, defaults to `None`):
+        Indices of the multi-token-prediction layers using sliding window attention. If `None`, every
+        multi-token-prediction layer uses full attention.
+    """
+
     model_type = "inkling_text"
     base_config_key = "text_config"
     base_model_tp_plan = {
@@ -182,8 +228,18 @@ class InklingTextConfig(PreTrainedConfig):
         return None
 
 
+@auto_docstring
 @strict
 class InklingAudioConfig(PreTrainedConfig):
+    r"""
+    n_mel_bins (`int`, *optional*, defaults to 80):
+        Number of mel-frequency bins per audio frame.
+    mel_vocab_size (`int`, *optional*, defaults to 256):
+        Number of discrete bins each mel value is quantized into before being embedded.
+    text_hidden_size (`int`, *optional*, defaults to 6144):
+        Dimensionality the audio embeddings are projected to, matching the text backbone.
+    """
+
     model_type = "inkling_audio"
     base_config_key = "audio_config"
     attribute_map = {
@@ -199,8 +255,14 @@ class InklingAudioConfig(PreTrainedConfig):
     initializer_range: float = 0.02
 
 
+@auto_docstring
 @strict
 class InklingVisionConfig(PreTrainedConfig):
+    r"""
+    text_hidden_size (`int`, *optional*, defaults to 6144):
+        Dimensionality the vision features are projected to by the last encoder layer, matching the text backbone.
+    """
+
     model_type = "inkling_vision"
     base_config_key = "vision_config"
     attribute_map = {"num_hidden_layers": "n_layers"}
@@ -216,9 +278,15 @@ class InklingVisionConfig(PreTrainedConfig):
     initializer_range: float = 0.02
 
 
+@auto_docstring(custom_intro="Top-level multimodal config (`InklingMMConfig` in the SGLang source).")
 @strict
 class InklingConfig(PreTrainedConfig):
-    """Top-level multimodal config (`InklingMMConfig` in the SGLang source)."""
+    r"""
+    image_bos_token_id (`int`, *optional*, defaults to 200005):
+        The beginning-of-image token index used to mark the start of image spans.
+    audio_bos_token_id (`int`, *optional*, defaults to 200020):
+        The beginning-of-audio token index used to mark the start of audio spans.
+    """
 
     model_type = "inkling_mm_model"
     sub_configs = {
@@ -889,13 +957,19 @@ class InklingForCausalLM(Gemma3ForCausalLM):
 class InklingAudioModelEmbeddings(HiggsAudioV2Embeddings): ...
 
 
+@auto_docstring
 class InklingAudioModel(InklingPreTrainedModel):
     def __init__(self, config: InklingAudioConfig):
         super().__init__(config)
         self.embed_audio_tokens = InklingAudioModelEmbeddings(config)
         self.norm = InklingRMSNorm(config.text_hidden_size, eps=1e-6)
 
-    def forward(self, audio_input_ids: torch.Tensor, **kwargs) -> torch.Tensor:
+    @auto_docstring
+    def forward(self, audio_input_ids: torch.Tensor, **kwargs) -> BaseModelOutputWithPooling:
+        r"""
+        audio_input_ids (`torch.Tensor` of shape `(num_audios, max_num_frames, n_mel_bins)`):
+            Mel-spectrogram frames of the input audios.
+        """
         hidden_states = self.embed_audio_tokens(audio_input_ids)
         hidden_states = self.norm(hidden_states)
         return BaseModelOutputWithPooling(
@@ -1020,6 +1094,7 @@ def plan_out_scales(
     return scales[idxs]
 
 
+@auto_docstring
 class InklingVisionModel(InklingPreTrainedModel):
     def __init__(self, config: InklingVisionConfig):
         super().__init__(config)
@@ -1052,7 +1127,8 @@ class InklingVisionModel(InklingPreTrainedModel):
         self.final_norm = InklingRMSNorm(config.text_hidden_size)
         self.post_init()
 
-    def forward(self, pixel_values: torch.Tensor, **kwargs: Unpack[TransformersKwargs]) -> torch.Tensor:
+    @auto_docstring
+    def forward(self, pixel_values: torch.Tensor, **kwargs: Unpack[TransformersKwargs]) -> BaseModelOutputWithPooling:
         num_patches = pixel_values.shape[0]
         hidden_states = pixel_values
         for layer in self.encoder_layers:

--- a/src/transformers/models/kimi_k25/modeling_kimi_k25.py
+++ b/src/transformers/models/kimi_k25/modeling_kimi_k25.py
@@ -475,6 +475,7 @@ def get_vision_temporal_merge_index(
     return torch.cat(rows, dim=0)
 
 
+@auto_docstring
 class Kimi_K25VisionModel(Kimi_K25PreTrainedModel):
     config: Kimi_K25VisionConfig
     input_modalities = ("image", "video")
@@ -582,6 +583,7 @@ class Kimi_K25MultimodalProjection(nn.Module):
         return hidden_states
 
 
+@auto_docstring
 class Kimi_K25Model(Kimi_K25PreTrainedModel):
     def __init__(self, config: Kimi_K25Config):
         super().__init__(config)
@@ -615,6 +617,7 @@ class Kimi_K25Model(Kimi_K25PreTrainedModel):
         vision_outputs.pooler_output = torch.split(image_embeds, split_sizes)
         return vision_outputs
 
+    @auto_docstring
     def get_video_features(
         self,
         pixel_values_videos: torch.FloatTensor,
@@ -732,6 +735,7 @@ class Kimi_K25Model(Kimi_K25PreTrainedModel):
         )
 
 
+@auto_docstring
 class Kimi_K25ForConditionalGeneration(Kimi_K25PreTrainedModel, GenerationMixin):
     _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
     # Reference: fix gemma3 grad acc #37208

--- a/src/transformers/models/kimi_k25/modular_kimi_k25.py
+++ b/src/transformers/models/kimi_k25/modular_kimi_k25.py
@@ -372,6 +372,7 @@ class Kimi_K25PreTrainedModel(Qwen2VLPreTrainedModel):
             init.trunc_normal_(module.position_embeddings, mean=0.0)
 
 
+@auto_docstring
 class Kimi_K25VisionModel(Kimi_K25PreTrainedModel):
     config: Kimi_K25VisionConfig
     input_modalities = ("image", "video")
@@ -479,6 +480,7 @@ class Kimi_K25MultimodalProjection(nn.Module):
         return hidden_states
 
 
+@auto_docstring
 class Kimi_K25Model(Kimi_K25PreTrainedModel):
     def __init__(self, config: Kimi_K25Config):
         super().__init__(config)
@@ -512,6 +514,7 @@ class Kimi_K25Model(Kimi_K25PreTrainedModel):
         vision_outputs.pooler_output = torch.split(image_embeds, split_sizes)
         return vision_outputs
 
+    @auto_docstring
     def get_video_features(
         self,
         pixel_values_videos: torch.FloatTensor,
@@ -629,6 +632,7 @@ class Kimi_K25Model(Kimi_K25PreTrainedModel):
         )
 
 
+@auto_docstring
 class Kimi_K25ForConditionalGeneration(Glm4vForConditionalGeneration):
     @can_return_tuple
     @auto_docstring

--- a/src/transformers/models/nemotron3_5_asr/modeling_nemotron3_5_asr.py
+++ b/src/transformers/models/nemotron3_5_asr/modeling_nemotron3_5_asr.py
@@ -41,9 +41,16 @@ if is_torch_available():
 logger = logging.get_logger(__name__)
 
 
+@auto_docstring
 @dataclass
 class Nemotron3_5AsrRNNTOutput(BaseModelOutputWithPooling):
-    """
+    r"""
+    loss (`torch.FloatTensor`, *optional*, returned when `labels` is provided):
+        RNN-T transducer loss.
+    logits (`torch.FloatTensor` of shape `(batch_size, encoder_length, decoder_length, vocab_size + 1)`):
+        Joint-network scores over the vocabulary plus the blank symbol, for every encoder/decoder frame pair.
+    decoder_cache (`Nemotron3_5AsrRNNTDecoderCache`, *optional*):
+        Updated decoder LSTM cache. Reused on blank predictions to skip the LSTM step.
     encoder_past_key_values (`Cache`, *optional*):
         Updated encoder attention K/V sliding-window cache, returned when encoding audio with `use_cache=True`
         (cache-aware streaming). Pass it to the next chunk's forward.
@@ -219,6 +226,7 @@ class Nemotron3_5AsrForRNNT(Nemotron3_5AsrPreTrainedModel, Nemotron3_5AsrGenerat
         self.post_init()
 
     @can_return_tuple
+    @auto_docstring
     def get_audio_features(
         self,
         input_features: torch.Tensor,
@@ -226,6 +234,11 @@ class Nemotron3_5AsrForRNNT(Nemotron3_5AsrPreTrainedModel, Nemotron3_5AsrGenerat
         prompt_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPooling:
+        r"""
+        prompt_ids (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Language-prompt indices for language-ID conditioning. Produced by the processor from
+            `language`. Turned into the broadcast one-hot consumed by `prompt_projector`.
+        """
         encoder_outputs = self.encoder(
             input_features=input_features,
             attention_mask=attention_mask,

--- a/src/transformers/models/nemotron3_5_asr/modular_nemotron3_5_asr.py
+++ b/src/transformers/models/nemotron3_5_asr/modular_nemotron3_5_asr.py
@@ -314,9 +314,16 @@ class Nemotron3_5AsrProcessor(NemotronAsrStreamingProcessor):
         return feature_extractor_input_names + ["labels", "decoder_input_ids", "prompt_ids"]
 
 
+@auto_docstring
 @dataclass
 class Nemotron3_5AsrRNNTOutput(BaseModelOutputWithPooling):
-    """
+    r"""
+    loss (`torch.FloatTensor`, *optional*, returned when `labels` is provided):
+        RNN-T transducer loss.
+    logits (`torch.FloatTensor` of shape `(batch_size, encoder_length, decoder_length, vocab_size + 1)`):
+        Joint-network scores over the vocabulary plus the blank symbol, for every encoder/decoder frame pair.
+    decoder_cache (`Nemotron3_5AsrRNNTDecoderCache`, *optional*):
+        Updated decoder LSTM cache. Reused on blank predictions to skip the LSTM step.
     encoder_past_key_values (`Cache`, *optional*):
         Updated encoder attention K/V sliding-window cache, returned when encoding audio with `use_cache=True`
         (cache-aware streaming). Pass it to the next chunk's forward.
@@ -371,6 +378,7 @@ class Nemotron3_5AsrForRNNT(NemotronAsrStreamingForRNNT, Nemotron3_5AsrGeneratio
         self.post_init()
 
     @can_return_tuple
+    @auto_docstring
     def get_audio_features(
         self,
         input_features: torch.Tensor,
@@ -378,6 +386,11 @@ class Nemotron3_5AsrForRNNT(NemotronAsrStreamingForRNNT, Nemotron3_5AsrGeneratio
         prompt_ids: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPooling:
+        r"""
+        prompt_ids (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Language-prompt indices for language-ID conditioning. Produced by the processor from
+            `language`. Turned into the broadcast one-hot consumed by `prompt_projector`.
+        """
         encoder_outputs = self.encoder(
             input_features=input_features,
             attention_mask=attention_mask,

--- a/src/transformers/models/radio/modeling_radio.py
+++ b/src/transformers/models/radio/modeling_radio.py
@@ -37,22 +37,16 @@ from ...utils.output_capturing import capture_outputs
 from .configuration_radio import RadioConfig
 
 
+@auto_docstring(custom_intro="Output of [`RadioModel`].")
 @dataclass
 class RadioModelOutput(ModelOutput):
-    """Output of [`RadioModel`].
-
-    Args:
-        summary (`torch.FloatTensor` of shape `(batch_size, num_summary_idxs * hidden_size)`):
-            Flattened summary embedding, gathered from the cls tokens selected by `config.summary_idxs`.
-        features (`torch.FloatTensor` of shape `(batch_size, num_patches, hidden_size)`):
-            Dense spatial patch features.
-        last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
-            Full token sequence (prefix tokens + patches) from the final encoder layer.
-        hidden_states (`tuple[torch.FloatTensor]`, *optional*, returned when `output_hidden_states=True`):
-            Tuple of `(batch_size, sequence_length, hidden_size)` tensors, one for the embedding output plus one for
-            each encoder layer.
-        attentions (`tuple[torch.FloatTensor]`, *optional*, returned when `output_attentions=True`):
-            Tuple of `(batch_size, num_heads, sequence_length, sequence_length)` attention weights, one per layer.
+    r"""
+    summary (`torch.FloatTensor` of shape `(batch_size, num_summary_idxs * hidden_size)`):
+        Flattened summary embedding, gathered from the cls tokens selected by `config.summary_idxs`.
+    features (`torch.FloatTensor` of shape `(batch_size, num_patches, hidden_size)`):
+        Dense spatial patch features.
+    last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
+        Full token sequence (prefix tokens + patches) from the final encoder layer.
     """
 
     summary: torch.FloatTensor | None = None
@@ -403,6 +397,7 @@ class RadioEncoder(RadioPreTrainedModel):
 
     @merge_with_config_defaults
     @capture_outputs(tie_last_hidden_states=False)
+    @auto_docstring
     def forward(self, hidden_states: torch.Tensor, **kwargs: Unpack[TransformersKwargs]) -> BaseModelOutput:
         for layer in self.layer:
             hidden_states = layer(hidden_states)

--- a/src/transformers/models/radio/modular_radio.py
+++ b/src/transformers/models/radio/modular_radio.py
@@ -40,22 +40,16 @@ logger = logging.get_logger(__name__)
 __all__ = ["RadioModel", "RadioPreTrainedModel"]
 
 
+@auto_docstring(custom_intro="Output of [`RadioModel`].")
 @dataclass
 class RadioModelOutput(ModelOutput):
-    """Output of [`RadioModel`].
-
-    Args:
-        summary (`torch.FloatTensor` of shape `(batch_size, num_summary_idxs * hidden_size)`):
-            Flattened summary embedding, gathered from the cls tokens selected by `config.summary_idxs`.
-        features (`torch.FloatTensor` of shape `(batch_size, num_patches, hidden_size)`):
-            Dense spatial patch features.
-        last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
-            Full token sequence (prefix tokens + patches) from the final encoder layer.
-        hidden_states (`tuple[torch.FloatTensor]`, *optional*, returned when `output_hidden_states=True`):
-            Tuple of `(batch_size, sequence_length, hidden_size)` tensors, one for the embedding output plus one for
-            each encoder layer.
-        attentions (`tuple[torch.FloatTensor]`, *optional*, returned when `output_attentions=True`):
-            Tuple of `(batch_size, num_heads, sequence_length, sequence_length)` attention weights, one per layer.
+    r"""
+    summary (`torch.FloatTensor` of shape `(batch_size, num_summary_idxs * hidden_size)`):
+        Flattened summary embedding, gathered from the cls tokens selected by `config.summary_idxs`.
+    features (`torch.FloatTensor` of shape `(batch_size, num_patches, hidden_size)`):
+        Dense spatial patch features.
+    last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
+        Full token sequence (prefix tokens + patches) from the final encoder layer.
     """
 
     summary: torch.FloatTensor | None = None
@@ -197,6 +191,7 @@ class RadioEncoder(RadioPreTrainedModel):
 
     @merge_with_config_defaults
     @capture_outputs(tie_last_hidden_states=False)
+    @auto_docstring
     def forward(self, hidden_states: torch.Tensor, **kwargs: Unpack[TransformersKwargs]) -> BaseModelOutput:
         for layer in self.layer:
             hidden_states = layer(hidden_states)

--- a/src/transformers/models/sapiens2/modeling_sapiens2.py
+++ b/src/transformers/models/sapiens2/modeling_sapiens2.py
@@ -848,6 +848,7 @@ class Sapiens2Encoder(Sapiens2PreTrainedModel):
 
     @merge_with_config_defaults
     @capture_outputs(tie_last_hidden_states=False)
+    @auto_docstring
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/src/transformers/models/tipsv2_dpt/modeling_tipsv2_dpt.py
+++ b/src/transformers/models/tipsv2_dpt/modeling_tipsv2_dpt.py
@@ -33,11 +33,10 @@ from ...utils import ModelOutput, TransformersKwargs, auto_docstring, can_return
 from .configuration_tipsv2_dpt import Tipsv2DptConfig
 
 
+@auto_docstring
 @dataclass
 class Tipsv2DptDensePredictorOutput(ModelOutput):
     r"""
-    predicted_depth (`torch.FloatTensor` of shape `(batch_size, height, width)`):
-        Predicted depth for each pixel.
     normals (`torch.FloatTensor` of shape `(batch_size, 3, height, width)`):
         Raw normal map predictions (unnormalized).
     segmentation_logits (`torch.FloatTensor` of shape `(batch_size, config.num_labels, height, width)`):

--- a/src/transformers/models/tipsv2_dpt/modular_tipsv2_dpt.py
+++ b/src/transformers/models/tipsv2_dpt/modular_tipsv2_dpt.py
@@ -39,11 +39,10 @@ from ..zoedepth.modeling_zoedepth import (
 )
 
 
+@auto_docstring
 @dataclass
 class Tipsv2DptDensePredictorOutput(ModelOutput):
     r"""
-    predicted_depth (`torch.FloatTensor` of shape `(batch_size, height, width)`):
-        Predicted depth for each pixel.
     normals (`torch.FloatTensor` of shape `(batch_size, 3, height, width)`):
         Raw normal map predictions (unnormalized).
     segmentation_logits (`torch.FloatTensor` of shape `(batch_size, config.num_labels, height, width)`):

--- a/src/transformers/utils/auto_docstring.py
+++ b/src/transformers/utils/auto_docstring.py
@@ -43,7 +43,7 @@ AUTODOC_FILES = [
     "processing_*.py",
     "image_processing_pil_*.py",
     "image_processing_*.py",
-    "feature_extractor_*.py",
+    "feature_extraction_*.py",
 ]
 
 PLACEHOLDER_TO_AUTO_MODULE = {
@@ -4480,10 +4480,10 @@ def auto_docstring(obj=None, *, custom_intro=None, custom_args=None, checkpoint=
 
         Using with ModelOutput classes:
         ```python
-        @dataclass
         @auto_docstring(
             custom_intro="Custom model outputs with additional fields."
         )
+        @dataclass
         class MyModelOutput(ImageClassifierOutput):
             r'''
             loss (`torch.FloatTensor`, *optional*):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47768)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47768)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Adds missing `auto_docstring` decorators for recent models. Also added an mlinter rule that checks for any missing decorators: https://github.com/huggingface/transformers-mlinter/pull/21