### PR TITLE
Fix GatedDeltaNet A_log -inf under bf16 init

### DIFF
--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -415,7 +415,8 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         # instantiate once and copy inv_dt in init_weights of PretrainedModel
         self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads))
 
-        A = torch.empty(self.num_v_heads).uniform_(0, 16)
+        # Sample in float32: bf16 uniform_(0, 16) can round to 0 → log(0)=-inf (#47831)
+        A = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(0, 16)
         self.A_log = nn.Parameter(torch.log(A))
 
         self.norm = Qwen3_5RMSNormGated(self.head_v_dim, eps=self.layer_norm_epsilon)
@@ -814,7 +815,13 @@ class Qwen3_5PreTrainedModel(PreTrainedModel):
         super()._init_weights(module)
         if isinstance(module, Qwen3_5GatedDeltaNet):
             init.ones_(module.dt_bias)
-            init.copy_(module.A_log, torch.empty_like(module.A_log).uniform_(0, 16).log_())
+            # Sample in float32 so re-init cannot recreate -inf A_log under bf16 (#47831)
+            init.copy_(
+                module.A_log,
+                torch.empty(module.num_v_heads, dtype=torch.float32, device=module.A_log.device)
+                .uniform_(0, 16)
+                .log_(),
+            )
         # We initialize with 0s to be 1 centered as the RMSNorm here does (1 + weight)
         elif isinstance(module, Qwen3_5RMSNorm):
             init.zeros_(module.weight)

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -418,7 +418,13 @@ class Qwen3_5PreTrainedModel(Qwen3NextPreTrainedModel):
         PreTrainedModel._init_weights(self, module)
         if isinstance(module, Qwen3_5GatedDeltaNet):
             init.ones_(module.dt_bias)
-            init.copy_(module.A_log, torch.empty_like(module.A_log).uniform_(0, 16).log_())
+            # Sample in float32 so re-init cannot recreate -inf A_log under bf16 (#47831)
+            init.copy_(
+                module.A_log,
+                torch.empty(module.num_v_heads, dtype=torch.float32, device=module.A_log.device)
+                .uniform_(0, 16)
+                .log_(),
+            )
         # We initialize with 0s to be 1 centered as the RMSNorm here does (1 + weight)
         elif isinstance(module, Qwen3_5RMSNorm):
             init.zeros_(module.weight)

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -413,7 +413,8 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         # instantiate once and copy inv_dt in init_weights of PretrainedModel
         self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads))
 
-        A = torch.empty(self.num_v_heads).uniform_(0, 16)
+        # Sample in float32: bf16 uniform_(0, 16) can round to 0 → log(0)=-inf (#47831)
+        A = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(0, 16)
         self.A_log = nn.Parameter(torch.log(A))
 
         self.norm = Qwen3_5MoeRMSNormGated(self.head_v_dim, eps=self.layer_norm_epsilon)
@@ -899,7 +900,13 @@ class Qwen3_5MoePreTrainedModel(PreTrainedModel):
         super()._init_weights(module)
         if isinstance(module, Qwen3_5MoeGatedDeltaNet):
             init.ones_(module.dt_bias)
-            init.copy_(module.A_log, torch.empty_like(module.A_log).uniform_(0, 16).log_())
+            # Sample in float32 so re-init cannot recreate -inf A_log under bf16 (#47831)
+            init.copy_(
+                module.A_log,
+                torch.empty(module.num_v_heads, dtype=torch.float32, device=module.A_log.device)
+                .uniform_(0, 16)
+                .log_(),
+            )
         # We initialize with 0s to be 1 centered as the RMSNorm here does (1 + weight)
         elif isinstance(module, Qwen3_5MoeRMSNorm):
             init.zeros_(module.weight)

--- a/src/transformers/models/qwen3_5_moe/modular_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modular_qwen3_5_moe.py
@@ -213,7 +213,13 @@ class Qwen3_5MoePreTrainedModel(Qwen3NextPreTrainedModel):
         PreTrainedModel._init_weights(self, module)
         if isinstance(module, Qwen3_5MoeGatedDeltaNet):
             init.ones_(module.dt_bias)
-            init.copy_(module.A_log, torch.empty_like(module.A_log).uniform_(0, 16).log_())
+            # Sample in float32 so re-init cannot recreate -inf A_log under bf16 (#47831)
+            init.copy_(
+                module.A_log,
+                torch.empty(module.num_v_heads, dtype=torch.float32, device=module.A_log.device)
+                .uniform_(0, 16)
+                .log_(),
+            )
         # We initialize with 0s to be 1 centered as the RMSNorm here does (1 + weight)
         elif isinstance(module, Qwen3_5MoeRMSNorm):
             init.zeros_(module.weight)

--- a/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modeling_qwen3_next.py
@@ -546,7 +546,8 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         # instantiate once and copy inv_dt in init_weights of PretrainedModel
         self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads))
 
-        A = torch.empty(self.num_v_heads).uniform_(0, 16)
+        # Sample in float32: bf16 uniform_(0, 16) can round to 0 → log(0)=-inf (#47831)
+        A = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(0, 16)
         self.A_log = nn.Parameter(torch.log(A))
 
         self.norm = Qwen3NextRMSNormGated(self.head_v_dim, eps=self.layer_norm_epsilon)
@@ -887,7 +888,13 @@ class Qwen3NextPreTrainedModel(PreTrainedModel):
         super()._init_weights(module)
         if isinstance(module, Qwen3NextGatedDeltaNet):
             init.ones_(module.dt_bias)
-            init.copy_(module.A_log, torch.empty_like(module.A_log).uniform_(0, 16).log_())
+            # Sample in float32 so re-init cannot recreate -inf A_log under bf16 (#47831)
+            init.copy_(
+                module.A_log,
+                torch.empty(module.num_v_heads, dtype=torch.float32, device=module.A_log.device)
+                .uniform_(0, 16)
+                .log_(),
+            )
         # We initialize with 0s to be 1 centered as the RMSNorm here does (1 + weight)
         elif isinstance(module, Qwen3NextRMSNorm):
             init.zeros_(module.weight)

--- a/src/transformers/models/qwen3_next/modular_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modular_qwen3_next.py
@@ -381,7 +381,8 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         # instantiate once and copy inv_dt in init_weights of PretrainedModel
         self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads))
 
-        A = torch.empty(self.num_v_heads).uniform_(0, 16)
+        # Sample in float32: bf16 uniform_(0, 16) can round to 0 → log(0)=-inf (#47831)
+        A = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(0, 16)
         self.A_log = nn.Parameter(torch.log(A))
 
         self.norm = Qwen3NextRMSNormGated(self.head_v_dim, eps=self.layer_norm_epsilon)
@@ -639,7 +640,13 @@ class Qwen3NextPreTrainedModel(PreTrainedModel):
         super()._init_weights(module)
         if isinstance(module, Qwen3NextGatedDeltaNet):
             init.ones_(module.dt_bias)
-            init.copy_(module.A_log, torch.empty_like(module.A_log).uniform_(0, 16).log_())
+            # Sample in float32 so re-init cannot recreate -inf A_log under bf16 (#47831)
+            init.copy_(
+                module.A_log,
+                torch.empty(module.num_v_heads, dtype=torch.float32, device=module.A_log.device)
+                .uniform_(0, 16)
+                .log_(),
+            )
         # We initialize with 0s to be 1 centered as the RMSNorm here does (1 + weight)
         elif isinstance(module, Qwen3NextRMSNorm):
             init.zeros_(module.weight)

--- a/tests/models/qwen3_next/test_gated_delta_net_init.py
+++ b/tests/models/qwen3_next/test_gated_delta_net_init.py
@@ -1,0 +1,73 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Init-only tests for Qwen3-Next GatedDeltaNet (no full model-tester imports)."""
+
+import unittest
+
+from transformers import is_torch_available
+from transformers.testing_utils import require_torch
+
+
+if is_torch_available():
+    import torch
+
+    from transformers import Qwen3NextConfig, Qwen3NextModel
+    from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextGatedDeltaNet
+
+
+@require_torch
+class Qwen3NextGatedDeltaNetInitTest(unittest.TestCase):
+    def test_gated_delta_net_a_log_finite_under_bf16(self):
+        """Regression for #47831: bf16 uniform init must not produce -inf A_log.
+
+        Sampling A in the module dtype can round to 0 under bfloat16; log(0) is
+        -inf and freezes that head. Init must keep A_log finite for every head,
+        including after _init_weights re-initialization.
+        """
+        config = Qwen3NextConfig(
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            intermediate_size=128,
+            vocab_size=256,
+            head_dim=16,
+            linear_conv_kernel_dim=2,
+            linear_key_head_dim=16,
+            linear_value_head_dim=16,
+            linear_num_key_heads=16,
+            # Large enough that the old bf16 path almost always hit dead heads.
+            linear_num_value_heads=32,
+            layer_types=["linear_attention", "full_attention"],
+        )
+
+        prev_dtype = torch.get_default_dtype()
+        try:
+            torch.set_default_dtype(torch.bfloat16)
+            torch.manual_seed(0)
+            layer = Qwen3NextGatedDeltaNet(config, layer_idx=0)
+            self.assertTrue(
+                torch.isfinite(layer.A_log).all(),
+                f"A_log has non-finite values after bf16 construction: {layer.A_log}",
+            )
+
+            torch.manual_seed(1)
+            model = Qwen3NextModel(config)
+            model._init_weights(layer)
+            self.assertTrue(
+                torch.isfinite(layer.A_log).all(),
+                f"A_log has non-finite values after _init_weights under bf16: {layer.A_log}",
+            )
+        finally:
+            torch.set_default_dtype(prev_dtype)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47842)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47842)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47831.

Under `bfloat16`, `torch.empty(...).uniform_(0, 16)` can round draws to exactly `0.0`, so `log(A)` becomes `-inf` for some GatedDeltaNet heads. Those heads get zero decay and zero gradient and stay permanently dead. This is especially visible on large hybrids (many GDN layers × many value heads).

**Change:** sample `A` in `float32` before `log` in constructors and matching `_init_weights` re-init paths for:

- `Qwen3NextGatedDeltaNet` (shared parent; same pattern on main)
- Qwen3.5 / Qwen3.5-MoE GDN init + weight re-init (modular + modeling)

This matches the approach already used for careful `A` init in models like Mamba2 / OlmoHybrid (build `A` in float32). Forward already uses `A_log.float().exp()` for the decay math.

## Code Agent Policy

- [x] **AI-assisted, not fully AI-written.** I used an AI coding assistant for drafting/editing support. I reviewed every changed line, ran local checks, and own the approach and PR description.

## Before submitting

- [x] Did you read the contributor guideline and PR checks?
- [x] Was this discussed via a GitHub issue? https://github.com/huggingface/transformers/issues/47831
- [x] Docs: N/A (init-only bugfix, no public API change)
- [x] New tests: `tests/models/qwen3_next/test_gated_delta_net_init.py`

## Tests

```bash
make style
# All 4 checks passed

make fix-repo
# modular_conversion / copies / ruff OK
# (global docstring checker fails on unrelated DeepseekVL/Kimi/PaddleOCR files on main)

python utils/tests_fetcher.py
# lists qwen3_next init + modeling, qwen3_5, qwen3_5_moe modeling

PYTHONPATH=src python3 -m unittest tests.models.qwen3_next.test_gated_delta_net_init -v
# ok — A_log finite under bf16 default dtype and after _init_weights
```

Smoke check: under `torch.set_default_dtype(torch.bfloat16)`, old-path `uniform` still shows dead heads; fixed path keeps `A_log` finite.

## Who can review?

Feel free to tag (after CI is green): @ArthurZucker @Cyrilvallez @vasqu (text / hybrid GDN)