### PR TITLE
Allow QuantizedCache with sliding and chunked attention

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1934,7 +1934,7 @@ class QuantizedCache(Cache):
         for layer_type in layer_types:
             if layer_type == "full_attention":
                 layers.append(layer_class(nbits, axis_key, axis_value, q_group_size, residual_length))
-            else:
+            elif layer_type in ("sliding_attention", "chunked_attention"):
                 layers.append(DynamicSlidingWindowLayer(sliding_window=layer_kwargs["sliding_window"]))
         super().__init__(layers=layers)
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1923,17 +1923,19 @@ class QuantizedCache(Cache):
             raise ValueError(f"Unknown quantization backend `{backend}`")
 
         config = config.get_text_config(decoder=True)
-        layer_types, _ = get_layer_types_and_kwargs(config)
-        invalid_layer_types = set(layer_types) - {"full_attention"}
+        layer_types, layer_kwargs = get_layer_types_and_kwargs(config)
+        invalid_layer_types = set(layer_types) - {"full_attention", "sliding_attention", "chunked_attention"}
         if len(invalid_layer_types) > 0:
             raise ValueError(
-                "`QuantizedCache` is only supported for models with only full attention layers. We found the following invalid layer "
+                "`QuantizedCache` is only supported for models with full, sliding, or chunked attention layers. We found the following invalid layer "
                 f"types: {invalid_layer_types}"
             )
-        layers = [
-            layer_class(nbits, axis_key, axis_value, q_group_size, residual_length)
-            for _ in range(config.num_hidden_layers)
-        ]
+        layers = []
+        for layer_type in layer_types:
+            if layer_type == "full_attention":
+                layers.append(layer_class(nbits, axis_key, axis_value, q_group_size, residual_length))
+            else:
+                layers.append(DynamicSlidingWindowLayer(sliding_window=layer_kwargs["sliding_window"]))
         super().__init__(layers=layers)
 
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -83,6 +83,7 @@ if is_torch_available():
     from transformers.cache_utils import (
         Cache,
         DynamicCache,
+        DynamicSlidingWindowLayer,
         EncoderDecoderCache,
         LinearAttentionAndFullAttentionLayer,
         LinearAttentionAndSlidingWindowAttentionLayer,
@@ -1584,7 +1585,11 @@ class GenerationTesterMixin(ExportGenerateTesterMixin):
             }
 
             results = model.generate(**generation_kwargs, **inputs_dict)
-            self.assertTrue(all(isinstance(layer, QuantoQuantizedLayer) for layer in results.past_key_values.layers))
+            cache_layers = results.past_key_values.layers
+            self.assertTrue(any(isinstance(layer, QuantoQuantizedLayer) for layer in cache_layers))
+            self.assertTrue(
+                all(isinstance(layer, (QuantoQuantizedLayer, DynamicSlidingWindowLayer)) for layer in cache_layers)
+            )
 
             # passing past key values of different type should raise Error
             with self.assertRaises(ValueError):

--- a/tests/models/granite_swa/test_modeling_granite_swa.py
+++ b/tests/models/granite_swa/test_modeling_granite_swa.py
@@ -48,11 +48,6 @@ class GraniteSWAModelTester(CausalLMModelTester):
 class GraniteSWAModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = GraniteSWAModelTester
 
-    @pytest.mark.generate
-    @unittest.skip("GraniteSWA does not support QuantizedCache as it uses sliding_attention layers")
-    def test_generate_with_quant_cache(self):
-        pass
-
 
 @slow
 @require_torch_accelerator

--- a/tests/models/granite_swa/test_modeling_granite_swa.py
+++ b/tests/models/granite_swa/test_modeling_granite_swa.py
@@ -15,8 +15,6 @@
 
 import unittest
 
-import pytest
-
 from transformers import is_torch_available
 from transformers.testing_utils import (
     Expectations,

--- a/tests/models/granitemoe_swa/test_modeling_granitemoe_swa.py
+++ b/tests/models/granitemoe_swa/test_modeling_granitemoe_swa.py
@@ -46,10 +46,6 @@ class GraniteMoeSWAModelTester(CausalLMModelTester):
 class GraniteMoeSWAModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = GraniteMoeSWAModelTester
 
-    @unittest.skip("GraniteMoeSWA sliding attention layers are not compatible with QuantizedCache.")
-    def test_generate_with_quant_cache(self):
-        pass
-
 
 @slow
 @require_torch_accelerator

--- a/tests/models/mimo_v2_flash/test_modeling_mimo_v2_flash.py
+++ b/tests/models/mimo_v2_flash/test_modeling_mimo_v2_flash.py
@@ -81,10 +81,6 @@ class MiMoV2FlashModelTest(CausalLMModelTest, unittest.TestCase):
     def test_model_rope_scaling_from_config(self, scaling_type):
         pass
 
-    @unittest.skip("MiMo-V2-Flash uses sliding_attention layers, which are not compatible with QuantizedCache")
-    def test_generate_with_quant_cache(self):
-        pass
-
     # Test from Gemma3 adapted to MiMo
     def test_model_rope_scaling_frequencies(self):
         """Tests the frequency properties of the different RoPE scaling types on the model RoPE layer."""

--- a/tests/models/qwen3_omni_moe/test_modeling_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_modeling_qwen3_omni_moe.py
@@ -447,7 +447,9 @@ class Qwen3OmniMoeThinkerForConditionalGenerationModelTest(ModelTesterMixin, Gen
     def test_generate_from_inputs_embeds_with_static_cache(self):
         pass
 
-    @unittest.skip("QuantizedCache does not support sliding attention")
+    @unittest.skip(
+        "The test config only has sliding attention layers, so there are no full attention layers to quantize"
+    )
     def test_generate_with_quant_cache(self):
         pass
 

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -64,6 +64,7 @@ if is_torch_available():
         LinearAttentionAndFullAttentionLayer,
         LinearAttentionAndSlidingWindowAttentionLayer,
         LinearAttentionLayer,
+        QuantoQuantizedLayer,
         StaticLayer,
     )
     from transformers.integrations.executorch import export_with_dynamic_cache
@@ -323,6 +324,18 @@ class CacheIntegrationTest(unittest.TestCase):
         self.assertListEqual(decoded, expected_generation)
 
         # Check that something is actually quantized
+
+    def test_quantized_cache_with_sliding_layers(self):
+        if not is_optimum_quanto_available():
+            self.skipTest("Quanto is not available")
+
+        config = LlamaConfig(
+            num_hidden_layers=2, layer_types=["full_attention", "sliding_attention"], sliding_window=8
+        )
+        cache = QuantizedCache(backend="quanto", config=config, nbits=4, q_group_size=16, residual_length=4)
+
+        self.assertIsInstance(cache.layers[0], QuantoQuantizedLayer)
+        self.assertIsInstance(cache.layers[1], DynamicSlidingWindowLayer)
 
     @parameterized.expand(TEST_CACHE_IMPLEMENTATIONS)
     def test_cache_extra_left_padding(self, cache_implementation):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47828)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47828)
<!-- ci-dashboard-badge:end -->

Adds hybrid QuantizedCache support for models with sliding or chunked attention by quantizing full-attention layers while keeping sliding/chunked layers on DynamicSlidingWindowLayer. This is useful for some models like gemma4,mimov2_flash and so on. Pls help review, thx! @Cyrilvallez @IlyasMoutawwakil