### PR TITLE
Fix interval merge bug in _find_disjoint that breaks weight tying

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -403,7 +403,7 @@ def _find_disjoint(tensors: list[set[str]], state_dict: dict[str, torch.Tensor])
                 filtered_tensors.append({name})
             else:
                 filtered_tensors[-1].add(name)
-            last_stop = stop
+            last_stop = max(last_stop, stop)
     disjoint_tensors = []
     shared_tensors = []
     for tensors in filtered_tensors:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47814)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47814)
<!-- ci-dashboard-badge:end -->

## Summary

- Fixed a bug in `_find_disjoint()` (`src/transformers/modeling_utils.py`, line 406) where `last_stop = stop` should be `last_stop = max(last_stop, stop)`
- When a short tensor is fully contained inside a larger tensor in shared storage, `last_stop` shrinks to the smaller tensor's end pointer, causing subsequent overlapping tensors to be incorrectly classified as disjoint
- This leads to shared weights being `.clone()`'d and saved as independent tensors, silently breaking weight tying after `save_pretrained` -> `from_pretrained` round-trip

## Example

```
Tensor A: [0 ------------------- 100]   (large tensor)
Tensor B:    [10 --- 50]                 (contained in A)
Tensor C:            [60 --- 90]         (contained in A)
```

After processing B, `last_stop` drops from 100 to 50. Then C's `start=60 >= 50` is true, so C is incorrectly put in a new disjoint group -- even though it overlaps with A.

## Test plan

- [ ] Verify existing `_find_disjoint` tests still pass
- [ ] Test with 3+ tensors sharing storage where one is a slice fully contained inside another
- [ ] Confirm `save_pretrained` -> `from_pretrained` round-trip preserves weight tying in this scenario