### PR TITLE
Fix duplicate flash-attention kwargs in Qwen omni/VL encoders

### DIFF
--- a/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
@@ -59,6 +59,7 @@ from ...utils import (
 from ...utils.deprecation import deprecate_kwarg
 from ...utils.generic import (
     accepts_precomputed_kwargs,
+    drop_inherited_flash_attention_kwargs,
     get_max_seqlen,
     is_flash_attention_requested,
     maybe_autocast,
@@ -892,6 +893,7 @@ class Qwen2_5OmniAudioEncoder(Qwen2_5OmniPreTrainedModel):
         pool_indices = get_pool_indices(feature_lens, kwargs=kwargs)
         cu_seqlens = get_audio_cu_seqlens(chunk_lengths, kwargs=kwargs)
         max_seqlen = get_max_seqlen(cu_seqlens, self.config, kwargs=kwargs)
+        drop_inherited_flash_attention_kwargs(kwargs)
 
         # Derive masks from chunk_lengths (traceable arithmetic + arange broadcasting)
         padded_feature = padded_feature.to(self.conv1.weight.dtype)
@@ -1287,6 +1289,7 @@ class Qwen2_5OmniVisionEncoder(Qwen2_5OmniPreTrainedModel):
         max_window_seqlen = get_max_seqlen(
             cu_window_seqlens, self.config, kwargs=kwargs, kwarg_name="max_window_seqlen"
         )
+        drop_inherited_flash_attention_kwargs(kwargs)
 
         hidden_states = self.patch_embed(hidden_states)
 

--- a/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
@@ -46,6 +46,7 @@ from ...utils import (
 from ...utils.deprecation import deprecate_kwarg
 from ...utils.generic import (
     accepts_precomputed_kwargs,
+    drop_inherited_flash_attention_kwargs,
     get_max_seqlen,
     is_flash_attention_requested,
     merge_with_config_defaults,
@@ -1372,6 +1373,7 @@ class Qwen2_5OmniAudioEncoder(Qwen2_5OmniPreTrainedModel):
         pool_indices = get_pool_indices(feature_lens, kwargs=kwargs)
         cu_seqlens = get_audio_cu_seqlens(chunk_lengths, kwargs=kwargs)
         max_seqlen = get_max_seqlen(cu_seqlens, self.config, kwargs=kwargs)
+        drop_inherited_flash_attention_kwargs(kwargs)
 
         # Derive masks from chunk_lengths (traceable arithmetic + arange broadcasting)
         padded_feature = padded_feature.to(self.conv1.weight.dtype)
@@ -1621,6 +1623,7 @@ class Qwen2_5OmniVisionEncoder(Qwen2_5_VisionTransformerPretrainedModel):
         max_window_seqlen = get_max_seqlen(
             cu_window_seqlens, self.config, kwargs=kwargs, kwarg_name="max_window_seqlen"
         )
+        drop_inherited_flash_attention_kwargs(kwargs)
 
         hidden_states = self.patch_embed(hidden_states)
 

--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -53,6 +53,7 @@ from ...utils.deprecation import deprecate_kwarg
 from ...utils.generic import (
     TransformersKwargs,
     accepts_precomputed_kwargs,
+    drop_inherited_flash_attention_kwargs,
     get_max_seqlen,
     is_flash_attention_requested,
     maybe_autocast,
@@ -819,6 +820,7 @@ class Qwen3OmniMoeAudioEncoder(Qwen3OmniMoePreTrainedModel):
             chunk_lengths, feature_lens, self.n_window_infer, self.n_window, kwargs=kwargs
         )
         max_seqlen = get_max_seqlen(cu_seqlens, self.config, kwargs=kwargs)
+        drop_inherited_flash_attention_kwargs(kwargs)
 
         # Add channel dim for Conv2d: (num_chunks, mel_bins, time) -> (num_chunks, 1, mel_bins, time)
         padded_feature = padded_feature.unsqueeze(1).to(dtype=self.conv2d1.weight.dtype)
@@ -1177,6 +1179,7 @@ class Qwen3OmniMoeVisionEncoder(Qwen3OmniMoePreTrainedModel):
         )
         position_ids = get_vision_position_ids(grid_thw, self.spatial_merge_size, kwargs=kwargs)
         cu_seqlens, max_seqlen = get_vision_attention_seqlens(grid_thw, self.config, kwargs=kwargs)
+        drop_inherited_flash_attention_kwargs(kwargs)
 
         hidden_states = self.patch_embed(hidden_states)
         pos_embeds = (self.pos_embed(interp_indices) * interp_weights[:, :, None]).sum(1)

--- a/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
@@ -49,6 +49,7 @@ from ...utils import auto_docstring, can_return_tuple, logging
 from ...utils.generic import (
     TransformersKwargs,
     accepts_precomputed_kwargs,
+    drop_inherited_flash_attention_kwargs,
     get_max_seqlen,
     merge_with_config_defaults,
 )
@@ -1036,6 +1037,7 @@ class Qwen3OmniMoeAudioEncoder(Qwen2_5OmniAudioEncoder):
             chunk_lengths, feature_lens, self.n_window_infer, self.n_window, kwargs=kwargs
         )
         max_seqlen = get_max_seqlen(cu_seqlens, self.config, kwargs=kwargs)
+        drop_inherited_flash_attention_kwargs(kwargs)
 
         # Add channel dim for Conv2d: (num_chunks, mel_bins, time) -> (num_chunks, 1, mel_bins, time)
         padded_feature = padded_feature.unsqueeze(1).to(dtype=self.conv2d1.weight.dtype)

--- a/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -48,6 +48,7 @@ from ...utils import (
 from ...utils.deprecation import deprecate_kwarg
 from ...utils.generic import (
     accepts_precomputed_kwargs,
+    drop_inherited_flash_attention_kwargs,
     get_max_seqlen,
     is_flash_attention_requested,
     maybe_autocast,
@@ -701,6 +702,7 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
         )
         position_ids = get_vision_position_ids(grid_thw, self.spatial_merge_size, kwargs=kwargs)
         cu_seqlens, max_seqlen = get_vision_attention_seqlens(grid_thw, self.config, kwargs=kwargs)
+        drop_inherited_flash_attention_kwargs(kwargs)
 
         hidden_states = self.patch_embed(hidden_states)
         pos_embeds = (self.pos_embed(interp_indices) * interp_weights[:, :, None]).sum(1)

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -38,6 +38,7 @@ from ...utils import auto_docstring, can_return_tuple, logging
 from ...utils.deprecation import deprecate_kwarg
 from ...utils.generic import (
     accepts_precomputed_kwargs,
+    drop_inherited_flash_attention_kwargs,
     maybe_autocast,
     merge_with_config_defaults,
 )
@@ -510,6 +511,7 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
         )
         position_ids = get_vision_position_ids(grid_thw, self.spatial_merge_size, kwargs=kwargs)
         cu_seqlens, max_seqlen = get_vision_attention_seqlens(grid_thw, self.config, kwargs=kwargs)
+        drop_inherited_flash_attention_kwargs(kwargs)
 
         hidden_states = self.patch_embed(hidden_states)
         pos_embeds = (self.pos_embed(interp_indices) * interp_weights[:, :, None]).sum(1)

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -49,6 +49,7 @@ from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, torch
 from ...utils.deprecation import deprecate_kwarg
 from ...utils.generic import (
     accepts_precomputed_kwargs,
+    drop_inherited_flash_attention_kwargs,
     get_max_seqlen,
     is_flash_attention_requested,
     maybe_autocast,
@@ -701,6 +702,7 @@ class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
         )
         position_ids = get_vision_position_ids(grid_thw, self.spatial_merge_size, kwargs=kwargs)
         cu_seqlens, max_seqlen = get_vision_attention_seqlens(grid_thw, self.config, kwargs=kwargs)
+        drop_inherited_flash_attention_kwargs(kwargs)
 
         hidden_states = self.patch_embed(hidden_states)
         pos_embeds = (self.pos_embed(interp_indices) * interp_weights[:, :, None]).sum(1)

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -330,6 +330,24 @@ def get_max_seqlen(
     return (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
 
 
+def drop_inherited_flash_attention_kwargs(kwargs: dict) -> None:
+    """Remove the text model's sequence-packing kwargs from an encoder's `kwargs`, in place.
+
+    Multimodal models forward the language model's `**kwargs` into their audio/vision towers, so packing
+    metadata describing the *text* batch (as produced by `DataCollatorWithFlattening`) reaches encoders
+    that derive their own boundaries from the modality inputs (e.g. `feature_lens` / `grid_thw`). Those
+    inherited values describe a different tensor and would otherwise collide with the `cu_seq_lens_q`
+    /`max_length_q` values each encoder passes to the attention interface, raising
+    ``TypeError: got multiple values for keyword argument 'cu_seq_lens_q'``. Encoder-side precomputed
+    values use their own names (e.g. `cu_seqlens`, `max_seqlen`), so they are left untouched.
+
+    Args:
+        kwargs: encoder caller kwargs, mutated in place.
+    """
+    for key in ("cu_seq_lens_q", "cu_seq_lens_k", "max_length_q", "max_length_k"):
+        kwargs.pop(key, None)
+
+
 def split_attention_implementation(implementation: str | None) -> tuple[bool, str | None]:
     """
     Split the optional `paged|` prefix from an attention implementation string.

--- a/tests/models/qwen3_omni_moe/test_modeling_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_modeling_qwen3_omni_moe.py
@@ -472,12 +472,6 @@ class Qwen3OmniMoeThinkerForConditionalGenerationModelTest(ModelTesterMixin, Gen
     def test_sdpa_padding_matches_padding_free_with_position_ids(self):
         pass
 
-    @unittest.skip(
-        "Text FlashAttention kwargs are also forwarded to vision attention, which computes its own cu_seqlens"
-    )
-    def test_flash_attention_2_padding_matches_padding_free_with_position_ids_and_fa_kwargs(self):
-        pass
-
     @unittest.skip("Cannot handle 4D attention mask")
     def test_generate_with_static_cache(self):
         pass


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47823)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47823)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes a `TypeError` raised when packed-sequence FlashAttention metadata is passed as top-level model inputs to the Qwen omni / VL models.

When `cu_seq_lens_q`, `cu_seq_lens_k`, `max_length_q`, `max_length_k` (e.g. produced by `DataCollatorWithFlattening`) are provided, the thinker forwards them verbatim through `**kwargs` into the audio and vision towers. Those encoders derive their **own** packing boundaries from the modality inputs and pass their own `cu_seq_lens_q=...` explicitly to the attention interface while also splatting `**kwargs`, so the same keyword is supplied twice:

```
TypeError: transformers.integrations.flash_attention.flash_attention_forward() got multiple values for keyword argument 'cu_seq_lens_q'
```

This happens before FlashAttention even runs, so it is a pure argument-binding error and is hardware-independent. The two sets of boundaries describe different tensors (the text batch vs. the audio/vision frames), so the encoder's own values must take precedence.

## Fix

Add a small shared helper `drop_inherited_flash_attention_kwargs` in `utils.generic` (next to `get_max_seqlen`) that strips the four text-side packing keys, and call it at each tower's entry point, right after it computes its own boundaries:

- `qwen2_5_omni`: audio + vision encoders (replaces a model-local helper with the shared one).
- `qwen3_vl` vision model — this also covers `qwen3_vl_moe` and `qwen3_omni_moe`, whose vision towers inherit this `forward`.
- `qwen3_omni_moe`: audio encoder.

The encoder-side precomputed channel uses different names (`cu_seqlens`, `max_seqlen`, `max_window_seqlen`), so the four dropped keys arriving at a tower are always text-side leakage and safe to remove. Each `**kwargs` is a fresh per-call dict, so mutating it inside a tower cannot affect the text path.

All edits are made in the `modular_*.py` sources with the `modeling_*.py` files regenerated (`utils/modular_model_converter.py`); regeneration is idempotent and `check_modular_conversion` / `ruff` are clean.

This also un-skips `Qwen3OmniMoeThinkerForConditionalGenerationModelTest::test_flash_attention_2_padding_matches_padding_free_with_position_ids_and_fa_kwargs`, which was previously skipped precisely because of this leak.

## Testing

Verified with real FlashAttention-2. The previously failing `*_padding_matches_padding_free_*_and_fa_kwargs` tests now pass (including the numerical padded-vs-padding-free logits assertion) for `qwen2_5_omni`, `qwen3_vl`, `qwen3_vl_moe` and `qwen3_omni_moe`, with no regressions in the padding-free test group.

## Before submitting
- [x] Did you make sure to update the documentation with your changes? (N/A - internal helper)
- [x] Did you write any new necessary tests? (re-enabled an existing test that this fixes)