### PR TITLE
fix(whisper): auto-cast input_features to encoder dtype to fix float16 checkpoints

### DIFF
--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -615,6 +615,13 @@ class WhisperEncoder(WhisperPreTrainedModel):
                 f"Whisper expects the mel input features to be of length {expected_seq_length}, but found {input_features.shape[-1]}. Make sure to pad the input mel features to {expected_seq_length}."
             )
 
+        # Auto-cast input_features to the encoder weight dtype so checkpoints
+        # that declare float16 (e.g. whisper-large-v3) work with the default
+        # WhisperFeatureExtractor output (float32) on the manual path.
+        # Mirrors what the pipeline does via `self.dtype`.
+        if input_features.dtype != self.conv1.weight.dtype:
+            input_features = input_features.to(dtype=self.conv1.weight.dtype)
+
         inputs_embeds = nn.functional.gelu(self.conv1(input_features))
         inputs_embeds = nn.functional.gelu(self.conv2(inputs_embeds))
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47816&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47816) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47816&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47816)
<!-- ci-dashboard-badge:end -->

Fixes #47805.

`WhisperFeatureExtractor` produces float32 features. Passing them directly to a half-precision Whisper encoder can fail at the convolution with a dtype mismatch.

Cast input features to the encoder convolution weight dtype at the start of `WhisperEncoder.forward`, matching the high-level pipeline's dtype conversion. Matching dtypes are unchanged.

Includes Kayvan Zahiri's regression test from https://github.com/sankalpsthakur/transformers/pull/1, as requested in review.

Validation on Python 3.12 / PyTorch 2.14.0, CPU: `python -m pytest tests/models/whisper/test_modeling_whisper.py -k test_generate_fp16 -q` passes both tests. Removing the dtype conversion makes the new test fail with the float/half convolution error; the existing FP16 test still passes. Ruff check and formatting pass.

### AI disclosure
Codex assisted with the implementation, review, validation and description. Kayvan Zahiri contributed the regression test and disclosed Claude Code assistance.
