### PR TITLE
fix: decode() batch path respects self.clean_up_tokenization_spaces

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2881,7 +2881,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
         # If we received batched input, decode each sequence
         if isinstance(token_ids, (list, tuple)) and len(token_ids) > 0 and isinstance(token_ids[0], (list, tuple)):
-            clean_up_tokenization_spaces = kwargs.pop("clean_up_tokenization_spaces", False)
+            clean_up_tokenization_spaces = kwargs.pop("clean_up_tokenization_spaces", None)
             return [
                 self._decode(
                     token_ids=seq,

--- a/tests/models/bert/test_tokenization_bert.py
+++ b/tests/models/bert/test_tokenization_bert.py
@@ -32,3 +32,15 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     integration_expected_token_ids = [2023, 2003, 1037, 3231, 100, 1045, 2001, 2141, 1999, 6227, 8889, 2692, 1010, 1998, 2023, 2003, 6270, 1012, 1910, 100, 1916, 1921, 100, 100, 7632, 7592, 7632, 7592, 7592, 1026, 1055, 1028, 7632, 1026, 1055, 1028, 2045, 1996, 2206, 5164, 2323, 2022, 7919, 12359, 1024, 7592, 1012, 2021, 20868, 2094, 1998, 100, 20868, 2094, 100, 4931, 2129, 2024, 2017, 2725]  # fmt: skip
     expected_tokens_from_ids = ['this', 'is', 'a', 'test', '[UNK]', 'i', 'was', 'born', 'in', '92', '##00', '##0', ',', 'and', 'this', 'is', 'false', '.', '生', '[UNK]', '的', '真', '[UNK]', '[UNK]', 'hi', 'hello', 'hi', 'hello', 'hello', '<', 's', '>', 'hi', '<', 's', '>', 'there', 'the', 'following', 'string', 'should', 'be', 'properly', 'encoded', ':', 'hello', '.', 'but', 'ir', '##d', 'and', '[UNK]', 'ir', '##d', '[UNK]', 'hey', 'how', 'are', 'you', 'doing']  # fmt: skip
     integration_expected_decoded_text = "this is a test [UNK] i was born in 92000, and this is false. 生 [UNK] 的 真 [UNK] [UNK] hi hello hi hello hello < s > hi < s > there the following string should be properly encoded : hello. but ird and [UNK] ird [UNK] hey how are you doing"
+
+    def test_decode_batch_uses_tokenizer_cleanup_setting(self):
+        tokenizer = self.get_tokenizer(clean_up_tokenization_spaces=True)
+        token_ids = tokenizer.encode("hello , world !", add_special_tokens=False)
+        tokenizer.backend_tokenizer.decoder.cleanup = False
+
+        self.assertEqual(tokenizer.decode(token_ids), "hello, world!")
+        self.assertEqual(tokenizer.decode([token_ids]), ["hello, world!"])
+        self.assertEqual(
+            tokenizer.decode([token_ids], clean_up_tokenization_spaces=False),
+            ["hello , world !"],
+        )


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47793&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47793) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47793&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47793)
<!-- ci-dashboard-badge:end -->

Fixes an inconsistency in `PreTrainedTokenizerBase.decode()`: the batch path (`decode([[ids]])`) hardcoded `clean_up_tokenization_spaces=False`, overriding `self.clean_up_tokenization_spaces`. The single-sequence path correctly passes `None` (the `_decode` default), allowing `_decode` to fall back to the tokenizer's own setting.