### PR TITLE
Feat : Add tqdm ASCII hook helper

### DIFF
--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -439,3 +439,28 @@ def set_tqdm_hook(hook: Callable[[Callable[..., Any], tuple[Any, ...], dict[str,
     previous_hook = _tqdm_hook
     _tqdm_hook = hook
     return previous_hook
+
+
+def set_tqdm_ascii(force_ascii: bool) -> Callable[[Callable[..., Any], tuple[Any, ...], dict[str, Any]], Any] | None:
+    """
+    Install a tqdm hook that forces the `ascii` kwarg on tqdm bars.
+
+    Args:
+        force_ascii (`bool`): If `True`, force ASCII progress bars. If `False`, only set `ascii=False` when the
+            caller did not already provide a value.
+
+    Returns:
+        The previous tqdm hook, which can be restored later.
+    """
+
+    previous_hook = _tqdm_hook
+
+    def _ascii_hook(factory: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+        kwargs = dict(kwargs)
+        if "ascii" not in kwargs or force_ascii:
+            kwargs["ascii"] = force_ascii
+        if previous_hook is not None:
+            return previous_hook(factory, args, kwargs)
+        return factory(*args, **kwargs)
+
+    return set_tqdm_hook(_ascii_hook)

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -20,6 +20,7 @@ from huggingface_hub.utils import are_progress_bars_disabled
 import transformers.models.roberta.tokenization_roberta
 from transformers import logging
 from transformers.testing_utils import CaptureLogger, mockenv, mockenv_context
+from transformers.utils import logging as transformers_logging
 from transformers.utils.logging import disable_progress_bar, enable_progress_bar
 
 
@@ -133,3 +134,21 @@ def test_set_progress_bar_enabled():
 
     enable_progress_bar()
     assert not are_progress_bars_disabled()
+
+
+def test_set_tqdm_ascii_does_not_mutate_kwargs():
+    previous_hook = transformers_logging.set_tqdm_hook(None)
+    try:
+        transformers_logging.set_tqdm_ascii(True)
+
+        kwargs = {"total": 3}
+
+        def factory(*args, **factory_kwargs):
+            return factory_kwargs
+
+        result = transformers_logging._tqdm_hook(factory, (), kwargs)
+
+        assert result["ascii"] is True
+        assert kwargs == {"total": 3}
+    finally:
+        transformers_logging.set_tqdm_hook(previous_hook)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47803)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47803)
<!-- ci-dashboard-badge:end -->

This PR adds support for forcing ASCII-style tqdm progress bars through a dedicated helper in the logging utilities. This allows users to opt out of the notebook/IPython widget rendering and use plain text progress bars instead, which can be preferable in terminal and non-interactive environments.

**Changes :**

Added a new helper in the logging utilities to install a tqdm hook that forces the ASCII kwarg.
Kept the implementation aligned with the existing tqdm customization mechanism already used in the logging module.
Added a regression test to confirm that the hook forces ASCII output without mutating the caller’s kwargs.

**Testing**
Verified that the modified Python files compile successfully.

**Fixes #39114  **