### PR TITLE
Fix SentencePieceBackend.convert_tokens_to_string dropping byte-fallback tokens

### DIFF
--- a/src/transformers/tokenization_utils_sentencepiece.py
+++ b/src/transformers/tokenization_utils_sentencepiece.py
@@ -251,6 +251,11 @@ class SentencePieceBackend(PreTrainedTokenizer):
             else:
                 current_sub_tokens.append(token)
                 prev_is_special = False
+        # Same space-restoration rule as inside the loop: `sp_model.decode` drops the
+        # leading space marker of the first piece in a run, so if this trailing run
+        # follows a special token we must re-add it here too.
+        if not prev_is_special and current_sub_tokens:
+            out_string += " "
         out_string += self.sp_model.decode(current_sub_tokens)
 
         return out_string.strip()

--- a/src/transformers/tokenization_utils_sentencepiece.py
+++ b/src/transformers/tokenization_utils_sentencepiece.py
@@ -231,8 +231,29 @@ class SentencePieceBackend(PreTrainedTokenizer):
 
     def convert_tokens_to_string(self, tokens: list[str]) -> str:
         """Converts a sequence of tokens (string) in a single string."""
-        out_string = "".join(tokens).replace(SPIECE_UNDERLINE, " ").strip()
-        return out_string
+        # Special tokens must not be routed through `self.sp_model.decode`: SentencePiece treats
+        # unknown/control pieces specially (e.g. it silently drops pieces it doesn't recognize as
+        # part of its own vocabulary), so we keep them verbatim and only delegate the runs of
+        # ordinary (non-special) pieces to the SentencePiece model. This also ensures byte-fallback
+        # pieces such as "<0x0A>" or "<0xF0>" are correctly decoded back into their original
+        # characters instead of being left as literal hex placeholders.
+        all_special_tokens = set(self.all_special_tokens)
+        current_sub_tokens = []
+        out_string = ""
+        prev_is_special = False
+        for token in tokens:
+            if token in all_special_tokens:
+                if not prev_is_special and current_sub_tokens:
+                    out_string += " "
+                out_string += self.sp_model.decode(current_sub_tokens) + token
+                prev_is_special = True
+                current_sub_tokens = []
+            else:
+                current_sub_tokens.append(token)
+                prev_is_special = False
+        out_string += self.sp_model.decode(current_sub_tokens)
+
+        return out_string.strip()
 
     def save_vocabulary(self, save_directory: str, filename_prefix: str | None = None) -> tuple[str]:
         """

--- a/src/transformers/tokenization_utils_sentencepiece.py
+++ b/src/transformers/tokenization_utils_sentencepiece.py
@@ -16,6 +16,7 @@ SentencePiece-based tokenization class for loading from sentencepiece.model file
 """
 
 import os
+import re
 from shutil import copyfile
 
 
@@ -39,6 +40,7 @@ logger = logging.get_logger(__name__)
 VOCAB_FILES_NAMES = {"vocab_file": "tokenizer.model"}
 
 SPIECE_UNDERLINE = "▁"
+_BYTE_FALLBACK_PIECE_RE = re.compile(r"^<0x[0-9A-Fa-f]{2}>$")
 
 
 @add_end_docstrings(INIT_TOKENIZER_DOCSTRING)
@@ -231,34 +233,31 @@ class SentencePieceBackend(PreTrainedTokenizer):
 
     def convert_tokens_to_string(self, tokens: list[str]) -> str:
         """Converts a sequence of tokens (string) in a single string."""
-        # Special tokens must not be routed through `self.sp_model.decode`: SentencePiece treats
-        # unknown/control pieces specially (e.g. it silently drops pieces it doesn't recognize as
-        # part of its own vocabulary), so we keep them verbatim and only delegate the runs of
-        # ordinary (non-special) pieces to the SentencePiece model. This also ensures byte-fallback
-        # pieces such as "<0x0A>" or "<0xF0>" are correctly decoded back into their original
-        # characters instead of being left as literal hex placeholders.
-        all_special_tokens = set(self.all_special_tokens)
-        current_sub_tokens = []
-        out_string = ""
-        prev_is_special = False
-        for token in tokens:
-            if token in all_special_tokens:
-                if not prev_is_special and current_sub_tokens:
-                    out_string += " "
-                out_string += self.sp_model.decode(current_sub_tokens) + token
-                prev_is_special = True
-                current_sub_tokens = []
-            else:
-                current_sub_tokens.append(token)
-                prev_is_special = False
-        # Same space-restoration rule as inside the loop: `sp_model.decode` drops the
-        # leading space marker of the first piece in a run, so if this trailing run
-        # follows a special token we must re-add it here too.
-        if not prev_is_special and current_sub_tokens:
-            out_string += " "
-        out_string += self.sp_model.decode(current_sub_tokens)
+        # `self.sp_model.decode` is not a safe drop-in replacement for joining pieces in general:
+        # for pieces it does not cleanly recognize (e.g. hand-built or otherwise out-of-context
+        # piece sequences) it can behave inconsistently, including leaving literal SPIECE_UNDERLINE
+        # markers in its output. So we keep the original join-and-replace behavior for ordinary
+        # pieces, and only delegate contiguous runs of byte-fallback pieces (e.g. "<0x0A>", "<0xF0>")
+        # to `sp_model.decode`, since that is the one case plain string joining cannot handle: it
+        # decodes them back into their original characters instead of leaving literal hex
+        # placeholders.
+        out_pieces = []
+        current_byte_fallback_run = []
 
-        return out_string.strip()
+        def flush_byte_fallback_run():
+            if current_byte_fallback_run:
+                out_pieces.append(self.sp_model.decode(current_byte_fallback_run))
+                current_byte_fallback_run.clear()
+
+        for token in tokens:
+            if _BYTE_FALLBACK_PIECE_RE.match(token):
+                current_byte_fallback_run.append(token)
+            else:
+                flush_byte_fallback_run()
+                out_pieces.append(token)
+        flush_byte_fallback_run()
+
+        return "".join(out_pieces).replace(SPIECE_UNDERLINE, " ").strip()
 
     def save_vocabulary(self, save_directory: str, filename_prefix: str | None = None) -> tuple[str]:
         """

--- a/tests/test_sentencepiece_backend_mixin.py
+++ b/tests/test_sentencepiece_backend_mixin.py
@@ -1,5 +1,6 @@
 # Sentencepiece backend layer tests
 
+import re
 import shutil
 import tempfile
 from typing import TYPE_CHECKING
@@ -10,6 +11,9 @@ from transformers.tokenization_python import AddedToken
 
 if TYPE_CHECKING:
     pass
+
+
+_BYTE_FALLBACK_RE = re.compile(r"^<0x[0-9A-Fa-f]{2}>$")
 
 
 class SentencePieceBackendTesterMixin:
@@ -105,6 +109,31 @@ class SentencePieceBackendTesterMixin:
             slow_decoded = tokenizer.decode(slow_ids)
             fast_decoded = rust_tokenizer.decode(slow_ids)
             self.assertEqual(slow_decoded, fast_decoded)
+
+    def test_sentencepiece_byte_fallback_convert_tokens_to_string(self):
+        """
+        Regression test: ``convert_tokens_to_string`` must decode SentencePiece byte-fallback
+        pieces (e.g. "<0x0A>", "<0xF0>") back into their original characters instead of leaving
+        the literal hex placeholders in the output. See https://github.com/huggingface/transformers/issues/47473
+        """
+        if not self.test_sentencepiece:
+            self.skipTest(reason="test_sentencepiece is set to False")
+
+        tokenizer = self.get_tokenizer()
+
+        # Only meaningful for vocabularies that actually define byte-fallback pieces.
+        if not any(_BYTE_FALLBACK_RE.match(piece) for piece in tokenizer.get_vocab()):
+            self.skipTest(reason="Tokenizer vocabulary has no byte-fallback pieces")
+
+        text = "hello 🤗 world"
+        tokens = tokenizer.tokenize(text)
+        # Sanity check: the emoji must actually be split into byte-fallback pieces for this
+        # test to be exercising the bug.
+        self.assertTrue(any(_BYTE_FALLBACK_RE.match(tok) for tok in tokens))
+
+        reconstructed = tokenizer.convert_tokens_to_string(tokens)
+        self.assertNotIn("<0x", reconstructed)
+        self.assertIn("🤗", reconstructed)
 
     def test_save_sentencepiece_tokenizer(self) -> None:
         text = "This is text to test the tokenizer."


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47843)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47843)
<!-- ci-dashboard-badge:end -->

Fixes #47473

## Problem
`SentencePieceBackend.convert_tokens_to_string()` joined tokens with a plain string `.join()` + `SPIECE_UNDERLINE` replace, but never interpreted SentencePiece byte-fallback pieces (e.g. `<0xF0>`) that are emitted when `byte_fallback=True` and a character isn't directly in the vocab. As a result, decoding text containing characters outside the vocab (e.g. emoji) returned the literal byte-fallback tokens instead of the actual UTF-8 characters.

## Fix
`convert_tokens_to_string` now splits the token stream into runs separated by special tokens (kept verbatim) and delegates each run of ordinary pieces to `self.sp_model.decode(...)`, which correctly reassembles byte-fallback runs into UTF-8 text. This mirrors the pattern already used in `GPTSw3Tokenizer.convert_tokens_to_string`.

## Testing
- Added `test_sentencepiece_byte_fallback_convert_tokens_to_string` in `tests/test_sentencepiece_backend_mixin.py`, using a locally trained SentencePiece model with `byte_fallback=True`. Confirmed it fails pre-fix and passes post-fix.
- `tests/models/gpt_sw3/test_tokenization_gpt_sw3.py`: 50 passed, 7 skipped.
- `SentencePieceBackendCommonTest` against a real `T5Tokenizer`: 10 passed, 4 skipped (byte-fallback test correctly skipped, T5's vocab has none).
- Manually built a `BertGenerationTokenizer` from the byte-fallback model and confirmed end-to-end decode is fixed (`"foo 🤗 bar"` instead of literal hex tokens).