### PR TITLE
Update vLLM CI workflow

### DIFF
--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -118,7 +118,7 @@ jobs:
         working-directory: vllm
         continue-on-error: true
         run: |
-          pytest -v -s "tests/models/transformers/test_backend.py::test_models[meta-llama/Llama-3.2-1B-Instruct-transformers-num_fused0]"
+          pytest -v -s tests/models/transformers/test_backend.py
 
       - name: "Test: multimodal processing"
         if: false

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -79,6 +79,7 @@ jobs:
           # Lower the global default in CacheConfig (covers EngineArgs default and anything reading the field)
           sed -i 's/gpu_memory_utilization: float = Field(default=0.92/gpu_memory_utilization: float = Field(default=0.5/g' vllm/vllm/config/cache.py
           # Lower the hardcoded default in LLM.__init__ (separate from CacheConfig)
+          # Needed by: test_backend.py::test_models[meta-llama/Llama-3.2-1B-Instruct-transformers-num_fused0]
           sed -i 's/gpu_memory_utilization: float = 0.92,/gpu_memory_utilization: float = 0.5,/g' vllm/vllm/entrypoints/llm.py
           # Verify all patches applied
           grep "gpu_memory_utilization" vllm/vllm/config/cache.py | head -2

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -68,7 +68,7 @@ jobs:
           uv pip install -e 'transformers/[sklearn,sentencepiece,vision,testing,tiktoken,num2words,video]'
           uv pip install git+https://github.com/ydshieh/pytest.git@8.4.1-ydshieh
           uv pip install pytest-random-order 'transformers-ci[otel] @ git+https://github.com/huggingface/transformers-ci@main'
-          VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_PRECOMPILED_WHEEL_COMMIT=$VLLM_COMMIT uv pip install --editable vllm/
+          VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu VLLM_PRECOMPILED_WHEEL_COMMIT=$VLLM_COMMIT uv pip install --editable vllm/
           uv pip install tblib
 
       - name: Pip freeze

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -39,14 +39,6 @@ jobs:
           persist-credentials: false
           path: vllm
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-
       - name: Install dependencies
         run: uv pip install vllm -e transformers
 

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -70,7 +70,7 @@ jobs:
           uv pip install git+https://github.com/ydshieh/pytest.git@8.4.1-ydshieh
           uv pip install pytest-random-order 'transformers-ci[otel] @ git+https://github.com/huggingface/transformers-ci@main'
           VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu VLLM_PRECOMPILED_WHEEL_COMMIT=$VLLM_COMMIT uv pip install --editable vllm/
-          uv pip install tblib pqdm
+          uv pip install tblib pqdm open-clip-torch==2.32.0
 
       - name: Patch vLLM gpu_memory_utilization for CPU
         run: |
@@ -174,7 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
     steps:
       - name: Checkout Transformers
@@ -220,7 +220,7 @@ jobs:
           uv pip install git+https://github.com/ydshieh/pytest.git@8.4.1-ydshieh
           uv pip install pytest-random-order 'transformers-ci[otel] @ git+https://github.com/huggingface/transformers-ci@main'
           VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu VLLM_PRECOMPILED_WHEEL_COMMIT=$VLLM_COMMIT uv pip install --editable vllm/
-          uv pip install tblib pqdm pytest-shard
+          uv pip install tblib pqdm pytest-shard open-clip-torch==2.32.0
 
       - name: Patch vLLM gpu_memory_utilization for CPU
         run: |
@@ -233,4 +233,4 @@ jobs:
         run: |
           pytest -v -s tests/models/multimodal/processing/ \
             --ignore tests/models/multimodal/processing/test_tensor_schema.py \
-            --num-shards=4 --shard-id=${{ matrix.shard }}
+            --num-shards=10 --shard-id=${{ matrix.shard }}

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -90,6 +90,7 @@ jobs:
           echo "=== Top processes by memory ===" && ps aux --sort=-%mem | head -20
 
       - name: "Test: test_initialization (subset)"
+        if: false
         working-directory: vllm
         continue-on-error: true
         run: |
@@ -99,7 +100,9 @@ jobs:
       - name: "Test: test_transformers"
         working-directory: vllm
         continue-on-error: true
-        run: pytest -v -s tests/models/transformers/
+        run: |
+          pytest -v -s "tests/models/transformers/fusers/test_linear.py::test_detects_and_rewrites_glu[False-GLUMLP]" \
+                       "tests/models/transformers/fusers/test_linear.py::test_detects_and_rewrites_glu[False-ReversedGLUMLP]"
 
       - name: "Test: multimodal processing"
         working-directory: vllm

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -120,7 +120,7 @@ jobs:
         working-directory: vllm
         continue-on-error: true
         run: |
-          pytest -v -s tests/models/transformers/test_backend.py
+          pytest -v -s tests/models/transformers/
 
       - name: "Test: multimodal processing"
         if: false

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -117,6 +117,7 @@ jobs:
             "tests/models/test_initialization.py::test_can_initialize_small_subset[XLMRobertaModel]"
 
       - name: "Test: test_transformers"
+        if: false
         working-directory: vllm
         continue-on-error: true
         run: |

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -134,12 +134,10 @@ jobs:
 
       - name: "Test: multimodal processing"
         if: false
-        # TODO: re-enable this step by reworking the workflow to use matrix job.
+        # Replaced by the vllm-multimodal-processing matrix job below.
         working-directory: vllm
         continue-on-error: true
         run: |
-          # Only transformers-backend-specific files; test_common.py excludes transformers models
-          # Full suite (1312 tests) requires pytest-shard parallelism (see .buildkite/test_areas/models_multimodal.yaml)
           pytest -v -s tests/models/multimodal/processing/test_transformers_image.py \
                        tests/models/multimodal/processing/test_transformers_audio.py
 
@@ -163,3 +161,76 @@ jobs:
         continue-on-error: true
         run: VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper
 
+  # Multimodal processing tests split across 4 parallel shards (1312 tests total).
+  # Each shard runs on a fresh runner — no cross-test memory accumulation.
+  # Mirrors vLLM's Buildkite CI: parallelism: 4 + pytest-shard (see .buildkite/test_areas/models_multimodal.yaml).
+  vllm-multimodal-processing:
+    name: "Test vLLM multimodal processing (shard ${{ matrix.shard }} / 4)"
+    runs-on:
+      group: aws-m8i-2xl-cache
+    container:
+      image: huggingface/transformers-torch-light
+      options: "--shm-size=16gb -v /mnt/cache/.cache/huggingface:/mnt/cache/"
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+
+    steps:
+      - name: Checkout Transformers
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: huggingface/transformers
+          persist-credentials: false
+          path: transformers
+
+      - name: Find latest vLLM commit with built CPU wheel
+        run: |
+          METADATA=$(curl -fsSL https://wheels.vllm.ai/nightly/cpu/vllm/metadata.json)
+          VLLM_COMMIT=$(echo "$METADATA" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          wheel = next(w for w in data if 'x86_64' in w['platform_tag'])
+          print(wheel['path'].split('/')[3])
+          ")
+          echo "VLLM_COMMIT=$VLLM_COMMIT" >> $GITHUB_ENV
+          echo "vLLM commit: $VLLM_COMMIT"
+
+      - name: Checkout vLLM at wheel commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: vllm-project/vllm
+          ref: ${{ env.VLLM_COMMIT }}
+          persist-credentials: false
+          path: vllm
+
+      - name: Set up Python 3.12 environment
+        run: |
+          uv venv /opt/venv312 --python 3.12
+          echo "VIRTUAL_ENV=/opt/venv312" >> $GITHUB_ENV
+          echo "/opt/venv312/bin" >> $GITHUB_PATH
+          echo "UV_PYTHON=" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          uv pip install 'torch<=2.13.0' torchaudio torchvision 'torchcodec<=0.15.0' --index-url https://download.pytorch.org/whl/cpu
+          uv pip install --no-deps timm accelerate
+          uv pip install librosa
+          uv pip install -e 'transformers/[sklearn,sentencepiece,vision,testing,tiktoken,num2words,video]'
+          uv pip install git+https://github.com/ydshieh/pytest.git@8.4.1-ydshieh
+          uv pip install pytest-random-order 'transformers-ci[otel] @ git+https://github.com/huggingface/transformers-ci@main'
+          VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu VLLM_PRECOMPILED_WHEEL_COMMIT=$VLLM_COMMIT uv pip install --editable vllm/
+          uv pip install tblib pqdm pytest-shard
+
+      - name: Patch vLLM gpu_memory_utilization for CPU
+        run: |
+          sed -i 's/gpu_memory_utilization: float = Field(default=0.92/gpu_memory_utilization: float = Field(default=0.4/g' vllm/vllm/config/cache.py
+          sed -i 's/gpu_memory_utilization: float = 0.92,/gpu_memory_utilization: float = 0.4,/g' vllm/vllm/entrypoints/llm.py
+
+      - name: "Test: multimodal processing (shard ${{ matrix.shard }} / 4)"
+        working-directory: vllm
+        continue-on-error: true
+        run: |
+          pytest -v -s tests/models/multimodal/processing/ \
+            --ignore tests/models/multimodal/processing/test_tensor_schema.py \
+            --num-shards=4 --shard-id=${{ matrix.shard }}

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install vllm -e transformers
-          uv pip install tblib
+          uv pip install -r vllm/requirements/test/cpu.txt
 
       - name: Run tests
         working-directory: vllm

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -174,7 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        shard: [0]
 
     steps:
       - name: Checkout Transformers
@@ -231,6 +231,8 @@ jobs:
         working-directory: vllm
         continue-on-error: true
         run: |
-          pytest -v -s tests/models/multimodal/processing/ \
-            --ignore tests/models/multimodal/processing/test_tensor_schema.py \
-            --num-shards=10 --shard-id=${{ matrix.shard }}
+          pytest -v -s \
+            "tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-0.3-nvidia/NVIDIA-Nemotron-Parse-v1.2]" \
+            "tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-0.5-nvidia/NVIDIA-Nemotron-Parse-v1.2]" \
+            "tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-1.0-nvidia/NVIDIA-Nemotron-Parse-v1.2]" \
+            "tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-0.3-openbmb/MiniCPM-o-2_6]"

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -82,10 +82,18 @@ jobs:
           echo "=== CPU ===" && lscpu | grep -E "^CPU\(s\)|^Model name|^Socket"
           echo "=== Memory ===" && free -h
           echo "=== Disk ===" && df -h
+          echo "=== Top processes by memory ===" && ps aux --sort=-%mem | head -20
 
       - name: Run tests
         working-directory: vllm
         run: |
+          # Start background memory monitor (prints every 5s with timestamp)
+          while true; do
+            echo "[$(date '+%H:%M:%S')] $(free -h | awk '/Mem:/{printf "total=%-6s used=%-6s free=%-6s available=%-6s", $2, $3, $4, $7}') | top-procs: $(ps aux --sort=-%mem | awk 'NR>1 && NR<=4 {printf "%s(%.0f%%) ", $11, $4}')"
+            sleep 5
+          done &
+          MONITOR_PID=$!
+
           pytest -v -s tests/models/test_initialization.py
           pytest -v -s tests/models/test_transformers.py
           pytest -v -s tests/models/multimodal/processing/
@@ -94,3 +102,5 @@ jobs:
           python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
           # Whisper needs spawn method to avoid deadlock
           VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper
+
+          kill $MONITOR_PID 2>/dev/null || true

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install vllm -e transformers
-          uv pip install -r vllm/requirements/test.txt
+          uv pip install tblib
 
       - name: Run tests
         working-directory: vllm

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -8,8 +8,8 @@ on:
   push:
     branches:
       - vllm_ci
+
 env:
-  UV_SYSTEM_PYTHON: "1"
   VLLM_TARGET_DEVICE: cpu
 
 permissions:
@@ -39,10 +39,21 @@ jobs:
           persist-credentials: false
           path: vllm
 
+      - name: Set up Python 3.12 environment
+        run: |
+          uv venv /opt/venv312 --python 3.12
+          echo "VIRTUAL_ENV=/opt/venv312" >> $GITHUB_ENV
+          echo "/opt/venv312/bin" >> $GITHUB_PATH
+
       - name: Install dependencies
         run: |
-          uv pip install vllm -e transformers
-          uv pip install tblib
+          uv pip install 'torch<=2.13.0' torchaudio torchvision 'torchcodec<=0.15.0' --index-url https://download.pytorch.org/whl/cpu
+          uv pip install --no-deps timm accelerate
+          uv pip install librosa
+          uv pip install -e 'transformers/[sklearn,sentencepiece,vision,testing,tiktoken,num2words,video]'
+          uv pip install git+https://github.com/ydshieh/pytest.git@8.4.1-ydshieh
+          uv pip install pytest-random-order 'transformers-ci[otel] @ git+https://github.com/huggingface/transformers-ci@main'
+          uv pip install vllm tblib
 
       - name: Run tests
         working-directory: vllm

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -76,12 +76,12 @@ jobs:
         run: |
           # Lower hardcoded value in test_initialization.py
           # Needed by: test_initialization.py::test_can_initialize_small_subset[*]
-          sed -i 's/gpu_memory_utilization=0.80/gpu_memory_utilization=0.5/g' vllm/tests/models/test_initialization.py
+          sed -i 's/gpu_memory_utilization=0.80/gpu_memory_utilization=0.4/g' vllm/tests/models/test_initialization.py
           # Lower the global default in CacheConfig (covers EngineArgs default and anything reading the field)
-          sed -i 's/gpu_memory_utilization: float = Field(default=0.92/gpu_memory_utilization: float = Field(default=0.5/g' vllm/vllm/config/cache.py
+          sed -i 's/gpu_memory_utilization: float = Field(default=0.92/gpu_memory_utilization: float = Field(default=0.4/g' vllm/vllm/config/cache.py
           # Lower the hardcoded default in LLM.__init__ (separate from CacheConfig)
           # Needed by: test_backend.py::test_models[meta-llama/Llama-3.2-1B-Instruct-transformers-num_fused0]
-          sed -i 's/gpu_memory_utilization: float = 0.92,/gpu_memory_utilization: float = 0.5,/g' vllm/vllm/entrypoints/llm.py
+          sed -i 's/gpu_memory_utilization: float = 0.92,/gpu_memory_utilization: float = 0.4,/g' vllm/vllm/entrypoints/llm.py
           # Verify all patches applied
           grep "gpu_memory_utilization" vllm/vllm/config/cache.py | head -2
           grep "gpu_memory_utilization: float" vllm/vllm/entrypoints/llm.py
@@ -117,13 +117,16 @@ jobs:
             "tests/models/test_initialization.py::test_can_initialize_small_subset[XLMRobertaModel]"
 
       - name: "Test: test_transformers"
-        if: false
         working-directory: vllm
         continue-on-error: true
         run: |
-          pytest -v -s tests/models/transformers/
+          # Skipped models:
+          #   allenai/OLMoE-1B-7B-0924 — OOM: previous test leaves insufficient free memory (13.35/27.83 GiB < 0.4*27.83)
+          pytest -v -s tests/models/transformers/ \
+            --deselect "tests/models/transformers/test_backend.py::test_models[allenai/OLMoE-1B-7B-0924-transformers-num_fused2]"
 
       - name: "Test: multimodal processing"
+        if: false
         working-directory: vllm
         continue-on-error: true
         run: |

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -5,10 +5,11 @@ on:
     # Run every night at 3 AM UTC
     - cron: "0 3 * * *"
   workflow_dispatch:
+  push:
+    branches:
+      - vllm_ci
 env:
   UV_SYSTEM_PYTHON: "1"
-  VLLM_USE_PRECOMPILED: "1"
-  VLLM_PRECOMPILED_WHEEL_VARIANT: cpu
   VLLM_TARGET_DEVICE: cpu
 
 permissions:
@@ -43,7 +44,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Install dependencies
-        run: uv pip install -e vllm -e transformers
+        run: uv pip install vllm -e transformers
 
       - name: Run tests
         run: |

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -84,23 +84,51 @@ jobs:
           echo "=== Disk ===" && df -h
           echo "=== Top processes by memory ===" && ps aux --sort=-%mem | head -20
 
-      - name: Run tests
-        working-directory: vllm
+      - name: Start memory monitor
         run: |
-          # Start background memory monitor (prints every 5s with timestamp)
           while true; do
             echo "[$(date '+%H:%M:%S')] $(free -h | awk '/Mem:/{printf "total=%-6s used=%-6s free=%-6s available=%-6s", $2, $3, $4, $7}') | top-procs: $(ps aux --sort=-%mem | awk 'NR>1 && NR<=4 {printf "%s(%.0f%%) ", $11, $4}')"
             sleep 5
           done &
-          MONITOR_PID=$!
+          echo "MONITOR_PID=$!" >> $GITHUB_ENV
 
-          pytest -v -s tests/models/test_initialization.py
-          pytest -v -s tests/models/test_transformers.py
-          pytest -v -s tests/models/multimodal/processing/
-          pytest -v -s tests/models/multimodal/test_mapping.py
-          python3 examples/basic/offline_inference/chat.py
-          python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
-          # Whisper needs spawn method to avoid deadlock
-          VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper
+      - name: "Test: test_initialization (subset)"
+        working-directory: vllm
+        continue-on-error: true
+        run: |
+          pytest -v -s "tests/models/test_initialization.py::test_can_initialize_small_subset[LlavaForConditionalGeneration]" \
+                       "tests/models/test_initialization.py::test_can_initialize_small_subset[Llama4ForConditionalGeneration]"
 
-          kill $MONITOR_PID 2>/dev/null || true
+      - name: "Test: test_transformers"
+        working-directory: vllm
+        continue-on-error: true
+        run: pytest -v -s tests/models/test_transformers.py
+
+      - name: "Test: multimodal processing"
+        working-directory: vllm
+        continue-on-error: true
+        run: pytest -v -s tests/models/multimodal/processing/
+
+      - name: "Test: test_mapping"
+        working-directory: vllm
+        continue-on-error: true
+        run: pytest -v -s tests/models/multimodal/test_mapping.py
+
+      - name: "Example: chat"
+        working-directory: vllm
+        continue-on-error: true
+        run: python3 examples/basic/offline_inference/chat.py
+
+      - name: "Example: vision language"
+        working-directory: vllm
+        continue-on-error: true
+        run: python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
+
+      - name: "Example: audio language (whisper)"
+        working-directory: vllm
+        continue-on-error: true
+        run: VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper
+
+      - name: Stop memory monitor
+        if: always()
+        run: kill $MONITOR_PID 2>/dev/null || true

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -71,6 +71,9 @@ jobs:
           VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_PRECOMPILED_WHEEL_COMMIT=$VLLM_COMMIT uv pip install --editable vllm/
           uv pip install tblib
 
+      - name: Pip freeze
+        run: pip freeze
+
       - name: Run tests
         working-directory: vllm
         run: |

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -123,9 +123,11 @@ jobs:
           # Skipped models:
           #   allenai/OLMoE-1B-7B-0924 — OOM: previous test leaves insufficient free memory (13.35/27.83 GiB < 0.4*27.83)
           #   test_hybrid_attention     — OOM: only 10.1/27.83 GiB free after 2 prior tests (needs 0.4*27.83=11.13 GiB)
+          #   test_mla                  — OOM + model too large: DeepSeek-V2-Lite-Chat (15.7B) exceeds 32 GiB runner
           pytest -v -s tests/models/transformers/ \
             --deselect "tests/models/transformers/test_backend.py::test_models[allenai/OLMoE-1B-7B-0924-transformers-num_fused2]" \
-            --deselect "tests/models/transformers/test_backend.py::test_hybrid_attention"
+            --deselect "tests/models/transformers/test_backend.py::test_hybrid_attention" \
+            --deselect "tests/models/transformers/test_backend.py::test_mla"
 
       - name: "Test: multimodal processing"
         if: false

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -19,7 +19,7 @@ jobs:
   vllm:
     name: Test vLLM integration
     runs-on:
-      group: aws-m8i-l-cache
+      group: aws-m8i-2xl-cache
     container:
       image: huggingface/transformers-torch-light
       options: "--shm-size=16gb -v /mnt/cache/.cache/huggingface:/mnt/cache/"

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -126,11 +126,13 @@ jobs:
             --deselect "tests/models/transformers/test_backend.py::test_models[allenai/OLMoE-1B-7B-0924-transformers-num_fused2]"
 
       - name: "Test: multimodal processing"
-        if: false
         working-directory: vllm
         continue-on-error: true
         run: |
-          pytest -v -n 8 tests/models/multimodal/processing/
+          # Only transformers-backend-specific files; test_common.py excludes transformers models
+          # Full suite (1312 tests) requires pytest-shard parallelism (see .buildkite/test_areas/models_multimodal.yaml)
+          pytest -v -s tests/models/multimodal/processing/test_transformers_image.py \
+                       tests/models/multimodal/processing/test_transformers_audio.py
 
       - name: "Test: test_mapping"
         if: false

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -71,6 +71,9 @@ jobs:
           VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu VLLM_PRECOMPILED_WHEEL_COMMIT=$VLLM_COMMIT uv pip install --editable vllm/
           uv pip install tblib
 
+      - name: Patch vLLM test gpu_memory_utilization for CPU
+        run: sed -i 's/gpu_memory_utilization=0.80/gpu_memory_utilization=0.5/g' vllm/tests/models/test_initialization.py
+
       - name: Pip freeze
         run: pip freeze
 

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -44,6 +44,7 @@ jobs:
           uv venv /opt/venv312 --python 3.12
           echo "VIRTUAL_ENV=/opt/venv312" >> $GITHUB_ENV
           echo "/opt/venv312/bin" >> $GITHUB_PATH
+          echo "UV_PYTHON=" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -18,7 +18,11 @@ permissions:
 jobs:
   vllm:
     name: Test vLLM integration
-    runs-on: ubuntu-latest
+    runs-on:
+      group: aws-m8i-l-cache
+    container:
+      image: huggingface/transformers-torch-light
+      options: "--shm-size=16gb -v /mnt/cache/.cache/huggingface:/mnt/cache/"
 
     steps:
       - name: Checkout Transformers

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -32,10 +32,33 @@ jobs:
           persist-credentials: false
           path: transformers
 
-      - name: Checkout vLLM
+      - name: Find latest vLLM commit with built CPU wheel
+        run: |
+          METADATA=$(curl -fsSL https://wheels.vllm.ai/nightly/cpu/vllm/metadata.json)
+          # path field is like '../../../{full_commit_hash}/{wheel_filename}' relative to nightly/cpu/vllm/
+          VLLM_COMMIT=$(echo "$METADATA" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          wheel = next(w for w in data if 'x86_64' in w['platform_tag'])
+          print(wheel['path'].split('/')[3])
+          ")
+          VLLM_WHEEL_URL=$(echo "$METADATA" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          wheel = next(w for w in data if 'x86_64' in w['platform_tag'])
+          rel = '/'.join(wheel['path'].split('/')[3:])
+          print(f'https://wheels.vllm.ai/{rel}')
+          ")
+          echo "VLLM_COMMIT=$VLLM_COMMIT" >> $GITHUB_ENV
+          echo "VLLM_WHEEL_URL=$VLLM_WHEEL_URL" >> $GITHUB_ENV
+          echo "vLLM commit: $VLLM_COMMIT"
+          echo "vLLM wheel: $VLLM_WHEEL_URL"
+
+      - name: Checkout vLLM at wheel commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: vllm-project/vllm
+          ref: ${{ env.VLLM_COMMIT }}
           persist-credentials: false
           path: vllm
 
@@ -54,7 +77,7 @@ jobs:
           uv pip install -e 'transformers/[sklearn,sentencepiece,vision,testing,tiktoken,num2words,video]'
           uv pip install git+https://github.com/ydshieh/pytest.git@8.4.1-ydshieh
           uv pip install pytest-random-order 'transformers-ci[otel] @ git+https://github.com/huggingface/transformers-ci@main'
-          uv pip install vllm tblib
+          uv pip install "$VLLM_WHEEL_URL" tblib
 
       - name: Run tests
         working-directory: vllm

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install vllm -e transformers
-          uv pip install -r vllm/requirements/test/cpu.txt
+          uv pip install tblib
 
       - name: Run tests
         working-directory: vllm

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -76,8 +76,13 @@ jobs:
         run: |
           # Lower hardcoded value in test_initialization.py
           sed -i 's/gpu_memory_utilization=0.80/gpu_memory_utilization=0.5/g' vllm/tests/models/test_initialization.py
-          # Lower the global default in CacheConfig (covers example scripts and anything else using the default)
+          # Lower the global default in CacheConfig (covers EngineArgs default and anything reading the field)
           sed -i 's/gpu_memory_utilization: float = Field(default=0.92/gpu_memory_utilization: float = Field(default=0.5/g' vllm/vllm/config/cache.py
+          # Lower the hardcoded default in LLM.__init__ (separate from CacheConfig)
+          sed -i 's/gpu_memory_utilization: float = 0.92,/gpu_memory_utilization: float = 0.5,/g' vllm/vllm/entrypoints/llm.py
+          # Verify all patches applied
+          grep "gpu_memory_utilization" vllm/vllm/config/cache.py | head -2
+          grep "gpu_memory_utilization: float" vllm/vllm/entrypoints/llm.py
 
       - name: Pip freeze
         run: pip freeze

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   VLLM_TARGET_DEVICE: cpu
+  HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
 
 permissions:
   contents: read
@@ -69,10 +70,14 @@ jobs:
           uv pip install git+https://github.com/ydshieh/pytest.git@8.4.1-ydshieh
           uv pip install pytest-random-order 'transformers-ci[otel] @ git+https://github.com/huggingface/transformers-ci@main'
           VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu VLLM_PRECOMPILED_WHEEL_COMMIT=$VLLM_COMMIT uv pip install --editable vllm/
-          uv pip install tblib
+          uv pip install tblib pqdm
 
-      - name: Patch vLLM test gpu_memory_utilization for CPU
-        run: sed -i 's/gpu_memory_utilization=0.80/gpu_memory_utilization=0.5/g' vllm/tests/models/test_initialization.py
+      - name: Patch vLLM gpu_memory_utilization for CPU
+        run: |
+          # Lower hardcoded value in test_initialization.py
+          sed -i 's/gpu_memory_utilization=0.80/gpu_memory_utilization=0.5/g' vllm/tests/models/test_initialization.py
+          # Lower the global default in CacheConfig (covers example scripts and anything else using the default)
+          sed -i 's/gpu_memory_utilization: float = Field(default=0.92/gpu_memory_utilization: float = Field(default=0.5/g' vllm/vllm/config/cache.py
 
       - name: Pip freeze
         run: pip freeze

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -30,10 +30,25 @@ jobs:
         with:
           repository: huggingface/transformers
           persist-credentials: false
+          path: transformers
+
+      - name: Checkout vLLM
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: vllm-project/vllm
+          persist-credentials: false
+          path: vllm
 
       - name: Install dependencies
-        run: uv pip install vllm -e .
+        run: uv pip install vllm -e transformers
 
       - name: Run tests
         run: |
-          echo "TODO: add tests"
+          pytest -v -s vllm/tests/models/test_initialization.py
+          pytest -v -s vllm/tests/models/test_transformers.py
+          pytest -v -s vllm/tests/models/multimodal/processing/
+          pytest -v -s vllm/tests/models/multimodal/test_mapping.py
+          python3 vllm/examples/basic/offline_inference/chat.py
+          python3 vllm/examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
+          # Whisper needs spawn method to avoid deadlock
+          VLLM_WORKER_MULTIPROC_METHOD=spawn python3 vllm/examples/generate/multimodal/audio_language_offline.py --model-type whisper

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -93,7 +93,10 @@ jobs:
         working-directory: vllm
         continue-on-error: true
         run: |
-          # Skip TransformersMultiModalForCausalLM and Gemma3nForCausalLM — cause OOM (exit code 137)
+          # Skipped models:
+          #   TransformersMultiModalForCausalLM — OOM (exit code 137)
+          #   Gemma3nForCausalLM               — OOM (exit code 137)
+          #   DeepSeekMTPModel                 — MLA not supported on CPU (vLLM-side issue, NotImplementedError)
           pytest -v -s \
             "tests/models/test_initialization.py::test_can_initialize_small_subset[LlavaForConditionalGeneration]" \
             "tests/models/test_initialization.py::test_can_initialize_small_subset[Llama4ForConditionalGeneration]" \
@@ -103,7 +106,6 @@ jobs:
             "tests/models/test_initialization.py::test_can_initialize_small_subset[InternLM2ForRewardModel]" \
             "tests/models/test_initialization.py::test_can_initialize_small_subset[PrithviGeoSpatialMAE]" \
             "tests/models/test_initialization.py::test_can_initialize_small_subset[UltravoxModel]" \
-            "tests/models/test_initialization.py::test_can_initialize_small_subset[DeepSeekMTPModel]" \
             "tests/models/test_initialization.py::test_can_initialize_small_subset[XLMRobertaModel]"
 
       - name: "Test: test_transformers"

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -90,6 +90,7 @@ jobs:
           echo "=== Top processes by memory ===" && ps aux --sort=-%mem | head -20
 
       - name: "Test: test_initialization"
+        if: false
         working-directory: vllm
         continue-on-error: true
         run: |
@@ -109,12 +110,10 @@ jobs:
             "tests/models/test_initialization.py::test_can_initialize_small_subset[XLMRobertaModel]"
 
       - name: "Test: test_transformers"
-        if: false
         working-directory: vllm
         continue-on-error: true
         run: |
-          pytest -v -s "tests/models/transformers/fusers/test_linear.py::test_detects_and_rewrites_glu[False-GLUMLP]" \
-                       "tests/models/transformers/fusers/test_linear.py::test_detects_and_rewrites_glu[False-ReversedGLUMLP]"
+          pytest -v -s "tests/models/transformers/test_backend.py::test_models[meta-llama/Llama-3.2-1B-Instruct-transformers-num_fused0]"
 
       - name: "Test: multimodal processing"
         if: false

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -93,12 +93,11 @@ jobs:
         working-directory: vllm
         continue-on-error: true
         run: |
-          # Skip TransformersMultiModalForCausalLM — causes OOM (exit code 137)
+          # Skip TransformersMultiModalForCausalLM and Gemma3nForCausalLM — cause OOM (exit code 137)
           pytest -v -s \
             "tests/models/test_initialization.py::test_can_initialize_small_subset[LlavaForConditionalGeneration]" \
             "tests/models/test_initialization.py::test_can_initialize_small_subset[Llama4ForConditionalGeneration]" \
             "tests/models/test_initialization.py::test_can_initialize_small_subset[BertForSequenceClassification]" \
-            "tests/models/test_initialization.py::test_can_initialize_small_subset[Gemma3nForCausalLM]" \
             "tests/models/test_initialization.py::test_can_initialize_small_subset[JinaVLForRanking]" \
             "tests/models/test_initialization.py::test_can_initialize_small_subset[InternVLChatModel]" \
             "tests/models/test_initialization.py::test_can_initialize_small_subset[InternLM2ForRewardModel]" \

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -42,17 +42,8 @@ jobs:
           wheel = next(w for w in data if 'x86_64' in w['platform_tag'])
           print(wheel['path'].split('/')[3])
           ")
-          VLLM_WHEEL_URL=$(echo "$METADATA" | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          wheel = next(w for w in data if 'x86_64' in w['platform_tag'])
-          rel = '/'.join(wheel['path'].split('/')[3:])
-          print(f'https://wheels.vllm.ai/{rel}')
-          ")
           echo "VLLM_COMMIT=$VLLM_COMMIT" >> $GITHUB_ENV
-          echo "VLLM_WHEEL_URL=$VLLM_WHEEL_URL" >> $GITHUB_ENV
           echo "vLLM commit: $VLLM_COMMIT"
-          echo "vLLM wheel: $VLLM_WHEEL_URL"
 
       - name: Checkout vLLM at wheel commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -77,7 +68,8 @@ jobs:
           uv pip install -e 'transformers/[sklearn,sentencepiece,vision,testing,tiktoken,num2words,video]'
           uv pip install git+https://github.com/ydshieh/pytest.git@8.4.1-ydshieh
           uv pip install pytest-random-order 'transformers-ci[otel] @ git+https://github.com/huggingface/transformers-ci@main'
-          uv pip install "$VLLM_WHEEL_URL" tblib
+          VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_PRECOMPILED_WHEEL_COMMIT=$VLLM_COMMIT uv pip install --editable vllm/
+          uv pip install tblib
 
       - name: Run tests
         working-directory: vllm

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -74,8 +74,8 @@ jobs:
 
       - name: Patch vLLM gpu_memory_utilization for CPU
         run: |
-          # Lower hardcoded value in test_initialization.py
-          # Needed by: test_initialization.py::test_can_initialize_small_subset[*]
+          # Lower hardcoded value in test_initialization.py (originally needed by test_initialization and
+          # test_transformers steps, now disabled). Kept in case other tests hit the same OOM issue.
           sed -i 's/gpu_memory_utilization=0.80/gpu_memory_utilization=0.4/g' vllm/tests/models/test_initialization.py
           # Lower the global default in CacheConfig (covers EngineArgs default and anything reading the field)
           sed -i 's/gpu_memory_utilization: float = Field(default=0.92/gpu_memory_utilization: float = Field(default=0.4/g' vllm/vllm/config/cache.py
@@ -97,71 +97,48 @@ jobs:
           echo "=== Top processes by memory ===" && ps aux --sort=-%mem | head -20
 
       - name: "Test: test_initialization"
+        if: false
+        # We need infra team to provide larger runner (say 128G CPU RAM)
         working-directory: vllm
-        continue-on-error: true
         run: |
-          # Skipped models:
-          #   TransformersMultiModalForCausalLM — OOM (exit code 137)
-          #   Gemma3nForCausalLM               — OOM (exit code 137)
-          #   DeepSeekMTPModel                 — MLA not supported on CPU (vLLM-side issue, NotImplementedError)
-          pytest -v -s \
-            "tests/models/test_initialization.py::test_can_initialize_small_subset[LlavaForConditionalGeneration]" \
-            "tests/models/test_initialization.py::test_can_initialize_small_subset[Llama4ForConditionalGeneration]" \
-            "tests/models/test_initialization.py::test_can_initialize_small_subset[BertForSequenceClassification]" \
-            "tests/models/test_initialization.py::test_can_initialize_small_subset[JinaVLForRanking]" \
-            "tests/models/test_initialization.py::test_can_initialize_small_subset[InternVLChatModel]" \
-            "tests/models/test_initialization.py::test_can_initialize_small_subset[InternLM2ForRewardModel]" \
-            "tests/models/test_initialization.py::test_can_initialize_small_subset[PrithviGeoSpatialMAE]" \
-            "tests/models/test_initialization.py::test_can_initialize_small_subset[UltravoxModel]" \
-            "tests/models/test_initialization.py::test_can_initialize_small_subset[XLMRobertaModel]"
+          pytest -v -s tests/models/test_initialization.py
 
       - name: "Test: test_transformers"
         if: false
-        # We constantly hit memory issues after the first 2 tests. The CPU memory doesn't seem to be
-        # released by the OS. A larger runner may work but it's unclear if the memory not being
-        # released issue would persist.
+        # We need infra team to provide larger runner (say 128G CPU RAM)
         working-directory: vllm
-        continue-on-error: true
         run: |
-          # Skipped models:
-          #   allenai/OLMoE-1B-7B-0924 — OOM: previous test leaves insufficient free memory (13.35/27.83 GiB < 0.4*27.83)
-          #   test_hybrid_attention     — OOM: only 10.1/27.83 GiB free after 2 prior tests (needs 0.4*27.83=11.13 GiB)
-          #   test_mla                  — OOM + model too large: DeepSeek-V2-Lite-Chat (15.7B) exceeds 32 GiB runner
-          pytest -v -s tests/models/transformers/ \
-            --deselect "tests/models/transformers/test_backend.py::test_models[allenai/OLMoE-1B-7B-0924-transformers-num_fused2]" \
-            --deselect "tests/models/transformers/test_backend.py::test_hybrid_attention" \
-            --deselect "tests/models/transformers/test_backend.py::test_mla"
+          pytest -v -s tests/models/transformers/
 
       - name: "Test: multimodal processing"
         if: false
         # Replaced by the vllm-multimodal-processing matrix job below.
         working-directory: vllm
-        continue-on-error: true
         run: |
           pytest -v -s tests/models/multimodal/processing/test_transformers_image.py \
                        tests/models/multimodal/processing/test_transformers_audio.py
 
       - name: "Test: test_mapping"
+        if: always()
         working-directory: vllm
-        continue-on-error: true
         run: pytest -v -s tests/models/multimodal/test_mapping.py
 
       - name: "Example: chat"
+        if: always()
         working-directory: vllm
-        continue-on-error: true
         run: python3 examples/basic/offline_inference/chat.py
 
       - name: "Example: vision language"
+        if: always()
         working-directory: vllm
-        continue-on-error: true
         run: python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
 
       - name: "Example: audio language (whisper)"
+        if: always()
         working-directory: vllm
-        continue-on-error: true
         run: VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper
 
-  # Multimodal processing tests split across 4 parallel shards (1312 tests total).
+  # Multimodal processing tests split across 4 parallel shards.
   # Each shard runs on a fresh runner — no cross-test memory accumulation.
   # Mirrors vLLM's Buildkite CI: parallelism: 4 + pytest-shard (see .buildkite/test_areas/models_multimodal.yaml).
   vllm-multimodal-processing:
@@ -174,7 +151,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        shard: [0, 1, 2, 3]
+    env:
+      SHARD_ID: ${{ matrix.shard }}
 
     steps:
       - name: Checkout Transformers
@@ -227,10 +206,9 @@ jobs:
           sed -i 's/gpu_memory_utilization: float = Field(default=0.92/gpu_memory_utilization: float = Field(default=0.4/g' vllm/vllm/config/cache.py
           sed -i 's/gpu_memory_utilization: float = 0.92,/gpu_memory_utilization: float = 0.4,/g' vllm/vllm/entrypoints/llm.py
 
-      - name: "Test: multimodal processing (shard ${{ matrix.shard }} / 10)"
+      - name: "Test: multimodal processing (shard ${{ matrix.shard }} / 4)"
         working-directory: vllm
-        continue-on-error: true
         run: |
           pytest -v -s tests/models/multimodal/processing/ \
             --ignore tests/models/multimodal/processing/test_tensor_schema.py \
-            --num-shards=10 --shard-id=${{ matrix.shard }}
+            --num-shards=4 --shard-id=$SHARD_ID

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -84,14 +84,6 @@ jobs:
           echo "=== Disk ===" && df -h
           echo "=== Top processes by memory ===" && ps aux --sort=-%mem | head -20
 
-      - name: Start memory monitor
-        run: |
-          while true; do
-            echo "[$(date '+%H:%M:%S')] $(free -h | awk '/Mem:/{printf "total=%-6s used=%-6s free=%-6s available=%-6s", $2, $3, $4, $7}') | top-procs: $(ps aux --sort=-%mem | awk 'NR>1 && NR<=4 {printf "%s(%.0f%%) ", $11, $4}')"
-            sleep 5
-          done &
-          echo "MONITOR_PID=$!" >> $GITHUB_ENV
-
       - name: "Test: test_initialization (subset)"
         working-directory: vllm
         continue-on-error: true
@@ -129,6 +121,3 @@ jobs:
         continue-on-error: true
         run: VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper
 
-      - name: Stop memory monitor
-        if: always()
-        run: kill $MONITOR_PID 2>/dev/null || true

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -174,7 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
     steps:
       - name: Checkout Transformers
@@ -227,12 +227,10 @@ jobs:
           sed -i 's/gpu_memory_utilization: float = Field(default=0.92/gpu_memory_utilization: float = Field(default=0.4/g' vllm/vllm/config/cache.py
           sed -i 's/gpu_memory_utilization: float = 0.92,/gpu_memory_utilization: float = 0.4,/g' vllm/vllm/entrypoints/llm.py
 
-      - name: "Test: multimodal processing (shard ${{ matrix.shard }} / 4)"
+      - name: "Test: multimodal processing (shard ${{ matrix.shard }} / 10)"
         working-directory: vllm
         continue-on-error: true
         run: |
-          pytest -v -s \
-            "tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-0.3-nvidia/NVIDIA-Nemotron-Parse-v1.2]" \
-            "tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-0.5-nvidia/NVIDIA-Nemotron-Parse-v1.2]" \
-            "tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-1.0-nvidia/NVIDIA-Nemotron-Parse-v1.2]" \
-            "tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-0.3-openbmb/MiniCPM-o-2_6]"
+          pytest -v -s tests/models/multimodal/processing/ \
+            --ignore tests/models/multimodal/processing/test_tensor_schema.py \
+            --num-shards=10 --shard-id=${{ matrix.shard }}

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -30,25 +30,10 @@ jobs:
         with:
           repository: huggingface/transformers
           persist-credentials: false
-          path: transformers
-
-      - name: Checkout vLLM
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: vllm-project/vllm
-          persist-credentials: false
-          path: vllm
 
       - name: Install dependencies
-        run: uv pip install vllm -e transformers
+        run: uv pip install vllm -e .
 
       - name: Run tests
         run: |
-          pytest -v -s vllm/tests/models/test_initialization.py
-          pytest -v -s vllm/tests/models/test_transformers.py
-          pytest -v -s vllm/tests/models/multimodal/processing/
-          pytest -v -s vllm/tests/models/multimodal/test_mapping.py
-          python3 vllm/examples/basic/offline_inference/chat.py
-          python3 vllm/examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
-          # Whisper needs spawn method to avoid deadlock
-          VLLM_WORKER_MULTIPROC_METHOD=spawn python3 vllm/examples/generate/multimodal/audio_language_offline.py --model-type whisper
+          echo "TODO: add tests"

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -70,7 +70,7 @@ jobs:
           uv pip install git+https://github.com/ydshieh/pytest.git@8.4.1-ydshieh
           uv pip install pytest-random-order 'transformers-ci[otel] @ git+https://github.com/huggingface/transformers-ci@main'
           VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu VLLM_PRECOMPILED_WHEEL_COMMIT=$VLLM_COMMIT uv pip install --editable vllm/
-          uv pip install tblib pqdm open-clip-torch==2.32.0
+          uv pip install tblib pqdm open-clip-torch==2.32.0 albumentations==1.4.6
 
       - name: Patch vLLM gpu_memory_utilization for CPU
         run: |
@@ -220,7 +220,7 @@ jobs:
           uv pip install git+https://github.com/ydshieh/pytest.git@8.4.1-ydshieh
           uv pip install pytest-random-order 'transformers-ci[otel] @ git+https://github.com/huggingface/transformers-ci@main'
           VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu VLLM_PRECOMPILED_WHEEL_COMMIT=$VLLM_COMMIT uv pip install --editable vllm/
-          uv pip install tblib pqdm pytest-shard open-clip-torch==2.32.0
+          uv pip install tblib pqdm pytest-shard open-clip-torch==2.32.0 albumentations==1.4.6
 
       - name: Patch vLLM gpu_memory_utilization for CPU
         run: |

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -117,16 +117,18 @@ jobs:
             "tests/models/test_initialization.py::test_can_initialize_small_subset[XLMRobertaModel]"
 
       - name: "Test: test_transformers"
-        if: false
         working-directory: vllm
         continue-on-error: true
         run: |
           # Skipped models:
           #   allenai/OLMoE-1B-7B-0924 — OOM: previous test leaves insufficient free memory (13.35/27.83 GiB < 0.4*27.83)
+          #   test_hybrid_attention     — OOM: only 10.1/27.83 GiB free after 2 prior tests (needs 0.4*27.83=11.13 GiB)
           pytest -v -s tests/models/transformers/ \
-            --deselect "tests/models/transformers/test_backend.py::test_models[allenai/OLMoE-1B-7B-0924-transformers-num_fused2]"
+            --deselect "tests/models/transformers/test_backend.py::test_models[allenai/OLMoE-1B-7B-0924-transformers-num_fused2]" \
+            --deselect "tests/models/transformers/test_backend.py::test_hybrid_attention"
 
       - name: "Test: multimodal processing"
+        if: false
         working-directory: vllm
         continue-on-error: true
         run: |

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -89,15 +89,26 @@ jobs:
           echo "=== Disk ===" && df -h
           echo "=== Top processes by memory ===" && ps aux --sort=-%mem | head -20
 
-      - name: "Test: test_initialization (subset)"
-        if: false
+      - name: "Test: test_initialization"
         working-directory: vllm
         continue-on-error: true
         run: |
-          pytest -v -s "tests/models/test_initialization.py::test_can_initialize_small_subset[LlavaForConditionalGeneration]" \
-                       "tests/models/test_initialization.py::test_can_initialize_small_subset[Llama4ForConditionalGeneration]"
+          # Skip TransformersMultiModalForCausalLM — causes OOM (exit code 137)
+          pytest -v -s \
+            "tests/models/test_initialization.py::test_can_initialize_small_subset[LlavaForConditionalGeneration]" \
+            "tests/models/test_initialization.py::test_can_initialize_small_subset[Llama4ForConditionalGeneration]" \
+            "tests/models/test_initialization.py::test_can_initialize_small_subset[BertForSequenceClassification]" \
+            "tests/models/test_initialization.py::test_can_initialize_small_subset[Gemma3nForCausalLM]" \
+            "tests/models/test_initialization.py::test_can_initialize_small_subset[JinaVLForRanking]" \
+            "tests/models/test_initialization.py::test_can_initialize_small_subset[InternVLChatModel]" \
+            "tests/models/test_initialization.py::test_can_initialize_small_subset[InternLM2ForRewardModel]" \
+            "tests/models/test_initialization.py::test_can_initialize_small_subset[PrithviGeoSpatialMAE]" \
+            "tests/models/test_initialization.py::test_can_initialize_small_subset[UltravoxModel]" \
+            "tests/models/test_initialization.py::test_can_initialize_small_subset[DeepSeekMTPModel]" \
+            "tests/models/test_initialization.py::test_can_initialize_small_subset[XLMRobertaModel]"
 
       - name: "Test: test_transformers"
+        if: false
         working-directory: vllm
         continue-on-error: true
         run: |
@@ -105,6 +116,7 @@ jobs:
                        "tests/models/transformers/fusers/test_linear.py::test_detects_and_rewrites_glu[False-ReversedGLUMLP]"
 
       - name: "Test: multimodal processing"
+        if: false
         working-directory: vllm
         continue-on-error: true
         run: |
@@ -112,21 +124,25 @@ jobs:
                        "tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-0.3-LGAI-EXAONE/EXAONE-4.5-33B]"
 
       - name: "Test: test_mapping"
+        if: false
         working-directory: vllm
         continue-on-error: true
         run: pytest -v -s tests/models/multimodal/test_mapping.py
 
       - name: "Example: chat"
+        if: false
         working-directory: vllm
         continue-on-error: true
         run: python3 examples/basic/offline_inference/chat.py
 
       - name: "Example: vision language"
+        if: false
         working-directory: vllm
         continue-on-error: true
         run: python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
 
       - name: "Example: audio language (whisper)"
+        if: false
         working-directory: vllm
         continue-on-error: true
         run: VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -97,7 +97,6 @@ jobs:
           echo "=== Top processes by memory ===" && ps aux --sort=-%mem | head -20
 
       - name: "Test: test_initialization"
-        if: false
         working-directory: vllm
         continue-on-error: true
         run: |
@@ -145,25 +144,21 @@ jobs:
                        tests/models/multimodal/processing/test_transformers_audio.py
 
       - name: "Test: test_mapping"
-        if: false
         working-directory: vllm
         continue-on-error: true
         run: pytest -v -s tests/models/multimodal/test_mapping.py
 
       - name: "Example: chat"
-        if: false
         working-directory: vllm
         continue-on-error: true
         run: python3 examples/basic/offline_inference/chat.py
 
       - name: "Example: vision language"
-        if: false
         working-directory: vllm
         continue-on-error: true
         run: python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
 
       - name: "Example: audio language (whisper)"
-        if: false
         working-directory: vllm
         continue-on-error: true
         run: VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -40,15 +40,18 @@ jobs:
           path: vllm
 
       - name: Install dependencies
-        run: uv pip install vllm -e transformers
+        run: |
+          uv pip install vllm -e transformers
+          uv pip install -r vllm/requirements/test.txt
 
       - name: Run tests
+        working-directory: vllm
         run: |
-          pytest -v -s vllm/tests/models/test_initialization.py
-          pytest -v -s vllm/tests/models/test_transformers.py
-          pytest -v -s vllm/tests/models/multimodal/processing/
-          pytest -v -s vllm/tests/models/multimodal/test_mapping.py
-          python3 vllm/examples/basic/offline_inference/chat.py
-          python3 vllm/examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
+          pytest -v -s tests/models/test_initialization.py
+          pytest -v -s tests/models/test_transformers.py
+          pytest -v -s tests/models/multimodal/processing/
+          pytest -v -s tests/models/multimodal/test_mapping.py
+          python3 examples/basic/offline_inference/chat.py
+          python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
           # Whisper needs spawn method to avoid deadlock
-          VLLM_WORKER_MULTIPROC_METHOD=spawn python3 vllm/examples/generate/multimodal/audio_language_offline.py --model-type whisper
+          VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -123,12 +123,10 @@ jobs:
           pytest -v -s tests/models/transformers/
 
       - name: "Test: multimodal processing"
-        if: false
         working-directory: vllm
         continue-on-error: true
         run: |
-          pytest -v -s "tests/models/multimodal/processing/test_audio_in_video.py::test_audio_in_video_cache_correctness[1-Qwen/Qwen2.5-Omni-3B]" \
-                       "tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-0.3-LGAI-EXAONE/EXAONE-4.5-33B]"
+          pytest -v -n 8 tests/models/multimodal/processing/
 
       - name: "Test: test_mapping"
         if: false

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -117,6 +117,10 @@ jobs:
             "tests/models/test_initialization.py::test_can_initialize_small_subset[XLMRobertaModel]"
 
       - name: "Test: test_transformers"
+        if: false
+        # We constantly hit memory issues after the first 2 tests. The CPU memory doesn't seem to be
+        # released by the OS. A larger runner may work but it's unclear if the memory not being
+        # released issue would persist.
         working-directory: vllm
         continue-on-error: true
         run: |
@@ -131,6 +135,7 @@ jobs:
 
       - name: "Test: multimodal processing"
         if: false
+        # TODO: re-enable this step by reworking the workflow to use matrix job.
         working-directory: vllm
         continue-on-error: true
         run: |

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -74,6 +74,12 @@ jobs:
       - name: Pip freeze
         run: pip freeze
 
+      - name: System info
+        run: |
+          echo "=== CPU ===" && lscpu | grep -E "^CPU\(s\)|^Model name|^Socket"
+          echo "=== Memory ===" && free -h
+          echo "=== Disk ===" && df -h
+
       - name: Run tests
         working-directory: vllm
         run: |

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -99,12 +99,14 @@ jobs:
       - name: "Test: test_transformers"
         working-directory: vllm
         continue-on-error: true
-        run: pytest -v -s tests/models/test_transformers.py
+        run: pytest -v -s tests/models/transformers/
 
       - name: "Test: multimodal processing"
         working-directory: vllm
         continue-on-error: true
-        run: pytest -v -s tests/models/multimodal/processing/
+        run: |
+          pytest -v -s "tests/models/multimodal/processing/test_audio_in_video.py::test_audio_in_video_cache_correctness[1-Qwen/Qwen2.5-Omni-3B]" \
+                       "tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-0.3-LGAI-EXAONE/EXAONE-4.5-33B]"
 
       - name: "Test: test_mapping"
         working-directory: vllm

--- a/.github/workflows/dependents-smoke-test.yml
+++ b/.github/workflows/dependents-smoke-test.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Patch vLLM gpu_memory_utilization for CPU
         run: |
           # Lower hardcoded value in test_initialization.py
+          # Needed by: test_initialization.py::test_can_initialize_small_subset[*]
           sed -i 's/gpu_memory_utilization=0.80/gpu_memory_utilization=0.5/g' vllm/tests/models/test_initialization.py
           # Lower the global default in CacheConfig (covers EngineArgs default and anything reading the field)
           sed -i 's/gpu_memory_utilization: float = Field(default=0.92/gpu_memory_utilization: float = Field(default=0.5/g' vllm/vllm/config/cache.py

--- a/.github/workflows/vllm-ci-caller.yml
+++ b/.github/workflows/vllm-ci-caller.yml
@@ -1,4 +1,4 @@
-name: Dependents Smoke Test
+name: vLLM Integration Tests
 
 on:
   schedule:
@@ -62,6 +62,8 @@ jobs:
           echo "UV_PYTHON=" >> $GITHUB_ENV
 
       - name: Install dependencies
+        # TODO: Better to build a dedicated Docker image for vLLM CI.
+        # But the workflow only runs once a day, so installing at runtime is fine for now.
         run: |
           uv pip install 'torch<=2.13.0' torchaudio torchvision 'torchcodec<=0.15.0' --index-url https://download.pytorch.org/whl/cpu
           uv pip install --no-deps timm accelerate
@@ -73,6 +75,7 @@ jobs:
           uv pip install tblib pqdm open-clip-torch==2.32.0 albumentations==1.4.6
 
       - name: Patch vLLM gpu_memory_utilization for CPU
+        # TODO: Try to remove this, especially once we have larger CPU runners.
         run: |
           # Lower hardcoded value in test_initialization.py (originally needed by test_initialization and
           # test_transformers steps, now disabled). Kept in case other tests hit the same OOM issue.
@@ -97,22 +100,28 @@ jobs:
           echo "=== Top processes by memory ===" && ps aux --sort=-%mem | head -20
 
       - name: "Test: test_initialization"
+        # Right now we constantly hit memory issues like:
+        #   ValueError: Available memory on node 0 (17.24/27.83 GiB) on startup is less than desired CPU memory utilization (0.8, 22.27 GiB)
+        # CPU memory is not released between tests on the 32 GiB runner.
+        # We need the infra team to provide a larger runner (say 128 GiB CPU RAM).
         if: false
-        # We need infra team to provide larger runner (say 128G CPU RAM)
         working-directory: vllm
         run: |
           pytest -v -s tests/models/test_initialization.py
 
       - name: "Test: test_transformers"
+        # Right now we constantly hit memory issues like:
+        #   ValueError: Available memory on node 0 (17.24/27.83 GiB) on startup is less than desired CPU memory utilization (0.8, 22.27 GiB)
+        # CPU memory is not released between tests on the 32 GiB runner.
+        # We need the infra team to provide a larger runner (say 128 GiB CPU RAM).
         if: false
-        # We need infra team to provide larger runner (say 128G CPU RAM)
         working-directory: vllm
         run: |
           pytest -v -s tests/models/transformers/
 
       - name: "Test: multimodal processing"
-        if: false
         # Replaced by the vllm-multimodal-processing matrix job below.
+        if: false
         working-directory: vllm
         run: |
           pytest -v -s tests/models/multimodal/processing/test_transformers_image.py \
@@ -138,8 +147,7 @@ jobs:
         working-directory: vllm
         run: VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper
 
-  # Multimodal processing tests split across 4 parallel shards.
-  # Each shard runs on a fresh runner — no cross-test memory accumulation.
+  # Multimodal processing tests split across 4 parallel shards (this test takes a long time).
   # Mirrors vLLM's Buildkite CI: parallelism: 4 + pytest-shard (see .buildkite/test_areas/models_multimodal.yaml).
   vllm-multimodal-processing:
     name: "Test vLLM multimodal processing (shard ${{ matrix.shard }} / 4)"
@@ -202,6 +210,7 @@ jobs:
           uv pip install tblib pqdm pytest-shard open-clip-torch==2.32.0 albumentations==1.4.6
 
       - name: Patch vLLM gpu_memory_utilization for CPU
+        # TODO: Try to remove this, especially once we have larger CPU runners.
         run: |
           sed -i 's/gpu_memory_utilization: float = Field(default=0.92/gpu_memory_utilization: float = Field(default=0.4/g' vllm/vllm/config/cache.py
           sed -i 's/gpu_memory_utilization: float = 0.92,/gpu_memory_utilization: float = 0.4,/g' vllm/vllm/entrypoints/llm.py
@@ -209,6 +218,7 @@ jobs:
       - name: "Test: multimodal processing (shard ${{ matrix.shard }} / 4)"
         working-directory: vllm
         run: |
+          # test_tensor_schema.py is run separately on GPU in vLLM's CI
           pytest -v -s tests/models/multimodal/processing/ \
             --ignore tests/models/multimodal/processing/test_tensor_schema.py \
             --num-shards=4 --shard-id=$SHARD_ID

--- a/.github/workflows/vllm-ci-caller.yml
+++ b/.github/workflows/vllm-ci-caller.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - vllm_ci
+      - vllm_ci*
 
 env:
   VLLM_TARGET_DEVICE: cpu

--- a/.github/workflows/vllm-ci-caller.yml
+++ b/.github/workflows/vllm-ci-caller.yml
@@ -43,6 +43,10 @@ jobs:
           wheel = next(w for w in data if 'x86_64' in w['platform_tag'])
           print(wheel['path'].split('/')[3])
           ")
+          if [[ ! "$VLLM_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ERROR: VLLM_COMMIT is not a valid 40-char hex commit hash: $VLLM_COMMIT" >&2
+            exit 1
+          fi
           echo "VLLM_COMMIT=$VLLM_COMMIT" >> $GITHUB_ENV
           echo "vLLM commit: $VLLM_COMMIT"
 
@@ -180,6 +184,10 @@ jobs:
           wheel = next(w for w in data if 'x86_64' in w['platform_tag'])
           print(wheel['path'].split('/')[3])
           ")
+          if [[ ! "$VLLM_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ERROR: VLLM_COMMIT is not a valid 40-char hex commit hash: $VLLM_COMMIT" >&2
+            exit 1
+          fi
           echo "VLLM_COMMIT=$VLLM_COMMIT" >> $GITHUB_ENV
           echo "vLLM commit: $VLLM_COMMIT"
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47864)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47864)
<!-- ci-dashboard-badge:end -->

Add a nightly CI workflow (`.github/workflows/vllm-ci-caller.yml`) that tests transformers compatibility with vLLM nightly CPU builds.

## What it does
- Installs the latest vLLM nightly CPU wheel + transformers from source
- Runs vLLM's multimodal processing test suite across 4 parallel shards
- Runs `test_mapping` and a few vLLM example scripts
- Triggers nightly (3 AM UTC) and on push to `vllm_ci*` branches

## Known remaining failures (vLLM-side, no fix needed on our end)
- `AmbiguousGlobalPerLayerAttributeError` (22 tests, Gemma-4 / Nemotron) — vLLM PR #49797 open
- `RuntimeError: piece must not include null character` (96 tests, InternVL) — not yet reported upstream

## Disabled steps (pending larger runner)
- `test_initialization` and `test_transformers` hit OOM on the 32 GiB runner; re-enable once infra provides a 128 GiB CPU runner