### PR TITLE
Fix RobertaTokenizerFast.from_pretrained when Hub tokenizer.json omits model.type

### DIFF
--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -146,19 +146,23 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 tok_from_file = TokenizerFast.from_file(fast_tokenizer_file)
 
             # Older Hub tokenizer.json files (e.g. roberta-base / roberta-large) omit
-            # `model.type`. When the class also does not declare a model (legacy Fast
-            # wrappers like RobertaTokenizerFast), reconstructing from vocab alone drops
-            # merges, pre_tokenizer, decoder, and normalizer and yields a broken
-            # character-level tokenizer. Keep the fully loaded backend instead (#47706).
-            if model_type is None and getattr(cls, "model", None) is None:
+            # `model.type` while still shipping BPE merges. When the class also does not
+            # declare a model (legacy Fast wrappers like RobertaTokenizerFast),
+            # reconstructing from vocab alone drops merges, pre_tokenizer, decoder, and
+            # normalizer and yields a broken character-level tokenizer. Keep the fully
+            # loaded backend only for that case (#47706) — do not short-circuit all
+            # model=None Fast classes (Llama/Idefics rebuild paths need vocab+merges).
+            json_model = tokenizer_json.get("model", {})
+            if model_type is None and getattr(cls, "model", None) is None and "merges" in json_model:
                 local_kwargs["tokenizer_object"] = tok_from_file
                 return local_kwargs
 
             local_kwargs["post_processor"] = tok_from_file.post_processor
             local_kwargs["tokenizer_padding"] = tok_from_file.padding
             local_kwargs["tokenizer_truncation"] = tok_from_file.truncation
-            # Pass pipeline components promised by the comment above so custom __init__
-            # rebuilds stay faithful to tokenizer.json when the class does not set them.
+            # Pass pipeline components promised by the comment above so hollow vocab/merges
+            # rebuilds can restore them. Applied in __init__ only when the backend was
+            # reconstructed from vocab (not when a class already built its own pipeline).
             if tok_from_file.pre_tokenizer is not None:
                 local_kwargs["pre_tokenizer"] = tok_from_file.pre_tokenizer
             if tok_from_file.decoder is not None:
@@ -368,6 +372,11 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         merges = kwargs.get("merges")
 
         fast_tokenizer = None
+        # True when we construct a hollow backend from extracted vocab/merges only.
+        # Pipeline components from tokenizer.json should only be applied in that case —
+        # classes that already built their own backend (e.g. LlamaTokenizer sets
+        # normalizer=None + Metaspace) must keep their intentional pipeline.
+        rebuilt_from_vocab = False
         if tokenizer_object is not None:
             fast_tokenizer = copy.deepcopy(tokenizer_object)
         elif fast_tokenizer_file is not None and os.path.isfile(fast_tokenizer_file):
@@ -386,6 +395,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 kwargs.update(additional_kwargs)
         elif self._tokenizer is None and vocab is not None:
             # Build from vocab/merges extracted by convert_to_native_format
+            rebuilt_from_vocab = True
             if merges is not None:
                 vocab_dict = vocab if isinstance(vocab, dict) else {w: i for i, (w, _) in enumerate(vocab)}
                 fast_tokenizer = TokenizerFast(BPE(vocab=vocab_dict, merges=merges, fuse_unk=True, dropout=None))
@@ -440,18 +450,19 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         self._add_eos_token = kwargs.get("add_eos_token", False)
         if post_processor := kwargs.pop("post_processor", None):  # most reliable way to get the post-processor
             self._tokenizer.post_processor = post_processor
-        # Apply pipeline components extracted from tokenizer.json when the backend was
-        # rebuilt without them (only fill gaps so class-defined pipelines win). Always
-        # pop so they are not forwarded into init_kwargs / super().__init__.
+        # Always pop pipeline kwargs so they are not stored in init_kwargs.
+        # Only apply them when we rebuilt a hollow backend from vocab/merges —
+        # never overwrite a class-built pipeline (Llama intentional normalizer=None).
         pre_tokenizer = kwargs.pop("pre_tokenizer", None)
         decoder = kwargs.pop("decoder", None)
         normalizer = kwargs.pop("normalizer", None)
-        if pre_tokenizer is not None and self._tokenizer.pre_tokenizer is None:
-            self._tokenizer.pre_tokenizer = pre_tokenizer
-        if decoder is not None and self._tokenizer.decoder is None:
-            self._tokenizer.decoder = decoder
-        if normalizer is not None and self._tokenizer.normalizer is None:
-            self._tokenizer.normalizer = normalizer
+        if rebuilt_from_vocab:
+            if pre_tokenizer is not None and self._tokenizer.pre_tokenizer is None:
+                self._tokenizer.pre_tokenizer = pre_tokenizer
+            if decoder is not None and self._tokenizer.decoder is None:
+                self._tokenizer.decoder = decoder
+            if normalizer is not None and self._tokenizer.normalizer is None:
+                self._tokenizer.normalizer = normalizer
         self._should_update_post_processor = explicit_bos_eos_in_kwargs or self._tokenizer.post_processor is None
         # We call this after having initialized the backend tokenizer because we update it.
         super().__init__(**kwargs)

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -145,9 +145,26 @@ class TokenizersBackend(PreTrainedTokenizerBase):
             else:
                 tok_from_file = TokenizerFast.from_file(fast_tokenizer_file)
 
+            # Older Hub tokenizer.json files (e.g. roberta-base / roberta-large) omit
+            # `model.type`. When the class also does not declare a model (legacy Fast
+            # wrappers like RobertaTokenizerFast), reconstructing from vocab alone drops
+            # merges, pre_tokenizer, decoder, and normalizer and yields a broken
+            # character-level tokenizer. Keep the fully loaded backend instead (#47706).
+            if model_type is None and getattr(cls, "model", None) is None:
+                local_kwargs["tokenizer_object"] = tok_from_file
+                return local_kwargs
+
             local_kwargs["post_processor"] = tok_from_file.post_processor
             local_kwargs["tokenizer_padding"] = tok_from_file.padding
             local_kwargs["tokenizer_truncation"] = tok_from_file.truncation
+            # Pass pipeline components promised by the comment above so custom __init__
+            # rebuilds stay faithful to tokenizer.json when the class does not set them.
+            if tok_from_file.pre_tokenizer is not None:
+                local_kwargs["pre_tokenizer"] = tok_from_file.pre_tokenizer
+            if tok_from_file.decoder is not None:
+                local_kwargs["decoder"] = tok_from_file.decoder
+            if tok_from_file.normalizer is not None:
+                local_kwargs["normalizer"] = tok_from_file.normalizer
             # Preserve truncation and padding baked into tokenizer.json so that classes
             # with a custom __init__ that rebuild the backend tokenizer from scratch
             # can still access these settings.
@@ -187,8 +204,12 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                     vocab = {token[0] if isinstance(token, list) else token: i for i, token in enumerate(vocab)}
             local_kwargs["vocab"] = vocab
 
-            model_type = getattr(cls, "model", None)
-            if "merges" in tokenizer_json.get("model", {}) and (model_type and model_type.__name__ == "BPE"):
+            cls_model = getattr(cls, "model", None)
+            # Extract merges for BPE whether declared on the class or in tokenizer.json
+            # (Hub files sometimes set model.type=BPE while the class has model=None).
+            if "merges" in tokenizer_json.get("model", {}) and (
+                (cls_model is not None and cls_model.__name__ == "BPE") or model_type == "BPE"
+            ):
                 merges = tokenizer_json["model"]["merges"]
                 merges = [tuple(merge.split(" ")) if isinstance(merge, str) else tuple(merge) for merge in merges]
                 local_kwargs["merges"] = merges
@@ -419,6 +440,18 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         self._add_eos_token = kwargs.get("add_eos_token", False)
         if post_processor := kwargs.pop("post_processor", None):  # most reliable way to get the post-processor
             self._tokenizer.post_processor = post_processor
+        # Apply pipeline components extracted from tokenizer.json when the backend was
+        # rebuilt without them (only fill gaps so class-defined pipelines win). Always
+        # pop so they are not forwarded into init_kwargs / super().__init__.
+        pre_tokenizer = kwargs.pop("pre_tokenizer", None)
+        decoder = kwargs.pop("decoder", None)
+        normalizer = kwargs.pop("normalizer", None)
+        if pre_tokenizer is not None and self._tokenizer.pre_tokenizer is None:
+            self._tokenizer.pre_tokenizer = pre_tokenizer
+        if decoder is not None and self._tokenizer.decoder is None:
+            self._tokenizer.decoder = decoder
+        if normalizer is not None and self._tokenizer.normalizer is None:
+            self._tokenizer.normalizer = normalizer
         self._should_update_post_processor = explicit_bos_eos_in_kwargs or self._tokenizer.post_processor is None
         # We call this after having initialized the backend tokenizer because we update it.
         super().__init__(**kwargs)

--- a/tests/models/roberta/test_tokenization_roberta.py
+++ b/tests/models/roberta/test_tokenization_roberta.py
@@ -14,9 +14,11 @@
 
 
 import json
+import os
+import tempfile
 import unittest
 
-from transformers import AutoTokenizer, RobertaTokenizer
+from transformers import AutoTokenizer, RobertaTokenizer, RobertaTokenizerFast
 from transformers.testing_utils import require_tokenizers
 
 from ...test_tokenization_common import TokenizerTesterMixin
@@ -114,6 +116,75 @@ class RobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         input_tokens = tokens + [tokenizer.unk_token]
         input_bpe_tokens = [0, 1, 2, 15, 10, 9, 3, 2, 15, 19]
         self.assertListEqual(tokenizer.convert_tokens_to_ids(input_tokens), input_bpe_tokens)
+
+    def test_roberta_tokenizer_fast_from_pretrained_matches_slow(self):
+        """Regression for #47706: Hub tokenizer.json omits model.type.
+
+        Legacy RobertaTokenizerFast must still recover BPE merges + ByteLevel
+        pre_tokenizer/decoder and match RobertaTokenizer encoding.
+        """
+        slow = RobertaTokenizer.from_pretrained("FacebookAI/roberta-base")
+        fast = RobertaTokenizerFast.from_pretrained("FacebookAI/roberta-base")
+
+        self.assertIsNotNone(fast.backend_tokenizer.pre_tokenizer)
+        self.assertIsNotNone(fast.backend_tokenizer.decoder)
+
+        for text in ("Hello world", " Hello world", "حسنا"):
+            self.assertListEqual(slow.encode(text), fast.encode(text), msg=f"mismatch for {text!r}")
+
+    def test_roberta_tokenizer_fast_omitted_model_type(self):
+        """Offline regression for #47706: omitted model.type must not break load."""
+        from tokenizers import Tokenizer, decoders, models, pre_tokenizers, processors
+        from tokenizers.trainers import BpeTrainer
+
+        backend = Tokenizer(models.BPE(unk_token="<unk>"))
+        backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+        trainer = BpeTrainer(
+            special_tokens=["<s>", "</s>", "<pad>", "<unk>", "<mask>"],
+            vocab_size=100,
+        )
+        backend.train_from_iterator(
+            ["Hello world", "Hello", "world", "test this", "encoding works"],
+            trainer=trainer,
+        )
+        backend.decoder = decoders.ByteLevel()
+        backend.post_processor = processors.RobertaProcessing(
+            sep=("</s>", backend.token_to_id("</s>")),
+            cls=("<s>", backend.token_to_id("<s>")),
+            add_prefix_space=False,
+            trim_offsets=True,
+        )
+        expected_ids = backend.encode("Hello world").ids
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tokenizer_path = os.path.join(tmpdir, "tokenizer.json")
+            backend.save(tokenizer_path)
+            with open(tokenizer_path, encoding="utf-8") as handle:
+                tokenizer_json = json.load(handle)
+            # Older Hub files omit model.type entirely (not "type": null).
+            tokenizer_json["model"].pop("type", None)
+            with open(tokenizer_path, "w", encoding="utf-8") as handle:
+                json.dump(tokenizer_json, handle)
+            with open(os.path.join(tmpdir, "tokenizer_config.json"), "w", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "tokenizer_class": "RobertaTokenizerFast",
+                        "bos_token": "<s>",
+                        "eos_token": "</s>",
+                        "sep_token": "</s>",
+                        "cls_token": "<s>",
+                        "unk_token": "<unk>",
+                        "pad_token": "<pad>",
+                        "mask_token": "<mask>",
+                        "add_prefix_space": False,
+                    },
+                    handle,
+                )
+
+            fast = RobertaTokenizerFast.from_pretrained(tmpdir)
+            self.assertIsNotNone(fast.backend_tokenizer.pre_tokenizer)
+            self.assertIsNotNone(fast.backend_tokenizer.decoder)
+            self.assertListEqual(fast.encode("Hello world"), expected_ids)
 
     # def roberta_dict_integration_testing(self):
     #     tokenizer = self.get_tokenizer()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47837)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47837)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Fixes #47706

In v5, loading the legacy `RobertaTokenizerFast` from Hub checkpoints whose `tokenizer.json` omits `model.type` (e.g. `roberta-base`, `roberta-large`) produced a **silently broken** backend: no `pre_tokenizer`, no `decoder`, empty BPE merges → character-level garbage encodings (and dropped non-ASCII text).

Root cause: `TokenizersBackend.convert_to_native_format` takes the “extract vocab and rebuild” path for classes with a custom `__init__`. When both JSON `model.type` and the class `model` attribute are missing (`RobertaTokenizerFast` has `model=None`), it kept only the vocab and rebuilt `BPE(vocab=…, merges=[])` with no pipeline.

### Fix

In `convert_to_native_format`, when neither the Hub JSON nor the class declares a model type, keep the fully loaded `tokenizer_object` instead of reconstructing from vocab alone.

Also:
- Pass `pre_tokenizer` / `decoder` / `normalizer` from the loaded file into kwargs (the comment already promised this; only `post_processor` was applied).
- Apply those components in `__init__` when the backend is missing them.
- Extract BPE merges when `model.type == "BPE"` even if `cls.model` is `None`.

`AutoTokenizer` / new `RobertaTokenizer` were already fine (they set ByteLevel themselves). This restores parity for direct `RobertaTokenizerFast.from_pretrained(...)`.

### Tests

- Hub regression: `RobertaTokenizerFast` matches `RobertaTokenizer` on `FacebookAI/roberta-base` (ASCII + Arabic).
- Offline: load a local `tokenizer.json` with `model.type` omitted; assert pre_tokenizer/decoder present and encoding matches the raw `tokenizers` backend.

Local verification (editable install from this branch):

```text
slow.encode("Hello world") == [0, 31414, 232, 2]
fast.encode("Hello world") == [0, 31414, 232, 2]  # was char-level garbage
fast.backend_tokenizer.pre_tokenizer  # ByteLevel (was None)
```

## Code Agent Policy

Not a first-time contributor to this repo (existing open PRs). AI coding tools were used to help draft the fix and this description; the change was reproduced, fixed, and tested locally before opening.

- [x] (if applicable) Disclosure: AI-assisted; human-verified repro + tests

## Before submitting

- [x] Discussed via GitHub issue #47706
- [x] New regression tests added
- [x] Did not change docs (behavior fix only)

## Who can review?

Tokenizers: @ArthurZucker @itazap

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- All functional changes were reviewed and verified with local repro + unit tests before opening the PR.

Assisted-by: Codex