### PR TITLE
Revert "Fix CodeLlama tokenizer dropping leading whitespace on decode (#47488)"

### DIFF
--- a/docs/source/en/model_doc/code_llama.md
+++ b/docs/source/en/model_doc/code_llama.md
@@ -150,7 +150,7 @@ visualizer("""def func(a, b):
 
 - Use `bfloat16` for further training or fine-tuning and `float16` for inference.
 - The `BOS` character is not used for infilling when encoding the prefix or suffix, but only at the beginning of each prompt.
-- The tokenizer is a byte-pair encoding model based on [SentencePiece](https://github.com/google/sentencepiece). Leading whitespace is preserved on decode, so indented text round trips exactly, including a single leading space, leading tabs and newlines, and multiple spaces.
+- The tokenizer is a byte-pair encoding model based on [SentencePiece](https://github.com/google/sentencepiece). During decoding, if the first token is the start of the word (for example, “Banana”), the tokenizer doesn’t prepend the prefix space to the string.
 
 ## CodeLlamaTokenizer
 

--- a/src/transformers/models/code_llama/tokenization_code_llama.py
+++ b/src/transformers/models/code_llama/tokenization_code_llama.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from tokenizers import Tokenizer, decoders, normalizers, processors
+from tokenizers import Tokenizer, decoders, normalizers, pre_tokenizers, processors
 from tokenizers.models import BPE
 
 from ...tokenization_utils_tokenizers import TokenizersBackend
@@ -155,17 +155,14 @@ class CodeLlamaTokenizer(TokenizersBackend):
                 unk_token=str(unk_token),
             )
         )
+        prepend_scheme = "first" if self.add_prefix_space else "never"
+        self._tokenizer.pre_tokenizer = pre_tokenizers.Metaspace(
+            replacement="▁", prepend_scheme=prepend_scheme, split=False
+        )
 
-        normalizer_sequence = []
-        if self.add_prefix_space:
-            normalizer_sequence.append(normalizers.Prepend(prepend="▁"))
-        normalizer_sequence.append(normalizers.Replace(pattern=" ", content="▁"))
-        self._tokenizer.normalizer = normalizers.Sequence(normalizer_sequence)
-
-        decoder_sequence = [decoders.Replace("▁", " "), decoders.ByteFallback(), decoders.Fuse()]
-        if self.add_prefix_space:
-            decoder_sequence.append(decoders.Strip(content=" ", left=1))
-        self._tokenizer.decoder = decoders.Sequence(decoder_sequence)
+        self._tokenizer.decoder = decoders.Sequence(
+            [decoders.Replace("▁", " "), decoders.ByteFallback(), decoders.Fuse(), decoders.Strip(content=" ", left=1)]
+        )
 
         super().__init__(
             clean_up_tokenization_spaces=clean_up_tokenization_spaces,
@@ -241,11 +238,12 @@ class CodeLlamaTokenizer(TokenizersBackend):
         is to add a prefix space for the normalizer, and add a `bos_token` to the input text for the `post_processor`.
         """
         if reset:
-            normalizer_sequence = []
-            if self.add_prefix_space:
-                normalizer_sequence.append(normalizers.Prepend(prepend="▁"))
-            normalizer_sequence.append(normalizers.Replace(pattern=" ", content="▁"))
-            self._tokenizer.normalizer = normalizers.Sequence(normalizer_sequence)
+            self._tokenizer.normalizer = normalizers.Sequence(
+                [
+                    normalizers.Prepend(prepend="▁"),
+                    normalizers.Replace(pattern=" ", content="▁"),
+                ]
+            )
             self.update_post_processor()
             return
 

--- a/tests/models/code_llama/test_tokenization_code_llama.py
+++ b/tests/models/code_llama/test_tokenization_code_llama.py
@@ -41,20 +41,13 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
 @require_tokenizers
 class CodeLlamaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     # TokenizerTesterMixin configuration
-    from_pretrained_id = ["codellama/CodeLlama-7b-hf"]
+    from_pretrained_id = ["hf-internal-testing/llama-code-tokenizer"]
     tokenizer_class = CodeLlamaTokenizer
 
-    integration_expected_tokens = ['▁This', '▁is', '▁a', '▁test', '▁', '<0xF0>', '<0x9F>', '<0x98>', '<0x8A>', '<0x0A>', 'I', '▁was', '▁born', '▁in', '▁', '9', '2', '0', '0', '0', ',', '▁and', '▁this', '▁is', '▁f', 'als', 'é', '.', '<0x0A>', '生', '活', '的', '真', '<0xE8>', '<0xB0>', '<0x9B>', '是', '<0x0A>', 'Hi', '▁', '▁Hello', '<0x0A>', 'Hi', '▁▁', '▁Hello', '<0x0A>', '<0x0A>', '▁', '<0x0A>', '▁▁', '<0x0A>', '▁Hello', '<0x0A>', '<s>', '▁', '<0x0A>', 'hi', '<s>', '▁there', '<0x0A>', 'The', '▁following', '▁string', '▁should', '▁be', '▁properly', '▁encoded', ':', '▁Hello', '.', '<0x0A>', 'But', '▁', 'ird', '▁and', '▁', 'ป', 'ี', '▁▁▁', 'ird', '▁▁▁', 'ด', '<0x0A>', 'H', 'ey', '▁how', '▁are', '▁you', '▁doing']  # fmt: skip
-    integration_expected_token_ids = [910, 338, 263, 1243, 29871, 243, 162, 155, 141, 13, 29902, 471, 6345, 297, 29871, 29929, 29906, 29900, 29900, 29900, 29892, 322, 445, 338, 285, 1338, 29948, 29889, 13, 30486, 31704, 30210, 30848, 235, 179, 158, 30392, 13, 18567, 29871, 15043, 13, 18567, 259, 15043, 13, 13, 29871, 13, 259, 13, 15043, 13, 1, 29871, 13, 2918, 1, 727, 13, 1576, 1494, 1347, 881, 367, 6284, 18511, 29901, 15043, 29889, 13, 6246, 29871, 1823, 322, 29871, 31010, 30691, 1678, 1823, 1678, 30718, 13, 29950, 1032, 920, 526, 366, 2599]  # fmt: skip
-    expected_tokens_from_ids = ['▁This', '▁is', '▁a', '▁test', '▁', '<0xF0>', '<0x9F>', '<0x98>', '<0x8A>', '<0x0A>', 'I', '▁was', '▁born', '▁in', '▁', '9', '2', '0', '0', '0', ',', '▁and', '▁this', '▁is', '▁f', 'als', 'é', '.', '<0x0A>', '生', '活', '的', '真', '<0xE8>', '<0xB0>', '<0x9B>', '是', '<0x0A>', 'Hi', '▁', '▁Hello', '<0x0A>', 'Hi', '▁▁', '▁Hello', '<0x0A>', '<0x0A>', '▁', '<0x0A>', '▁▁', '<0x0A>', '▁Hello', '<0x0A>', '<s>', '▁', '<0x0A>', 'hi', '<s>', '▁there', '<0x0A>', 'The', '▁following', '▁string', '▁should', '▁be', '▁properly', '▁encoded', ':', '▁Hello', '.', '<0x0A>', 'But', '▁', 'ird', '▁and', '▁', 'ป', 'ี', '▁▁▁', 'ird', '▁▁▁', 'ด', '<0x0A>', 'H', 'ey', '▁how', '▁are', '▁you', '▁doing']  # fmt: skip
-    integration_expected_decoded_text = "This is a test 😊\nI was born in 92000, and this is falsé.\n生活的真谛是\nHi  Hello\nHi   Hello\n\n \n  \n Hello\n<s> \nhi<s> there\nThe following string should be properly encoded: Hello.\nBut ird and ปี   ird   ด\nHey how are you doing"
-
-    @unittest.skip(
-        "get_clean_sequence() rejoins split words with single spaces, losing this vocab's multi-space "
-        "sample text, same mismatch exists on the raw tokenizer.json, not a CodeLlamaTokenizer bug."
-    )
-    def test_pretokenized_inputs(self):
-        pass
+    integration_expected_tokens = ['▁This', '▁is', '▁a', '▁test', '▁', '<0xF0>', '<0x9F>', '<0x98>', '<0x8A>', '<0x0A>', 'I', '▁was', '▁born', '▁in', '▁', '9', '2', '0', '0', '0', ',', '▁and', '▁this', '▁is', '▁f', 'als', 'é', '.', '<0x0A>', '生', '活', '的', '真', '<0xE8>', '<0xB0>', '<0x9B>', '是', '<0x0A>', 'Hi', '▁', '▁Hello', '<0x0A>', 'Hi', '▁▁', '▁Hello', '<0x0A>', '<0x0A>', '▁', '<0x0A>', '▁▁', '<0x0A>', '▁Hello', '<0x0A>', '<s>', '<0x0A>', 'hi', '<s>', 'there', '<0x0A>', 'The', '▁following', '▁string', '▁should', '▁be', '▁properly', '▁encoded', ':', '▁Hello', '.', '<0x0A>', 'But', '▁', 'ird', '▁and', '▁', 'ป', 'ี', '▁▁▁', 'ird', '▁▁▁', 'ด', '<0x0A>', 'H', 'ey', '▁how', '▁are', '▁you', '▁doing']  # fmt: skip
+    integration_expected_token_ids = [910, 338, 263, 1243, 29871, 243, 162, 155, 141, 13, 29902, 471, 6345, 297, 29871, 29929, 29906, 29900, 29900, 29900, 29892, 322, 445, 338, 285, 1338, 29948, 29889, 13, 30486, 31704, 30210, 30848, 235, 179, 158, 30392, 13, 18567, 29871, 15043, 13, 18567, 259, 15043, 13, 13, 29871, 13, 259, 13, 15043, 13, 1, 13, 2918, 1, 12711, 13, 1576, 1494, 1347, 881, 367, 6284, 18511, 29901, 15043, 29889, 13, 6246, 29871, 1823, 322, 29871, 31010, 30691, 1678, 1823, 1678, 30718, 13, 29950, 1032, 920, 526, 366, 2599]  # fmt: skip
+    expected_tokens_from_ids = ['▁This', '▁is', '▁a', '▁test', '▁', '<0xF0>', '<0x9F>', '<0x98>', '<0x8A>', '<0x0A>', 'I', '▁was', '▁born', '▁in', '▁', '9', '2', '0', '0', '0', ',', '▁and', '▁this', '▁is', '▁f', 'als', 'é', '.', '<0x0A>', '生', '活', '的', '真', '<0xE8>', '<0xB0>', '<0x9B>', '是', '<0x0A>', 'Hi', '▁', '▁Hello', '<0x0A>', 'Hi', '▁▁', '▁Hello', '<0x0A>', '<0x0A>', '▁', '<0x0A>', '▁▁', '<0x0A>', '▁Hello', '<0x0A>', '<s>', '<0x0A>', 'hi', '<s>', 'there', '<0x0A>', 'The', '▁following', '▁string', '▁should', '▁be', '▁properly', '▁encoded', ':', '▁Hello', '.', '<0x0A>', 'But', '▁', 'ird', '▁and', '▁', 'ป', 'ี', '▁▁▁', 'ird', '▁▁▁', 'ด', '<0x0A>', 'H', 'ey', '▁how', '▁are', '▁you', '▁doing']  # fmt: skip
+    integration_expected_decoded_text = "This is a test 😊\nI was born in 92000, and this is falsé.\n生活的真谛是\nHi  Hello\nHi   Hello\n\n \n  \n Hello\n<s>\nhi<s>there\nThe following string should be properly encoded: Hello.\nBut ird and ปี   ird   ด\nHey how are you doing"
 
     def test_save_and_load_tokenizer(self):
         """Override to handle non-deterministic vocabulary order from Rust tokenizer."""
@@ -171,7 +164,7 @@ class CodeLlamaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 class LlamaIntegrationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        checkpoint_name = "codellama/CodeLlama-7b-hf"
+        checkpoint_name = "hf-internal-testing/llama-code-tokenizer"
         cls.tokenizer: CodeLlamaTokenizer = CodeLlamaTokenizer.from_pretrained(checkpoint_name)
         cls.rust_tokenizer = CodeLlamaTokenizer.from_pretrained(checkpoint_name)
         return cls
@@ -213,44 +206,10 @@ class LlamaIntegrationTest(unittest.TestCase):
         self.tokenizer.add_eos_token = False
         self.rust_tokenizer.add_eos_token = False
 
-    def test_decode_preserves_leading_whitespace(self):
-        # Decode must keep real leading whitespace, including a single leading space, which the
-        # old `Metaspace` pipeline fused into the synthetic prefix and could not recover.
-        tokenizer = self.tokenizer
-
-        # Real leading whitespace round-trips exactly, down to a single space.
-        for text in [" hello", "  hello", "   leading spaces", "    indented_line", "\tindented"]:
-            ids = tokenizer.encode(text, add_special_tokens=False)
-            self.assertEqual(tokenizer.decode(ids), text)
-
-        # The synthetic prefix is still stripped, so text without leading
-        # whitespace does not gain a spurious leading space.
-        for text in ["hello", "def foo():", "import numpy"]:
-            ids = tokenizer.encode(text, add_special_tokens=False)
-            self.assertEqual(tokenizer.decode(ids), text)
-
-        # A real leading space is encoded as a distinct `▁` token rather than fused into
-        # the prefix, so " hello" and "hello" no longer collapse to the same ids.
-        self.assertNotEqual(
-            tokenizer.encode(" hello", add_special_tokens=False),
-            tokenizer.encode("hello", add_special_tokens=False),
-        )
-
-        # The same holds when the ids carry special tokens (e.g. BOS) that are
-        # skipped on decode: the synthetic prefix is still removed.
-        for text in ["hello", "Hello world", "  hello", "    indented_line"]:
-            ids = tokenizer.encode(text, add_special_tokens=True)
-            self.assertEqual(tokenizer.decode(ids, skip_special_tokens=True), text)
-
-        # batch_decode routes each sequence through the same path.
-        batch = ["  hello", "world", "\tindented"]
-        batch_ids = [tokenizer.encode(text, add_special_tokens=False) for text in batch]
-        self.assertEqual(tokenizer.batch_decode(batch_ids), batch)
-
-        # A dict of ids (as returned by the tokenizer call) decodes the same way.
-        encoded = tokenizer("  hello", add_special_tokens=True)
-        self.assertEqual(tokenizer.decode(encoded["input_ids"], skip_special_tokens=True), "  hello")
-
+    @unittest.skip(
+        "Skipped in v5 - CodeLlama tokenization differences related to SPM legacy flag and Metaspace handling. "
+        "CodeLlama always uses legacy=False (Metaspace pre_tokenizer, no normalizer)"
+    )
     def test_simple_encode_decode(self):
         pyth_tokenizer = self.tokenizer
         rust_tokenizer = self.rust_tokenizer
@@ -299,6 +258,10 @@ class LlamaIntegrationTest(unittest.TestCase):
         self.assertEqual(pyth_tokenizer.encode(" Hello"), [1, 29871, 15043])
         self.assertEqual(rust_tokenizer.encode(" Hello"), [1, 29871, 15043])
 
+    @unittest.skip(
+        "Skipped in v5 - CodeLlama tokenization differences related to SPM legacy flag and Metaspace handling. "
+        "CodeLlama always uses legacy=False (Metaspace pre_tokenizer, no normalizer)"
+    )
     def test_no_differences_showcase(self):
         pyth_tokenizer = self.tokenizer
         rust_tokenizer = self.rust_tokenizer
@@ -390,14 +353,13 @@ class LlamaIntegrationTest(unittest.TestCase):
         # the word inform should be split as ['in', 'form']
         tokenizer = CodeLlamaTokenizer.from_pretrained("codellama/CodeLlama-7b-hf", legacy=False)
         tokens = tokenizer.tokenize("[INST] How are you doing?<s>[/INST]")
-        # The `▁` before `[` after `<s>` matches the reference SentencePiece tokenizer: the
-        # `Prepend("▁")` normalizer re-adds a metaspace at the start of the fragment following the
-        # special token, exactly as the shipped tokenizer.json does.
         self.assertEqual(
-            tokens, ["▁[", "INST", "]", "▁How", "▁are", "▁you", "▁doing", "?", "<s>", "▁[", "/", "INST", "]"]
+            tokens, ["▁[", "INST", "]", "▁How", "▁are", "▁you", "▁doing", "?", "<s>", "[", "/", "INST", "]"]
         )
         inputs_ids = tokenizer.encode("[INST] How are you doing?<s>[/INST]")
-        self.assertEqual(inputs_ids, [1, 518, 25580, 29962, 1128, 526, 366, 2599, 29973, 1, 518, 29914, 25580, 29962])
+        self.assertEqual(
+            inputs_ids, [1, 518, 25580, 29962, 1128, 526, 366, 2599, 29973, 1, 29961, 29914, 25580, 29962]
+        )
 
     def test_infilling_tokenization(self):
         PROMPTS = [


### PR DESCRIPTION
# What does this PR do?

Reverts #47488. Needed for the release.

Follow-up: **#47862** fixes #47487 properly — decode-only, encoding byte-identical, no id changes.

#47488 swapped the `Metaspace` pre-tokenizer for a `Prepend("▁") + Replace(" ", "▁")` normalizer. Both look equivalent, but the normalizer form changes tokenization in two ways that break checkpoints already in the wild.

**1. Added tokens stop matching.** The normalizer is applied to the added tokens themselves when the added-vocabulary matcher (daachorse) is rebuilt, so `<s>` is stored as `▁<s>` and no longer matches `<s>` in the text. Any checkpoint that ships its specials with `normalized=True` loses them:

```python
tok.tokenize("Hey how are<s>you?<unk> <unk>")
['▁Hey', '▁how', '▁are', '<', 's', '>', 'you', '?', '<', 'unk', '>', '▁<unk>']
```

**2. A spurious metaspace after every special token.** The prepend runs on each chunk produced by the added-token split, not once on the sequence. So `[INST] How are you doing?<s>[/INST]` moves `[` from `29961` to `518` — every multi-turn Llama-2 chat prompt tokenizes differently. #47488 wrote this into its own expected outputs rather than treating it as a regression:

```diff
-    tokens, ["▁[", "INST", "]", "▁How", "▁are", "▁you", "▁doing", "?", "<s>", "[", "/", "INST", "]"]
+    tokens, ["▁[", "INST", "]", "▁How", "▁are", "▁you", "▁doing", "?", "<s>", "▁[", "/", "INST", "]"]
```

`meta-llama/Llama-2-7b-hf`'s `tokenizer.json` is not a reference here — we built it ourselves, before metaspace was fixed.

The round-trip issue reported in #47487 is real but it is decode-only and does not need a pipeline change. It is fixed in #47862, which keeps encoding byte-identical.

This is an exact `git revert`; `tests/models/code_llama/test_tokenization_code_llama.py` and `tests/models/llama/test_tokenization_llama.py` pass (116 passed, 14 skipped).

## Who can review?

@itazap
