### PR TITLE
[conftest] Also wrap snapshot_download for EROFS fallback

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -253,8 +253,8 @@ def pytest_configure(config):
         # `snapshot_download` as a whole so the entire retry uses a writable cache_dir,
         # avoiding the mismatch where individual file downloads land in tmp but
         # snapshot_download resolves the snapshot folder from the original cache_dir.
-        import huggingface_hub.file_download as _file_download_mod
         import huggingface_hub._snapshot_download as _snapshot_download_mod
+        import huggingface_hub.file_download as _file_download_mod
 
         if getattr(_file_download_mod, "hf_hub_download", None) is _original_hf_hub_download:
             _file_download_mod.hf_hub_download = _wrapped_hf_hub_download

--- a/conftest.py
+++ b/conftest.py
@@ -241,19 +241,29 @@ def pytest_configure(config):
             if getattr(_mod, "hf_hub_download", None) is _original_hf_hub_download:
                 _mod.hf_hub_download = _wrapped_hf_hub_download
 
-        # Special case: third-party libraries such as `kernels` call
-        # `api.hf_hub_download(...)` (HfApi instance method).  Inside that method,
-        # `hf_hub_download` is resolved via a *local* import:
-        #   `from .file_download import hf_hub_download`
-        # Local imports read `file_download.__dict__` at *call time*, so patching
-        # `file_download.hf_hub_download` is the right interception point.
-        # Module-level references already imported by other huggingface_hub modules
-        # (e.g. snapshot_download.py) are frozen before conftest runs and are therefore
-        # unaffected — only call-time local imports pick up the new binding.
+        # Special case: third-party libraries such as `kernels` call HfApi methods
+        # (`api.hf_hub_download`, `api.snapshot_download`).  Both methods use *local*
+        # imports inside the method body, e.g.:
+        #   `from .file_download import hf_hub_download`       (HfApi.hf_hub_download)
+        #   `from ._snapshot_download import snapshot_download` (HfApi.snapshot_download)
+        # Local imports read the source module's __dict__ at *call time*, so patching
+        # those module-level names is the right interception point.
+        # Module-level references already imported by _snapshot_download.py itself
+        # (its own `hf_hub_download`) are frozen before conftest runs; we wrap
+        # `snapshot_download` as a whole so the entire retry uses a writable cache_dir,
+        # avoiding the mismatch where individual file downloads land in tmp but
+        # snapshot_download resolves the snapshot folder from the original cache_dir.
         import huggingface_hub.file_download as _file_download_mod
+        import huggingface_hub._snapshot_download as _snapshot_download_mod
 
         if getattr(_file_download_mod, "hf_hub_download", None) is _original_hf_hub_download:
             _file_download_mod.hf_hub_download = _wrapped_hf_hub_download
+
+        _original_snapshot_download = _snapshot_download_mod.snapshot_download
+        if not getattr(_original_snapshot_download, "_ci_fallback_wrapped", False):
+            _wrapped_snapshot_download = _with_tmpdir_cache_fallback(_original_snapshot_download)
+            _wrapped_snapshot_download._ci_fallback_wrapped = True
+            _snapshot_download_mod.snapshot_download = _wrapped_snapshot_download
 
     config.addinivalue_line("markers", "slow: mark test as slow")
     config.addinivalue_line("markers", "is_pipeline_test: mark test to run only when pipelines are tested")


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47796)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47796)
<!-- ci-dashboard-badge:end -->

## Summary

Follow-up to #47794.

The `kernels` library calls both `api.hf_hub_download` and `api.snapshot_download`. The previous fix covered the `hf_hub_download` path; this covers `snapshot_download`.

**Why the same approach works:**
`HfApi.snapshot_download` also uses a local import at call time:
```python
from ._snapshot_download import snapshot_download
```
So patching `_snapshot_download.snapshot_download` is picked up correctly.

**Why we wrap `snapshot_download` as a whole (not its inner `hf_hub_download` calls):**
`_snapshot_download.py` has a frozen module-level reference to `hf_hub_download` (line 18). Patching that would redirect individual file downloads to `tmp_dir` but leave `snapshot_download` computing the snapshot folder from the original (read-only) `cache_dir` — a mismatch.

Wrapping the entire `snapshot_download` avoids this: on retry with `cache_dir=tmp_dir`, `_inner_hf_hub_download` passes `cache_dir=tmp_dir` explicitly, all files and the returned snapshot path land in `tmp_dir`, and the `kernels` library uses that path correctly.

The `OSError` from a failed internal thread propagates cleanly through `future.result()` → `hf_thread_map` → `snapshot_download`, where our wrapper catches it.

Fixes: https://github.com/huggingface/transformers/actions/runs/30959531329/job/92160713490?pr=47773