### PR TITLE
cancel deterministic for XPU in gemma4 tests

### DIFF
--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -142,12 +142,6 @@ class Gemma4TextModelTest(CausalLMModelTest, unittest.TestCase):
     def test_flash_attn_2_inference_equivalence_right_padding(self):
         pass
 
-    @unittest.skip(
-        "QuantizedCache is only supported for models with only full attention layers, but Gemma4 has sliding_attention."
-    )
-    def test_generate_with_quant_cache(self):
-        pass
-
     def test_all_bidirectional_attention_uses_bidirectional_mask(self):
         self.model_tester.use_bidirectional_attention = "all"
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
@@ -322,12 +316,6 @@ class Gemma4Audio2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unittes
 
     @unittest.skip("Gemma4 needs correct embeddings for per-layer-input computation, random won't work!")
     def test_generate_from_random_inputs_embeds(self):
-        pass
-
-    @unittest.skip(
-        "QuantizedCache is only supported for models with only full attention layers, but Gemma4 has sliding_attention."
-    )
-    def test_generate_with_quant_cache(self):
         pass
 
     @unittest.skip(GEMMA4_RANDOM_MOE_FA2_SKIP_REASON)
@@ -560,12 +548,6 @@ class Gemma4Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
 
     @unittest.skip("Gemma4 needs correct embeddings for per-layer-input computation, random won't work!")
     def test_generate_from_random_inputs_embeds(self):
-        pass
-
-    @unittest.skip(
-        "QuantizedCache is only supported for models with only full attention layers, but Gemma4 has sliding_attention."
-    )
-    def test_generate_with_quant_cache(self):
         pass
 
     @unittest.skip(

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -142,6 +142,12 @@ class Gemma4TextModelTest(CausalLMModelTest, unittest.TestCase):
     def test_flash_attn_2_inference_equivalence_right_padding(self):
         pass
 
+    @unittest.skip(
+        "QuantizedCache is only supported for models with only full attention layers, but Gemma4 has sliding_attention."
+    )
+    def test_generate_with_quant_cache(self):
+        pass
+
     def test_all_bidirectional_attention_uses_bidirectional_mask(self):
         self.model_tester.use_bidirectional_attention = "all"
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
@@ -316,6 +322,12 @@ class Gemma4Audio2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unittes
 
     @unittest.skip("Gemma4 needs correct embeddings for per-layer-input computation, random won't work!")
     def test_generate_from_random_inputs_embeds(self):
+        pass
+
+    @unittest.skip(
+        "QuantizedCache is only supported for models with only full attention layers, but Gemma4 has sliding_attention."
+    )
+    def test_generate_with_quant_cache(self):
         pass
 
     @unittest.skip(GEMMA4_RANDOM_MOE_FA2_SKIP_REASON)
@@ -548,6 +560,12 @@ class Gemma4Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
 
     @unittest.skip("Gemma4 needs correct embeddings for per-layer-input computation, random won't work!")
     def test_generate_from_random_inputs_embeds(self):
+        pass
+
+    @unittest.skip(
+        "QuantizedCache is only supported for models with only full attention layers, but Gemma4 has sliding_attention."
+    )
+    def test_generate_with_quant_cache(self):
         pass
 
     @unittest.skip(
@@ -991,7 +1009,6 @@ class Gemma4IntegrationTest(unittest.TestCase):
 
     # Note: we do not test FA2 as the head dim is 512 on some layers, which is not compatible with the kernels
     @parameterized.expand([("sdpa",), ("eager",)])
-    @require_deterministic_for_xpu
     def test_generation_beyond_sliding_window(self, attn_implementation: str):
         """Test that we can correctly generate beyond the sliding window. Outputs for every attention functions
         should be coherent and identical.


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47790)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47790)
<!-- ci-dashboard-badge:end -->

There is an underlying bug for PT 2.13 XPU for `test_generation_beyond_sliding_window` test case using deterministic, and I rerun this case for 10 times, no `require_deterministic_for_xpu` decorator is needed. Besides, skip all QuantizedCache related test cases for gemma4 model. Pls help review, thx! @IlyasMoutawwakil @ydshieh