### PR TITLE
[conftest] Fix EROFS fallback for kernel downloads via HfApi

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -241,6 +241,20 @@ def pytest_configure(config):
             if getattr(_mod, "hf_hub_download", None) is _original_hf_hub_download:
                 _mod.hf_hub_download = _wrapped_hf_hub_download
 
+        # Special case: `huggingface_hub.hf_api` is skipped by the loop above, but
+        # `HfApi.hf_hub_download` (the instance method) calls `hf_hub_download` by resolving
+        # the bare name from its own module namespace (`hf_api.py`).  Third-party libraries
+        # such as `kernels` call `api.hf_hub_download(...)` (HfApi instance), so their
+        # downloads bypass the wrapping above and the EROFS fallback never fires.
+        # Re-binding the module-level name in `hf_api` fixes this without touching
+        # `snapshot_download` (which imports `hf_hub_download` from `file_download.py`
+        # directly and resolves symlinks in the caller's cache_dir, so redirecting it
+        # would produce a spurious "missing file" — the concern that drove the skip above).
+        import huggingface_hub.hf_api as _hf_api_mod
+
+        if getattr(_hf_api_mod, "hf_hub_download", None) is _original_hf_hub_download:
+            _hf_api_mod.hf_hub_download = _wrapped_hf_hub_download
+
     config.addinivalue_line("markers", "slow: mark test as slow")
     config.addinivalue_line("markers", "is_pipeline_test: mark test to run only when pipelines are tested")
     config.addinivalue_line("markers", "is_staging_test: mark test to run only in the staging environment")


### PR DESCRIPTION
## Summary

- The CI read-only cache fallback wraps `huggingface_hub.hf_hub_download`, but the `kernels` library calls `api.hf_hub_download(...)` (an `HfApi` instance method). Inside that method, `hf_hub_download` is resolved from `hf_api.py`'s own module namespace — which the re-binding loop explicitly skips — so the EROFS retry never fired.
- Fix: after the loop, also patch `huggingface_hub.hf_api.hf_hub_download` (the module-level name `HfApi.hf_hub_download` resolves at call time).
- `snapshot_download` is unaffected: it imports `hf_hub_download` from `file_download.py` directly and is not routed through `hf_api`.

Fixes the failing CI test: https://github.com/huggingface/transformers/actions/runs/30959531329/job/92160713490?pr=47773

```
FAILED tests/kernels/test_kernels.py::TestAttentionKernelRegistration::test_trust_remote_code_for_attention_kernels
OSError: [Errno 30] Read-only file system: '/mnt/cache/hub/kernels--kernels-community--flash-attn2/...'
```