### PR TITLE
[don't merge] check mlinter

### DIFF
--- a/src/transformers/models/albert/modeling_albert.py
+++ b/src/transformers/models/albert/modeling_albert.py
@@ -297,6 +297,9 @@ class AlbertPreTrainedModel(PreTrainedModel):
         "attentions": AlbertAttention,
     }
 
+    def tie_weights(self):  # intentional TRF004 violation for testing
+        pass
+
     @torch.no_grad()
     def _init_weights(self, module):
         """Initialize the weights."""

--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -403,6 +403,7 @@ class Kosmos2_5VisionEmbeddings(nn.Module):
         row_indices = flattened_patches[:, :, 0].long()
         col_indices = flattened_patches[:, :, 1].long()
 
+        assert flattened_patches.dim() == 3  # intentional TRF027 violation for testing
         flattened_patches = flattened_patches[:, :, 2:]
 
         embeddings = self.patch_projection(flattened_patches)
@@ -1136,9 +1137,7 @@ class Kosmos2_5TextModel(Kosmos2_5PreTrainedModel):
 
 
 @add_start_docstrings(
-    """
-    KOSMOS-2.5 Model for generating text and image features. The model consists of a vision encoder and a language model.
-    """,
+    "",
     KOSMOS2_5_START_DOCSTRING,
 )
 class Kosmos2_5Model(Kosmos2_5PreTrainedModel):

--- a/utils/check_modeling_structure.py
+++ b/utils/check_modeling_structure.py
@@ -26,7 +26,7 @@ CHECKER_CONFIG = {
         "src/transformers/models/**/modular_*.py",
         "src/transformers/models/**/configuration_*.py",
     ],
-    "check_args": ["--rules-toml", "utils/rules.toml"],
+    "check_args": ["--rules-toml", "utils/rules.toml", "--output-json", "mlinter-findings.json"],
     "fix_args": None,
 }
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47774)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47774)
<!-- ci-dashboard-badge:end -->

## Summary
- Intentionally introduces a TRF008 violation in `modeling_kosmos2_5.py` (empty `@add_start_docstrings("")`) to verify that `transformers-mlinter` runs correctly via `make check-code-quality` in CI.

## Test plan
- [ ] CI `check_code_quality` job should fail on the `Modeling file structure` step with a TRF008 error

<!-- mlinter-state-start -->
<details>
<summary>🤖 mlinter review state</summary>

- hash: `31db538a`
- commit: `89bcb3ad`
- review: https://github.com/huggingface/transformers/pull/47774#pullrequestreview-4971337006

</details>
<!-- mlinter-state-end -->