### PR TITLE
Post mlinter findings as inline PR review comments

### DIFF
--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -48,10 +48,12 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Show mlinter findings
+      - name: Checkout repo (for post_mlinter_review.py and github_utils.py)
         if: steps.download.outcome == 'success'
-        run: |
-          echo "=== mlinter-pr-number.txt ==="
-          cat mlinter-pr-number.txt
-          echo "=== mlinter-findings.json ==="
-          cat mlinter-findings.json
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Post mlinter review
+        if: steps.download.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 utils/post_mlinter_review.py

--- a/utils/post_mlinter_review.py
+++ b/utils/post_mlinter_review.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Post mlinter findings as an inline PR review.
+
+Runs in the workflow_run privileged job (pull-requests: write). Reads
+mlinter-findings.json and mlinter-pr-number.txt produced by the
+check_code_quality job. Never checks out or executes PR code.
+
+Usage:
+    GITHUB_TOKEN=... GITHUB_REPOSITORY=owner/repo python utils/post_mlinter_review.py
+"""
+
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+# github_utils is present because the workflow checks out the repo.
+from github_utils import get_github_json, github_request
+
+
+GITHUB_API_URL = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+# Lets a re-run recognise its own previous review instead of stacking duplicates.
+MARKER = "<!-- mlinter-review -->"
+MAX_INLINE = 40
+MAX_PER_FILE = 10
+
+
+def _paginate(url, token):
+    items = []
+    page = 1
+    while page <= 20:
+        sep = "&" if "?" in url else "?"
+        batch = get_github_json(f"{url}{sep}per_page=100&page={page}", token=token)
+        if not isinstance(batch, list) or not batch:
+            break
+        items.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return items
+
+
+def _commentable_lines(patch):
+    """Return line numbers on the head side that GitHub accepts as comment anchors."""
+    lines = set()
+    head = 0
+    for raw in (patch or "").splitlines():
+        if raw.startswith("@@"):
+            try:
+                head = int(raw.split("+", 1)[1].split(",")[0].split()[0])
+            except (IndexError, ValueError):
+                head = 0
+            continue
+        if raw.startswith("-"):
+            continue
+        if raw.startswith(("+", " ")) and head:
+            lines.add(head)
+            head += 1
+    return lines
+
+
+def _comment_body(finding, rules):
+    rule = finding["rule"]
+    spec = rules.get(rule, {})
+    lines = [f"**{rule}** — {finding['message']}"]
+    why = (spec.get("why_bad") or "").strip()
+    diff = (spec.get("diff") or "").strip()
+    if why or diff:
+        lines += ["", "<details><summary>Why this matters</summary>", ""]
+        if why:
+            lines += [why, ""]
+        if diff:
+            lines += ["```diff", diff, "```", ""]
+        lines += [f"Suppress with `# trf-ignore: {rule}` if intentional.", "", "</details>"]
+    return "\n".join(lines)
+
+
+def _review_body(findings, rules, skipped):
+    counts = Counter(f["rule"] for f in findings)
+    lines = [
+        MARKER,
+        "## Model linter — first pass",
+        "",
+        f"`transformers-mlinter` found **{len(findings)} item(s)** in the model files this PR touches. "
+        "These are structural conventions a maintainer would otherwise flag by hand.",
+        "",
+        "This is automated and advisory — it does not block merging.",
+        "",
+        "| rule | count | what it checks |",
+        "| --- | --- | --- |",
+    ]
+    for rule, count in counts.most_common():
+        description = (rules.get(rule, {}).get("description") or "").replace("|", "\\|")
+        lines.append(f"| `{rule}` | {count} | {description} |")
+    if skipped:
+        lines += [
+            "",
+            f"<details><summary>{len(skipped)} item(s) outside this diff</summary>",
+            "",
+        ]
+        for f in skipped:
+            lines.append(f"- `{f['path']}:{f['line']}` **{f['rule']}** — {f['message']}")
+        lines += ["", "</details>"]
+    return "\n".join(lines)
+
+
+def main():
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+
+    pr_number_path = Path("mlinter-pr-number.txt")
+    findings_path = Path("mlinter-findings.json")
+
+    if not pr_number_path.exists() or not findings_path.exists():
+        print("Artifact files missing; skipping.")
+        return 0
+
+    pr_number = pr_number_path.read_text().strip()
+    if not pr_number:
+        print("No PR number; skipping.")
+        return 0
+
+    payload = json.loads(findings_path.read_text())
+    findings = payload.get("findings") or []
+    rules = payload.get("rules") or {}
+
+    if not findings:
+        print("No findings; not posting.")
+        return 0
+
+    pulls_url = f"{GITHUB_API_URL}/repos/{repo}/pulls/{pr_number}"
+
+    # Don't post twice on the same PR.
+    for review in _paginate(f"{pulls_url}/reviews", token):
+        if MARKER in (review.get("body") or ""):
+            print(f"Already posted review {review['id']}; skipping.")
+            return 0
+
+    # Map each changed file to its commentable lines.
+    anchors = {
+        f["filename"]: _commentable_lines(f.get("patch"))
+        for f in _paginate(f"{pulls_url}/files", token)
+    }
+
+    comments = []
+    skipped = []
+    per_file = defaultdict(int)
+    for finding in findings:
+        path, line = finding["path"], finding["line"]
+        if line in anchors.get(path, set()) and len(comments) < MAX_INLINE and per_file[path] < MAX_PER_FILE:
+            comments.append({"path": path, "line": line, "side": "RIGHT", "body": _comment_body(finding, rules)})
+            per_file[path] += 1
+        else:
+            skipped.append(finding)
+
+    body = _review_body(findings, rules, skipped)
+    try:
+        review = github_request(
+            f"{pulls_url}/reviews",
+            token=token,
+            method="POST",
+            payload={"event": "COMMENT", "body": body, "comments": comments},
+        )
+        print(f"Posted review {review['id']} with {len(comments)} inline comment(s).")
+    except RuntimeError as exc:
+        # Anchor rejection (e.g. force-push race): fall back to summary-only.
+        print(f"Inline review failed: {exc}; posting summary only.", file=sys.stderr)
+        review = github_request(
+            f"{pulls_url}/reviews",
+            token=token,
+            method="POST",
+            payload={"event": "COMMENT", "body": body},
+        )
+        print(f"Posted summary-only review {review['id']}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/post_mlinter_review.py
+++ b/utils/post_mlinter_review.py
@@ -151,10 +151,7 @@ def main():
             return 0
 
     # Map each changed file to its commentable lines.
-    anchors = {
-        f["filename"]: _commentable_lines(f.get("patch"))
-        for f in _paginate(f"{pulls_url}/files", token)
-    }
+    anchors = {f["filename"]: _commentable_lines(f.get("patch")) for f in _paginate(f"{pulls_url}/files", token)}
 
     comments = []
     skipped = []


### PR DESCRIPTION
## What this does

Adds a `post-mlinter-review` job to `pr-ci-post-dashboard-link.yml` that:
1. Downloads the `mlinter-findings` artifact produced by the `check_code_quality` job
2. Posts the findings as a single PR review with inline comments anchored to the diff

The review includes a summary table (rule → count) and per-finding inline comments with a collapsible `<details>` block explaining why the rule matters and showing an example fix.

## Security
Follows the same `workflow_run` split as the existing `post-link` job:
- The untrusted job (`check_code_quality`) only writes the artifact — no write access
- This job runs with `pull-requests: write` but checks out main (not PR code)

## Depends on
- `transformers-mlinter` PR #22 (`--output-json` flag with rule specs)
- `transformers-ci` `check_mlinter` branch (artifact upload step)