### PR TITLE
Strip the metaspace prefix space only when it is unambiguous

### DIFF
--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -27,6 +27,7 @@ from tokenizers import AddedToken, Regex, Tokenizer, decoders, normalizers, pre_
 from tokenizers.models import BPE, Unigram, WordPiece
 
 from .integrations.mistral.constants import is_tekken_vocab_filename
+from .tokenization_utils_base import PREFIX_SPACE_PATTERN
 from .utils import is_protobuf_available, is_sentencepiece_available, logging, requires_backends
 from .utils.import_utils import PROTOBUF_IMPORT_ERROR
 
@@ -1637,7 +1638,7 @@ class LlamaConverter(SpmConverter):
             decoders.Fuse(),
         ]
         if add_prefix_space:
-            sequence += [decoders.Strip(content=" ", left=1)]
+            sequence += [decoders.Replace(Regex(PREFIX_SPACE_PATTERN), "")]
         return decoders.Sequence(sequence)
 
     def normalizer(self, proto):
@@ -1731,7 +1732,7 @@ class MoshiConverter(SpmConverter):
             decoders.Fuse(),
         ]
         if add_prefix_space:
-            sequence += [decoders.Strip(content=" ", left=1)]
+            sequence += [decoders.Replace(Regex(PREFIX_SPACE_PATTERN), "")]
         return decoders.Sequence(sequence)
 
     def pre_tokenizer(self, replacement, add_prefix_space):
@@ -1801,7 +1802,7 @@ class HeliumConverter(SpmConverter):
             decoders.ByteFallback(),
             decoders.Fuse(),
         ]
-        sequence += [decoders.Strip(content=" ", left=1)]
+        sequence += [decoders.Replace(Regex(PREFIX_SPACE_PATTERN), "")]
         return decoders.Sequence(sequence)
 
     def normalizer(self, proto):

--- a/src/transformers/models/code_llama/tokenization_code_llama.py
+++ b/src/transformers/models/code_llama/tokenization_code_llama.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 
-from tokenizers import Tokenizer, decoders, normalizers, pre_tokenizers, processors
+from tokenizers import Regex, Tokenizer, decoders, normalizers, pre_tokenizers, processors
 from tokenizers.models import BPE
 
+from ...tokenization_utils_base import PREFIX_SPACE_PATTERN
 from ...tokenization_utils_tokenizers import TokenizersBackend
 from ...utils import logging
 
@@ -161,7 +162,12 @@ class CodeLlamaTokenizer(TokenizersBackend):
         )
 
         self._tokenizer.decoder = decoders.Sequence(
-            [decoders.Replace("▁", " "), decoders.ByteFallback(), decoders.Fuse(), decoders.Strip(content=" ", left=1)]
+            [
+                decoders.Replace("▁", " "),
+                decoders.ByteFallback(),
+                decoders.Fuse(),
+                decoders.Replace(Regex(PREFIX_SPACE_PATTERN), ""),
+            ]
         )
 
         super().__init__(

--- a/src/transformers/models/llama/tokenization_llama.py
+++ b/src/transformers/models/llama/tokenization_llama.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tokenizers import Tokenizer, decoders, pre_tokenizers
+from tokenizers import Regex, Tokenizer, decoders, pre_tokenizers
 from tokenizers.models import BPE
 
-from ...tokenization_utils_base import _get_prepend_scheme
+from ...tokenization_utils_base import PREFIX_SPACE_PATTERN, _get_prepend_scheme
 from ...tokenization_utils_tokenizers import TokenizersBackend
 from ...utils import logging
 
@@ -128,7 +128,7 @@ class LlamaTokenizer(TokenizersBackend):
         ]
 
         if self.add_prefix_space:
-            sequence += [decoders.Strip(content=" ", left=1)]
+            sequence += [decoders.Replace(Regex(PREFIX_SPACE_PATTERN), "")]
 
         self._tokenizer.decoder = decoders.Sequence(sequence)
         self.use_default_system_prompt = use_default_system_prompt

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3653,6 +3653,13 @@ if PreTrainedTokenizerBase.push_to_hub.__doc__ is not None:
     )
 
 
+# Decoder-side counterpart of the Metaspace prefix space. Metaspace only prepends `▁` when the text does not already
+# start with one, so a lone leading space is the synthetic prefix and must go, while two or more are the user's own and
+# must stay. Matching " " not followed by " " expresses exactly that; `Strip(content=" ", left=1)` ate a real space.
+# `\A` and not `^`: the regex engine is multiline, and `^` would eat the indentation of every line, not just the first.
+PREFIX_SPACE_PATTERN = r"\A (?! )"
+
+
 def _get_prepend_scheme(add_prefix_space: bool, original_tokenizer) -> str:
     if add_prefix_space:
         prepend_scheme = "always"

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3653,10 +3653,9 @@ if PreTrainedTokenizerBase.push_to_hub.__doc__ is not None:
     )
 
 
-# Decoder-side counterpart of the Metaspace prefix space. Metaspace only prepends `▁` when the text does not already
-# start with one, so a lone leading space is the synthetic prefix and must go, while two or more are the user's own and
-# must stay. Matching " " not followed by " " expresses exactly that; `Strip(content=" ", left=1)` ate a real space.
-# `\A` and not `^`: the regex engine is multiline, and `^` would eat the indentation of every line, not just the first.
+# Metaspace only prepends `▁` when the text does not already start with one.
+# If the text did start with a space, `Strip(content=" ", left=1)` would remove it. 
+# `\A` and not `^` because `^` is multiline.
 PREFIX_SPACE_PATTERN = r"\A (?! )"
 
 

--- a/tests/models/code_llama/test_tokenization_code_llama.py
+++ b/tests/models/code_llama/test_tokenization_code_llama.py
@@ -206,6 +206,26 @@ class LlamaIntegrationTest(unittest.TestCase):
         self.tokenizer.add_eos_token = False
         self.rust_tokenizer.add_eos_token = False
 
+    def test_decode_keeps_real_leading_whitespace(self):
+        # Metaspace only prepends `▁` when the text does not already start with one, so with two or
+        # more leading spaces there is no synthetic prefix to remove and the old
+        # `Strip(content=" ", left=1)` decoder ate one of the user's own spaces. Indentation matters
+        # for a code model, so this is the case worth pinning. Regression test for #47487.
+        tokenizer = self.tokenizer
+        for text in ["  hello", "   leading spaces", "    indented_line", "def f():\n    return 1"]:
+            ids = tokenizer.encode(text, add_special_tokens=False)
+            self.assertEqual(tokenizer.decode(ids), text)
+
+        # The synthetic prefix is still stripped, so text without leading whitespace does not gain a
+        # space. A single leading space is fused into the prefix at encode time and stays unrecoverable.
+        for text in ["hello", "\tindented", "élan"]:
+            ids = tokenizer.encode(text, add_special_tokens=False)
+            self.assertEqual(tokenizer.decode(ids), text)
+        self.assertEqual(tokenizer.decode(tokenizer.encode(" hello", add_special_tokens=False)), "hello")
+
+        # Only the very start of the string is affected, never the indentation of later lines.
+        self.assertEqual(tokenizer.decode(tokenizer.encode(" a\n  b", add_special_tokens=False)), "a\n  b")
+
     @unittest.skip(
         "Skipped in v5 - CodeLlama tokenization differences related to SPM legacy flag and Metaspace handling. "
         "CodeLlama always uses legacy=False (Metaspace pre_tokenizer, no normalizer)"

--- a/tests/models/llama/test_tokenization_llama.py
+++ b/tests/models/llama/test_tokenization_llama.py
@@ -53,6 +53,25 @@ class LlamaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         decoded = tokenizer.decode(tokens, skip_special_tokens=True)
         self.assertEqual(decoded, text)
 
+    def test_decode_keeps_real_leading_whitespace(self):
+        # Metaspace only prepends `▁` when the text does not already start with one, so with two or
+        # more leading spaces there is no synthetic prefix to remove and the old
+        # `Strip(content=" ", left=1)` decoder ate one of the user's own spaces. Regression test for #47487.
+        tokenizer = LlamaTokenizer.from_pretrained("hf-internal-testing/llama-tokenizer")
+        for text in ["  hello", "   leading spaces", "    indented_line", "def f():\n    return 1"]:
+            ids = tokenizer.encode(text, add_special_tokens=False)
+            self.assertEqual(tokenizer.decode(ids), text)
+
+        # The synthetic prefix is still stripped, so text without leading whitespace does not gain a
+        # space. A single leading space is fused into the prefix at encode time and stays unrecoverable.
+        for text in ["hello", "\tindented", "élan"]:
+            ids = tokenizer.encode(text, add_special_tokens=False)
+            self.assertEqual(tokenizer.decode(ids), text)
+        self.assertEqual(tokenizer.decode(tokenizer.encode(" hello", add_special_tokens=False)), "hello")
+
+        # Only the very start of the string is affected, never the indentation of later lines.
+        self.assertEqual(tokenizer.decode(tokenizer.encode(" a\n  b", add_special_tokens=False)), "a\n  b")
+
     @slow
     def test_llama3_bpe_skips_clean_up_tokenization_spaces(self):
         # Llama 3 ships with `clean_up_tokenization_spaces=True` in its config, but as a


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47862&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47862) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47862&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47862)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47487 without touching the encoding pipeline. Follow-up to #47861, which reverted #47488 — this is the version of that fix which does not change any ids.

### The actual bug

`Metaspace` only prepends `▁` when the text does not already start with one. So with two or more leading spaces there is **no synthetic prefix at all**, and the trailing `Strip(content=" ", left=1)` removed one of the user's own spaces:

```
"  hello"  ->  ▁▁hello  ->  "  hello"  ->  Strip(left=1)  ->  " hello"
```

Encoding was already lossless here — only the decoder was wrong. That is why this does not need a pipeline change.

### The fix

```diff
-decoders.Strip(content=" ", left=1)
+decoders.Replace(Regex(r"\A (?! )"), "")
```

Remove the leading space only when there is exactly one, which is exactly the case where it is synthetic. The count of leading `▁` separates the two cases perfectly, because the prepend is guarded by that same `starts_with` condition.

`\A` and not `^`: the regex engine is Oniguruma and multiline, so `^` eats the indentation of *every* line, not just the first. `test_integration` catches it if you get this wrong.

### Why this is safe

- **Encoding is untouched.** Verified on `hf-internal-testing/llama-tokenizer`, `NousResearch/Llama-2-13b-hf` and `codellama/CodeLlama-7b-hf`: encode ids are identical to `main` on every probe, including text containing special tokens. No id changes, no added-token changes, no checkpoint changes.
- **It still serializes into `tokenizer.json`**, so tokenizers-rs and transformers.js get the fix too — unlike a Python-side `_decode` override.

A single leading space stays unrecoverable: `" hello"` and `"hello"` both encode to `[22172]`. That is documented SentencePiece behaviour and is deliberately unchanged; #47487 asks for it to stay that way too.

### Tests

`test_decode_keeps_real_leading_whitespace` added for both models. Each fails on `main` (`' hello' != '  hello'`) and passes here. It also pins the two things worth not regressing: text with no leading whitespace must not gain a space, and later lines must keep their indentation.

`tests/models/{llama,code_llama,moshi,helium}` — 182 passed, 33 skipped.

The same `Strip` appears three times in `convert_slow_tokenizer.py` (Llama, Moshi, Helium converters) and is swapped there too. The three `ggml.py` sites are deliberately left alone: two of them have no `Fuse` before the strip, so they already strip per token (`"▁def", "▁f"` -> `deff`) — a separate pre-existing bug in the GGUF path, worth its own issue.

## Who can review?

@itazap