### PR TITLE
docs(tests): fix typos in test comments

### DIFF
--- a/tests/models/diffusion_gemma/test_generation_diffusion_gemma.py
+++ b/tests/models/diffusion_gemma/test_generation_diffusion_gemma.py
@@ -205,7 +205,7 @@ class DiffusionGemmaGenerationClassesTester(unittest.TestCase):
             stability_threshold=0, confidence_threshold=9.22
         )
 
-        # this should NEVER trigger the stopping criteria, assuming the the theshold is < ln(1/vocab_size)
+        # this should NEVER trigger the stopping criteria, assuming the threshold is < ln(1/vocab_size)
         logits_max_entropy = torch.zeros((1, 10, 10000), device=torch_device)
         self.assertFalse(stopping_criteria_strict(argmax_canvas=None, logits=logits_max_entropy).all())
         self.assertFalse(stopping_criteria_lax(argmax_canvas=None, logits=logits_max_entropy).all())

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -3173,7 +3173,7 @@ class TestAttentionImplementation(unittest.TestCase):
         # Simulate the "module cleared from sys.modules" case (test cleanup, REPL).
         from transformers.models.llama.modeling_llama import LlamaModel
 
-        # The method _can_set_attn_implementation caches the result on a succesful call, so we need to clear the cache
+        # The method _can_set_attn_implementation caches the result on a successful call, so we need to clear the cache
         if hasattr(LlamaModel, "_can_set_attn_implementation_cached_value"):
             delattr(LlamaModel, "_can_set_attn_implementation_cached_value")
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47859)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47859)
<!-- ci-dashboard-badge:end -->

### WHY

Two test comments contain typos:

- `succesful` → `successful` in `tests/utils/test_modeling_utils.py`
- `the the theshold` → `the threshold` in `tests/models/diffusion_gemma/test_generation_diffusion_gemma.py` (duplicated `the` + `theshold` misspelling of `threshold`)

### WHAT

Comments only; no test logic or assertions changed.