### PR TITLE
Fix MI355 CI: bump hf-workflows pin to NUM_SLICES=4

### DIFF
--- a/.github/workflows/self-scheduled-amd-mi355-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi355-caller.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   model-ci:
     name: Model CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@63657f571a92cc9759159442936061c51d6d9ae4 # main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@50acccfe9afb8927b9b74ed7e750f2b0d3991b62 # main
     with:
       job: run_models_gpu
       slack_report_channel: "#amd-hf-ci"
@@ -31,7 +31,7 @@ jobs:
 
   torch-pipeline:
     name: Torch pipeline CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@63657f571a92cc9759159442936061c51d6d9ae4 # main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@50acccfe9afb8927b9b74ed7e750f2b0d3991b62 # main
     with:
       job: run_pipelines_torch_gpu
       slack_report_channel: "#amd-hf-ci"
@@ -43,7 +43,7 @@ jobs:
 
   example-ci:
     name: Example CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@63657f571a92cc9759159442936061c51d6d9ae4 # main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@50acccfe9afb8927b9b74ed7e750f2b0d3991b62 # main
     with:
       job: run_examples_gpu
       slack_report_channel: "#amd-hf-ci"
@@ -55,7 +55,7 @@ jobs:
 
   deepspeed-ci:
     name: DeepSpeed CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@63657f571a92cc9759159442936061c51d6d9ae4 # main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@50acccfe9afb8927b9b74ed7e750f2b0d3991b62 # main
     with:  
       job: run_torch_cuda_extensions_gpu
       slack_report_channel: "#amd-hf-ci"


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47792)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47792)
<!-- ci-dashboard-badge:end -->

The MI355 caller was pinned to hf-workflows@63657f57 (NUM_SLICES=2). With >512 model folders, that's 260 configs/slice - over GitHub's 256 matrix limit, so run_models_gpu never expands and no per-model tests run. Re-pin to current main SHA (NUM_SLICES=4, ~130/slice), matching MI300.