### PR TITLE
[Fix] Swapped height and width in KimiK25

### DIFF
--- a/src/transformers/models/kimi_k25/image_processing_kimi_k25.py
+++ b/src/transformers/models/kimi_k25/image_processing_kimi_k25.py
@@ -14,7 +14,6 @@
 """Torchvision Image processor class for KimiK2.5."""
 
 import math
-from typing import Any
 
 import torch
 from torchvision.transforms.v2 import functional as tvF

--- a/src/transformers/models/kimi_k25/image_processing_kimi_k25.py
+++ b/src/transformers/models/kimi_k25/image_processing_kimi_k25.py
@@ -14,6 +14,7 @@
 """Torchvision Image processor class for KimiK2.5."""
 
 import math
+from typing import Any
 
 import torch
 from torchvision.transforms.v2 import functional as tvF
@@ -48,31 +49,31 @@ class Kimi_K25ImageProcessorKwargs(ImagesKwargs, total=False):
 
 
 def navit_resize(
-    width: int,
     height: int,
+    width: int,
     patch_size: int,
     merge_kernel_size: int,
     max_patches: int,
     max_size_per_side: int,
-):
-    num_patches_w = max(1.0, width // patch_size)
+) -> tuple[tuple[int, int], tuple[int, int]]:
     num_patches_h = max(1.0, height // patch_size)
-    current_patch_count = num_patches_w * num_patches_h
+    num_patches_w = max(1.0, width // patch_size)
+    current_patch_count = num_patches_h * num_patches_w
 
     # Scale to satisfy total patch budget (affects both dims, hence sqrt)
     scale_for_total_patches = math.sqrt(max_patches / current_patch_count)
 
     # Scale to satisfy per-side patch budget
-    scale_for_width_patches = (max_size_per_side * patch_size) / width
     scale_for_height_patches = (max_size_per_side * patch_size) / height
+    scale_for_width_patches = (max_size_per_side * patch_size) / width
 
     # Use the most restrictive scale, never upscale
-    scale = min(1.0, scale_for_total_patches, scale_for_width_patches, scale_for_height_patches)
+    scale = min(1.0, scale_for_total_patches, scale_for_height_patches, scale_for_width_patches)
 
     # Make sure the resized size doesn't go beyond predefined `max`
-    new_width, new_height = max(1, int(width * scale)), max(1, int(height * scale))
-    new_width = min(new_width, max_size_per_side * patch_size)
+    new_height, new_width = max(1, int(height * scale)), max(1, int(width * scale))
     new_height = min(new_height, max_size_per_side * patch_size)
+    new_width = min(new_width, max_size_per_side * patch_size)
 
     # Calculate the padding to make the height and width divisible by the merge kernel size and patch size.
     factor = merge_kernel_size * patch_size
@@ -145,8 +146,8 @@ class Kimi_K25ImageProcessor(TorchvisionBackend):
             height, width = stacked_images.shape[-2:]
             if do_resize:
                 (resized_height, resized_width), (pad_height, pad_width) = navit_resize(
-                    height,
-                    width,
+                    height=height,
+                    width=width,
                     patch_size=patch_size,
                     merge_kernel_size=merge_size,
                     max_patches=max_patches,

--- a/src/transformers/models/kimi_k25/video_processing_kimi_k25.py
+++ b/src/transformers/models/kimi_k25/video_processing_kimi_k25.py
@@ -31,7 +31,41 @@ from ...processing_utils import Unpack, VideosKwargs
 from ...utils import TensorType
 from ...video_processing_utils import BaseVideoProcessor
 from ...video_utils import group_videos_by_shape, reorder_videos
-from .image_processing_kimi_k25 import navit_resize
+
+
+def navit_resize(
+    height: int,
+    width: int,
+    patch_size: int,
+    merge_kernel_size: int,
+    max_patches: int,
+    max_size_per_side: int,
+) -> tuple[tuple[int, int], tuple[int, int]]:
+    num_patches_h = max(1.0, height // patch_size)
+    num_patches_w = max(1.0, width // patch_size)
+    current_patch_count = num_patches_h * num_patches_w
+
+    # Scale to satisfy total patch budget (affects both dims, hence sqrt)
+    scale_for_total_patches = math.sqrt(max_patches / current_patch_count)
+
+    # Scale to satisfy per-side patch budget
+    scale_for_height_patches = (max_size_per_side * patch_size) / height
+    scale_for_width_patches = (max_size_per_side * patch_size) / width
+
+    # Use the most restrictive scale, never upscale
+    scale = min(1.0, scale_for_total_patches, scale_for_height_patches, scale_for_width_patches)
+
+    # Make sure the resized size doesn't go beyond predefined `max`
+    new_height, new_width = max(1, int(height * scale)), max(1, int(width * scale))
+    new_height = min(new_height, max_size_per_side * patch_size)
+    new_width = min(new_width, max_size_per_side * patch_size)
+
+    # Calculate the padding to make the height and width divisible by the merge kernel size and patch size.
+    factor = merge_kernel_size * patch_size
+    pad_height = (factor - new_height % factor) % factor + new_height
+    pad_width = (factor - new_width % factor) % factor + new_width
+
+    return (new_height, new_width), (pad_height, pad_width)
 
 
 class Kimi_K25VideoProcessorInitKwargs(VideosKwargs, total=False):

--- a/src/transformers/models/kimi_k25/video_processing_kimi_k25.py
+++ b/src/transformers/models/kimi_k25/video_processing_kimi_k25.py
@@ -33,6 +33,7 @@ from ...video_processing_utils import BaseVideoProcessor
 from ...video_utils import group_videos_by_shape, reorder_videos
 
 
+# Same resize as in image processing
 def navit_resize(
     height: int,
     width: int,

--- a/src/transformers/models/kimi_k25/video_processing_kimi_k25.py
+++ b/src/transformers/models/kimi_k25/video_processing_kimi_k25.py
@@ -31,42 +31,7 @@ from ...processing_utils import Unpack, VideosKwargs
 from ...utils import TensorType
 from ...video_processing_utils import BaseVideoProcessor
 from ...video_utils import group_videos_by_shape, reorder_videos
-
-
-# Same resize as in image processing
-def navit_resize(
-    width: int,
-    height: int,
-    patch_size: int,
-    merge_kernel_size: int,
-    max_patches: int,
-    max_size_per_side: int,
-):
-    num_patches_w = max(1.0, width // patch_size)
-    num_patches_h = max(1.0, height // patch_size)
-    current_patch_count = num_patches_w * num_patches_h
-
-    # Scale to satisfy total patch budget (affects both dims, hence sqrt)
-    scale_for_total_patches = math.sqrt(max_patches / current_patch_count)
-
-    # Scale to satisfy per-side patch budget
-    scale_for_width_patches = (max_size_per_side * patch_size) / width
-    scale_for_height_patches = (max_size_per_side * patch_size) / height
-
-    # Use the most restrictive scale, never upscale
-    scale = min(1.0, scale_for_total_patches, scale_for_width_patches, scale_for_height_patches)
-
-    # Make sure the resized size doesn't go beyond predefined `max`
-    new_width, new_height = max(1, int(width * scale)), max(1, int(height * scale))
-    new_width = min(new_width, max_size_per_side * patch_size)
-    new_height = min(new_height, max_size_per_side * patch_size)
-
-    # Calculate the padding to make the height and width divisible by the merge kernel size and patch size.
-    factor = merge_kernel_size * patch_size
-    pad_height = (factor - new_height % factor) % factor + new_height
-    pad_width = (factor - new_width % factor) % factor + new_width
-
-    return (new_height, new_width), (pad_height, pad_width)
+from .image_processing_kimi_k25 import navit_resize
 
 
 class Kimi_K25VideoProcessorInitKwargs(VideosKwargs, total=False):

--- a/tests/models/kimi_k25/test_image_processing_kimi_k25.py
+++ b/tests/models/kimi_k25/test_image_processing_kimi_k25.py
@@ -246,6 +246,21 @@ class Kimi26ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
             self.assertTrue((encoded_images_nested == encoded_images).all())
             self.assertTrue((image_grid_thws_nested == expected_image_grid_thws).all())
 
+    def test_non_square_grid_orientation(self):
+        # Regression test: `navit_resize` used to be called with transposed (height, width) arguments, distorting
+        # every non-square image. The grid must be [1, height // patch, width // patch] after padding.
+        for image_processing_class in self.image_processing_classes.values():
+            image_processor_dict = {**self.image_processor_dict, "max_patches": 16384}
+            image_processing = image_processing_class(**image_processor_dict)
+            image = Image.fromarray(np.random.default_rng(0).integers(0, 256, (56, 112, 3), dtype=np.uint8))
+            process_out = image_processing(image, return_tensors="pt")
+            self.assertEqual(process_out.image_grid_thw.tolist(), [[1, 4, 8]])
+
+            # A landscape image and its portrait transpose must produce transposed grids
+            portrait = Image.fromarray(np.asarray(image).transpose(1, 0, 2))
+            process_out = image_processing(portrait, return_tensors="pt")
+            self.assertEqual(process_out.image_grid_thw.tolist(), [[1, 8, 4]])
+
     def test_custom_pixels(self):
         "Test different values for min and max pixels when resizing"
         pixel_choices = frozenset((100, 150, 200, 20000))


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47786)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47786)
<!-- ci-dashboard-badge:end -->

This PR fixes an height / width inversion that was impacting Kimi K2.5 : `navit_resize` was called with the `height` and `width` arguments swapped. This is fixed in this PR and a regression test was added.
Also, the `navit_resize` function was duplicated across two files (image and video processing) so now video only import from imagr rather than re-writing the fn.