### PR TITLE
[Fix] Wrong type hint in get_number_of_image_patches

### DIFF
--- a/src/transformers/models/aria/image_processing_aria.py
+++ b/src/transformers/models/aria/image_processing_aria.py
@@ -202,7 +202,7 @@ class AriaImageProcessor(TorchvisionBackend):
             tensor_type=return_tensors,
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -217,6 +217,7 @@ class AriaImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of patches per image.
         """
+        images_kwargs = images_kwargs or {}
         split_image = images_kwargs.get("split_image", self.split_image)
         max_image_size = images_kwargs.get("max_image_size", self.max_image_size)
         split_resolutions = images_kwargs.get("split_resolutions", self.split_resolutions)

--- a/src/transformers/models/aria/image_processing_pil_aria.py
+++ b/src/transformers/models/aria/image_processing_pil_aria.py
@@ -206,7 +206,7 @@ class AriaImageProcessorPil(PilBackend):
             tensor_type=return_tensors,
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -221,6 +221,7 @@ class AriaImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of patches per image.
         """
+        images_kwargs = images_kwargs or {}
         split_image = images_kwargs.get("split_image", self.split_image)
         max_image_size = images_kwargs.get("max_image_size", self.max_image_size)
         split_resolutions = images_kwargs.get("split_resolutions", self.split_resolutions)

--- a/src/transformers/models/aria/modular_aria.py
+++ b/src/transformers/models/aria/modular_aria.py
@@ -494,7 +494,7 @@ class AriaImageProcessor(TorchvisionBackend):
             tensor_type=return_tensors,
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -509,6 +509,7 @@ class AriaImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of patches per image.
         """
+        images_kwargs = images_kwargs or {}
         split_image = images_kwargs.get("split_image", self.split_image)
         max_image_size = images_kwargs.get("max_image_size", self.max_image_size)
         split_resolutions = images_kwargs.get("split_resolutions", self.split_resolutions)

--- a/src/transformers/models/cohere2_vision/image_processing_cohere2_vision.py
+++ b/src/transformers/models/cohere2_vision/image_processing_cohere2_vision.py
@@ -254,7 +254,7 @@ class Cohere2VisionImageProcessor(TorchvisionBackend):
             data={"pixel_values": processed_images, "num_patches": num_patches}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number patches for a given image size.
 
@@ -268,12 +268,11 @@ class Cohere2VisionImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of patches per image.
         """
-        min_patches = images_kwargs.get("min_patches", self.min_patches) if images_kwargs else self.min_patches
-        max_patches = images_kwargs.get("max_patches", self.max_patches) if images_kwargs else self.max_patches
-        patch_size = images_kwargs.get("patch_size", self.size) if images_kwargs else self.size
-        crop_to_patches = (
-            images_kwargs.get("crop_to_patches", self.crop_to_patches) if images_kwargs else self.crop_to_patches
-        )
+        images_kwargs = images_kwargs or {}
+        min_patches = images_kwargs.get("min_patches", self.min_patches)
+        max_patches = images_kwargs.get("max_patches", self.max_patches)
+        patch_size = images_kwargs.get("patch_size", self.size)
+        crop_to_patches = images_kwargs.get("crop_to_patches", self.crop_to_patches)
 
         num_patches = 1
         if crop_to_patches and max_patches > 1:

--- a/src/transformers/models/cosmos3_edge/image_processing_cosmos3_edge.py
+++ b/src/transformers/models/cosmos3_edge/image_processing_cosmos3_edge.py
@@ -231,7 +231,7 @@ class Cosmos3EdgeImageProcessor(TorchvisionBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -245,6 +245,7 @@ class Cosmos3EdgeImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         patch_size = images_kwargs.get("patch_size", self.patch_size)
         merge_size = images_kwargs.get("merge_size", self.merge_size)
         size = images_kwargs.get("size", self.size)

--- a/src/transformers/models/cosmos3_edge/image_processing_pil_cosmos3_edge.py
+++ b/src/transformers/models/cosmos3_edge/image_processing_pil_cosmos3_edge.py
@@ -228,7 +228,7 @@ class Cosmos3EdgeImageProcessorPil(PilBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -242,14 +242,10 @@ class Cosmos3EdgeImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of image patches per image.
         """
-        if images_kwargs is not None:
-            patch_size = images_kwargs.get("patch_size", self.patch_size)
-            merge_size = images_kwargs.get("merge_size", self.merge_size)
-            size = images_kwargs.get("size", {"shortest_edge": 112 * 112, "longest_edge": 28 * 28 * 15000})
-        else:
-            patch_size = self.patch_size
-            merge_size = self.merge_size
-            size = self.size
+        images_kwargs = images_kwargs or {}
+        patch_size = images_kwargs.get("patch_size", self.patch_size)
+        merge_size = images_kwargs.get("merge_size", self.merge_size)
+        size = images_kwargs.get("size", self.size)
 
         factor = patch_size * merge_size
         resized_height, resized_width = smart_resize(

--- a/src/transformers/models/deepseek_ocr2/image_processing_deepseek_ocr2.py
+++ b/src/transformers/models/deepseek_ocr2/image_processing_deepseek_ocr2.py
@@ -285,12 +285,11 @@ class DeepseekOcr2ImageProcessor(TorchvisionBackend):
 
         return BatchFeature(data=data, tensor_type=return_tensors)
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None) -> int:
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         Returns the number of image patches for a given image size (1 global + local patches).
         """
-        if images_kwargs is None:
-            images_kwargs = {}
+        images_kwargs = images_kwargs or {}
         min_patches = images_kwargs.get("min_patches", self.min_patches)
         max_patches = images_kwargs.get("max_patches", self.max_patches)
         tile_size = images_kwargs.get("tile_size", self.tile_size)

--- a/src/transformers/models/deepseek_ocr2/image_processing_pil_deepseek_ocr2.py
+++ b/src/transformers/models/deepseek_ocr2/image_processing_pil_deepseek_ocr2.py
@@ -273,7 +273,7 @@ class DeepseekOcr2ImageProcessorPil(PilBackend):
 
         return BatchFeature(data=data, tensor_type=return_tensors)
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number patches for a given image size.
 
@@ -287,12 +287,11 @@ class DeepseekOcr2ImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of patches per image.
         """
-        min_patches = images_kwargs.get("min_patches", self.min_patches) if images_kwargs else self.min_patches
-        max_patches = images_kwargs.get("max_patches", self.max_patches) if images_kwargs else self.max_patches
-        patch_size = images_kwargs.get("patch_size", self.size) if images_kwargs else self.size
-        crop_to_patches = (
-            images_kwargs.get("crop_to_patches", self.crop_to_patches) if images_kwargs else self.crop_to_patches
-        )
+        images_kwargs = images_kwargs or {}
+        min_patches = images_kwargs.get("min_patches", self.min_patches)
+        max_patches = images_kwargs.get("max_patches", self.max_patches)
+        patch_size = images_kwargs.get("patch_size", self.size)
+        crop_to_patches = images_kwargs.get("crop_to_patches", self.crop_to_patches)
 
         num_patches = 1
         if crop_to_patches and max_patches > 1:

--- a/src/transformers/models/deepseek_ocr2/modular_deepseek_ocr2.py
+++ b/src/transformers/models/deepseek_ocr2/modular_deepseek_ocr2.py
@@ -297,12 +297,11 @@ class DeepseekOcr2ImageProcessor(GotOcr2ImageProcessor):
 
         return BatchFeature(data=data, tensor_type=return_tensors)
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None) -> int:
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         Returns the number of image patches for a given image size (1 global + local patches).
         """
-        if images_kwargs is None:
-            images_kwargs = {}
+        images_kwargs = images_kwargs or {}
         min_patches = images_kwargs.get("min_patches", self.min_patches)
         max_patches = images_kwargs.get("max_patches", self.max_patches)
         tile_size = images_kwargs.get("tile_size", self.tile_size)

--- a/src/transformers/models/ernie4_5_vl_moe/image_processing_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/image_processing_ernie4_5_vl_moe.py
@@ -224,7 +224,7 @@ class Ernie4_5_VLMoeImageProcessor(TorchvisionBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -241,6 +241,7 @@ class Ernie4_5_VLMoeImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/ernie4_5_vl_moe/image_processing_pil_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/image_processing_pil_ernie4_5_vl_moe.py
@@ -217,7 +217,7 @@ class Ernie4_5_VLMoeImageProcessorPil(PilBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -234,6 +234,7 @@ class Ernie4_5_VLMoeImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/glm46v/image_processing_glm46v.py
+++ b/src/transformers/models/glm46v/image_processing_glm46v.py
@@ -232,7 +232,7 @@ class Glm46VImageProcessor(TorchvisionBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -246,6 +246,7 @@ class Glm46VImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         patch_size = images_kwargs.get("patch_size", self.patch_size)
         merge_size = images_kwargs.get("merge_size", self.merge_size)
         size = images_kwargs.get("size", self.size)

--- a/src/transformers/models/glm46v/image_processing_pil_glm46v.py
+++ b/src/transformers/models/glm46v/image_processing_pil_glm46v.py
@@ -227,7 +227,7 @@ class Glm46VImageProcessorPil(PilBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -241,14 +241,10 @@ class Glm46VImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of image patches per image.
         """
-        if images_kwargs is not None:
-            patch_size = images_kwargs.get("patch_size", self.patch_size)
-            merge_size = images_kwargs.get("merge_size", self.merge_size)
-            size = images_kwargs.get("size", {"shortest_edge": 112 * 112, "longest_edge": 28 * 28 * 15000})
-        else:
-            patch_size = self.patch_size
-            merge_size = self.merge_size
-            size = self.size
+        images_kwargs = images_kwargs or {}
+        patch_size = images_kwargs.get("patch_size", self.patch_size)
+        merge_size = images_kwargs.get("merge_size", self.merge_size)
+        size = images_kwargs.get("size", self.size)
 
         factor = patch_size * merge_size
         resized_height, resized_width = smart_resize(

--- a/src/transformers/models/glm4v/image_processing_glm4v.py
+++ b/src/transformers/models/glm4v/image_processing_glm4v.py
@@ -235,7 +235,7 @@ class Glm4vImageProcessor(TorchvisionBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -249,6 +249,7 @@ class Glm4vImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         patch_size = images_kwargs.get("patch_size", self.patch_size)
         merge_size = images_kwargs.get("merge_size", self.merge_size)
         size = images_kwargs.get("size", self.size)

--- a/src/transformers/models/glm4v/image_processing_pil_glm4v.py
+++ b/src/transformers/models/glm4v/image_processing_pil_glm4v.py
@@ -231,7 +231,7 @@ class Glm4vImageProcessorPil(PilBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -245,14 +245,10 @@ class Glm4vImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of image patches per image.
         """
-        if images_kwargs is not None:
-            patch_size = images_kwargs.get("patch_size", self.patch_size)
-            merge_size = images_kwargs.get("merge_size", self.merge_size)
-            size = images_kwargs.get("size", {"shortest_edge": 112 * 112, "longest_edge": 28 * 28 * 15000})
-        else:
-            patch_size = self.patch_size
-            merge_size = self.merge_size
-            size = self.size
+        images_kwargs = images_kwargs or {}
+        patch_size = images_kwargs.get("patch_size", self.patch_size)
+        merge_size = images_kwargs.get("merge_size", self.merge_size)
+        size = images_kwargs.get("size", self.size)
 
         factor = patch_size * merge_size
         resized_height, resized_width = smart_resize(

--- a/src/transformers/models/glm_image/image_processing_glm_image.py
+++ b/src/transformers/models/glm_image/image_processing_glm_image.py
@@ -260,7 +260,7 @@ class GlmImageImageProcessor(TorchvisionBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -277,6 +277,7 @@ class GlmImageImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/glm_image/image_processing_pil_glm_image.py
+++ b/src/transformers/models/glm_image/image_processing_pil_glm_image.py
@@ -254,7 +254,7 @@ class GlmImageImageProcessorPil(PilBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -271,6 +271,7 @@ class GlmImageImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/glmga/image_processing_glmga.py
+++ b/src/transformers/models/glmga/image_processing_glmga.py
@@ -234,7 +234,7 @@ class GlmgaImageProcessor(TorchvisionBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -248,6 +248,7 @@ class GlmgaImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         patch_size = images_kwargs.get("patch_size", self.patch_size)
         merge_size = images_kwargs.get("merge_size", self.merge_size)
         size = images_kwargs.get("size", self.size)

--- a/src/transformers/models/glmga/image_processing_pil_glmga.py
+++ b/src/transformers/models/glmga/image_processing_pil_glmga.py
@@ -231,7 +231,7 @@ class GlmgaImageProcessorPil(PilBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -245,14 +245,10 @@ class GlmgaImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of image patches per image.
         """
-        if images_kwargs is not None:
-            patch_size = images_kwargs.get("patch_size", self.patch_size)
-            merge_size = images_kwargs.get("merge_size", self.merge_size)
-            size = images_kwargs.get("size", {"shortest_edge": 112 * 112, "longest_edge": 28 * 28 * 15000})
-        else:
-            patch_size = self.patch_size
-            merge_size = self.merge_size
-            size = self.size
+        images_kwargs = images_kwargs or {}
+        patch_size = images_kwargs.get("patch_size", self.patch_size)
+        merge_size = images_kwargs.get("merge_size", self.merge_size)
+        size = images_kwargs.get("size", self.size)
 
         factor = patch_size * merge_size
         resized_height, resized_width = smart_resize(

--- a/src/transformers/models/got_ocr2/image_processing_got_ocr2.py
+++ b/src/transformers/models/got_ocr2/image_processing_got_ocr2.py
@@ -268,7 +268,7 @@ class GotOcr2ImageProcessor(TorchvisionBackend):
             data={"pixel_values": processed_images, "num_patches": num_patches}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number patches for a given image size.
 
@@ -282,12 +282,11 @@ class GotOcr2ImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of patches per image.
         """
-        min_patches = images_kwargs.get("min_patches", self.min_patches) if images_kwargs else self.min_patches
-        max_patches = images_kwargs.get("max_patches", self.max_patches) if images_kwargs else self.max_patches
-        patch_size = images_kwargs.get("patch_size", self.size) if images_kwargs else self.size
-        crop_to_patches = (
-            images_kwargs.get("crop_to_patches", self.crop_to_patches) if images_kwargs else self.crop_to_patches
-        )
+        images_kwargs = images_kwargs or {}
+        min_patches = images_kwargs.get("min_patches", self.min_patches)
+        max_patches = images_kwargs.get("max_patches", self.max_patches)
+        patch_size = images_kwargs.get("patch_size", self.size)
+        crop_to_patches = images_kwargs.get("crop_to_patches", self.crop_to_patches)
 
         num_patches = 1
         if crop_to_patches and max_patches > 1:

--- a/src/transformers/models/got_ocr2/image_processing_pil_got_ocr2.py
+++ b/src/transformers/models/got_ocr2/image_processing_pil_got_ocr2.py
@@ -271,7 +271,7 @@ class GotOcr2ImageProcessorPil(PilBackend):
             data={"pixel_values": processed_images, "num_patches": num_patches}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number patches for a given image size.
 
@@ -285,12 +285,11 @@ class GotOcr2ImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of patches per image.
         """
-        min_patches = images_kwargs.get("min_patches", self.min_patches) if images_kwargs else self.min_patches
-        max_patches = images_kwargs.get("max_patches", self.max_patches) if images_kwargs else self.max_patches
-        patch_size = images_kwargs.get("patch_size", self.size) if images_kwargs else self.size
-        crop_to_patches = (
-            images_kwargs.get("crop_to_patches", self.crop_to_patches) if images_kwargs else self.crop_to_patches
-        )
+        images_kwargs = images_kwargs or {}
+        min_patches = images_kwargs.get("min_patches", self.min_patches)
+        max_patches = images_kwargs.get("max_patches", self.max_patches)
+        patch_size = images_kwargs.get("patch_size", self.size)
+        crop_to_patches = images_kwargs.get("crop_to_patches", self.crop_to_patches)
 
         num_patches = 1
         if crop_to_patches and max_patches > 1:

--- a/src/transformers/models/hunyuan_vl/image_processing_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/image_processing_hunyuan_vl.py
@@ -253,7 +253,9 @@ class HunYuanVLImageProcessor(TorchvisionBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs: dict | None = None
+    ) -> tuple[int, int]:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -268,8 +270,9 @@ class HunYuanVLImageProcessor(TorchvisionBackend):
             images_kwargs (`dict`, *optional*)
                 Any kwargs to override defaults of the image processor.
         Returns:
-            `int`: Number of image patches per image.
+            `tuple[int, int]`: Number of image patches per image, as a `(height, width)` grid.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/image_processing_pil_hunyuan_vl.py
@@ -249,7 +249,9 @@ class HunYuanVLImageProcessorPil(PilBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs: dict | None = None
+    ) -> tuple[int, int]:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -264,8 +266,9 @@ class HunYuanVLImageProcessorPil(PilBackend):
             images_kwargs (`dict`, *optional*)
                 Any kwargs to override defaults of the image processor.
         Returns:
-            `int`: Number of image patches per image.
+            `tuple[int, int]`: Number of image patches per image, as a `(height, width)` grid.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
@@ -411,7 +411,9 @@ class HunYuanVLImageProcessor(Qwen2VLImageProcessor):
 
         return flatten_patches, grid_h, grid_w
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs: dict | None = None
+    ) -> tuple[int, int]:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -426,8 +428,9 @@ class HunYuanVLImageProcessor(Qwen2VLImageProcessor):
             images_kwargs (`dict`, *optional*)
                 Any kwargs to override defaults of the image processor.
         Returns:
-            `int`: Number of image patches per image.
+            `tuple[int, int]`: Number of image patches per image, as a `(height, width)` grid.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)
@@ -516,7 +519,9 @@ class HunYuanVLImageProcessorPil(Qwen2VLImageProcessorPil):
         )
         return flatten_patches, grid_h, grid_w
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs: dict | None = None
+    ) -> tuple[int, int]:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -531,8 +536,9 @@ class HunYuanVLImageProcessorPil(Qwen2VLImageProcessorPil):
             images_kwargs (`dict`, *optional*)
                 Any kwargs to override defaults of the image processor.
         Returns:
-            `int`: Number of image patches per image.
+            `tuple[int, int]`: Number of image patches per image, as a `(height, width)` grid.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/idefics3/image_processing_idefics3.py
+++ b/src/transformers/models/idefics3/image_processing_idefics3.py
@@ -505,7 +505,9 @@ class Idefics3ImageProcessor(TorchvisionBackend):
         encoder_dict.pop("return_row_col_info", None)
         return encoder_dict
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict):
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs: dict | None = None
+    ) -> tuple[int, int, int]:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -514,11 +516,12 @@ class Idefics3ImageProcessor(TorchvisionBackend):
                 Height of the input image.
             width (`int`):
                 Width of the input image.
-            images_kwargs (`dict`)
+            images_kwargs (`dict`, *optional*)
                 Any kwargs to override defaults of the image processor.
         Returns:
-            `int`: Number of patches per image.
+            `tuple[int, int, int]`: Number of patches per image, and the number of rows and columns they form.
         """
+        images_kwargs = images_kwargs or {}
         do_image_splitting = images_kwargs.get("do_image_splitting", self.do_image_splitting)
         max_image_size = images_kwargs.get("max_image_size", self.max_image_size)
         size = images_kwargs.get("size", self.size)

--- a/src/transformers/models/idefics3/image_processing_pil_idefics3.py
+++ b/src/transformers/models/idefics3/image_processing_pil_idefics3.py
@@ -435,7 +435,9 @@ class Idefics3ImageProcessorPil(PilBackend):
         encoder_dict.pop("return_row_col_info", None)
         return encoder_dict
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict):
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs: dict | None = None
+    ) -> tuple[int, int, int]:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -444,11 +446,12 @@ class Idefics3ImageProcessorPil(PilBackend):
                 Height of the input image.
             width (`int`):
                 Width of the input image.
-            images_kwargs (`dict`)
+            images_kwargs (`dict`, *optional*)
                 Any kwargs to override defaults of the image processor.
         Returns:
-            `int`: Number of patches per image.
+            `tuple[int, int, int]`: Number of patches per image, and the number of rows and columns they form.
         """
+        images_kwargs = images_kwargs or {}
         do_image_splitting = images_kwargs.get("do_image_splitting", self.do_image_splitting)
         max_image_size = images_kwargs.get("max_image_size", self.max_image_size)
         size = images_kwargs.get("size", self.size)

--- a/src/transformers/models/kimi_k25/image_processing_kimi_k25.py
+++ b/src/transformers/models/kimi_k25/image_processing_kimi_k25.py
@@ -221,7 +221,7 @@ class Kimi_K25ImageProcessor(TorchvisionBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -238,6 +238,7 @@ class Kimi_K25ImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         max_size_per_side = images_kwargs["size"]["max_height"] if "size" in images_kwargs else self.size["max_height"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)
         merge_size = images_kwargs.get("merge_size", self.merge_size)

--- a/src/transformers/models/minimax_m3_vl/image_processing_minimax_m3_vl.py
+++ b/src/transformers/models/minimax_m3_vl/image_processing_minimax_m3_vl.py
@@ -252,7 +252,7 @@ class MiniMaxM3VLImageProcessor(TorchvisionBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -269,6 +269,7 @@ class MiniMaxM3VLImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/paddleocr_vl/image_processing_paddleocr_vl.py
+++ b/src/transformers/models/paddleocr_vl/image_processing_paddleocr_vl.py
@@ -255,7 +255,7 @@ class PaddleOCRVLImageProcessor(TorchvisionBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -272,6 +272,7 @@ class PaddleOCRVLImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/paddleocr_vl/image_processing_pil_paddleocr_vl.py
+++ b/src/transformers/models/paddleocr_vl/image_processing_pil_paddleocr_vl.py
@@ -248,7 +248,7 @@ class PaddleOCRVLImageProcessorPil(PilBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -265,6 +265,7 @@ class PaddleOCRVLImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/qwen2_vl/image_processing_pil_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/image_processing_pil_qwen2_vl.py
@@ -245,7 +245,7 @@ class Qwen2VLImageProcessorPil(PilBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -262,6 +262,7 @@ class Qwen2VLImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
@@ -254,7 +254,7 @@ class Qwen2VLImageProcessor(TorchvisionBackend):
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -271,6 +271,7 @@ class Qwen2VLImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/smolvlm/image_processing_pil_smolvlm.py
+++ b/src/transformers/models/smolvlm/image_processing_pil_smolvlm.py
@@ -436,7 +436,9 @@ class SmolVLMImageProcessorPil(PilBackend):
         encoder_dict.pop("return_row_col_info", None)
         return encoder_dict
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict):
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs: dict | None = None
+    ) -> tuple[int, int, int]:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -445,11 +447,12 @@ class SmolVLMImageProcessorPil(PilBackend):
                 Height of the input image.
             width (`int`):
                 Width of the input image.
-            images_kwargs (`dict`)
+            images_kwargs (`dict`, *optional*)
                 Any kwargs to override defaults of the image processor.
         Returns:
-            `int`: Number of patches per image.
+            `tuple[int, int, int]`: Number of patches per image, and the number of rows and columns they form.
         """
+        images_kwargs = images_kwargs or {}
         do_image_splitting = images_kwargs.get("do_image_splitting", self.do_image_splitting)
         max_image_size = images_kwargs.get("max_image_size", self.max_image_size)
         size = images_kwargs.get("size", self.size)

--- a/src/transformers/models/smolvlm/image_processing_smolvlm.py
+++ b/src/transformers/models/smolvlm/image_processing_smolvlm.py
@@ -494,7 +494,9 @@ class SmolVLMImageProcessor(TorchvisionBackend):
         encoder_dict.pop("return_row_col_info", None)
         return encoder_dict
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict):
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs: dict | None = None
+    ) -> tuple[int, int, int]:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -503,11 +505,12 @@ class SmolVLMImageProcessor(TorchvisionBackend):
                 Height of the input image.
             width (`int`):
                 Width of the input image.
-            images_kwargs (`dict`)
+            images_kwargs (`dict`, *optional*)
                 Any kwargs to override defaults of the image processor.
         Returns:
-            `int`: Number of patches per image.
+            `tuple[int, int, int]`: Number of patches per image, and the number of rows and columns they form.
         """
+        images_kwargs = images_kwargs or {}
         do_image_splitting = images_kwargs.get("do_image_splitting", self.do_image_splitting)
         max_image_size = images_kwargs.get("max_image_size", self.max_image_size)
         size = images_kwargs.get("size", self.size)

--- a/src/transformers/models/video_llama_3/image_processing_pil_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/image_processing_pil_video_llama_3.py
@@ -252,7 +252,7 @@ class VideoLlama3ImageProcessorPil(PilBackend):
             tensor_type=return_tensors,
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -269,6 +269,7 @@ class VideoLlama3ImageProcessorPil(PilBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)

--- a/src/transformers/models/video_llama_3/image_processing_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/image_processing_video_llama_3.py
@@ -261,7 +261,7 @@ class VideoLlama3ImageProcessor(TorchvisionBackend):
             tensor_type=return_tensors,
         )
 
-    def get_number_of_image_patches(self, height: int, width: int, images_kwargs=None):
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict | None = None) -> int:
         """
         A utility that returns number of image patches for a given image size.
 
@@ -278,6 +278,7 @@ class VideoLlama3ImageProcessor(TorchvisionBackend):
         Returns:
             `int`: Number of image patches per image.
         """
+        images_kwargs = images_kwargs or {}
         min_pixels = images_kwargs["min_pixels"] if "min_pixels" in images_kwargs else self.size["shortest_edge"]
         max_pixels = images_kwargs["max_pixels"] if "max_pixels" in images_kwargs else self.size["longest_edge"]
         patch_size = images_kwargs.get("patch_size", self.patch_size)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47788)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47788)
<!-- ci-dashboard-badge:end -->

This PR fixes a wrong type hint + default value in `get_number_of_image_patches`: currently, the `image_kwargs` is annotated as an optionnal dictionary with default value `None` but passing `None` would crash the function.
To correect this, we use `image_kwargs = image_kwargs or {}` to go from the default dict to an empty one and then use `get` with appropriate defaults. 

Also, `glm4v` used to hardcode a default value (call it `V`) for `size` that was different from a potential user-supplied `self.size`: now, we default to `self.size`, which if not user supplied, defaults itself to `V`. So in absence of user intervention, behavior is identical. 

One thing to consider: depending on the model, `get_number_of_image_patches` returns either an `int` (number of patches, `n_patches = n_width_patches * n_height_patches`) a tuple of 2 ints (`n_width_patches, n_height_patches`) or a tuple of 3 ints (`n_patches, n_width_patches, n_height_patches`) -> maybe it would be worth uniformising this. WDYT? cc. @molbap @zucchini-nlp 

PS: we can go the other route and force image_kwargs to be passed, but it seems even more breaking, plus I think VLLM uses this function.