### PR TITLE
Hotfix axk2 indexer norm

### DIFF
--- a/src/transformers/models/axk2/modeling_axk2.py
+++ b/src/transformers/models/axk2/modeling_axk2.py
@@ -204,7 +204,7 @@ class AXK2Indexer(nn.Module):
     `past_key_values.update_indexer()`.
     """
 
-    def __init__(self, config: "AXK2Config", layer_idx: int):
+    def __init__(self, config: AXK2Config, layer_idx: int):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx

--- a/src/transformers/models/axk2/modeling_axk2.py
+++ b/src/transformers/models/axk2/modeling_axk2.py
@@ -204,7 +204,7 @@ class AXK2Indexer(nn.Module):
     `past_key_values.update_indexer()`.
     """
 
-    def __init__(self, config: AXK2Config, layer_idx: int):
+    def __init__(self, config: "AXK2Config", layer_idx: int):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx

--- a/src/transformers/models/axk2/modeling_axk2.py
+++ b/src/transformers/models/axk2/modeling_axk2.py
@@ -204,7 +204,7 @@ class AXK2Indexer(nn.Module):
     `past_key_values.update_indexer()`.
     """
 
-    def __init__(self, config: AXK2Config, layer_idx: int):
+    def __init__(self, config: "AXK2Config", layer_idx: int):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
@@ -218,7 +218,7 @@ class AXK2Indexer(nn.Module):
 
         self.wq_b = nn.Linear(self.q_lora_rank, self.n_heads * self.head_dim, bias=False)
         self.wk = nn.Linear(self.hidden_size, self.head_dim, bias=False)
-        self.k_norm = nn.LayerNorm(self.head_dim, eps=1e-5)
+        self.k_norm = nn.LayerNorm(self.head_dim, eps=1e-6)
         self.weights_proj = nn.Linear(self.hidden_size, self.n_heads, bias=False)
         self.softmax_scale = self.head_dim**-0.5
 
@@ -628,7 +628,7 @@ class AXK2Attention(nn.Module):
         indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
         topk_indices = self.indexer(
             hidden_states,
-            q_compressed,
+            q_resid,
             position_embeddings,
             indexer_mask,
             position_ids,

--- a/src/transformers/models/axk2/modular_axk2.py
+++ b/src/transformers/models/axk2/modular_axk2.py
@@ -214,7 +214,8 @@ class AXK2RotaryEmbedding(DeepseekV32RotaryEmbedding):
 
 
 class AXK2Indexer(DeepseekV32Indexer):
-    pass
+    def __init__(self, config: AXK2Config, layer_idx: int):
+        super().__init__(config, layer_idx)
 
 
 class AXK2TopkRouter(DeepseekV32TopkRouter):

--- a/src/transformers/models/axk2/modular_axk2.py
+++ b/src/transformers/models/axk2/modular_axk2.py
@@ -214,8 +214,7 @@ class AXK2RotaryEmbedding(DeepseekV32RotaryEmbedding):
 
 
 class AXK2Indexer(DeepseekV32Indexer):
-    def __init__(self, config: AXK2Config, layer_idx: int):
-        super().__init__(config, layer_idx)
+    pass
 
 
 class AXK2TopkRouter(DeepseekV32TopkRouter):

--- a/src/transformers/models/axk2/modular_axk2.py
+++ b/src/transformers/models/axk2/modular_axk2.py
@@ -214,9 +214,7 @@ class AXK2RotaryEmbedding(DeepseekV32RotaryEmbedding):
 
 
 class AXK2Indexer(DeepseekV32Indexer):
-    def __init__(self, config: AXK2Config, layer_idx: int):
-        super().__init__(config, layer_idx)
-        self.k_norm = nn.LayerNorm(self.head_dim, eps=1e-5)
+    pass
 
 
 class AXK2TopkRouter(DeepseekV32TopkRouter):
@@ -357,7 +355,7 @@ class AXK2Attention(DeepseekV32Attention):
         indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
         topk_indices = self.indexer(
             hidden_states,
-            q_compressed,
+            q_resid,
             position_embeddings,
             indexer_mask,
             position_ids,

--- a/tests/models/axk2/test_modeling_axk2.py
+++ b/tests/models/axk2/test_modeling_axk2.py
@@ -115,14 +115,14 @@ class AXK1IntegrationTest(unittest.TestCase):
         # Last-3x3 logits slice, left-padded (batch 0) and unpadded (batch 1) rows.
         EXPECTED_LOGITS_LEFT_PADDED = Expectations(
             {
-                ("cuda", (8, 6)): [[-1.9062, -3.9688, 2.8438], [-3.5625, -1.6562, 4.2500], [-1.6172, -2.7812, 2.6094]],
+                ("cuda", (8, 6)): [[-1.9062, -3.9688,  2.8438], [-3.5625, -1.6484,  4.2500], [-1.5859, -2.7656,  2.5938]],
                 ("xpu", None): [[-1.9219, -3.9844, 2.8438], [-3.5938, -1.6484, 4.2500], [-1.5859, -2.7812, 2.6094]],
             }
         )
         expected_left_padded = torch.tensor(EXPECTED_LOGITS_LEFT_PADDED.get_expectation(), device=model.device)
         EXPECTED_LOGITS_UNPADDED = Expectations(
             {
-                ("cuda", (8, 6)): [[0.6211, -0.4336, 1.8906], [-3.4219, -1.9219, 2.7188], [-2.0156, -1.5547, -1.3906]],
+                ("cuda", (8, 6)): [[ 0.6133, -0.4355,  1.8906], [-3.4062, -1.9062,  2.7344], [-2.0156, -1.5312, -1.3750]],
                 ("xpu", None): [[0.6250, -0.3906, 1.8984], [-3.4375, -1.8672, 2.7500], [-2.0156, -1.5391, -1.3828]],
             }
         )


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47810)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47810)
<!-- ci-dashboard-badge:end -->

There is currently a mismatch between the HF and vLLM implementations of the AXK2 indexer input.
HF passes the pre-normalization q_compressed, directly after q_a_proj, to the indexer.
vLLM passes the post-normalization q_c, after q_a_layernorm, to the indexer.
This difference may change the indexer scores and top-k selections. For consistency, we are considering updating the HF implementation to match the current vLLM serving behavior by passing the post-normalization query to the indexer.
We are planning to submit the following change as a PR. Would it be possible to handle this as a hotfix and merge it quickly?
topk_indices = self.indexer(
    hidden_states,
-   q_compressed,
+   q_resid,  # post-normalization query
    position_embeddings,
    indexer_mask,
    position_ids,
    past_key_values=past_key_values,
)
This change only affects the indexer input. The main query and attention output-gate paths remain unchanged.!