### PR TITLE
Fix broken links in troubleshooting guide

### DIFF
--- a/docs/source/en/troubleshooting.md
+++ b/docs/source/en/troubleshooting.md
@@ -30,7 +30,7 @@ Sometimes errors occur, but we are here to help! This guide covers some of the m
 
 2. Create an [Issue](https://github.com/huggingface/transformers/issues/new/choose) on the 🤗 Transformers repository if it is a bug related to the library. Try to include as much information describing the bug as possible to help us better figure out what's wrong and how we can fix it.
 
-3. Check the [Migration](migration) guide if you use an older version of 🤗 Transformers since some important changes have been introduced between versions.
+3. Check the [Migration guide](https://github.com/huggingface/transformers/blob/main/MIGRATION_GUIDE_V5.md) if you use an older version of 🤗 Transformers since some important changes have been introduced between versions.
 
 For more details about troubleshooting and getting help, take a look at [Chapter 8](https://huggingface.co/course/chapter8/1?fw=pt) of the Hugging Face course.
 
@@ -60,7 +60,7 @@ Here are some potential solutions you can try to lessen memory use:
 
 <Tip>
 
-Refer to the Performance [guide](performance) for more details about memory-saving techniques.
+Refer to the Performance [guide](./model_memory_anatomy) for more details about memory-saving techniques.
 
 </Tip>
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47778)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47778)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes two broken links in `docs/source/en/troubleshooting.md`:

1. The Migration link pointed to a `migration` docs page that no longer exists (it was only present in older versioned docs). Point it to the Version 5 migration guide in the repository instead.
2. The Performance guide link pointed to a `performance` page that does not exist (the Performance entry in `_toctree.yml` is a section header, not a page). Since the tip is about memory-saving techniques, point it to the [GPU memory usage](./model_memory_anatomy) page.

Both links currently resolve to 404 on the live docs site.