### PR TITLE
[security] Block non-global hosts in load_video and audio URL fetches

### DIFF
--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -40,6 +40,7 @@ from .utils import (
     requires_backends,
 )
 from .utils.generic import retry
+from .utils.remote_url import validate_remote_url
 
 
 if TYPE_CHECKING:
@@ -66,6 +67,7 @@ AudioInput = Union[np.ndarray, "torch.Tensor", Sequence[np.ndarray], Sequence["t
 @retry(exceptions=(httpx.HTTPError,))
 def _fetch_audio_bytes(url: str, timeout: float | None = 10.0) -> bytes:
     """Fetch audio bytes from a URL with automatic retry and exponential backoff."""
+    validate_remote_url(url)
     response = httpx.get(url, follow_redirects=True, timeout=timeout)
     response.raise_for_status()
     return response.content

--- a/src/transformers/utils/remote_url.py
+++ b/src/transformers/utils/remote_url.py
@@ -1,0 +1,57 @@
+# Copyright 2026 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SSRF guards for remote media URL fetches (image/audio/video helpers)."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+def validate_remote_url(url: str) -> None:
+    """Raise ``ValueError`` if ``url`` resolves to a non-global address.
+
+    Blocks loopback, RFC1918/ULA private, link-local (cloud metadata),
+    CGNAT, and other non-global ranges before ``httpx.get`` runs. Used by
+    video/audio (and sibling of open ``load_image`` hardening).
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"URL scheme must be http or https for remote media fetch, got {parsed.scheme!r}."
+        )
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("Remote media URL is missing a hostname.")
+
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        # Let httpx surface resolution failures on the actual request.
+        return
+
+    for info in infos:
+        ip = info[4][0]
+        try:
+            ip_obj = ipaddress.ip_address(ip)
+        except ValueError:
+            continue
+        if not ip_obj.is_global:
+            raise ValueError(
+                f"URL hostname '{hostname}' resolves to a non-global address ({ip}). "
+                "Requests to internal addresses are blocked to prevent SSRF. "
+                "If this is a legitimate local media server, download the file and "
+                "pass a local path or bytes instead."
+            )

--- a/src/transformers/video_utils.py
+++ b/src/transformers/video_utils.py
@@ -40,6 +40,7 @@ from .utils import (
     logging,
     requires_backends,
 )
+from .utils.remote_url import validate_remote_url
 
 
 if is_vision_available():
@@ -698,6 +699,7 @@ def load_video(
         bytes_obj = buffer.getvalue()
         file_obj = BytesIO(bytes_obj)
     elif video.startswith("http://") or video.startswith("https://"):
+        validate_remote_url(video)
         file_obj = BytesIO(httpx.get(video, follow_redirects=True).content)
     elif os.path.isfile(video):
         file_obj = video

--- a/tests/utils/test_remote_url.py
+++ b/tests/utils/test_remote_url.py
@@ -1,0 +1,51 @@
+# Copyright 2026 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import socket
+import unittest
+from unittest.mock import patch
+
+from transformers.utils.remote_url import validate_remote_url
+
+
+def _fake_addrinfo(ip: str):
+    # (family, type, proto, canonname, sockaddr)
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))]
+
+
+class ValidateRemoteUrlTester(unittest.TestCase):
+    def test_rejects_non_http_schemes(self):
+        with self.assertRaises(ValueError):
+            validate_remote_url("file:///etc/passwd")
+        with self.assertRaises(ValueError):
+            validate_remote_url("javascript:alert(1)")
+
+    def test_rejects_loopback(self):
+        with patch("socket.getaddrinfo", return_value=_fake_addrinfo("127.0.0.1")):
+            with self.assertRaises(ValueError):
+                validate_remote_url("http://metadata.local/latest")
+
+    def test_rejects_link_local_metadata(self):
+        with patch("socket.getaddrinfo", return_value=_fake_addrinfo("169.254.169.254")):
+            with self.assertRaises(ValueError):
+                validate_remote_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_rejects_cgnat(self):
+        with patch("socket.getaddrinfo", return_value=_fake_addrinfo("100.64.0.1")):
+            with self.assertRaises(ValueError):
+                validate_remote_url("http://cgnat.example/audio.wav")
+
+    def test_allows_public_ip(self):
+        with patch("socket.getaddrinfo", return_value=_fake_addrinfo("8.8.8.8")):
+            validate_remote_url("https://cdn.example.com/video.mp4")


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47849)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47849)
<!-- ci-dashboard-badge:end -->

## Summary

Sibling of open `#47230` (`load_image` SSRF). `load_video` and `_fetch_audio_bytes` still call `httpx.get(..., follow_redirects=True)` with no host/IP check, so pipeline video/audio URLs can hit loopback, link-local metadata, private, or CGNAT addresses.

This adds `transformers.utils.remote_url.validate_remote_url` (http/https + resolved IP must be global) and calls it before those fetches.

## Test plan

- [x] Standalone unit cases for scheme / loopback / link-local / CGNAT / public (mocked `getaddrinfo`)
- [x] `tests/utils/test_remote_url.py` added
- [ ] CI unit shard for `tests/utils/test_remote_url.py`


Made with [Cursor](https://cursor.com)