### PR TITLE
[Mistral] Add params.json and HF config conversion

### DIFF
--- a/src/transformers/integrations/mistral/__init__.py
+++ b/src/transformers/integrations/mistral/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Mistral native format integration: tekken tokenizer conversion."""
+"""Mistral native format integration: tokenizer and config conversion utilities."""
 
 from typing import TYPE_CHECKING
 
@@ -20,6 +20,14 @@ from ...utils import _LazyModule
 
 
 _import_structure = {
+    "native_config": [
+        "MistralNativeConfig",
+        "mistral_native_config_from_params",
+    ],
+    "params_conversion": [
+        "mistral_native_config_from_hf_config",
+        "mistral_native_config_to_hf_config",
+    ],
     "tokenizer": [
         "MistralConverter",
         "convert_tekken_tokenizer",
@@ -28,11 +36,12 @@ _import_structure = {
 }
 
 if TYPE_CHECKING:
-    from .tokenizer import (
-        MistralConverter,
-        convert_tekken_tokenizer,
-        resolve_mistral_format,
+    from .native_config import (
+        MistralNativeConfig,
+        mistral_native_config_from_params,
     )
+    from .params_conversion import mistral_native_config_from_hf_config, mistral_native_config_to_hf_config
+    from .tokenizer import MistralConverter, convert_tekken_tokenizer, resolve_mistral_format
 else:
     import sys
 

--- a/src/transformers/integrations/mistral/native_config.py
+++ b/src/transformers/integrations/mistral/native_config.py
@@ -1,0 +1,303 @@
+# Copyright 2026 Mistral AI and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Mistral native params.json schema and its parsing into MistralNativeConfig."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, TypeVar
+
+from ...quantizers.auto import AutoQuantizationConfig
+from ...utils.quantization_config import QuantizationConfigMixin
+
+
+@dataclass
+class Llama4Scaling:
+    """Llama 4 scaling parameters for extended context RoPE."""
+
+    original_max_position_embeddings: int
+    beta: float
+
+
+@dataclass
+class YarnArgs:
+    """YaRN (Yet another RoPE extensioN) parameters.
+
+    Note:
+        The Mistral native format uses `beta` / `alpha`, which map to HF
+        `rope_parameters["beta_fast"]` / `rope_parameters["beta_slow"]` respectively.
+    """
+
+    factor: float
+    original_max_position_embeddings: int
+    beta: float  # corresponds to HF rope_parameters["beta_fast"]
+    alpha: float  # corresponds to HF rope_parameters["beta_slow"]
+    apply_scale: bool
+
+
+# Maps a native `qscheme_act` value to the corresponding HF quantization `activation_scheme`.
+# The single source of truth for which quantization schemes this module supports.
+_QUANTIZATION_SCHEME_MAP: dict[str, str] = {"TENSOR": "static"}
+
+
+class QFormat(str, Enum):
+    """Supported quantization weight formats."""
+
+    FP8_E4M3 = "fp8_e4m3"
+
+
+@dataclass
+class QuantizationArgs:
+    """Native Mistral quantization configuration.
+
+    `qformat_weight` accepts a `str` (e.g. `"fp8_e4m3"`) at construction time; `__post_init__`
+    coerces it to `QFormat`, so it is a `QFormat` on every instance afterward.
+    """
+
+    qformat_weight: QFormat
+    qscheme_act: str
+
+    def __post_init__(self) -> None:
+        try:
+            self.qformat_weight = QFormat(self.qformat_weight)
+        except ValueError as e:
+            raise ValueError(
+                f"Unsupported quantization format {self.qformat_weight!r}; only {[q.value for q in QFormat]} are supported."
+            ) from e
+        if self.qscheme_act not in _QUANTIZATION_SCHEME_MAP:
+            raise ValueError(
+                f"Unsupported quantization scheme {self.qscheme_act!r}; "
+                f"supported schemes: {sorted(_QUANTIZATION_SCHEME_MAP)}."
+            )
+
+
+@dataclass
+class MOEModelArgs:
+    """Mixture-of-Experts architecture parameters."""
+
+    first_k_dense_replace: int
+    num_experts: int
+    num_experts_per_tok: int
+    num_expert_groups: int
+    num_expert_groups_per_tok: int
+    routed_scale: float
+    expert_hidden_dim: int
+    num_shared_experts: int
+    # Runtime topology, unrepresentable in HF configs. These constructor defaults are what
+    # applies when `mistral_extras` is absent or omits the field.
+    expert_parallel: int = 1
+    expert_model_parallel: int = 1
+    route_every_n: int = 1
+
+
+@dataclass
+class VisionEncoderArgs:
+    """Vision encoder configuration for multimodal Mistral models."""
+
+    image_token_id: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    mm_projector_id: str
+    spatial_merge_size: int
+    hidden_size: int
+    num_channels: int
+    image_size: int
+    max_image_size: int
+    patch_size: int
+    rope_theta: float
+    add_pre_mm_projector_layer_norm: bool
+    adapter_bias: bool
+    # Token id defaults match Mistral's tekken.json: [IMG_BREAK] = 12, [IMG_END] = 13.
+    # `max_image_size` above has no fixed default; callers derive one from the vision config
+    # instead.
+    image_break_token_id: int = 12
+    image_end_token_id: int = 13
+
+
+@dataclass
+class MistralNativeConfig:
+    """Complete native Mistral configuration from params.json."""
+
+    dim: int
+    n_layers: int
+    head_dim: int
+    hidden_dim: int
+    n_heads: int
+    n_kv_heads: int
+    rope_theta: float
+    norm_eps: float
+    vocab_size: int
+    max_position_embeddings: int | None = None
+    sliding_window: int | None = None
+    tied_embeddings: bool = False
+    llama_4_scaling: Llama4Scaling | None = None
+    q_lora_rank: int | None = None
+    qk_rope_head_dim: int | None = None
+    qk_nope_head_dim: int | None = None
+    kv_lora_rank: int | None = None
+    v_head_dim: int | None = None
+    quantization: QuantizationArgs | None = None
+    quantization_config: QuantizationConfigMixin | None = None
+    yarn: YarnArgs | None = None
+    moe: MOEModelArgs | None = None
+    vision_encoder: VisionEncoderArgs | None = None
+
+    def __post_init__(self) -> None:
+        if self.quantization is not None and self.quantization_config is not None:
+            raise ValueError(
+                "Cannot set both `quantization` (Mistral format) and `quantization_config` (HF format) "
+                "at the same time. Use one or the other."
+            )
+
+
+# Top-level `params.json` keys this parser knows how to interpret when their value is a
+# nested dict (a "section" describing a sub-architecture). A dict-valued key outside this set
+# describes a sub-architecture this module has no converter for (e.g. `multimodal` for Voxtral's
+# audio encoder); see `_check_supported_architecture`.
+_KNOWN_SECTION_KEYS: frozenset[str] = frozenset(
+    {"yarn", "llama_4_scaling", "quantization", "quantization_config", "moe", "vision_encoder"}
+)
+
+_DEFAULT_MAX_POSITION_EMBEDDINGS = 32768
+
+
+def _check_supported_architecture(params: dict) -> None:
+    """Raise if `params` describes a sub-architecture this module has no converter for.
+
+    Args:
+        params (`dict`):
+            Raw key/value pairs from a Mistral `params.json` file.
+
+    Raises:
+        ValueError: If `params` contains a dict-valued key not in `_KNOWN_SECTION_KEYS`.
+    """
+    unsupported_sections = sorted(
+        key for key, value in params.items() if isinstance(value, dict) and key not in _KNOWN_SECTION_KEYS
+    )
+    if unsupported_sections:
+        raise ValueError(
+            f"params.json contains section(s) {unsupported_sections} describing an architecture that "
+            "`transformers.integrations.mistral` does not support converting."
+        )
+
+
+def _resolve_sliding_window(sliding_window: Any) -> int | None:
+    """Coerce a raw `params.json` `sliding_window` value to `int | None`.
+
+    Args:
+        sliding_window (`Any`):
+            The raw `params.json` `sliding_window` value.
+
+    Returns:
+        The coerced `int`, or `None` if `sliding_window` is `None`.
+
+    Raises:
+        TypeError: If `sliding_window` is a list (interleaved per-layer pattern).
+    """
+    if isinstance(sliding_window, list):
+        raise TypeError(
+            f"params.json `sliding_window={sliding_window!r}` is a per-layer interleaved "
+            "pattern, which is not supported."
+        )
+    if sliding_window is None:
+        return None
+    return int(sliding_window)
+
+
+_SectionT = TypeVar("_SectionT")
+
+
+def _section_from_dict(section_name: str, section_dict: dict[str, Any], section_type: type[_SectionT]) -> _SectionT:
+    """Build a section dataclass from its raw `params.json` sub-dict.
+
+    Field names match `params.json` keys one-for-one, so the dict is splatted directly. An
+    undeclared key is an error rather than dropped: it means `params.json` grew a field this
+    converter does not model yet.
+
+    Args:
+        section_name (`str`):
+            The `params.json` key this section came from, used only for the error message.
+        section_dict (`dict`):
+            The raw `params.json` sub-dict for this section.
+        section_type (`type`):
+            The dataclass to build, e.g. `YarnArgs`.
+
+    Returns:
+        The built section dataclass instance.
+
+    Raises:
+        ValueError: If `section_dict` omits a field `section_type` cannot default, or carries
+            a key `section_type` does not declare.
+    """
+    try:
+        return section_type(**section_dict)
+    except TypeError as e:
+        raise ValueError(f"params.json '{section_name}' section is invalid: {e}") from e
+
+
+def mistral_native_config_from_params(params: dict[str, Any]) -> MistralNativeConfig:
+    """Build a `MistralNativeConfig` from a raw `params.json` dict.
+
+    Args:
+        params (`dict`):
+            Raw key/value pairs from a Mistral `params.json` file.
+
+    Raises:
+        KeyError: If a required top-level field is missing from `params`.
+        ValueError: If a section is missing a required field or carries an unknown one.
+
+    Returns:
+        The parsed native config.
+    """
+    _check_supported_architecture(params)
+
+    sections: dict[str, Any] = {
+        name: _section_from_dict(name, section_dict, section_type)
+        for name, section_type in (
+            ("yarn", YarnArgs),
+            ("llama_4_scaling", Llama4Scaling),
+            ("quantization", QuantizationArgs),
+            ("moe", MOEModelArgs),
+            ("vision_encoder", VisionEncoderArgs),
+        )
+        if (section_dict := params.get(name)) is not None
+    }
+
+    quantization_config = params.get("quantization_config")
+    if quantization_config is not None:
+        quantization_config = AutoQuantizationConfig.from_dict(quantization_config)
+
+    return MistralNativeConfig(
+        dim=params["dim"],
+        n_layers=params["n_layers"],
+        head_dim=params["head_dim"],
+        hidden_dim=params["hidden_dim"],
+        n_heads=params["n_heads"],
+        n_kv_heads=params["n_kv_heads"],
+        rope_theta=params["rope_theta"],
+        norm_eps=params["norm_eps"],
+        vocab_size=params["vocab_size"],
+        max_position_embeddings=params.get("max_position_embeddings", _DEFAULT_MAX_POSITION_EMBEDDINGS),
+        sliding_window=_resolve_sliding_window(params.get("sliding_window")),
+        tied_embeddings=params.get("tied_embeddings", False),
+        q_lora_rank=params.get("q_lora_rank"),
+        qk_rope_head_dim=params.get("qk_rope_head_dim"),
+        qk_nope_head_dim=params.get("qk_nope_head_dim"),
+        kv_lora_rank=params.get("kv_lora_rank"),
+        v_head_dim=params.get("v_head_dim"),
+        quantization_config=quantization_config,
+        **sections,
+    )

--- a/src/transformers/integrations/mistral/params_conversion.py
+++ b/src/transformers/integrations/mistral/params_conversion.py
@@ -1,0 +1,841 @@
+# Copyright 2026 Mistral AI and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Config conversion for Mistral models.
+
+params.json to native lives in `native_config.py`; this module converts native to and from HF.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from ...configuration_utils import PreTrainedConfig
+from ...modeling_rope_utils import RopeParameters
+from ...models.ministral3.configuration_ministral3 import Ministral3Config
+from ...models.mistral.configuration_mistral import MistralConfig
+from ...models.mistral3.configuration_mistral3 import Mistral3Config
+from ...models.mistral4.configuration_mistral4 import Mistral4Config
+from ...models.pixtral.configuration_pixtral import PixtralVisionConfig
+from ...quantizers.auto import AutoQuantizationConfig
+from ...utils.quantization_config import QuantizationConfigMixin
+from .native_config import (
+    _QUANTIZATION_SCHEME_MAP,
+    Llama4Scaling,
+    MistralNativeConfig,
+    MOEModelArgs,
+    QFormat,
+    QuantizationArgs,
+    VisionEncoderArgs,
+    YarnArgs,
+)
+
+
+_REVERSE_QUANTIZATION_SCHEME_MAP = {v: k for k, v in _QUANTIZATION_SCHEME_MAP.items()}
+
+
+MistralHFConfigType = MistralConfig | Mistral3Config | Ministral3Config | Mistral4Config
+
+
+_MISTRAL_EXTRAS_KEY = "mistral_extras"
+_MISTRAL_EXTRAS_DOC = (
+    "params.json fields with no HF equivalent, kept for reverse conversion. Not read by modeling code."
+)
+
+
+# Native `params.json` fields with no home in the HF config schema, preserved in `mistral_extras`
+# on the outermost config so the native config can be rebuilt losslessly.
+_RESIDUAL_FIELD_NAMES: dict[str, tuple[str, ...]] = {
+    "moe": ("expert_parallel", "expert_model_parallel", "route_every_n"),
+    "vision_encoder": ("max_image_size", "image_break_token_id", "image_end_token_id"),
+}
+
+
+def _build_mistral_extras(moe: MOEModelArgs | None, vision_encoder: VisionEncoderArgs | None) -> dict[str, Any]:
+    """Build the `mistral_extras` config entry from residual native fields.
+
+    Args:
+        moe (`MOEModelArgs`):
+            The native MoE args to read residual fields from, or `None`.
+        vision_encoder (`VisionEncoderArgs`):
+            The native vision encoder args to read residual fields from, or `None`.
+
+    Returns:
+        A dict with a `moe` and/or `vision_encoder` sub-dict (only present when the
+        corresponding native section exists) plus a `_comment` entry, or `{}` when there
+        is nothing to preserve.
+    """
+    extras: dict[str, Any] = {}
+    if moe is not None:
+        extras["moe"] = {field: getattr(moe, field) for field in _RESIDUAL_FIELD_NAMES["moe"]}
+    if vision_encoder is not None:
+        extras["vision_encoder"] = {
+            field: getattr(vision_encoder, field) for field in _RESIDUAL_FIELD_NAMES["vision_encoder"]
+        }
+    if not extras:
+        return {}
+    extras["_comment"] = _MISTRAL_EXTRAS_DOC
+    return extras
+
+
+def _extract_residual_fields(extras: dict[str, Any] | None, section_name: str) -> dict[str, Any]:
+    """Read a `mistral_extras` residual section.
+
+    Args:
+        extras (`dict`):
+            The parsed `mistral_extras` payload, or `None`.
+        section_name (`str`):
+            Which residual section to read, a key of `_RESIDUAL_FIELD_NAMES`.
+
+    Returns:
+        The residual fields `mistral_extras` actually carries for `section_name`. A field the
+        payload omits is left out of the result entirely, so the section dataclass's own
+        constructor default applies.
+    """
+    field_names = _RESIDUAL_FIELD_NAMES[section_name]
+    section = (extras or {}).get(section_name) or {}
+    return {name: section[name] for name in field_names if name in section}
+
+
+def mistral_native_config_to_hf_config(
+    native_config: MistralNativeConfig,
+) -> MistralHFConfigType:
+    """Convert a native Mistral config to the corresponding HF config, attaching residue.
+
+    Args:
+        native_config (`MistralNativeConfig`):
+            The native config to convert.
+
+    Returns:
+        The HF config, with any residual native fields with no HF equivalent attached as
+        a `mistral_extras` attribute so the native config can be rebuilt losslessly.
+    """
+    hf_config = _dispatch_mistral_native_config_to_hf_config(native_config)
+    extras = _build_mistral_extras(native_config.moe, native_config.vision_encoder)
+    if extras:
+        setattr(hf_config, _MISTRAL_EXTRAS_KEY, extras)
+    return hf_config
+
+
+def _dispatch_mistral_native_config_to_hf_config(
+    native_config: MistralNativeConfig,
+) -> MistralHFConfigType:
+    """Dispatch a native Mistral config to the correct HF config class.
+
+    The mapping is the following:
+    - If it has vision, it is mapped to Mistral 3 that will resolve sub text config using the same function.
+    - If it is a MOE, it should also be MLA and it is mapped to Mistral 4.
+    - If it has yarn, it is mapped to Ministral 3 else to Mistral.
+
+    Args:
+        native_config (`MistralNativeConfig`):
+            The native config to dispatch.
+
+    Returns:
+        The HF config class matching `native_config`'s architecture.
+
+    Raises:
+        ValueError: If `native_config` combines MoE and MLA inconsistently, or if
+            `native_config.vision_encoder` is set to a type other than `VisionEncoderArgs` or `None`.
+    """
+    is_moe = native_config.moe is not None
+    is_mla = native_config.q_lora_rank is not None
+    has_yarn = native_config.yarn is not None
+
+    if not (is_moe == is_mla):
+        raise ValueError("MOE and MLA config are only supported together. Please ensure to have a valid model config.")
+
+    match native_config.vision_encoder, is_moe, has_yarn:
+        case VisionEncoderArgs() as vision_encoder, _, _:
+            return _native_config_to_mistral3(native_config=native_config, vision_encoder=vision_encoder)
+        case None, True, _:
+            return _native_config_to_mistral4(native_config=native_config)
+        case None, False, True:
+            return _native_config_to_text_config(native_config=native_config, config_cls=Ministral3Config)
+        case None, False, False:
+            return _native_config_to_text_config(native_config=native_config, config_cls=MistralConfig)
+        case _:
+            raise ValueError(
+                f"Unsupported vision_encoder type {type(native_config.vision_encoder).__name__}; "
+                "expected a VisionEncoderArgs instance or None."
+            )
+
+
+def _get_maybe_quant_config(
+    is_vision_model: bool, quantization_args: QuantizationArgs | None
+) -> QuantizationConfigMixin | None:
+    """Build an HF quantization config from Mistral native quantization args.
+
+    Args:
+        is_vision_model (`bool`):
+            If `True`, adds vision/projector modules to `modules_to_not_convert`.
+        quantization_args (`QuantizationArgs`):
+            Native quantization parameters, or `None`. Returns `None` when this is `None`.
+
+    Returns:
+        The HF quantization config, or `None` if no quantization is configured.
+
+    Raises:
+        ValueError: If the quantization format is not `FP8_E4M3`.
+    """
+    if quantization_args is None:
+        return None
+
+    modules_to_not_convert = ["lm_head"]
+    if is_vision_model:
+        modules_to_not_convert += [
+            "model.vision_tower",
+            "model.multi_modal_projector",
+        ]
+
+    match quantization_args.qformat_weight:
+        case QFormat.FP8_E4M3:
+            # `QuantizationArgs.__post_init__` already validated `qscheme_act` against
+            # `_QUANTIZATION_SCHEME_MAP`'s keys, so this lookup cannot miss.
+            activation_scheme = _QUANTIZATION_SCHEME_MAP[quantization_args.qscheme_act]
+            quantization_config = {
+                "activation_scheme": activation_scheme,
+                "modules_to_not_convert": modules_to_not_convert,
+                "quant_method": "fp8",
+                "weight_block_size": None,
+            }
+            return AutoQuantizationConfig.from_dict(quantization_config)
+        case _:
+            raise ValueError(f"invalid quantization config {quantization_args.qformat_weight=}.")
+
+
+def _get_rope_parameters(
+    rope_theta: float,
+    yarn_args: YarnArgs | None,
+    llama4_scaling: Llama4Scaling | None,
+    qk_rope: int | None,
+    qk_nope: int | None,
+) -> RopeParameters:
+    """Build a `RopeParameters` dict from native rope/yarn/MLA fields.
+
+    Args:
+        rope_theta (`float`):
+            The base RoPE theta value.
+        yarn_args (`YarnArgs`):
+            The native YaRN parameters, or `None` for default (non-extended) RoPE.
+        llama4_scaling (`Llama4Scaling`):
+            The native Llama 4 scaling parameters, or `None`. Only meaningful when `yarn_args`
+            is also set.
+        qk_rope (`int`):
+            The MLA `qk_rope_head_dim`, or `None` for a non-MLA architecture.
+        qk_nope (`int`):
+            The MLA `qk_nope_head_dim`, or `None` for a non-MLA architecture.
+
+    Returns:
+        The `RopeParameters` dict for the HF config.
+
+    Raises:
+        ValueError: If `qk_rope` and `qk_nope` are not both set or both `None`.
+    """
+    if (qk_rope is None) != (qk_nope is None):
+        raise ValueError(f"qk_rope and qk_nope must both be None or both set, got {qk_rope=}, {qk_nope=}")
+    rope_kwargs = {}
+
+    if qk_rope is not None and qk_nope is not None:
+        rope_kwargs["partial_rotary_factor"] = qk_rope / (qk_nope + qk_rope)
+
+    if yarn_args is None:
+        if llama4_scaling is not None:
+            raise ValueError(
+                "`llama_4_scaling` is only meaningful as a modifier on top of yarn's rope "
+                "extension; it is not supported without `yarn` also being set."
+            )
+        return RopeParameters(rope_type="default", rope_theta=rope_theta, **rope_kwargs)
+    elif llama4_scaling is not None:
+        if yarn_args.original_max_position_embeddings != llama4_scaling.original_max_position_embeddings:
+            raise ValueError(
+                f"yarn.original_max_position_embeddings ({yarn_args.original_max_position_embeddings}) "
+                f"must match llama_4_scaling.original_max_position_embeddings "
+                f"({llama4_scaling.original_max_position_embeddings})"
+            )
+        rope_kwargs["llama_4_scaling_beta"] = llama4_scaling.beta
+    else:
+        # Sentinel for "no llama4 scaling": beta=0 is a no-op in the attention scale formula
+        # (see `get_llama_4_attn_scale` in modeling_mistral4.py), so it round-trips back to
+        # absent in `_extract_llama4_scaling_from_rope_params` below.
+        rope_kwargs["llama_4_scaling_beta"] = 0
+
+    mscale = 1.0
+    mscale_all_dim = 0.0 if yarn_args.apply_scale else 1.0
+
+    return RopeParameters(
+        rope_type="yarn",
+        rope_theta=rope_theta,
+        factor=float(yarn_args.factor),
+        original_max_position_embeddings=yarn_args.original_max_position_embeddings,
+        beta_fast=float(yarn_args.beta),
+        beta_slow=float(yarn_args.alpha),
+        mscale=mscale,
+        mscale_all_dim=mscale_all_dim,
+        **rope_kwargs,
+    )
+
+
+def _hf_config_base_kwargs(
+    native_config: MistralNativeConfig,
+    rope_parameters: RopeParameters,
+    include_head_dim: bool = True,
+) -> dict[str, Any]:
+    """Build the base HF config kwargs shared by all forward converters.
+
+    Args:
+        native_config (`MistralNativeConfig`):
+            The native config to read common fields from.
+        rope_parameters (`RopeParameters`):
+            The already-resolved `RopeParameters` for this config.
+        include_head_dim (`bool`, *optional*, defaults to `True`):
+            If `False`, omits `head_dim` (e.g. for MLA architectures that derive it from
+            `qk_rope_head_dim` / `qk_nope_head_dim` instead).
+
+    Returns:
+        A kwargs dict ready to be passed to an HF config constructor.
+    """
+    kwargs: dict[str, Any] = {
+        "hidden_size": native_config.dim,
+        "num_hidden_layers": native_config.n_layers,
+        "intermediate_size": native_config.hidden_dim,
+        "num_attention_heads": native_config.n_heads,
+        "rms_norm_eps": native_config.norm_eps,
+        "vocab_size": native_config.vocab_size,
+        "num_key_value_heads": native_config.n_kv_heads,
+        "sliding_window": native_config.sliding_window,
+        "max_position_embeddings": native_config.max_position_embeddings,
+        "tie_word_embeddings": native_config.tied_embeddings,
+        "rope_parameters": rope_parameters,
+    }
+    if include_head_dim:
+        kwargs["head_dim"] = native_config.head_dim
+    return kwargs
+
+
+def _resolve_native_quant_config_kwargs(
+    native_config: MistralNativeConfig, is_vision_model: bool = False
+) -> dict[str, Any]:
+    """Resolve the `quantization_config` kwarg (if any) for a forward converter.
+
+    Args:
+        native_config (`MistralNativeConfig`):
+            The native config to read quantization fields from.
+        is_vision_model (`bool`, *optional*, defaults to `False`):
+            If `True`, adds vision/projector modules to `modules_to_not_convert` when a
+            quantization config is built.
+
+    Returns:
+        An empty dict, or a dict with a single `quantization_config` key.
+    """
+    quant_config = native_config.quantization_config or _get_maybe_quant_config(
+        is_vision_model=is_vision_model, quantization_args=native_config.quantization
+    )
+    optional_kwargs: dict[str, Any] = {}
+    if quant_config is not None:
+        optional_kwargs["quantization_config"] = quant_config
+    return optional_kwargs
+
+
+def _native_config_to_text_config(
+    native_config: MistralNativeConfig, config_cls: type[MistralConfig] | type[Ministral3Config]
+) -> MistralConfig | Ministral3Config:
+    """Convert a native config to a `MistralConfig` or `Ministral3Config`.
+
+    Args:
+        native_config (`MistralNativeConfig`):
+            The native config to convert.
+        config_cls (`type[MistralConfig] | type[Ministral3Config]`):
+            `MistralConfig` for a config without yarn, `Ministral3Config` for one with yarn.
+            The dispatcher (`_dispatch_mistral_native_config_to_hf_config`) has already
+            determined which applies.
+
+    Returns:
+        The converted HF config.
+    """
+    rope_parameters = _get_rope_parameters(
+        rope_theta=native_config.rope_theta,
+        yarn_args=native_config.yarn,
+        llama4_scaling=native_config.llama_4_scaling,
+        qk_rope=None,
+        qk_nope=None,
+    )
+    base_kwargs = _hf_config_base_kwargs(native_config=native_config, rope_parameters=rope_parameters)
+    optional_kwargs = _resolve_native_quant_config_kwargs(native_config)
+
+    return config_cls(**base_kwargs, **optional_kwargs)
+
+
+def _native_config_to_mistral4(native_config: MistralNativeConfig) -> Mistral4Config:
+    """Convert a native config to a `Mistral4Config` (MLA + MoE architecture).
+
+    Args:
+        native_config (`MistralNativeConfig`):
+            The native config to convert. Must have both `moe` and `q_lora_rank` set.
+
+    Returns:
+        The converted `Mistral4Config`.
+
+    Raises:
+        ValueError: If `head_dim` is set to a value other than
+            `qk_nope_head_dim + qk_rope_head_dim`. The HF Mistral4
+            architecture always derives `head_dim` from those two fields
+            (see the reverse converter), so any other value cannot be
+            represented and would otherwise be silently discarded.
+    """
+    if native_config.qk_nope_head_dim is not None and native_config.qk_rope_head_dim is not None:
+        expected_head_dim = native_config.qk_nope_head_dim + native_config.qk_rope_head_dim
+        if native_config.head_dim != expected_head_dim:
+            raise ValueError(
+                f"Unsupported head_dim={native_config.head_dim!r} for a Mistral4 (MLA) config; "
+                f"the only supported value is qk_nope_head_dim + qk_rope_head_dim = {expected_head_dim}."
+            )
+    rope_parameters = _get_rope_parameters(
+        rope_theta=native_config.rope_theta,
+        yarn_args=native_config.yarn,
+        llama4_scaling=native_config.llama_4_scaling,
+        qk_rope=native_config.qk_rope_head_dim,
+        qk_nope=native_config.qk_nope_head_dim,
+    )
+    base_kwargs = _hf_config_base_kwargs(
+        native_config=native_config,
+        rope_parameters=rope_parameters,
+        include_head_dim=False,
+    )
+    optional_kwargs = _resolve_native_quant_config_kwargs(native_config)
+
+    return Mistral4Config(
+        **base_kwargs,
+        q_lora_rank=native_config.q_lora_rank,
+        qk_rope_head_dim=native_config.qk_rope_head_dim,
+        qk_nope_head_dim=native_config.qk_nope_head_dim,
+        kv_lora_rank=native_config.kv_lora_rank,
+        v_head_dim=native_config.v_head_dim,
+        n_routed_experts=native_config.moe.num_experts,
+        num_experts_per_tok=native_config.moe.num_experts_per_tok,
+        first_k_dense_replace=native_config.moe.first_k_dense_replace,
+        n_shared_experts=native_config.moe.num_shared_experts,
+        moe_intermediate_size=native_config.moe.expert_hidden_dim,
+        routed_scaling_factor=native_config.moe.routed_scale,
+        n_group=native_config.moe.num_expert_groups,
+        topk_group=native_config.moe.num_expert_groups_per_tok,
+        norm_topk_prob=True,
+        **optional_kwargs,
+    )
+
+
+def _native_config_to_mistral3(
+    native_config: MistralNativeConfig, vision_encoder: VisionEncoderArgs
+) -> Mistral3Config:
+    """Convert a native config to a `Mistral3Config` (vision-language model).
+
+    Args:
+        native_config (`MistralNativeConfig`):
+            The native config to convert.
+        vision_encoder (`VisionEncoderArgs`):
+            `native_config.vision_encoder`, non-`None`. The dispatcher
+            (`_dispatch_mistral_native_config_to_hf_config`) has already established this and
+            passes it separately so its non-optional type is visible here.
+
+    Returns:
+        The converted `Mistral3Config`.
+
+    Raises:
+        ValueError: If `mm_projector_id` or `add_pre_mm_projector_layer_norm` are set
+            to a value other than what `Mistral3MultiModalProjector`
+            unconditionally implements.
+    """
+    if vision_encoder.mm_projector_id != "patch_merge":
+        raise ValueError(
+            f"Unsupported vision_encoder.mm_projector_id={vision_encoder.mm_projector_id!r}; "
+            "Mistral3MultiModalProjector unconditionally builds a patch-merge projector, so "
+            "'patch_merge' is the only supported value."
+        )
+    if not vision_encoder.add_pre_mm_projector_layer_norm:
+        raise ValueError(
+            f"Unsupported vision_encoder.add_pre_mm_projector_layer_norm={vision_encoder.add_pre_mm_projector_layer_norm!r}; "
+            "Mistral3MultiModalProjector unconditionally builds a pre-projector norm layer, so "
+            "`True` is the only supported value."
+        )
+    vision_hf = PixtralVisionConfig(
+        hidden_size=vision_encoder.hidden_size,
+        num_hidden_layers=vision_encoder.num_hidden_layers,
+        num_attention_heads=vision_encoder.num_attention_heads,
+        patch_size=vision_encoder.patch_size,
+        image_size=vision_encoder.image_size,
+        intermediate_size=vision_encoder.intermediate_size,
+        num_channels=vision_encoder.num_channels,
+        hidden_act="silu",
+        rope_theta=vision_encoder.rope_theta,
+    )
+    optional_kwargs = _resolve_native_quant_config_kwargs(native_config, is_vision_model=True)
+
+    native_text_config = replace(native_config, vision_encoder=None, quantization=None, quantization_config=None)
+
+    # Use the raw dispatcher (not the `mistral_native_config_to_hf_config` wrapper) so the nested text
+    # config does not get its own `mistral_extras`: the outer wrapper call attaches a
+    # single combined entry (moe + vision_encoder) to this function's returned `Mistral3Config`.
+    text_hf = _dispatch_mistral_native_config_to_hf_config(native_config=native_text_config)
+
+    return Mistral3Config(
+        vision_config=vision_hf,
+        text_config=text_hf,
+        multimodal_projector_bias=vision_encoder.adapter_bias,
+        image_token_id=vision_encoder.image_token_id,
+        spatial_merge_size=vision_encoder.spatial_merge_size,
+        vision_feature_layer=-1,
+        tie_word_embeddings=native_config.tied_embeddings,
+        **optional_kwargs,
+    )
+
+
+def _extract_hf_quantization_config(
+    hf_config: PreTrainedConfig,
+) -> QuantizationConfigMixin | None:
+    """Extract the `quantization_config` attribute from an HF config, if present.
+
+    Args:
+        hf_config (`PreTrainedConfig`):
+            The HF config to read `quantization_config` from.
+
+    Returns:
+        The quantization config, or `None` if `hf_config` has none.
+
+    Raises:
+        TypeError: If `quantization_config` is set to a type other than
+            `QuantizationConfigMixin`, `dict`, or `None`.
+    """
+    quant_cfg = getattr(hf_config, "quantization_config", None)
+    if quant_cfg is None:
+        return None
+    if isinstance(quant_cfg, QuantizationConfigMixin):
+        return quant_cfg
+    if isinstance(quant_cfg, dict):
+        return AutoQuantizationConfig.from_dict(quant_cfg)
+    raise TypeError(
+        f"Unsupported `quantization_config` type {type(quant_cfg).__name__}; expected "
+        "`QuantizationConfigMixin`, `dict`, or `None`."
+    )
+
+
+def _hf_quant_config_to_native(quant_cfg: QuantizationConfigMixin | None) -> QuantizationArgs | None:
+    """Convert an already-extracted HF quantization config back to native `QuantizationArgs`.
+
+    Args:
+        quant_cfg (`QuantizationConfigMixin`):
+            The HF quantization config to convert, or `None`.
+
+    Returns:
+        The native `QuantizationArgs`, or `None` if `quant_cfg` is `None` or the mapping is
+        not reversible (e.g. a non-fp8 quant method or an unsupported activation scheme).
+    """
+    # TODO: The issue here is that ignored_layers are probably not in Mistral format which would ultimately fail.
+    # We need to map the patterns from one format to another.
+    if quant_cfg is None:
+        return None
+    qc = quant_cfg.to_dict()
+    if qc.get("quant_method") != "fp8":
+        return None
+    scheme = _REVERSE_QUANTIZATION_SCHEME_MAP.get(qc.get("activation_scheme", "static"))
+    if scheme is None:
+        return None
+    return QuantizationArgs(qformat_weight=QFormat.FP8_E4M3, qscheme_act=scheme)
+
+
+def _resolve_hf_quant_for_native(
+    hf_config: PreTrainedConfig,
+) -> tuple[QuantizationArgs | None, QuantizationConfigMixin | None]:
+    """Resolve an HF quantization config to native fields.
+
+    Tries the direct reverse mapping first. If that is not feasible (e.g.
+    non-fp8 quant method), the original HF config is preserved as-is in
+    `quantization_config` so it is not silently dropped.
+
+    Args:
+        hf_config (`PreTrainedConfig`):
+            The HF config to read `quantization_config` from.
+
+    Returns:
+        A `(quantization, quantization_config)` pair where exactly one
+        (or neither) is non-`None`.
+
+    Raises:
+        TypeError: If `hf_config.quantization_config` is set to a type other than
+            `QuantizationConfigMixin`, `dict`, or `None`, propagated from
+            `_extract_hf_quantization_config`.
+    """
+    hf_quant = _extract_hf_quantization_config(hf_config)
+    native_quant = _hf_quant_config_to_native(hf_quant)
+    if native_quant is not None:
+        return native_quant, None
+    return None, hf_quant
+
+
+def _extract_llama4_scaling_from_rope_params(
+    rope_params: dict | RopeParameters | None,
+) -> Llama4Scaling | None:
+    """Extract `Llama4Scaling` from an HF `rope_parameters` dict, if present.
+
+    Args:
+        rope_params (`dict | RopeParameters`):
+            The HF `rope_parameters` dict to read `llama_4_scaling_beta` from, or `None`.
+
+    Returns:
+        The `Llama4Scaling`, or `None` if `rope_params` carries no (or a no-op) llama4 scaling.
+
+    Raises:
+        ValueError: If `llama_4_scaling_beta` is set but `original_max_position_embeddings` is missing.
+    """
+    if (
+        not rope_params
+        or not isinstance(rope_params, dict)
+        or (beta := rope_params.get("llama_4_scaling_beta")) is None
+        # 0 is the sentinel `_get_rope_parameters` writes for "no llama4 scaling"; treat it the
+        # same as a missing key rather than a real (no-op) scaling factor.
+        or beta == 0
+    ):
+        return None
+
+    if (original_max_position_embeddings := rope_params.get("original_max_position_embeddings")) is None:
+        raise ValueError("original_max_position_embeddings should not be None if llama4 scaling is set.")
+
+    return Llama4Scaling(
+        original_max_position_embeddings=int(original_max_position_embeddings),
+        beta=float(beta),
+    )
+
+
+def mistral_native_config_from_hf_config(hf_config: MistralHFConfigType) -> MistralNativeConfig:
+    """Convert an HF config to a `MistralNativeConfig`.
+
+    The target architecture is determined by the runtime type of `hf_config`.
+
+    Args:
+        hf_config (`MistralHFConfigType`):
+            The HuggingFace config to convert.
+
+    Returns:
+        The converted native config.
+
+    Raises:
+        ValueError: If the config type is unsupported.
+        TypeError: If `hf_config.quantization_config` is set to a type other than
+            `QuantizationConfigMixin`, `dict`, or `None`, propagated from
+            `_extract_hf_quantization_config`.
+    """
+    match hf_config:
+        case Mistral3Config():
+            return _hf_mistral3_to_native(hf_config)
+        case Mistral4Config():
+            return _hf_mistral4_to_native(hf_config)
+        case Ministral3Config():
+            return _hf_ministral3_to_native(hf_config)
+        case MistralConfig():
+            return _hf_mistral_to_native(hf_config)
+        case _:
+            raise ValueError(f"Unsupported HF config type: {type(hf_config).__name__}")
+
+
+def _extract_rope_theta(config: PreTrainedConfig) -> float:
+    """Extract `rope_theta` from an HF config, checking `rope_parameters` first."""
+    rope_params = getattr(config, "rope_parameters", None)
+    if rope_params and isinstance(rope_params, dict) and "rope_theta" in rope_params:
+        return float(rope_params["rope_theta"])
+    elif hasattr(config, "rope_theta"):
+        return float(config.rope_theta)
+    raise ValueError("`rope_theta` not found.")
+
+
+def _extract_yarn(config: PreTrainedConfig) -> YarnArgs | None:
+    """Extract YaRN parameters from an HF config's `rope_parameters`."""
+    rope_params = getattr(config, "rope_parameters", None)
+    if not rope_params or not isinstance(rope_params, dict):
+        return None
+    rope_type = rope_params.get("rope_type", rope_params.get("type"))
+    if rope_type != "yarn":
+        return None
+    rope_mscale_all_dim = rope_params.get("mscale_all_dim")
+    apply_scale = rope_mscale_all_dim is None or rope_mscale_all_dim != 1.0
+    return YarnArgs(
+        factor=rope_params["factor"],
+        original_max_position_embeddings=rope_params["original_max_position_embeddings"],
+        beta=float(rope_params["beta_fast"]),
+        alpha=float(rope_params["beta_slow"]),
+        apply_scale=apply_scale,
+    )
+
+
+def _native_config_base_kwargs(hf_config: PreTrainedConfig, head_dim: int) -> dict[str, Any]:
+    """Build the base native config kwargs shared by all reverse converters.
+
+    Args:
+        hf_config (`PreTrainedConfig`):
+            The HF config to read common fields from.
+        head_dim (`int`):
+            The resolved `head_dim` value (callers derive this differently depending on
+            whether the architecture uses MLA).
+
+    Returns:
+        A kwargs dict ready to be passed to `MistralNativeConfig`.
+    """
+    quantization, quantization_config = _resolve_hf_quant_for_native(hf_config)
+    return {
+        "dim": hf_config.hidden_size,
+        "n_layers": hf_config.num_hidden_layers,
+        "head_dim": head_dim,
+        "hidden_dim": hf_config.intermediate_size,
+        "n_heads": hf_config.num_attention_heads,
+        "n_kv_heads": hf_config.num_key_value_heads,
+        "rope_theta": _extract_rope_theta(hf_config),
+        "norm_eps": hf_config.rms_norm_eps,
+        "vocab_size": hf_config.vocab_size,
+        "max_position_embeddings": hf_config.max_position_embeddings,
+        "sliding_window": getattr(hf_config, "sliding_window", None),
+        "tied_embeddings": hf_config.tie_word_embeddings,
+        "yarn": _extract_yarn(hf_config),
+        "quantization": quantization,
+        "quantization_config": quantization_config,
+    }
+
+
+def _hf_mistral_to_native(hf_config: MistralConfig) -> MistralNativeConfig:
+    """Convert a `MistralConfig` back to a `MistralNativeConfig`.
+
+    Args:
+        hf_config (`MistralConfig`):
+            The HF config to convert.
+
+    Returns:
+        The converted native config.
+
+    Raises:
+        ValueError: If `head_dim` is not set on the HF config.
+    """
+    if hf_config.head_dim is None:
+        raise ValueError("head_dim must be set on the HF config")
+    base_kwargs = _native_config_base_kwargs(hf_config=hf_config, head_dim=hf_config.head_dim)
+
+    return MistralNativeConfig(**base_kwargs)
+
+
+def _hf_ministral3_to_native(hf_config: Ministral3Config) -> MistralNativeConfig:
+    """Convert a `Ministral3Config` back to a `MistralNativeConfig`."""
+    base_kwargs = _native_config_base_kwargs(hf_config=hf_config, head_dim=hf_config.head_dim)
+
+    return MistralNativeConfig(
+        **base_kwargs,
+        llama_4_scaling=_extract_llama4_scaling_from_rope_params(
+            getattr(hf_config, "rope_parameters", None),
+        ),
+    )
+
+
+def _hf_mistral4_to_native(hf_config: Mistral4Config) -> MistralNativeConfig:
+    """Convert a `Mistral4Config` (MLA + MoE) back to a `MistralNativeConfig`.
+
+    The MoE parallelism-topology fields with no HF representation
+    (`expert_parallel`, `expert_model_parallel`, `route_every_n`) are read
+    back from `mistral_extras` when present, falling back to their
+    native defaults otherwise (e.g. for a hand-written HF config).
+
+    Args:
+        hf_config (`Mistral4Config`):
+            The HF config to convert.
+
+    Returns:
+        The converted native config.
+
+    Raises:
+        ValueError: If any of `num_key_value_heads`, `num_experts_per_tok`,
+            `first_k_dense_replace`, `n_group`, or `topk_group` is `None` on `hf_config`.
+    """
+    rope_params = getattr(hf_config, "rope_parameters", None)
+    required_fields = {
+        "num_key_value_heads": hf_config.num_key_value_heads,
+        "num_experts_per_tok": hf_config.num_experts_per_tok,
+        "first_k_dense_replace": hf_config.first_k_dense_replace,
+        "n_group": hf_config.n_group,
+        "topk_group": hf_config.topk_group,
+    }
+    missing = [name for name, value in required_fields.items() if value is None]
+    if missing:
+        raise ValueError(f"Mistral4 config requires non-None fields: {missing}")
+    base_kwargs = _native_config_base_kwargs(
+        hf_config=hf_config,
+        head_dim=hf_config.qk_nope_head_dim + hf_config.qk_rope_head_dim,
+    )
+    moe_residual = _extract_residual_fields(extras=getattr(hf_config, _MISTRAL_EXTRAS_KEY, None), section_name="moe")
+
+    return MistralNativeConfig(
+        **base_kwargs,
+        q_lora_rank=hf_config.q_lora_rank,
+        qk_rope_head_dim=hf_config.qk_rope_head_dim,
+        qk_nope_head_dim=hf_config.qk_nope_head_dim,
+        kv_lora_rank=hf_config.kv_lora_rank,
+        v_head_dim=hf_config.v_head_dim,
+        llama_4_scaling=_extract_llama4_scaling_from_rope_params(rope_params),
+        moe=MOEModelArgs(
+            num_experts=hf_config.n_routed_experts,
+            num_experts_per_tok=hf_config.num_experts_per_tok,
+            first_k_dense_replace=hf_config.first_k_dense_replace,
+            num_shared_experts=hf_config.n_shared_experts,
+            expert_hidden_dim=hf_config.moe_intermediate_size,
+            routed_scale=hf_config.routed_scaling_factor,
+            num_expert_groups=hf_config.n_group,
+            num_expert_groups_per_tok=hf_config.topk_group,
+            **moe_residual,
+        ),
+    )
+
+
+def _hf_mistral3_to_native(hf_config: Mistral3Config) -> MistralNativeConfig:
+    """Convert a `Mistral3Config` (VLM) back to a `MistralNativeConfig`."""
+    text_native = mistral_native_config_from_hf_config(hf_config.text_config)
+    vision_hf: PixtralVisionConfig = hf_config.vision_config
+    extras = getattr(hf_config, _MISTRAL_EXTRAS_KEY, None)
+
+    vision_residual = {
+        "max_image_size": vision_hf.image_size,
+        **_extract_residual_fields(extras=extras, section_name="vision_encoder"),
+    }
+    vision_encoder = VisionEncoderArgs(
+        hidden_size=vision_hf.hidden_size,
+        num_hidden_layers=vision_hf.num_hidden_layers,
+        num_attention_heads=vision_hf.num_attention_heads,
+        patch_size=vision_hf.patch_size,
+        image_size=vision_hf.image_size,
+        intermediate_size=vision_hf.intermediate_size,
+        num_channels=vision_hf.num_channels,
+        rope_theta=_extract_rope_theta(vision_hf),
+        adapter_bias=hf_config.multimodal_projector_bias,
+        spatial_merge_size=hf_config.spatial_merge_size,
+        image_token_id=hf_config.image_token_id,
+        mm_projector_id="patch_merge",
+        add_pre_mm_projector_layer_norm=True,
+        **vision_residual,
+    )
+
+    moe = text_native.moe
+    moe_residual = _extract_residual_fields(extras=extras, section_name="moe")
+    if moe is not None and moe_residual:
+        moe = replace(moe, **moe_residual)
+
+    quantization, quantization_config = _resolve_hf_quant_for_native(hf_config)
+    return replace(
+        text_native,
+        vision_encoder=vision_encoder,
+        quantization=quantization,
+        quantization_config=quantization_config,
+        moe=moe,
+    )

--- a/tests/integrations/mistral/mistral_fixture_data.py
+++ b/tests/integrations/mistral/mistral_fixture_data.py
@@ -1,0 +1,482 @@
+# Copyright 2026 Mistral AI and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import dataclasses
+
+from transformers import Ministral3Config, Mistral3Config, Mistral4Config, MistralConfig
+from transformers.integrations.mistral.native_config import (
+    Llama4Scaling,
+    MistralNativeConfig,
+    MOEModelArgs,
+    QFormat,
+    QuantizationArgs,
+    VisionEncoderArgs,
+    YarnArgs,
+)
+from transformers.models.pixtral.configuration_pixtral import PixtralVisionConfig
+from transformers.quantizers.auto import AutoQuantizationConfig
+from transformers.utils.quantization_config import QuantizationConfigMixin
+
+
+# A minimal raw `params.json` payload, as read straight off disk.
+RAW_MISTRAL_PARAMS = {
+    "dim": 4096,
+    "n_layers": 32,
+    "hidden_dim": 14336,
+    "n_heads": 32,
+    "n_kv_heads": 8,
+    "norm_eps": 1e-5,
+    "head_dim": 128,
+    "vocab_size": 32000,
+    "rope_theta": 10000.0,
+    "sliding_window": 4096,
+    "max_position_embeddings": 32768,
+}
+
+
+def make_hf_fp8_quant_config(activation_scheme: str = "static") -> QuantizationConfigMixin:
+    return AutoQuantizationConfig.from_dict(
+        {
+            "quant_method": "fp8",
+            "activation_scheme": activation_scheme,
+            "modules_to_not_convert": ["lm_head"],
+            "weight_block_size": None,
+        }
+    )
+
+
+def make_non_reversible_quant_config() -> QuantizationConfigMixin:
+    return AutoQuantizationConfig.from_dict(
+        {
+            "quant_method": "gptq",
+            "bits": 4,
+            "group_size": 128,
+        }
+    )
+
+
+def base_native_config() -> MistralNativeConfig:
+    return MistralNativeConfig(
+        dim=4096,
+        n_layers=32,
+        head_dim=128,
+        hidden_dim=14336,
+        n_heads=32,
+        n_kv_heads=8,
+        rope_theta=10000.0,
+        norm_eps=1e-5,
+        vocab_size=32000,
+        max_position_embeddings=32768,
+    )
+
+
+def yarn_args() -> YarnArgs:
+    return YarnArgs(factor=16.0, original_max_position_embeddings=16384, beta=32.0, alpha=1.0, apply_scale=False)
+
+
+def llama4_scaling() -> Llama4Scaling:
+    return Llama4Scaling(original_max_position_embeddings=16384, beta=0.1)
+
+
+def vision_encoder_args() -> VisionEncoderArgs:
+    return VisionEncoderArgs(
+        hidden_size=1024,
+        num_hidden_layers=24,
+        num_attention_heads=16,
+        patch_size=14,
+        image_size=1540,
+        intermediate_size=4096,
+        num_channels=3,
+        max_image_size=1540,
+        rope_theta=10000.0,
+        mm_projector_id="patch_merge",
+        add_pre_mm_projector_layer_norm=True,
+        adapter_bias=False,
+        spatial_merge_size=2,
+        image_token_id=10,
+        image_break_token_id=12,
+        image_end_token_id=13,
+    )
+
+
+def moe_args() -> MOEModelArgs:
+    return MOEModelArgs(
+        num_experts=128,
+        num_experts_per_tok=4,
+        expert_hidden_dim=2048,
+        first_k_dense_replace=0,
+        num_shared_experts=1,
+        routed_scale=1.0,
+        num_expert_groups=1,
+        num_expert_groups_per_tok=1,
+    )
+
+
+def ministral3_native_config() -> MistralNativeConfig:
+    _yarn_args = yarn_args()
+    _llama4_scaling = llama4_scaling()
+    return MistralNativeConfig(
+        dim=4096,
+        n_layers=32,
+        head_dim=128,
+        hidden_dim=14336,
+        n_heads=32,
+        n_kv_heads=8,
+        rope_theta=1000000.0,
+        norm_eps=1e-5,
+        vocab_size=32000,
+        max_position_embeddings=262144,
+        tied_embeddings=True,
+        yarn=_yarn_args,
+        llama_4_scaling=_llama4_scaling,
+    )
+
+
+def mistral3_native_config() -> MistralNativeConfig:
+    _vision_encoder_args = vision_encoder_args()
+    return MistralNativeConfig(
+        dim=4096,
+        n_layers=32,
+        head_dim=128,
+        hidden_dim=14336,
+        n_heads=32,
+        n_kv_heads=8,
+        rope_theta=1000000000.0,
+        norm_eps=1e-5,
+        vocab_size=32000,
+        max_position_embeddings=131072,
+        vision_encoder=_vision_encoder_args,
+    )
+
+
+def mistral4_native_config() -> MistralNativeConfig:
+    _moe_args = moe_args()
+    return MistralNativeConfig(
+        dim=4096,
+        n_layers=32,
+        head_dim=128,
+        hidden_dim=14336,
+        n_heads=32,
+        n_kv_heads=32,
+        rope_theta=10000.0,
+        norm_eps=1e-5,
+        vocab_size=32000,
+        max_position_embeddings=1048576,
+        q_lora_rank=1024,
+        qk_rope_head_dim=64,
+        qk_nope_head_dim=64,
+        kv_lora_rank=256,
+        v_head_dim=128,
+        yarn=YarnArgs(factor=128.0, original_max_position_embeddings=8192, beta=32.0, alpha=1.0, apply_scale=False),
+        llama_4_scaling=Llama4Scaling(original_max_position_embeddings=8192, beta=0.1),
+        moe=_moe_args,
+    )
+
+
+def mistral4_asymmetric_mla_native_config() -> MistralNativeConfig:
+    """A Mistral4 (MLA) native config with an asymmetric `qk_rope_head_dim` / `qk_nope_head_dim`
+    split, so `partial_rotary_factor` cannot be produced by the swapped
+    `qk_nope / (qk_nope + qk_rope)` formula. Every other MLA fixture in this module has an equal
+    rope/nope split, which makes the correct and swapped formulas indistinguishable.
+    """
+    return MistralNativeConfig(
+        dim=4096,
+        n_layers=32,
+        head_dim=128,
+        hidden_dim=14336,
+        n_heads=32,
+        n_kv_heads=32,
+        rope_theta=10000.0,
+        norm_eps=1e-5,
+        vocab_size=32000,
+        max_position_embeddings=1048576,
+        q_lora_rank=1024,
+        qk_rope_head_dim=32,
+        qk_nope_head_dim=96,
+        kv_lora_rank=256,
+        v_head_dim=128,
+        moe=moe_args(),
+    )
+
+
+def expected_mistral_hf_config() -> MistralConfig:
+    return MistralConfig(
+        hidden_size=4096,
+        num_hidden_layers=32,
+        intermediate_size=14336,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        rms_norm_eps=1e-5,
+        head_dim=128,
+        vocab_size=32000,
+        max_position_embeddings=32768,
+        sliding_window=None,
+        rope_parameters={
+            "rope_type": "default",
+            "rope_theta": 10000.0,
+        },
+        quantization_config=None,
+    )
+
+
+def expected_ministral3_hf_config() -> Ministral3Config:
+    return Ministral3Config(
+        hidden_size=4096,
+        num_hidden_layers=32,
+        intermediate_size=14336,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        rms_norm_eps=1e-5,
+        head_dim=128,
+        vocab_size=32000,
+        max_position_embeddings=262144,
+        sliding_window=None,
+        tie_word_embeddings=True,
+        rope_parameters={
+            "rope_type": "yarn",
+            "rope_theta": 1000000.0,
+            "factor": 16.0,
+            "original_max_position_embeddings": 16384,
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+            "llama_4_scaling_beta": 0.1,
+        },
+        quantization_config=None,
+    )
+
+
+def expected_mistral4_hf_config() -> Mistral4Config:
+    return Mistral4Config(
+        hidden_size=4096,
+        num_hidden_layers=32,
+        intermediate_size=14336,
+        num_attention_heads=32,
+        num_key_value_heads=32,
+        rms_norm_eps=1e-5,
+        vocab_size=32000,
+        max_position_embeddings=1048576,
+        sliding_window=None,
+        q_lora_rank=1024,
+        qk_rope_head_dim=64,
+        qk_nope_head_dim=64,
+        kv_lora_rank=256,
+        v_head_dim=128,
+        n_routed_experts=128,
+        num_experts_per_tok=4,
+        moe_intermediate_size=2048,
+        first_k_dense_replace=0,
+        n_shared_experts=1,
+        routed_scaling_factor=1.0,
+        n_group=1,
+        topk_group=1,
+        norm_topk_prob=True,
+        quantization_config=None,
+        rope_parameters={
+            "rope_type": "yarn",
+            "rope_theta": 10000.0,
+            "factor": 128.0,
+            "original_max_position_embeddings": 8192,
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+            "llama_4_scaling_beta": 0.1,
+            "partial_rotary_factor": 0.5,
+        },
+    )
+
+
+def expected_mistral3_hf_config() -> Mistral3Config:
+    text_config = MistralConfig(
+        hidden_size=4096,
+        num_hidden_layers=32,
+        intermediate_size=14336,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        rms_norm_eps=1e-5,
+        head_dim=128,
+        vocab_size=32000,
+        max_position_embeddings=131072,
+        sliding_window=None,
+        rope_parameters={
+            "rope_type": "default",
+            "rope_theta": 1000000000.0,
+        },
+        quantization_config=None,
+    )
+    vision_config = PixtralVisionConfig(
+        hidden_size=1024,
+        num_hidden_layers=24,
+        num_attention_heads=16,
+        patch_size=14,
+        image_size=1540,
+        intermediate_size=4096,
+        num_channels=3,
+        hidden_act="silu",
+        rope_theta=10000.0,
+    )
+    return Mistral3Config(
+        text_config=text_config,
+        vision_config=vision_config,
+        multimodal_projector_bias=False,
+        image_token_id=10,
+        spatial_merge_size=2,
+        vision_feature_layer=-1,
+        quantization_config=None,
+        tie_word_embeddings=False,
+    )
+
+
+def perturbed_mistral_native_config() -> MistralNativeConfig:
+    """A base Mistral native config with every applicable field set to a non-default value."""
+    return MistralNativeConfig(
+        dim=5120,
+        n_layers=40,
+        head_dim=160,
+        hidden_dim=18432,
+        n_heads=40,
+        n_kv_heads=10,
+        rope_theta=50000.0,
+        norm_eps=1e-6,
+        vocab_size=33000,
+        max_position_embeddings=65536,
+        sliding_window=8192,
+        tied_embeddings=True,
+        quantization=QuantizationArgs(qformat_weight=QFormat.FP8_E4M3, qscheme_act="TENSOR"),
+    )
+
+
+def perturbed_ministral3_native_config() -> MistralNativeConfig:
+    """A Ministral3 native config with every applicable field set to a non-default value."""
+    return MistralNativeConfig(
+        dim=5120,
+        n_layers=40,
+        head_dim=160,
+        hidden_dim=18432,
+        n_heads=40,
+        n_kv_heads=10,
+        rope_theta=2000000.0,
+        norm_eps=1e-6,
+        vocab_size=33000,
+        max_position_embeddings=1048576,
+        sliding_window=8192,
+        tied_embeddings=False,
+        yarn=YarnArgs(factor=32.0, original_max_position_embeddings=32768, beta=16.0, alpha=2.0, apply_scale=True),
+        llama_4_scaling=Llama4Scaling(original_max_position_embeddings=32768, beta=0.25),
+        quantization=QuantizationArgs(qformat_weight=QFormat.FP8_E4M3, qscheme_act="TENSOR"),
+    )
+
+
+def perturbed_mistral4_native_config() -> MistralNativeConfig:
+    """A Mistral4 (MLA + MoE) native config with every field set to a non-default value.
+
+    `head_dim` is kept consistent with `qk_nope_head_dim + qk_rope_head_dim`, as anything
+    else is rejected.
+    """
+    return MistralNativeConfig(
+        dim=5120,
+        n_layers=48,
+        head_dim=192,
+        hidden_dim=20480,
+        n_heads=48,
+        n_kv_heads=48,
+        rope_theta=20000.0,
+        norm_eps=1e-6,
+        vocab_size=34000,
+        max_position_embeddings=1048576,
+        sliding_window=4096,
+        tied_embeddings=True,
+        q_lora_rank=2048,
+        qk_rope_head_dim=96,
+        qk_nope_head_dim=96,
+        kv_lora_rank=512,
+        v_head_dim=192,
+        yarn=YarnArgs(factor=64.0, original_max_position_embeddings=16384, beta=16.0, alpha=2.0, apply_scale=True),
+        llama_4_scaling=Llama4Scaling(original_max_position_embeddings=16384, beta=0.2),
+        moe=MOEModelArgs(
+            first_k_dense_replace=2,
+            num_experts=256,
+            num_experts_per_tok=8,
+            num_expert_groups=4,
+            num_expert_groups_per_tok=2,
+            routed_scale=2.5,
+            expert_hidden_dim=4096,
+            num_shared_experts=2,
+            expert_parallel=4,
+            expert_model_parallel=2,
+            route_every_n=3,
+        ),
+        quantization=QuantizationArgs(qformat_weight=QFormat.FP8_E4M3, qscheme_act="TENSOR"),
+    )
+
+
+def perturbed_vision_encoder_args() -> VisionEncoderArgs:
+    """A vision encoder config with every field set to a non-default value.
+
+    `mm_projector_id` and `add_pre_mm_projector_layer_norm` are kept at their only supported
+    values, as anything else is rejected.
+    """
+    return VisionEncoderArgs(
+        hidden_size=2048,
+        num_hidden_layers=32,
+        num_attention_heads=32,
+        patch_size=16,
+        image_size=2048,
+        intermediate_size=8192,
+        num_channels=4,
+        max_image_size=1024,
+        rope_theta=20000.0,
+        mm_projector_id="patch_merge",
+        add_pre_mm_projector_layer_norm=True,
+        adapter_bias=True,
+        spatial_merge_size=4,
+        image_token_id=20,
+        image_break_token_id=99,
+        image_end_token_id=100,
+    )
+
+
+def perturbed_mistral3_native_config() -> MistralNativeConfig:
+    """A Mistral3 (VLM) native config with every field set to a non-default value."""
+    return MistralNativeConfig(
+        dim=5120,
+        n_layers=40,
+        head_dim=160,
+        hidden_dim=18432,
+        n_heads=40,
+        n_kv_heads=10,
+        rope_theta=5000000.0,
+        norm_eps=1e-6,
+        vocab_size=33000,
+        max_position_embeddings=262144,
+        sliding_window=6144,
+        tied_embeddings=True,
+        quantization=QuantizationArgs(qformat_weight=QFormat.FP8_E4M3, qscheme_act="TENSOR"),
+        vision_encoder=perturbed_vision_encoder_args(),
+    )
+
+
+def perturbed_mistral3_moe_native_config() -> MistralNativeConfig:
+    """A Mistral3 (VLM) native config whose text sub-config is itself Mistral4 (MLA + MoE).
+
+    Has both `vision_encoder` and `moe` set, with every field at a non-default value, so the
+    preserved extras must carry both sections at once.
+    """
+    return dataclasses.replace(
+        perturbed_mistral4_native_config(),
+        vision_encoder=perturbed_vision_encoder_args(),
+    )

--- a/tests/integrations/mistral/test_params_conversion_forward.py
+++ b/tests/integrations/mistral/test_params_conversion_forward.py
@@ -1,0 +1,604 @@
+# Copyright 2026 Mistral AI and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from parameterized import parameterized
+
+from transformers import Ministral3Config, Mistral3Config, Mistral4Config, MistralConfig
+from transformers.integrations.mistral.native_config import (
+    Llama4Scaling,
+    MistralNativeConfig,
+    QFormat,
+    QuantizationArgs,
+    YarnArgs,
+    mistral_native_config_from_params,
+)
+from transformers.integrations.mistral.params_conversion import (
+    _get_maybe_quant_config,
+    _get_rope_parameters,
+    mistral_native_config_to_hf_config,
+)
+from transformers.quantizers.auto import AutoQuantizationConfig
+from transformers.testing_utils import require_compressed_tensors
+from transformers.utils.quantization_config import QuantizationConfigMixin
+
+from .mistral_fixture_data import (
+    RAW_MISTRAL_PARAMS,
+    base_native_config,
+    expected_ministral3_hf_config,
+    expected_mistral3_hf_config,
+    expected_mistral4_hf_config,
+    expected_mistral_hf_config,
+    make_hf_fp8_quant_config,
+    ministral3_native_config,
+    mistral3_native_config,
+    mistral4_asymmetric_mla_native_config,
+    mistral4_native_config,
+    moe_args,
+    perturbed_mistral3_native_config,
+    vision_encoder_args,
+)
+
+
+# Shapes of real published `params.json` files. Most of these are invented shapes (matching the
+# real file's schema, not its values); `_RAW_PARAMS_MISTRAL_7B_INSTRUCT_V0_3` below is the
+# exception, and is real ground truth.
+
+# Mirrors mistralai/Mistral-7B-Instruct-v0.3 verbatim: `params.json`.
+_RAW_PARAMS_MISTRAL_7B_INSTRUCT_V0_3 = {
+    "dim": 4096,
+    "n_layers": 32,
+    "head_dim": 128,
+    "hidden_dim": 14336,
+    "n_heads": 32,
+    "n_kv_heads": 8,
+    "norm_eps": 1e-05,
+    "vocab_size": 32768,
+    "rope_theta": 1000000.0,
+}
+
+# Mirrors `params.json` files that serialize `sliding_window` as a numeric string rather than
+# an int, as called out in the reference native-weights converter's `convert_config`.
+_RAW_PARAMS_STRING_SLIDING_WINDOW = {
+    "dim": 4096,
+    "n_layers": 32,
+    "head_dim": 128,
+    "hidden_dim": 14336,
+    "n_heads": 32,
+    "n_kv_heads": 8,
+    "norm_eps": 1e-05,
+    "vocab_size": 32000,
+    "rope_theta": 10000.0,
+    "sliding_window": "4096",
+    "max_position_embeddings": 32768,
+}
+
+# Mirrors mistralai/Ministral-8B-Instruct-2410: `sliding_window` is an interleaved per-layer
+# list (e.g. `[null, 32768, 32768, 32768]`), which cannot be represented by `MistralConfig` yet.
+_RAW_PARAMS_MINISTRAL_8B_INTERLEAVED_SLIDING_WINDOW = {
+    "dim": 4096,
+    "n_layers": 4,
+    "head_dim": 128,
+    "hidden_dim": 12288,
+    "n_heads": 32,
+    "n_kv_heads": 8,
+    "norm_eps": 1e-05,
+    "vocab_size": 131072,
+    "rope_theta": 100000000.0,
+    "sliding_window": [None, 32768, 32768, 32768],
+    "max_position_embeddings": 32768,
+}
+
+# Mirrors mistralai/Mistral-Small-4-119B-2603-NVFP4's `params.json` `quantization_config` block
+# verbatim. That repo publishes no `config.json` (it cannot join the parity list in
+# test_published_config_parity.py), so this is the only ground truth for a full
+# compressed-tensors block, with nested `config_groups`/`input_activations`/`weights`, which is
+# exactly what `AutoQuantizationConfig.from_dict` round-tripping needs to be stressed against.
+_QUANTIZATION_CONFIG_NVFP4 = {
+    "quant_method": "compressed-tensors",
+    "format": "nvfp4-pack-quantized",
+    "quantization_status": "compressed",
+    "kv_cache_scheme": None,
+    "global_compression_ratio": None,
+    "sparsity_config": {},
+    "transform_config": {},
+    "version": "0.13.0",
+    "ignore": [
+        "model.embed_tokens",
+        "re:patch_merger.*",
+        "re:vision_encoder.*",
+        "re:vision_language_adapter.*",
+        "re:.*kv_a_proj_with_mqa$",
+        "re:.*q_a_proj$",
+        "re:.*gate$",
+        "re:.*self_attn.*",
+        "re:.*attention.*",
+        "lm_head",
+    ],
+    "config_groups": {
+        "NVFP4A16": {
+            "format": "nvfp4-pack-quantized",
+            "targets": ["Linear"],
+            "output_activations": None,
+            "input_activations": {
+                "num_bits": 4,
+                "type": "float",
+                "symmetric": True,
+                "strategy": "tensor_group",
+                "group_size": 16,
+                "dynamic": "local",
+                "actorder": None,
+                "observer": "static_minmax",
+                "observer_kwargs": {},
+                "block_structure": None,
+            },
+            "weights": {
+                "num_bits": 4,
+                "type": "float",
+                "symmetric": True,
+                "strategy": "tensor_group",
+                "group_size": 16,
+                "dynamic": False,
+                "actorder": None,
+                "observer": "static_minmax",
+                "observer_kwargs": {},
+                "block_structure": None,
+                "scale_dtype": "torch.float8_e4m3fn",
+                "zp_dtype": None,
+            },
+        }
+    },
+}
+
+# Mirrors mistralai/Devstral-2-123B-Instruct-2512 verbatim: `params.json`. A text-only model,
+# despite its published `config.json` listing vision/projector paths in
+# `quantization_config.modules_to_not_convert` (`_KNOWN_DEVIATIONS["devstral2"]` in
+# test_published_config_parity.py excludes that as a known-wrong artifact of the legacy
+# conversion script; see `test_devstral2_text_only_modules_to_not_convert_excludes_vision_paths`
+# below for the correct value this converter actually produces).
+_RAW_PARAMS_DEVSTRAL_2_123B_INSTRUCT_2512 = {
+    "dim": 12288,
+    "n_layers": 88,
+    "head_dim": 128,
+    "hidden_dim": 28672,
+    "n_heads": 96,
+    "n_kv_heads": 8,
+    "rope_theta": 1000000.0,
+    "norm_eps": 1e-05,
+    "vocab_size": 131072,
+    "tied_embeddings": False,
+    "max_position_embeddings": 262144,
+    "q_lora_rank": None,
+    "qk_rope_head_dim": None,
+    "qk_nope_head_dim": None,
+    "kv_lora_rank": None,
+    "v_head_dim": None,
+    "quantization": {"qformat_weight": "fp8_e4m3", "qscheme_act": "TENSOR"},
+    "yarn": {
+        "original_max_position_embeddings": 4096,
+        "factor": 64,
+        "apply_scale": True,
+        "beta": 4,
+        "alpha": 1,
+    },
+}
+
+# Mirrors mistralai/Voxtral-Mini-3B-2507: `params.json` carries a `multimodal` section with a
+# `whisper_model_args` audio encoder that this module has no converter for.
+_RAW_PARAMS_VOXTRAL_MULTIMODAL = {
+    "dim": 3072,
+    "n_layers": 26,
+    "head_dim": 128,
+    "hidden_dim": 8192,
+    "n_heads": 24,
+    "n_kv_heads": 8,
+    "norm_eps": 1e-05,
+    "vocab_size": 131072,
+    "rope_theta": 100000000.0,
+    "sliding_window": None,
+    "max_position_embeddings": 131072,
+    "multimodal": {
+        "whisper_model_args": {
+            "encoder_args": {"dim": 1280, "n_layers": 32},
+            "downsample_factor": 4,
+        }
+    },
+}
+
+
+class TestQuantizationArgs(unittest.TestCase):
+    def test_valid_tensor_scheme(self) -> None:
+        config = QuantizationArgs(QFormat.FP8_E4M3, "TENSOR")
+        self.assertEqual(config, QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"))
+
+    def test_qformat_weight_is_coerced_to_qformat(self) -> None:
+        """`qformat_weight` is a `QFormat` at runtime regardless of whether the raw string
+        (as read from `params.json`) or the enum member was passed in."""
+        config = QuantizationArgs("fp8_e4m3", "TENSOR")
+        self.assertIs(config.qformat_weight, QFormat.FP8_E4M3)
+
+    def test_invalid_scheme_raises(self) -> None:
+        for scheme in ["DYNAMIC", "UNSUPPORTED", "static"]:
+            with self.subTest(scheme=scheme):
+                with self.assertRaisesRegex(ValueError, scheme):
+                    QuantizationArgs(QFormat.FP8_E4M3, scheme)
+
+    def test_unsupported_format_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "fp8_e4m3"):
+            QuantizationArgs("int8", "TENSOR")
+
+
+class TestGetMaybeQuantConfig(unittest.TestCase):
+    def test_none_returns_none(self) -> None:
+        self.assertIsNone(_get_maybe_quant_config(is_vision_model=False, quantization_args=None))
+
+    def test_tensor_produces_static(self) -> None:
+        qc = _get_maybe_quant_config(
+            is_vision_model=False,
+            quantization_args=QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"),
+        )
+        qc_dict = qc.to_dict()
+        self.assertEqual(qc_dict["quant_method"], "fp8")
+        self.assertEqual(qc_dict["activation_scheme"], "static")
+
+    def test_vision_model_adds_modules_to_skip(self) -> None:
+        qc = _get_maybe_quant_config(
+            is_vision_model=True,
+            quantization_args=QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"),
+        )
+        qc_dict = qc.to_dict()
+        self.assertIn("model.vision_tower", qc_dict["modules_to_not_convert"])
+        self.assertIn("model.multi_modal_projector", qc_dict["modules_to_not_convert"])
+        self.assertIn("lm_head", qc_dict["modules_to_not_convert"])
+
+    def test_unrecognized_qformat_weight_raises(self) -> None:
+        """`QuantizationArgs.__post_init__` rejects any `qformat_weight` other than a `QFormat`
+        member, so this state can only be reached by mutating an already-constructed instance.
+        `_get_maybe_quant_config` must raise rather than silently returning `None` or a
+        mislabeled config."""
+        quantization_args = QuantizationArgs(QFormat.FP8_E4M3, "TENSOR")
+        quantization_args.qformat_weight = "not-a-real-qformat"
+        with self.assertRaisesRegex(ValueError, "invalid quantization config"):
+            _get_maybe_quant_config(is_vision_model=False, quantization_args=quantization_args)
+
+
+class TestNativeConfigFromParams(unittest.TestCase):
+    """Parsing a raw `params.json` dict into a `MistralNativeConfig`."""
+
+    def test_parses_flat_fields_and_applies_defaults(self) -> None:
+        native = mistral_native_config_from_params(RAW_MISTRAL_PARAMS)
+        self.assertEqual(native.dim, 4096)
+        self.assertEqual(native.n_layers, 32)
+        self.assertEqual(native.head_dim, 128)
+        self.assertEqual(native.n_kv_heads, 8)
+        self.assertEqual(native.sliding_window, 4096)
+        # Absent from the raw dict, so the dataclass defaults apply.
+        self.assertFalse(native.tied_embeddings)
+        self.assertIsNone(native.yarn)
+        self.assertIsNone(native.moe)
+        self.assertIsNone(native.vision_encoder)
+        self.assertIsNone(native.quantization)
+
+    def test_parses_nested_sections(self) -> None:
+        raw = {
+            **RAW_MISTRAL_PARAMS,
+            "tied_embeddings": True,
+            "yarn": {
+                "factor": 16.0,
+                "original_max_position_embeddings": 16384,
+                "beta": 32.0,
+                "alpha": 1.0,
+                "apply_scale": True,
+            },
+            "llama_4_scaling": {"original_max_position_embeddings": 16384, "beta": 0.1},
+            "quantization": {"qformat_weight": "fp8_e4m3", "qscheme_act": "TENSOR"},
+        }
+        native = mistral_native_config_from_params(raw)
+        self.assertTrue(native.tied_embeddings)
+        self.assertEqual(native.yarn, YarnArgs(16.0, 16384, 32.0, 1.0, True))
+        self.assertEqual(native.llama_4_scaling, Llama4Scaling(16384, 0.1))
+        self.assertEqual(native.quantization, QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"))
+
+    def test_parsed_config_converts_to_hf(self) -> None:
+        native = mistral_native_config_from_params(RAW_MISTRAL_PARAMS)
+        self.assertIsInstance(mistral_native_config_to_hf_config(native), MistralConfig)
+
+    def test_sliding_window_forwards_numeric_value_to_hf_config(self) -> None:
+        """A non-null numeric `sliding_window` from `params.json` must reach the HF config
+        unchanged. Hardcoding `None` in the forward mapping would only be caught by the
+        round-trip loop, which a symmetric mistake in both directions could survive."""
+        native = mistral_native_config_from_params(RAW_MISTRAL_PARAMS)
+        hf = mistral_native_config_to_hf_config(native)
+        self.assertEqual(hf.sliding_window, 4096)
+
+    def test_missing_required_field_raises(self) -> None:
+        raw = {k: v for k, v in RAW_MISTRAL_PARAMS.items() if k != "dim"}
+        with self.assertRaises(KeyError):
+            mistral_native_config_from_params(raw)
+
+
+class TestNativeConfigFromParamsRealisticShapes(unittest.TestCase):
+    """Parsing published `params.json` shapes, each omitting fields `RAW_MISTRAL_PARAMS` supplies."""
+
+    def test_missing_max_position_embeddings_defaults(self) -> None:
+        """Mistral-7B-Instruct-v0.3 shape: no `max_position_embeddings`, so the default applies."""
+        native = mistral_native_config_from_params(_RAW_PARAMS_MISTRAL_7B_INSTRUCT_V0_3)
+        self.assertEqual(native.max_position_embeddings, 32768)
+        self.assertIsInstance(mistral_native_config_to_hf_config(native), MistralConfig)
+
+    @parameterized.expand(["head_dim", "n_kv_heads", "rope_theta"])
+    def test_missing_non_defaultable_field_raises(self, field: str) -> None:
+        """Every published `params.json` supplies these, so omitting one is an error, not a default."""
+        raw = {k: v for k, v in RAW_MISTRAL_PARAMS.items() if k != field}
+        with self.assertRaises(KeyError):
+            mistral_native_config_from_params(raw)
+
+    def test_string_sliding_window_is_coerced_to_int(self) -> None:
+        native = mistral_native_config_from_params(_RAW_PARAMS_STRING_SLIDING_WINDOW)
+        self.assertEqual(native.sliding_window, 4096)
+        self.assertIsInstance(native.sliding_window, int)
+
+    def test_interleaved_sliding_window_raises(self) -> None:
+        """Ministral-8B-Instruct-2410 shape: per-layer interleaved `sliding_window` list."""
+        with self.assertRaisesRegex(TypeError, "sliding_window"):
+            mistral_native_config_from_params(_RAW_PARAMS_MINISTRAL_8B_INTERLEAVED_SLIDING_WINDOW)
+
+    def test_voxtral_multimodal_section_raises(self) -> None:
+        """Voxtral-Mini-3B-2507 shape: unsupported `multimodal`/`whisper_model_args` section."""
+        with self.assertRaisesRegex(ValueError, "multimodal"):
+            mistral_native_config_from_params(_RAW_PARAMS_VOXTRAL_MULTIMODAL)
+
+    @require_compressed_tensors
+    def test_ready_made_quantization_config_is_carried_through_verbatim(self) -> None:
+        """Mistral-Small-4-119B-2603-NVFP4 shape: `params.json` ships an HF `quantization_config`,
+        here the real compressed-tensors block (not installed locally, hence the skip)."""
+        raw = {**RAW_MISTRAL_PARAMS, "quantization_config": _QUANTIZATION_CONFIG_NVFP4}
+        expected = AutoQuantizationConfig.from_dict(_QUANTIZATION_CONFIG_NVFP4)
+
+        native = mistral_native_config_from_params(raw)
+
+        self.assertIsInstance(native.quantization_config, QuantizationConfigMixin)
+        self.assertEqual(native.quantization_config, expected)
+        self.assertIsNone(native.quantization)
+        self.assertEqual(mistral_native_config_to_hf_config(native).quantization_config, expected)
+
+    def test_devstral2_text_only_modules_to_not_convert_excludes_vision_paths(self) -> None:
+        """Devstral-2-123B-Instruct-2512 is text-only, so `is_vision_model=False` must yield
+        exactly `["lm_head"]`. Its published `config.json` wrongly carries vision/projector
+        paths too (excluded from parity as a known deviation), which otherwise leaves this
+        branch with no published ground truth at all."""
+        native = mistral_native_config_from_params(_RAW_PARAMS_DEVSTRAL_2_123B_INSTRUCT_2512)
+        hf = mistral_native_config_to_hf_config(native)
+        self.assertEqual(hf.quantization_config.to_dict()["modules_to_not_convert"], ["lm_head"])
+
+    def test_vision_encoder_missing_required_fields_raises_domain_error(self) -> None:
+        """Pixtral-12B-2409 shape: `vision_encoder` missing several required fields must raise
+        a `ValueError` naming the section and the missing keys, not a bare `KeyError`."""
+        raw = {**RAW_MISTRAL_PARAMS, "vision_encoder": {"hidden_size": 1024, "num_hidden_layers": 24}}
+        with self.assertRaisesRegex(ValueError, r"vision_encoder.*max_image_size"):
+            mistral_native_config_from_params(raw)
+
+    def test_moe_missing_required_fields_raises_domain_error(self) -> None:
+        raw = {**RAW_MISTRAL_PARAMS, "moe": {"num_experts": 8}}
+        with self.assertRaisesRegex(ValueError, r"moe.*num_experts_per_tok"):
+            mistral_native_config_from_params(raw)
+
+
+class TestMistralNativeConfig(unittest.TestCase):
+    def test_mutual_exclusivity_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Cannot set both"):
+            MistralNativeConfig(
+                dim=4096,
+                n_layers=32,
+                head_dim=128,
+                hidden_dim=14336,
+                n_heads=32,
+                n_kv_heads=8,
+                rope_theta=10000.0,
+                norm_eps=1e-5,
+                vocab_size=32000,
+                max_position_embeddings=32768,
+                quantization=QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"),
+                quantization_config=make_hf_fp8_quant_config(),
+            )
+
+    def test_single_or_no_quantization_ok(self) -> None:
+        test_cases = [
+            ("native_only", {"quantization": QuantizationArgs(QFormat.FP8_E4M3, "TENSOR")}),
+            ("hf_only", {"quantization_config": make_hf_fp8_quant_config()}),
+            ("neither", {}),
+        ]
+        for test_id, quant_kwargs in test_cases:
+            with self.subTest(test_id):
+                native = MistralNativeConfig(
+                    dim=4096,
+                    n_layers=32,
+                    head_dim=128,
+                    hidden_dim=14336,
+                    n_heads=32,
+                    n_kv_heads=8,
+                    rope_theta=10000.0,
+                    norm_eps=1e-5,
+                    vocab_size=32000,
+                    max_position_embeddings=32768,
+                    **quant_kwargs,
+                )
+                has_native = "quantization" in quant_kwargs
+                has_hf = "quantization_config" in quant_kwargs
+                self.assertEqual(native.quantization is not None, has_native)
+                self.assertEqual(native.quantization_config is not None, has_hf)
+
+
+class TestNativeToHF(unittest.TestCase):
+    def test_native_to_hf(self) -> None:
+        test_cases = [
+            ("mistral", base_native_config, MistralConfig, expected_mistral_hf_config),
+            ("ministral3", ministral3_native_config, Ministral3Config, expected_ministral3_hf_config),
+            ("mistral4", mistral4_native_config, Mistral4Config, expected_mistral4_hf_config),
+            ("mistral3", mistral3_native_config, Mistral3Config, expected_mistral3_hf_config),
+        ]
+        for test_id, native_factory, expected_type, expected_factory in test_cases:
+            with self.subTest(test_id):
+                hf = mistral_native_config_to_hf_config(native_factory())
+                self.assertIsInstance(hf, expected_type)
+                self.assertEqual(hf, expected_factory())
+
+    def test_partial_rotary_factor_uses_qk_rope_over_total(self) -> None:
+        """`qk_rope_head_dim=32`, `qk_nope_head_dim=96` is asymmetric, so only the correct
+        `qk_rope / (qk_nope + qk_rope)` formula can produce 0.25; the swapped formula
+        (`qk_nope / (qk_nope + qk_rope)`) would produce 0.75 instead. Every other MLA fixture
+        in this module has an equal rope/nope split, which makes the two formulas
+        indistinguishable."""
+        hf = mistral_native_config_to_hf_config(mistral4_asymmetric_mla_native_config())
+        self.assertEqual(hf.rope_parameters["partial_rotary_factor"], 0.25)
+
+    def test_non_yarn_omits_llama_4_scaling_beta(self) -> None:
+        hf = mistral_native_config_to_hf_config(base_native_config())
+        self.assertNotIn("llama_4_scaling_beta", hf.rope_parameters)
+
+    def test_forward_moe_without_mla_raises(self) -> None:
+        moe = moe_args()
+        native = MistralNativeConfig(
+            dim=4096,
+            n_layers=32,
+            head_dim=128,
+            hidden_dim=14336,
+            n_heads=32,
+            n_kv_heads=8,
+            rope_theta=10000.0,
+            norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=32768,
+            moe=moe,
+        )
+        with self.assertRaisesRegex(ValueError, "MOE and MLA"):
+            mistral_native_config_to_hf_config(native)
+
+    def test_qk_rope_nope_mismatch_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "qk_rope and qk_nope must both be None or both set"):
+            _get_rope_parameters(
+                rope_theta=10000.0,
+                yarn_args=None,
+                llama4_scaling=None,
+                qk_rope=64,
+                qk_nope=None,
+            )
+
+    def test_llama_4_scaling_without_yarn_raises(self) -> None:
+        native = mistral4_native_config()
+        native.yarn = None
+        native.llama_4_scaling = Llama4Scaling(original_max_position_embeddings=16384, beta=0.2)
+        with self.assertRaisesRegex(ValueError, "llama_4_scaling"):
+            mistral_native_config_to_hf_config(native)
+
+    def test_mm_projector_id_other_than_patch_merge_raises(self) -> None:
+        native = mistral3_native_config()
+        native.vision_encoder.mm_projector_id = "something_else"
+        with self.assertRaisesRegex(ValueError, "mm_projector_id.*something_else.*patch_merge"):
+            mistral_native_config_to_hf_config(native)
+
+    def test_outer_tie_word_embeddings_matches_native(self) -> None:
+        """The outer `Mistral3Config.tie_word_embeddings` must reflect `native.tied_embeddings`
+        directly: the reverse converter reads tying off `text_config` instead, so a wrong
+        outer value here is otherwise invisible to every round-trip test."""
+        native = perturbed_mistral3_native_config()
+        self.assertTrue(native.tied_embeddings)
+        hf = mistral_native_config_to_hf_config(native)
+        self.assertEqual(hf.tie_word_embeddings, native.tied_embeddings)
+
+    def test_add_pre_mm_projector_layer_norm_false_raises(self) -> None:
+        native = mistral3_native_config()
+        native.vision_encoder.add_pre_mm_projector_layer_norm = False
+        with self.assertRaisesRegex(ValueError, "add_pre_mm_projector_layer_norm"):
+            mistral_native_config_to_hf_config(native)
+
+    def test_mistral4_head_dim_inconsistent_with_mla_split_raises(self) -> None:
+        native = mistral4_native_config()
+        native.head_dim = native.qk_nope_head_dim + native.qk_rope_head_dim + 1
+        with self.assertRaisesRegex(ValueError, "head_dim"):
+            mistral_native_config_to_hf_config(native)
+
+    def test_vision_encoder_unsupported_type_raises(self) -> None:
+        """`vision_encoder` is typed `VisionEncoderArgs | None` but not enforced at runtime;
+        no public path can build a `MistralNativeConfig` with any other value, but the dispatcher
+        must still refuse rather than silently returning `None`."""
+        native = base_native_config()
+        native.vision_encoder = "not-a-vision-encoder"
+        with self.assertRaisesRegex(ValueError, "Unsupported vision_encoder type"):
+            mistral_native_config_to_hf_config(native)
+
+
+class TestNativeToHFQuantization(unittest.TestCase):
+    def test_tensor_fp8_propagates_to_mistral3(self) -> None:
+        native = MistralNativeConfig(
+            dim=4096,
+            n_layers=32,
+            head_dim=128,
+            hidden_dim=14336,
+            n_heads=32,
+            n_kv_heads=8,
+            rope_theta=1000000000.0,
+            norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=131072,
+            quantization=QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"),
+            vision_encoder=vision_encoder_args(),
+        )
+        hf = mistral_native_config_to_hf_config(native)
+        qc = hf.quantization_config
+        if hasattr(qc, "to_dict"):
+            qc = qc.to_dict()
+        self.assertEqual(qc["activation_scheme"], "static")
+
+    def test_quantization_config_passthrough_mistral(self) -> None:
+        native = MistralNativeConfig(
+            dim=4096,
+            n_layers=32,
+            head_dim=128,
+            hidden_dim=14336,
+            n_heads=32,
+            n_kv_heads=8,
+            rope_theta=10000.0,
+            norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=32768,
+            quantization_config=make_hf_fp8_quant_config("dynamic"),
+        )
+        hf = mistral_native_config_to_hf_config(native)
+        qc_dict = hf.quantization_config.to_dict()
+        self.assertEqual(qc_dict["activation_scheme"], "dynamic")
+        self.assertEqual(qc_dict["quant_method"], "fp8")
+
+    def test_native_quantization_forward_still_works(self) -> None:
+        native = MistralNativeConfig(
+            dim=4096,
+            n_layers=32,
+            head_dim=128,
+            hidden_dim=14336,
+            n_heads=32,
+            n_kv_heads=8,
+            rope_theta=10000.0,
+            norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=32768,
+            quantization=QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"),
+        )
+        hf = mistral_native_config_to_hf_config(native)
+        qc_dict = hf.quantization_config.to_dict()
+        self.assertEqual(qc_dict["activation_scheme"], "static")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integrations/mistral/test_params_conversion_reverse.py
+++ b/tests/integrations/mistral/test_params_conversion_reverse.py
@@ -1,0 +1,485 @@
+# Copyright 2026 Mistral AI and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from types import SimpleNamespace
+
+from transformers import Ministral3Config, Mistral3Config, Mistral4Config, MistralConfig
+from transformers.integrations.mistral.native_config import (
+    Llama4Scaling,
+    MistralNativeConfig,
+    QFormat,
+    QuantizationArgs,
+    YarnArgs,
+)
+from transformers.integrations.mistral.params_conversion import (
+    _extract_rope_theta,
+    _hf_mistral_to_native,
+    _hf_quant_config_to_native,
+    mistral_native_config_from_hf_config,
+    mistral_native_config_to_hf_config,
+)
+from transformers.models.pixtral.configuration_pixtral import PixtralVisionConfig
+
+from .mistral_fixture_data import (
+    base_native_config,
+    llama4_scaling,
+    make_hf_fp8_quant_config,
+    make_non_reversible_quant_config,
+    ministral3_native_config,
+    mistral3_native_config,
+    mistral4_native_config,
+    moe_args,
+    yarn_args,
+)
+
+
+class TestHFToNativeMistral(unittest.TestCase):
+    def test_unknown_fp8_activation_scheme_returns_none(self) -> None:
+        """An unrecognised FP8 activation_scheme yields None rather than mapping to TENSOR."""
+        self.assertIsNone(_hf_quant_config_to_native(make_hf_fp8_quant_config("dynamic")))
+
+    def test_basic_reverse(self) -> None:
+        config = base_native_config()
+        hf = MistralConfig(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            rms_norm_eps=1e-5,
+            head_dim=128,
+            vocab_size=32000,
+            max_position_embeddings=32768,
+            sliding_window=None,
+        )
+        native = mistral_native_config_from_hf_config(hf)
+        self.assertEqual(native, config)
+
+    def test_roundtrip(self) -> None:
+        config = base_native_config()
+        restored = mistral_native_config_from_hf_config(mistral_native_config_to_hf_config(config))
+        self.assertEqual(restored, config)
+
+    def test_reverse_with_quantization_config(self) -> None:
+        hf = MistralConfig(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            rms_norm_eps=1e-5,
+            head_dim=128,
+            vocab_size=32000,
+            max_position_embeddings=32768,
+            sliding_window=None,
+            quantization_config=make_hf_fp8_quant_config(),
+        )
+        native = mistral_native_config_from_hf_config(hf)
+        self.assertIsNotNone(native.quantization)
+        self.assertIsNone(native.quantization_config)
+        self.assertEqual(native.quantization, QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"))
+        expected = MistralNativeConfig(
+            dim=4096,
+            n_layers=32,
+            head_dim=128,
+            hidden_dim=14336,
+            n_heads=32,
+            n_kv_heads=8,
+            rope_theta=10000.0,
+            norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=32768,
+            quantization=native.quantization,
+        )
+        self.assertEqual(native, expected)
+
+    def test_reverse_with_non_reversible_quant(self) -> None:
+        hf_quant = make_non_reversible_quant_config()
+        hf = MistralConfig(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            rms_norm_eps=1e-5,
+            head_dim=128,
+            vocab_size=32000,
+            max_position_embeddings=32768,
+            quantization_config=hf_quant,
+        )
+        native = mistral_native_config_from_hf_config(hf)
+        self.assertIsNone(native.quantization)
+        self.assertIsNotNone(native.quantization_config)
+        self.assertEqual(native.quantization_config.to_dict()["quant_method"], "gptq")
+
+
+class TestHFToNativeMinistral3(unittest.TestCase):
+    def test_basic_reverse(self) -> None:
+        config = ministral3_native_config()
+        hf = Ministral3Config(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            rms_norm_eps=1e-5,
+            head_dim=128,
+            vocab_size=32000,
+            max_position_embeddings=262144,
+            tie_word_embeddings=True,
+            rope_parameters={
+                "type": "yarn",
+                "rope_theta": 1000000.0,
+                "factor": 16.0,
+                "original_max_position_embeddings": 16384,
+                "beta_fast": 32.0,
+                "beta_slow": 1.0,
+                "mscale_all_dim": 1.0,
+                "mscale": 1.0,
+                "llama_4_scaling_beta": 0.1,
+            },
+        )
+        native = mistral_native_config_from_hf_config(hf)
+        self.assertEqual(native, config)
+
+    def test_roundtrip(self) -> None:
+        """mscale is always 1.0; mscale_all_dim is 0.0 when apply_scale is True, else 1.0."""
+        for apply_scale, expected_mscale_all_dim in [(False, 1.0), (True, 0.0)]:
+            with self.subTest(apply_scale=apply_scale):
+                ya = YarnArgs(
+                    factor=16.0, original_max_position_embeddings=16384, beta=32, alpha=1, apply_scale=apply_scale
+                )
+                l4s = Llama4Scaling(original_max_position_embeddings=16384, beta=0.1)
+                native = MistralNativeConfig(
+                    dim=4096,
+                    n_layers=32,
+                    head_dim=128,
+                    hidden_dim=14336,
+                    n_heads=32,
+                    n_kv_heads=8,
+                    rope_theta=1000000.0,
+                    norm_eps=1e-5,
+                    vocab_size=32000,
+                    max_position_embeddings=262144,
+                    tied_embeddings=True,
+                    yarn=ya,
+                    llama_4_scaling=l4s,
+                )
+                hf = mistral_native_config_to_hf_config(native)
+                rope = hf.rope_parameters
+                assert "mscale" in rope, f"mscale missing from rope_parameters when {apply_scale=}"
+                assert rope["mscale"] == 1.0, f"Expected mscale=1.0 for {apply_scale=}, got {rope['mscale']}"
+                assert rope["mscale_all_dim"] == expected_mscale_all_dim, (
+                    f"Expected mscale_all_dim={expected_mscale_all_dim} for {apply_scale=}, "
+                    f"got {rope['mscale_all_dim']}"
+                )
+                restored = mistral_native_config_from_hf_config(hf)
+                self.assertEqual(restored, native)
+
+    def test_llama_4_scaling_defaults_to_zero_and_roundtrips_to_none(self) -> None:
+        """A yarn config with no `llama_4_scaling` emits beta 0 and round-trips back to None."""
+        native = MistralNativeConfig(
+            dim=4096,
+            n_layers=32,
+            head_dim=128,
+            hidden_dim=14336,
+            n_heads=32,
+            n_kv_heads=8,
+            rope_theta=1000000.0,
+            norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=262144,
+            tied_embeddings=True,
+            yarn=yarn_args(),
+        )
+        hf = mistral_native_config_to_hf_config(native)
+        self.assertEqual(hf.rope_parameters["llama_4_scaling_beta"], 0)
+        restored = mistral_native_config_from_hf_config(hf)
+        self.assertIsNone(restored.llama_4_scaling)
+        self.assertEqual(restored, native)
+
+    def test_roundtrip_with_quantization(self) -> None:
+        ya = yarn_args()
+        l4s = llama4_scaling()
+        native = MistralNativeConfig(
+            dim=4096,
+            n_layers=32,
+            head_dim=128,
+            hidden_dim=14336,
+            n_heads=32,
+            n_kv_heads=8,
+            rope_theta=1000000.0,
+            norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=262144,
+            tied_embeddings=True,
+            yarn=ya,
+            llama_4_scaling=l4s,
+            quantization=QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"),
+        )
+        hf = mistral_native_config_to_hf_config(native)
+        restored = mistral_native_config_from_hf_config(hf)
+        self.assertIsNotNone(restored.quantization)
+        self.assertIsNone(restored.quantization_config)
+        self.assertEqual(restored.quantization, QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"))
+        self.assertEqual(restored, native)
+
+    def test_reverse_with_non_reversible_quant(self) -> None:
+        hf_quant = make_non_reversible_quant_config()
+        hf = Ministral3Config(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            rms_norm_eps=1e-5,
+            head_dim=128,
+            vocab_size=32000,
+            max_position_embeddings=262144,
+            tie_word_embeddings=True,
+            rope_parameters={
+                "type": "yarn",
+                "rope_theta": 1000000.0,
+                "factor": 16.0,
+                "original_max_position_embeddings": 16384,
+                "beta_fast": 32.0,
+                "beta_slow": 1.0,
+                "mscale_all_dim": 1.0,
+                "llama_4_scaling_beta": 0.1,
+            },
+            quantization_config=hf_quant,
+        )
+        native = mistral_native_config_from_hf_config(hf)
+        self.assertIsNone(native.quantization)
+        self.assertIsNotNone(native.quantization_config)
+        self.assertEqual(native.quantization_config.to_dict()["quant_method"], "gptq")
+
+
+class TestHFToNativeMistral3(unittest.TestCase):
+    def test_basic_reverse(self) -> None:
+        config = mistral3_native_config()
+        text_config = MistralConfig(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            rms_norm_eps=1e-5,
+            head_dim=128,
+            vocab_size=32000,
+            rope_theta=1000000000.0,
+            sliding_window=None,
+            max_position_embeddings=131072,
+        )
+        vision_config = PixtralVisionConfig(
+            hidden_size=1024,
+            num_hidden_layers=24,
+            num_attention_heads=16,
+            patch_size=14,
+            image_size=1540,
+            intermediate_size=4096,
+            hidden_act="silu",
+            rope_theta=10000.0,
+        )
+        hf = Mistral3Config(
+            text_config=text_config,
+            vision_config=vision_config,
+            multimodal_projector_bias=False,
+            image_token_id=10,
+            spatial_merge_size=2,
+            vision_feature_layer=-1,
+        )
+        native = mistral_native_config_from_hf_config(hf)
+        self.assertEqual(native, config)
+
+    def test_reverse_with_non_reversible_quant(self) -> None:
+        hf_quant = make_non_reversible_quant_config()
+        text_config = MistralConfig(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            rms_norm_eps=1e-5,
+            head_dim=128,
+            vocab_size=32000,
+            max_position_embeddings=131072,
+        )
+        vision_config = PixtralVisionConfig(
+            hidden_size=1024,
+            num_hidden_layers=24,
+            num_attention_heads=16,
+            patch_size=14,
+            image_size=1540,
+            intermediate_size=4096,
+            hidden_act="silu",
+            rope_theta=10000.0,
+        )
+        hf = Mistral3Config(
+            text_config=text_config,
+            vision_config=vision_config,
+            multimodal_projector_bias=False,
+            image_token_id=10,
+            spatial_merge_size=2,
+            vision_feature_layer=-1,
+            quantization_config=hf_quant,
+        )
+        native = mistral_native_config_from_hf_config(hf)
+        self.assertIsNone(native.quantization)
+        self.assertIsNotNone(native.quantization_config)
+        self.assertEqual(native.quantization_config.to_dict()["quant_method"], "gptq")
+
+
+class TestHFToNativeMistral4(unittest.TestCase):
+    def test_basic_reverse(self) -> None:
+        config = mistral4_native_config()
+        hf = Mistral4Config(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=32,
+            rms_norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=1048576,
+            q_lora_rank=1024,
+            qk_rope_head_dim=64,
+            qk_nope_head_dim=64,
+            kv_lora_rank=256,
+            v_head_dim=128,
+            n_routed_experts=128,
+            num_experts_per_tok=4,
+            moe_intermediate_size=2048,
+            first_k_dense_replace=0,
+            n_shared_experts=1,
+            routed_scaling_factor=1.0,
+            n_group=1,
+            topk_group=1,
+        )
+        native = mistral_native_config_from_hf_config(hf)
+        self.assertEqual(native, config)
+
+    def test_roundtrip(self) -> None:
+        config = mistral4_native_config()
+        restored = mistral_native_config_from_hf_config(mistral_native_config_to_hf_config(config))
+        self.assertEqual(restored, config)
+
+    def test_roundtrip_with_quantization(self) -> None:
+        _moe_args = moe_args()
+        native = MistralNativeConfig(
+            dim=4096,
+            n_layers=32,
+            head_dim=128,
+            hidden_dim=14336,
+            n_heads=32,
+            n_kv_heads=32,
+            rope_theta=10000.0,
+            norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=1048576,
+            q_lora_rank=1024,
+            qk_rope_head_dim=64,
+            qk_nope_head_dim=64,
+            kv_lora_rank=256,
+            v_head_dim=128,
+            yarn=YarnArgs(
+                factor=128.0, original_max_position_embeddings=8192, beta=32.0, alpha=1.0, apply_scale=False
+            ),
+            llama_4_scaling=Llama4Scaling(original_max_position_embeddings=8192, beta=0.1),
+            moe=_moe_args,
+            quantization=QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"),
+        )
+        hf = mistral_native_config_to_hf_config(native)
+        restored = mistral_native_config_from_hf_config(hf)
+        self.assertIsNotNone(restored.quantization)
+        self.assertIsNone(restored.quantization_config)
+        self.assertEqual(restored.quantization, QuantizationArgs(QFormat.FP8_E4M3, "TENSOR"))
+        self.assertEqual(restored, native)
+
+    def test_reverse_with_non_reversible_quant(self) -> None:
+        hf_quant = make_non_reversible_quant_config()
+        hf = Mistral4Config(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=32,
+            rms_norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=1048576,
+            q_lora_rank=1024,
+            qk_rope_head_dim=64,
+            qk_nope_head_dim=64,
+            kv_lora_rank=256,
+            v_head_dim=128,
+            n_routed_experts=128,
+            num_experts_per_tok=4,
+            moe_intermediate_size=2048,
+            first_k_dense_replace=0,
+            n_shared_experts=1,
+            routed_scaling_factor=1.0,
+            n_group=1,
+            topk_group=1,
+            quantization_config=hf_quant,
+        )
+        native = mistral_native_config_from_hf_config(hf)
+        self.assertIsNone(native.quantization)
+        self.assertIsNotNone(native.quantization_config)
+        self.assertEqual(native.quantization_config.to_dict()["quant_method"], "gptq")
+
+
+class TestErrorPaths(unittest.TestCase):
+    def test_hf_mistral_missing_head_dim_raises(self) -> None:
+        hf = MistralConfig(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            rms_norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=32768,
+        )
+        # MistralConfig auto-computes head_dim; force it to None to test the guard
+        hf.head_dim = None
+        with self.assertRaisesRegex(ValueError, "head_dim must be set"):
+            _hf_mistral_to_native(hf)
+
+    def test_extract_rope_theta_missing_raises(self) -> None:
+        config = SimpleNamespace(rope_scaling=None)
+        with self.assertRaisesRegex(ValueError, "rope_theta"):
+            _extract_rope_theta(config)
+
+    def test_unrecognized_quantization_config_type_raises(self) -> None:
+        """A `quantization_config` neither `None`, a `dict`, nor a `QuantizationConfigMixin`
+        must be reported loudly rather than silently treated as absent."""
+        hf = MistralConfig(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            rms_norm_eps=1e-5,
+            head_dim=128,
+            vocab_size=32000,
+            max_position_embeddings=32768,
+        )
+        hf.quantization_config = 42
+        with self.assertRaisesRegex(TypeError, "Unsupported `quantization_config` type"):
+            mistral_native_config_from_hf_config(hf)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integrations/mistral/test_params_conversion_roundtrip.py
+++ b/tests/integrations/mistral/test_params_conversion_roundtrip.py
@@ -1,0 +1,259 @@
+# Copyright 2026 Mistral AI and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+import unittest
+
+from transformers import Mistral3Config, Mistral4Config, MistralConfig
+from transformers.configuration_utils import PreTrainedConfig
+from transformers.integrations.mistral.native_config import mistral_native_config_from_params
+from transformers.integrations.mistral.params_conversion import (
+    _MISTRAL_EXTRAS_KEY,
+    mistral_native_config_from_hf_config,
+    mistral_native_config_to_hf_config,
+)
+from transformers.models.pixtral.configuration_pixtral import PixtralVisionConfig
+from transformers.utils.quantization_config import QuantizationConfigMixin
+
+from .mistral_fixture_data import (
+    RAW_MISTRAL_PARAMS,
+    base_native_config,
+    make_non_reversible_quant_config,
+    mistral3_native_config,
+    mistral4_native_config,
+    perturbed_ministral3_native_config,
+    perturbed_mistral3_moe_native_config,
+    perturbed_mistral3_native_config,
+    perturbed_mistral4_native_config,
+    perturbed_mistral_native_config,
+)
+
+
+class TestPublicAPI(unittest.TestCase):
+    """Coverage for the module's public exports."""
+
+    def test_public_roundtrip(self) -> None:
+        native = base_native_config()
+        restored = mistral_native_config_from_hf_config(mistral_native_config_to_hf_config(native))
+        self.assertEqual(restored, native)
+
+    def test_mistral_native_config_from_hf_config_unsupported_type_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unsupported HF config type"):
+            mistral_native_config_from_hf_config(PreTrainedConfig())
+
+
+class TestExhaustiveRoundtrip(unittest.TestCase):
+    """Every native field the reverse converter reads back must survive a native -> HF -> native
+    round-trip unchanged.
+
+    Seven forward outputs are write-only, and this class cannot prove anything about them: the
+    reverse converter hardcodes `mm_projector_id` and `add_pre_mm_projector_layer_norm` rather
+    than reading them back, and never reads back `norm_topk_prob`, `vision_feature_layer`,
+    `hidden_act`, `mscale`, or `partial_rotary_factor`. For those fields, a round-trip here
+    compares the reverse converter's own constants to the forward converter's inputs, which
+    cannot fail regardless of whether the forward mapping is correct. See
+    `TestReverseFromPublishedConfig` in test_published_config_parity.py for the oracle that
+    covers the reverse direction from data this class cannot touch.
+    """
+
+    def test_raw_quantization_config_dict_survives_round_trip(self) -> None:
+        """A `quantization_config` shipped as a raw dict in `params.json` must hold the same
+        runtime type (`QuantizationConfigMixin`) as one produced by a native -> HF -> native
+        round-trip, or the round-trip equality check silently lies about what was preserved."""
+        quant_config = {
+            "quant_method": "fp8",
+            "activation_scheme": "dynamic",
+            "modules_to_not_convert": ["lm_head"],
+            "weight_block_size": None,
+        }
+        raw = {**RAW_MISTRAL_PARAMS, "quantization_config": quant_config}
+
+        native = mistral_native_config_from_params(raw)
+        restored = mistral_native_config_from_hf_config(mistral_native_config_to_hf_config(native))
+
+        self.assertIsInstance(native.quantization_config, QuantizationConfigMixin)
+        self.assertEqual(restored, native)
+
+    def test_quantization_config_passthrough_roundtrip(self) -> None:
+        """A non-fp8 HF quantization config has no native equivalent, so it rides through
+        both directions untouched in `quantization_config`."""
+        for test_id, factory in [("mistral", base_native_config), ("mistral3", mistral3_native_config)]:
+            with self.subTest(test_id):
+                native = factory()
+                native.quantization = None
+                native.quantization_config = make_non_reversible_quant_config()
+
+                restored = mistral_native_config_from_hf_config(mistral_native_config_to_hf_config(native))
+
+                self.assertIsNone(restored.quantization)
+                self.assertIsNotNone(restored.quantization_config)
+                self.assertEqual(restored.quantization_config.to_dict()["quant_method"], "gptq")
+                self.assertEqual(restored, native)
+
+    def test_roundtrip_is_lossless(self) -> None:
+        factories = [
+            ("mistral", perturbed_mistral_native_config),
+            ("ministral3", perturbed_ministral3_native_config),
+            ("mistral4", perturbed_mistral4_native_config),
+            ("mistral3", perturbed_mistral3_native_config),
+            ("mistral3_moe_text_config", perturbed_mistral3_moe_native_config),
+        ]
+        for test_id, factory in factories:
+            with self.subTest(test_id):
+                native = factory()
+                restored = mistral_native_config_from_hf_config(mistral_native_config_to_hf_config(native))
+                self.assertEqual(restored, native)
+
+
+class TestMistralExtras(unittest.TestCase):
+    """Behaviour of the `mistral_extras` config entry that carries the native fields
+    with no HF equivalent."""
+
+    def test_extras_survive_save_and_load(self) -> None:
+        native = perturbed_mistral4_native_config()
+        hf = mistral_native_config_to_hf_config(native)
+        extras_before = getattr(hf, _MISTRAL_EXTRAS_KEY)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            hf.save_pretrained(tmp_dir)
+            reloaded = Mistral4Config.from_pretrained(tmp_dir)
+
+        extras_after = getattr(reloaded, _MISTRAL_EXTRAS_KEY, None)
+        self.assertEqual(extras_after, extras_before)
+
+        restored = mistral_native_config_from_hf_config(reloaded)
+        self.assertEqual(restored, native)
+
+    def test_extras_absent_when_nothing_to_preserve(self) -> None:
+        native = base_native_config()
+        hf = mistral_native_config_to_hf_config(native)
+        self.assertFalse(hasattr(hf, _MISTRAL_EXTRAS_KEY))
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            hf.save_pretrained(tmp_dir)
+            reloaded = MistralConfig.from_pretrained(tmp_dir)
+        self.assertFalse(hasattr(reloaded, _MISTRAL_EXTRAS_KEY))
+
+    def test_vlm_with_moe_text_config_extras_survive_save_and_load(self) -> None:
+        """For a VLM with a MoE text config, the combined extras land once on the outer
+        config and never on the nested text config."""
+        native = perturbed_mistral3_moe_native_config()
+        hf = mistral_native_config_to_hf_config(native)
+        self.assertTrue(hasattr(hf, _MISTRAL_EXTRAS_KEY))
+        self.assertFalse(hasattr(hf.text_config, _MISTRAL_EXTRAS_KEY))
+
+        restored_in_memory = mistral_native_config_from_hf_config(hf)
+        self.assertEqual(restored_in_memory, native)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            hf.save_pretrained(tmp_dir)
+            reloaded = Mistral3Config.from_pretrained(tmp_dir)
+
+        self.assertEqual(getattr(reloaded, _MISTRAL_EXTRAS_KEY), getattr(hf, _MISTRAL_EXTRAS_KEY))
+        restored_from_disk = mistral_native_config_from_hf_config(reloaded)
+        self.assertEqual(restored_from_disk, native)
+
+    def test_outer_without_extras_preserves_nested_moe_residual(self) -> None:
+        """An outer config only overrides the MoE fields its own extras carry, so values
+        recovered from a nested text config's extras are not clobbered."""
+        text_native = mistral4_native_config()
+        text_native.moe.expert_parallel = 8
+        text_native.moe.route_every_n = 3
+        text_hf = mistral_native_config_to_hf_config(text_native)
+        self.assertTrue(hasattr(text_hf, _MISTRAL_EXTRAS_KEY))
+
+        vision_hf = mistral_native_config_to_hf_config(mistral3_native_config()).vision_config
+
+        outer = Mistral3Config(
+            text_config=text_hf,
+            vision_config=vision_hf,
+            image_token_id=10,
+            spatial_merge_size=2,
+        )
+        self.assertFalse(hasattr(outer, _MISTRAL_EXTRAS_KEY))
+
+        restored = mistral_native_config_from_hf_config(outer)
+        self.assertEqual(restored.moe.expert_parallel, 8)
+        self.assertEqual(restored.moe.route_every_n, 3)
+
+    def test_mistral4_defaults_when_extras_absent(self) -> None:
+        """An HF config without `mistral_extras` still reverses, using default values."""
+        hf = Mistral4Config(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=32,
+            rms_norm_eps=1e-5,
+            vocab_size=32000,
+            max_position_embeddings=1048576,
+            q_lora_rank=1024,
+            qk_rope_head_dim=64,
+            qk_nope_head_dim=64,
+            kv_lora_rank=256,
+            v_head_dim=128,
+            n_routed_experts=128,
+            num_experts_per_tok=4,
+            moe_intermediate_size=2048,
+            first_k_dense_replace=0,
+            n_shared_experts=1,
+            routed_scaling_factor=1.0,
+            n_group=1,
+            topk_group=1,
+        )
+        self.assertFalse(hasattr(hf, _MISTRAL_EXTRAS_KEY))
+        native = mistral_native_config_from_hf_config(hf)
+        self.assertEqual(native.moe.expert_parallel, 1)
+        self.assertEqual(native.moe.expert_model_parallel, 1)
+        self.assertEqual(native.moe.route_every_n, 1)
+
+    def test_mistral3_defaults_when_extras_absent(self) -> None:
+        text_config = MistralConfig(
+            hidden_size=4096,
+            num_hidden_layers=32,
+            intermediate_size=14336,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            rms_norm_eps=1e-5,
+            head_dim=128,
+            vocab_size=32000,
+            max_position_embeddings=131072,
+        )
+        vision_config = PixtralVisionConfig(
+            hidden_size=1024,
+            num_hidden_layers=24,
+            num_attention_heads=16,
+            patch_size=14,
+            image_size=1540,
+            intermediate_size=4096,
+            hidden_act="silu",
+            rope_theta=10000.0,
+        )
+        hf = Mistral3Config(
+            text_config=text_config,
+            vision_config=vision_config,
+            multimodal_projector_bias=False,
+            image_token_id=10,
+            spatial_merge_size=2,
+            vision_feature_layer=-1,
+        )
+        self.assertFalse(hasattr(hf, _MISTRAL_EXTRAS_KEY))
+        native = mistral_native_config_from_hf_config(hf)
+        self.assertEqual(native.vision_encoder.max_image_size, vision_config.image_size)
+        self.assertEqual(native.vision_encoder.image_break_token_id, 12)
+        self.assertEqual(native.vision_encoder.image_end_token_id, 13)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integrations/mistral/test_published_config_parity.py
+++ b/tests/integrations/mistral/test_published_config_parity.py
@@ -1,0 +1,288 @@
+# Copyright 2026 Mistral AI and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import dataclasses
+import json
+import unittest
+from enum import Enum
+from typing import Any
+
+from huggingface_hub import hf_hub_download
+from parameterized import parameterized
+
+from transformers import Ministral3Config, Mistral3Config, Mistral4Config, MistralConfig
+from transformers.integrations.mistral.native_config import mistral_native_config_from_params
+from transformers.integrations.mistral.params_conversion import (
+    _MISTRAL_EXTRAS_DOC,
+    mistral_native_config_from_hf_config,
+    mistral_native_config_to_hf_config,
+)
+from transformers.testing_utils import slow
+
+
+# Real published repos, paired with the config.json section their params.json must reproduce.
+# A section means the `vision_encoder` block is dropped and only the text config is compared.
+_CONFIG_PARITY_CASES = [
+    ("mistral", "mistralai/Mistral-7B-Instruct-v0.3", None),
+    ("ministral3", "mistralai/Ministral-3-3B-Instruct-2512", "text_config"),
+    ("mistral4", "mistralai/Mistral-Small-4-119B-2603", "text_config"),
+    ("mistral3_vlm", "mistralai/Ministral-3-3B-Instruct-2512", None),
+    ("mistral3_vlm_moe_text", "mistralai/Mistral-Small-4-119B-2603", None),
+    ("devstral2", "mistralai/Devstral-2-123B-Instruct-2512", None),
+    ("mistral_medium_3_5", "mistralai/Mistral-Medium-3.5-128B", None),
+    # Mistral3Config wrapping a plain MistralConfig text config (no yarn), unlike every other VLM
+    # case above (all yarn, so Ministral3Config or Mistral4Config text configs).
+    ("mistral3_vlm_plain_text", "mistralai/Mistral-Small-3.2-24B-Instruct-2506", None),
+    ("mistral3_vlm_plain_text", "mistralai/Magistral-Small-2509", None),
+]
+
+# HF config classes for the full (non-sectioned) parity cases above, used by
+# `TestReverseFromPublishedConfig` to load each published `config.json` as the right type.
+_CONFIG_CLASSES: dict[str, type[MistralConfig | Ministral3Config | Mistral4Config | Mistral3Config]] = {
+    "mistral": MistralConfig,
+    "mistral3_vlm": Mistral3Config,
+    "mistral3_vlm_moe_text": Mistral3Config,
+    "devstral2": Ministral3Config,
+    "mistral_medium_3_5": Mistral3Config,
+    "mistral3_vlm_plain_text": Mistral3Config,
+}
+
+# Per-case keys to exclude from `_collect_mismatches`, keyed by the case name in
+# `_CONFIG_PARITY_CASES`. Reserved for known, explained deviations, not a general escape hatch.
+_KNOWN_DEVIATIONS: dict[str, frozenset[str]] = {
+    # Devstral-2-123B-Instruct-2512 is text-only, yet publishes `model.vision_tower` and
+    # `model.multi_modal_projector` in `quantization_config.modules_to_not_convert`: an artifact of
+    # `convert_ministral3_weights_to_hf.py` hard-coding those regardless of `is_vision`.
+    "devstral2": frozenset({"modules_to_not_convert"}),
+}
+
+# Converter-computed values the published config omits entirely, keyed by case name. Unlike
+# `_KNOWN_DEVIATIONS` (which excludes a published value known to be wrong), these assert what the
+# converter must produce for a key `_collect_mismatches` never reaches, because the published
+# config carries no value at all to compare against (either because a superset key lives outside
+# the compared section, or the schema has no place for it).
+_ADDITIONAL_EXPECTATIONS: dict[str, dict[str, Any]] = {
+    # No `head_dim` and no `rope_parameters.rope_type` in this legacy (pre-rope_parameters)
+    # published config; both are still converter-computed and must be right.
+    "mistral": {"head_dim": 128, "rope_parameters": {"rope_type": "default"}},
+    # `quantization_config` lives outside `text_config` in the published (VLM) document, so the
+    # text-only conversion this case exercises is never checked against it at all.
+    "ministral3": {
+        "quantization_config": {
+            "quant_method": "fp8",
+            "activation_scheme": "static",
+            "modules_to_not_convert": ["lm_head"],
+            "weight_block_size": None,
+        }
+    },
+    # Neither `rope_parameters.partial_rotary_factor` (an MLA-only field) nor `mistral_extras`
+    # (which no published config carries) appear in the published document at all.
+    "mistral4": {
+        "rope_parameters": {"partial_rotary_factor": 0.5},
+        "mistral_extras": {
+            "moe": {"expert_parallel": 1, "expert_model_parallel": 1, "route_every_n": 1},
+            "_comment": _MISTRAL_EXTRAS_DOC,
+        },
+    },
+    # The published document omits the outer `tie_word_embeddings` key entirely (only
+    # `text_config.tie_word_embeddings` is present); `Mistral3Config`'s own default (`True`)
+    # happens to match, which is exactly what makes an injected wrong value unfalsifiable.
+    "mistral3_vlm": {"tie_word_embeddings": True},
+}
+
+# Not derivable from params.json. Published configs also carry HF defaults that params.json never
+# feeds (`initializer_range`, `pretraining_tp`, ...); if a transformers release changes one of
+# those, extend this set rather than changing the converter.
+_METADATA_KEYS = frozenset({"transformers_version", "architectures", "dtype", "torch_dtype", "_name_or_path"})
+
+# Mistral-Small-4-119B-2603 publishes `mlp_bias` in its text config, but Mistral4Config has no such
+# attribute. Excluded by name rather than by a generic unknown-key rule, which would mask real gaps.
+_STALE_PUBLISHED_KEYS = frozenset({"mlp_bias"})
+
+
+def _fold_legacy_rope_theta(section: dict[str, Any]) -> dict[str, Any]:
+    """Move a pre-`rope_parameters` top-level `rope_theta` into `rope_parameters`."""
+    if "rope_theta" not in section:
+        return section
+    section = dict(section)
+    rope_theta = section.pop("rope_theta")
+    section["rope_parameters"] = {**section.get("rope_parameters", {}), "rope_theta": rope_theta}
+    return section
+
+
+def _fold_legacy_rope_type(rope_parameters: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite the deprecated `type` spelling of `rope_type`, which current configs no longer emit.
+
+    See the back-compat handling in `modeling_rope_utils.py`. Published configs carry `type` either
+    alone or alongside an identical `rope_type`; a disagreeing pair is left alone so it still fails.
+    """
+    if "type" not in rope_parameters:
+        return rope_parameters
+    rope_type = rope_parameters.get("rope_type", rope_parameters["type"])
+    if rope_type != rope_parameters["type"]:
+        return rope_parameters
+    return {k: v for k, v in rope_parameters.items() if k != "type"} | {"rope_type": rope_type}
+
+
+def _normalize_published_section(section: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite a published config section into the schema current transformers emits."""
+    section = _fold_legacy_rope_theta(section)
+    normalized = {}
+    for key, value in section.items():
+        if key == "rope_parameters" and isinstance(value, dict):
+            value = _fold_legacy_rope_type(value)
+        elif isinstance(value, dict):
+            value = _normalize_published_section(value)
+        normalized[key] = value
+    return normalized
+
+
+def _collect_mismatches(
+    expected: dict[str, Any],
+    actual: dict[str, Any],
+    path: str = "",
+    excluded_keys: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Report every published key that is missing from or differs in `actual`.
+
+    Extra keys in `actual` are ignored: current transformers emits defaults that predate the
+    published configs, and those are not conversion errors. `excluded_keys` adds per-case
+    exclusions on top of the module-wide `_METADATA_KEYS` and `_STALE_PUBLISHED_KEYS`.
+    """
+    mismatches = []
+    for key, expected_value in expected.items():
+        if key in _METADATA_KEYS or key in _STALE_PUBLISHED_KEYS or key in excluded_keys:
+            continue
+        where = f"{path}.{key}" if path else key
+        if key not in actual:
+            mismatches.append(f"{where}: missing, expected {expected_value!r}")
+            continue
+        actual_value = actual[key]
+        if key == "modules_to_not_convert" and isinstance(expected_value, list) and isinstance(actual_value, list):
+            # Only membership matters: `Quantizer.get_modules_to_not_convert` deduplicates this list
+            # before use. Ministral-3-3B-Instruct-2512 ships it concatenated with itself.
+            if set(expected_value) != set(actual_value):
+                mismatches.append(
+                    f"{where}: expected {sorted(set(expected_value))!r}, got {sorted(set(actual_value))!r}"
+                )
+        elif isinstance(expected_value, dict) and isinstance(actual_value, dict):
+            mismatches += _collect_mismatches(expected_value, actual_value, where, excluded_keys=excluded_keys)
+        elif expected_value != actual_value:
+            mismatches.append(f"{where}: expected {expected_value!r}, got {actual_value!r}")
+    return mismatches
+
+
+class TestNativeToHFPublishedConfigs(unittest.TestCase):
+    """Published params.json files must reproduce the config.json published alongside them."""
+
+    _documents: dict[str, tuple[dict[str, Any], dict[str, Any]]] = {}
+
+    @classmethod
+    def _get_documents(cls, repo: str) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Download and cache (params.json, config.json) for a repo."""
+        if repo not in cls._documents:
+            with open(hf_hub_download(repo, "params.json")) as f:
+                params = json.load(f)
+            with open(hf_hub_download(repo, "config.json")) as f:
+                config = json.load(f)
+            cls._documents[repo] = (params, config)
+        params, config = cls._documents[repo]
+        return copy.deepcopy(params), copy.deepcopy(config)
+
+    @parameterized.expand(_CONFIG_PARITY_CASES)
+    @slow
+    def test_reproduces_published_config(self, name: str, repo: str, section: str | None) -> None:
+        params, published = self._get_documents(repo)
+        if section is not None:
+            params.pop("vision_encoder", None)
+
+        actual = json.loads(
+            mistral_native_config_to_hf_config(mistral_native_config_from_params(params)).to_json_string()
+        )
+        expected = _normalize_published_section(published[section] if section else published)
+
+        mismatches = _collect_mismatches(expected, actual, excluded_keys=_KNOWN_DEVIATIONS.get(name, frozenset()))
+        # Keys the published document omits entirely, so the pass above never reaches them, but
+        # that the converter still computes and must get right (see `_ADDITIONAL_EXPECTATIONS`).
+        mismatches += _collect_mismatches(_ADDITIONAL_EXPECTATIONS.get(name, {}), actual)
+        self.assertEqual(mismatches, [], "\n".join([f"{repo} does not round-trip:", *mismatches]))
+
+    def test_mlp_bias_is_still_absent(self) -> None:
+        """`mlp_bias` may only stay in `_STALE_PUBLISHED_KEYS` while Mistral4Config lacks it."""
+        self.assertFalse(hasattr(Mistral4Config(), "mlp_bias"))
+
+
+def _native_config_to_comparable_dict(value: Any) -> Any:
+    """Render a `MistralNativeConfig` (or one of its section dataclasses) as a `params.json`-
+    shaped structure.
+
+    Native section dataclasses (`YarnArgs`, `Llama4Scaling`, `QuantizationArgs`, `MOEModelArgs`,
+    `VisionEncoderArgs`) use the same field names as their `params.json` counterparts one-for-one,
+    so this is a direct render rather than a schema translation.
+    """
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _native_config_to_comparable_dict(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        }
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+# Native fields no published `config.json` can recover: a published config never carries
+# `mistral_extras` (it is a transformers-internal attribute, never published), so the reverse
+# converter falls back to these fields' native dataclass defaults regardless of the repo's real
+# native value. Mistral-Medium-3.5-128B already demonstrates the resulting silent mismatch for the
+# image token ids: its own `params.json` sets both to -1, but with no `mistral_extras` to recover
+# that from, reversing its published `config.json` yields the default 12/13 instead.
+_REVERSE_UNRECOVERABLE_FIELDS = frozenset(
+    {
+        "expert_parallel",
+        "expert_model_parallel",
+        "route_every_n",
+        "max_image_size",
+        "image_break_token_id",
+        "image_end_token_id",
+    }
+)
+
+
+class TestReverseFromPublishedConfig(unittest.TestCase):
+    """A published `config.json`, converted back to native, must reproduce that repo's own
+    `params.json` on the subset of fields a published config can possibly recover.
+
+    Not full equality: no published config carries `mistral_extras`, so every field in
+    `_REVERSE_UNRECOVERABLE_FIELDS` is unrecoverable by construction (see the comment there).
+    Restricted to the `_CONFIG_PARITY_CASES` entries with `section=None`: the sectioned
+    (text-config-only) cases have no published `config.json` of their own to load as a
+    standalone HF config.
+    """
+
+    @parameterized.expand([(name, repo) for name, repo, section in _CONFIG_PARITY_CASES if section is None])
+    @slow
+    def test_reproduces_published_params(self, name: str, repo: str) -> None:
+        params, _ = TestNativeToHFPublishedConfigs._get_documents(repo)
+        hf_config = _CONFIG_CLASSES[name].from_pretrained(repo)
+
+        native = mistral_native_config_from_hf_config(hf_config)
+        actual = _native_config_to_comparable_dict(native)
+
+        mismatches = _collect_mismatches(params, actual, excluded_keys=_REVERSE_UNRECOVERABLE_FIELDS)
+        self.assertEqual(mismatches, [], "\n".join([f"{repo} does not reverse-convert:", *mismatches]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47835)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47835)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Adds the standalone conversion layer between Mistral native `params.json` data and Hugging Face config objects.

- Parses native `params.json` into a typed `MistralNativeConfig`.
- Converts native configs to and from `MistralConfig`, `Ministral3Config`, `Mistral3Config`, and `Mistral4Config`.
- Preserves RoPE, YaRN, MLA, MoE, vision, and supported quantization settings across conversions.
- Exports the conversion entry points from `transformers.integrations.mistral`.
- Adds exhaustive round-trip tests and parity checks against published Mistral model configs.

This follows the Mistral integration package introduced in #46603. Invalid Llama 4 scaling without YaRN now fails through RoPE parameter validation rather than a separate model-family guard.

## Code Agent Policy

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that is the case).
- [x] Did you read the contributor guideline and Pull Request checks?
- [ ] Was this discussed/approved via a Github issue or the forum? Not applicable.
- [x] Did you make sure to update the documentation with your changes according to the guidelines? No documentation change is needed for this integration utility.
- [x] Did you write any new necessary tests?

## Test plan

- `RUN_SLOW=1 ./.venv/bin/python -m pytest tests/integrations/mistral/` — 216 passed, 1 skipped (`compressed-tensors` unavailable).
- `make style` — passed.
- `make check-repo` — feature checks pass; current upstream auto-docstring checks fail on missing unrelated Qwen processor argument documentation.