### PR TITLE
Fix interval merge invariant in _find_disjoint

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -403,7 +403,7 @@ def _find_disjoint(tensors: list[set[str]], state_dict: dict[str, torch.Tensor])
                 filtered_tensors.append({name})
             else:
                 filtered_tensors[-1].add(name)
-            last_stop = stop
+            last_stop = max(last_stop, stop)
     disjoint_tensors = []
     shared_tensors = []
     for tensors in filtered_tensors:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47860)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47860)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Supersedes #47814 (closed). That PR claimed this bug breaks weight tying on save/reload — after investigating properly, **that claim was wrong**, and this PR rewrites the description to match what the change actually does.

Fixes the sweep-line invariant in `_find_disjoint` (`src/transformers/modeling_utils.py`).

The function merges tensor memory ranges to decide which tensors in a shared storage genuinely overlap. It sorts `(start, stop, name)` tuples and walks them, but updates the running boundary with `last_stop = stop` instead of the running maximum:

```python
for start, stop, name in areas[1:]:
    if start >= last_stop:
        filtered_tensors.append({name})
    else:
        filtered_tensors[-1].add(name)
    last_stop = stop          # <-- shrinks when a contained tensor is processed
```

When a tensor is strictly contained inside an earlier, larger one, `last_stop` shrinks to the contained tensor's end pointer. A subsequent tensor that genuinely overlaps the larger tensor then satisfies `start >= last_stop` and is mis-classified as disjoint.

Concrete case — ranges `A=[0,3000)`, `B=[500,1000)`, `C=[1000,2000)` (all in one storage):

| step | current `last_stop` | decision for next |
|---|---|---|
| process `A` | 3000 | — |
| process `B` (start 500 < 3000 → overlap ✓) | **1000** (shrunk) | — |
| process `C` (start 1000 ≥ 1000) | — | **disjoint ✗** — but `C` overlaps `A` |

The fix is the standard sweep-line invariant:

```python
last_stop = max(last_stop, stop)
```

## Honest scoping of the impact

**This is a latent correctness fix, not a user-facing bug fix.** I want to be upfront about that rather than overstate it.

Triggering the mis-classification requires *strict* containment (`start_A < start_B` and `stop_B < stop_A`) — equal-start intervals can't trigger it, because the tuple sort already orders the smaller `stop` first. But strict containment also guarantees the resulting group has differing `(device, data_ptr, end_ptr)` keys, so `_find_identical` never marks it identical, and `remove_tied_weights_from_state_dict` reaches the `RuntimeError` at the end regardless of which branch was taken.

I verified this exhaustively rather than by argument alone — brute-forcing every 3- and 4-interval configuration over a coordinate grid (54,000 configs), comparing against ground-truth connected components computed with union-find:

```
configs tested                                   : 54000
fixed version disagrees with ground truth        : 0
classification differs (buggy vs fixed)          : 7182
configs where save RAISES vs SUCCEEDS differs    : 0
configs that SUCCEED but clone different tensors : 0
```

So: the current code is provably wrong in 7,182 configurations, the corrected code matches ground truth in 100% of them — **but** no configuration changes whether `save_pretrained` succeeds or raises.

The observable improvement is diagnostic quality. In the example above:

```
buggy: cloned=['C'], raises=True, error_names=[['A', 'B']]
fixed: cloned=[],    raises=True, error_names=[['A', 'B', 'C']]
```

The error message currently reports a **truncated** set of overlapping tensors, and a tensor gets needlessly `.clone()`d on a path that then aborts. After the fix the message names the complete overlap set, which is what a user debugging a tying misconfiguration needs.

Happy to close this if a one-line invariant fix without a user-visible repro isn't worth the churn — but since the corrected line is strictly more correct and no less efficient, it seemed worth offering.

## Before submitting

- [x] This PR fixes a typo/improves the docs (no test needed) — n/a
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Did you make sure to update the documentation with your changes? — n/a, internal helper
- [x] Did you write any new necessary tests? — behavior is unobservable through the public API (see above), so a regression test would have to target `_find_disjoint` directly. Glad to add one if you'd like it.

## Who can review?

@SunMarc — thanks for the earlier review asking for a real example. Digging into it properly showed my original framing was wrong, so I've rewritten the PR to describe what the change actually does.