### PR TITLE
Add post-mlinter-review job to post-dashboard-link workflow

### DIFF
--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -40,24 +40,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download mlinter findings artifact
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${GITHUB_REPOSITORY}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" \
-            --jq '.artifacts[] | select(.name == "mlinter-findings") | .id' \
-            > artifact_id.txt
-          ARTIFACT_ID=$(cat artifact_id.txt)
-          if [ -z "$ARTIFACT_ID" ]; then
-            echo "No mlinter-findings artifact found, skipping."
-            exit 0
-          fi
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" \
-            > mlinter-findings.zip
-          unzip -o mlinter-findings.zip
+        uses: actions/download-artifact@v4
+        with:
+          name: mlinter-findings
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Show mlinter findings
         run: |

--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -34,3 +34,34 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 update_pr_ci_dashboard_recap.py
+
+  post-mlinter-review:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download mlinter findings artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" \
+            --jq '.artifacts[] | select(.name == "mlinter-findings") | .id' \
+            > artifact_id.txt
+          ARTIFACT_ID=$(cat artifact_id.txt)
+          if [ -z "$ARTIFACT_ID" ]; then
+            echo "No mlinter-findings artifact found, skipping."
+            exit 0
+          fi
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" \
+            > mlinter-findings.zip
+          unzip -o mlinter-findings.zip
+
+      - name: Show mlinter findings
+        run: |
+          echo "=== mlinter-pr-number.txt ==="
+          cat mlinter-pr-number.txt || echo "(not found)"
+          echo "=== mlinter-findings.json ==="
+          cat mlinter-findings.json || echo "(not found)"

--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -40,6 +40,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download mlinter findings artifact
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: mlinter-findings
@@ -47,8 +49,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Show mlinter findings
+        if: steps.download.outcome == 'success'
         run: |
           echo "=== mlinter-pr-number.txt ==="
-          cat mlinter-pr-number.txt || echo "(not found)"
+          cat mlinter-pr-number.txt
           echo "=== mlinter-findings.json ==="
-          cat mlinter-findings.json || echo "(not found)"
+          cat mlinter-findings.json


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47800)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47800)
<!-- ci-dashboard-badge:end -->

## Summary
- Adds a `post-mlinter-review` job to `pr-ci-post-dashboard-link.yml` that downloads the `mlinter-findings` artifact from the triggering PR CI run and prints its content
- First step toward posting mlinter violations as inline PR review comments

## Note
This needs to be merged to main to take effect (workflow_run workflows always run from the default branch).

## Test plan
- [ ] After merge, trigger a PR CI run and verify the `post-mlinter-review` job successfully downloads and prints the mlinter findings