### PR TITLE
Serialize post-mlinter-review after post-link to avoid PR description race

### DIFF
--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -36,7 +36,7 @@ jobs:
         run: python3 update_pr_ci_dashboard_recap.py
 
   post-mlinter-review:
-    if: github.event.workflow_run.event == 'pull_request'
+    if: always() && github.event.workflow_run.event == 'pull_request'
     needs: post-link
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -37,6 +37,7 @@ jobs:
 
   post-mlinter-review:
     if: github.event.workflow_run.event == 'pull_request'
+    needs: post-link
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo (for post_mlinter_review.py and github_utils.py)


### PR DESCRIPTION
## Summary

Both `post-link` and `post-mlinter-review` jobs patch the PR description concurrently. Since both read the description before either writes, the last writer silently overwrites the other's changes — the mlinter state block gets lost when `post-link` writes last.

Adding `needs: post-link` serializes the jobs so `post-mlinter-review` waits for `post-link` to finish, then reads the already-updated description (with CI badge) before appending the mlinter state block. `always()` ensures `post-mlinter-review` still runs even if `post-link` fails.

One-line fix, no code changes.

## Related
- #47830 (mlinter state block in PR description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)