### PR TITLE
Fix additional_special_tokens data loss with extra_special_tokens

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1165,10 +1165,8 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         # V5: Allowed keys are SPECIAL_TOKENS_ATTRIBUTES + "extra_special_tokens"
         # Backward compatibility: convert "additional_special_tokens" to "extra_special_tokens"
         special_tokens_dict = dict(special_tokens_dict)
-        if "additional_special_tokens" in special_tokens_dict:
-            special_tokens_dict.setdefault(
-                "extra_special_tokens", special_tokens_dict.pop("additional_special_tokens")
-            )
+        if "additional_special_tokens" in special_tokens_dict and "extra_special_tokens" not in special_tokens_dict:
+            special_tokens_dict["extra_special_tokens"] = special_tokens_dict.pop("additional_special_tokens")
 
         allowed_keys = set(self.SPECIAL_TOKENS_ATTRIBUTES) | {"extra_special_tokens"}
         tokens_to_add = []
@@ -1809,8 +1807,8 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         init_kwargs.update(kwargs)
 
         # V5: Convert deprecated additional_special_tokens to extra_special_tokens
-        if "additional_special_tokens" in init_kwargs:
-            init_kwargs.setdefault("extra_special_tokens", init_kwargs.pop("additional_special_tokens"))
+        if "additional_special_tokens" in init_kwargs and "extra_special_tokens" not in init_kwargs:
+            init_kwargs["extra_special_tokens"] = init_kwargs.pop("additional_special_tokens")
 
         # V5: Collect model-specific tokens (custom *_token keys not in standard attributes)
         default_attrs = set(cls.SPECIAL_TOKENS_ATTRIBUTES)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -2827,6 +2827,14 @@ class SentencePieceBackendCommonTest(unittest.TestCase, SentencePieceBackendTest
         self.assertEqual(tokenizer_r.add_special_tokens({}), 0)
         self.assertEqual(tokenizer_r.add_special_tokens({"bos_token": "[BOS]", "eos_token": "[EOS]"}), 2)
         self.assertRaises(ValueError, tokenizer_r.add_special_tokens, {"additional_special_tokens": "<testtoken1>"})
+        self.assertRaises(
+            ValueError,
+            tokenizer_r.add_special_tokens,
+            {
+                "additional_special_tokens": ["<deprecated>"],
+                "extra_special_tokens": ["<preferred>"],
+            },
+        )
         self.assertEqual(tokenizer_r.add_special_tokens({"additional_special_tokens": ["<testtoken2>"]}), 1)
         self.assertEqual(
             tokenizer_r.add_special_tokens({"additional_special_tokens": ["<testtoken3>", "<testtoken4>"]}), 2

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -285,6 +285,29 @@ class TokenizerUtilsTest(unittest.TestCase):
             self.assertIn("benign_repo_token", vocab)
             self.assertNotIn("secret_leaked_token", vocab)
 
+    def test_additional_special_tokens_are_preserved_when_extra_tokens_are_configured(self):
+        class CapturingBertTokenizer(BertTokenizer):
+            def __init__(self, *args, **kwargs):
+                self.received_additional_special_tokens = kwargs.get("additional_special_tokens")
+                super().__init__(*args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as repo:
+            with open(os.path.join(repo, "vocab.txt"), "w", encoding="utf-8") as f:
+                f.write("\n".join(["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"]))
+            with open(os.path.join(repo, "tokenizer_config.json"), "w", encoding="utf-8") as f:
+                json.dump(
+                    {
+                        "tokenizer_class": "BertTokenizer",
+                        "additional_special_tokens": ["<deprecated>"],
+                        "extra_special_tokens": {},
+                    },
+                    f,
+                )
+
+            tokenizer = CapturingBertTokenizer.from_pretrained(repo)
+
+            self.assertEqual(tokenizer.received_additional_special_tokens, ["<deprecated>"])
+
     def test_len_tokenizer(self):
         for tokenizer_class in [BertTokenizer, BertTokenizer]:
             with self.subTest(f"{tokenizer_class}"):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47848)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47848)
<!-- ci-dashboard-badge:end -->

Fixes #47838.

When both deprecated additional_special_tokens and extra_special_tokens are present, eagerly popping the deprecated key before setdefault silently discarded user-provided tokens. Guard both conversion sites so the deprecated value is only migrated when the new key is absent. Add regression coverage for loading and explicit add_special_tokens calls.

Validation: git diff --check and python3 -m py_compile passed. The focused pytest was not run because pytest and the local transformers package are not installed.