### PR TITLE
Fix DFlash candidate token device mismatch with device_map="auto"

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1675,7 +1675,9 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
             candidate_ids = input_ids
             # We need to sample 1 by 1 for the processors
             for i in range(candidate_logits.shape[1]):
-                next_token_logits = self.logits_processor(candidate_ids, candidate_logits[:, i, :].float())
+                next_token_logits = self.logits_processor(
+                    candidate_ids, candidate_logits[:, i, :].to(candidate_ids.device).float()
+                )
                 if self.do_sample:
                     probs = nn.functional.softmax(next_token_logits, dim=-1, dtype=torch.float32)
                     next_token = torch.multinomial(probs, num_samples=1)
@@ -1691,7 +1693,7 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
                 candidate_ids = torch.multinomial(probs.squeeze(0), num_samples=1)
             else:
                 candidate_ids = candidate_logits.argmax(dim=-1)
-            candidate_ids = torch.cat([input_ids, candidate_ids], dim=-1)
+            candidate_ids = torch.cat([input_ids, candidate_ids.to(input_ids.device)], dim=-1)
 
         return candidate_ids, candidate_logits
 

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1393,9 +1393,7 @@ class SinglePositionMultiTokenCandidateGenerator(AssistedCandidateGenerator):
             if sequence_stopped.any():
                 stopped = sequence_stopped.unsqueeze(1)  # (batch, 1) for broadcasting
                 last_token_id = torch.where(stopped, self.generation_config.pad_token_id, last_token_id)
-                drafted_logits.append(
-                    torch.where(stopped.unsqueeze(-1), torch.zeros_like(logits), logits)
-                )
+                drafted_logits.append(torch.where(stopped.unsqueeze(-1), torch.zeros_like(logits), logits))
             else:
                 drafted_logits.append(logits)
 
@@ -1676,9 +1674,7 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
             candidate_ids = input_ids
             # We need to sample 1 by 1 for the processors
             for i in range(candidate_logits.shape[1]):
-                next_token_logits = self.logits_processor(
-                    candidate_ids, candidate_logits[:, i, :].float()
-                )
+                next_token_logits = self.logits_processor(candidate_ids, candidate_logits[:, i, :].float())
                 if self.do_sample:
                     probs = nn.functional.softmax(next_token_logits, dim=-1, dtype=torch.float32)
                     next_token = torch.multinomial(probs, num_samples=1)

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1385,18 +1385,19 @@ class SinglePositionMultiTokenCandidateGenerator(AssistedCandidateGenerator):
                     use_cache=False,
                 )
 
-            last_token_id = outputs.logits.argmax(dim=-1)
-            last_hidden_state = outputs.last_hidden_state
+            logits = outputs.logits.to(input_ids.device)
+            last_token_id = logits.argmax(dim=-1)
+            last_hidden_state = outputs.last_hidden_state.to(input_ids.device)
 
             # For stopped sequences, replace drafted tokens with pad and logits with zeros.
             if sequence_stopped.any():
                 stopped = sequence_stopped.unsqueeze(1)  # (batch, 1) for broadcasting
                 last_token_id = torch.where(stopped, self.generation_config.pad_token_id, last_token_id)
                 drafted_logits.append(
-                    torch.where(stopped.unsqueeze(-1), torch.zeros_like(outputs.logits), outputs.logits)
+                    torch.where(stopped.unsqueeze(-1), torch.zeros_like(logits), logits)
                 )
             else:
-                drafted_logits.append(outputs.logits)
+                drafted_logits.append(logits)
 
             drafted_tokens.append(last_token_id)
 
@@ -1668,7 +1669,7 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
         # Once we arrive here the first time, it's no longer the case
         self.is_main_model_prefill = False
 
-        candidate_logits = self.main_model_output_embeddings(outputs.last_hidden_state)[:, 1:]
+        candidate_logits = self.main_model_output_embeddings(outputs.last_hidden_state)[:, 1:].to(input_ids.device)
 
         # Potentially allow some logits manipulation and sampling - in this case we need to loop over new tokens to correctly apply processors
         if self.logits_processor is not None:
@@ -1676,7 +1677,7 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
             # We need to sample 1 by 1 for the processors
             for i in range(candidate_logits.shape[1]):
                 next_token_logits = self.logits_processor(
-                    candidate_ids, candidate_logits[:, i, :].to(candidate_ids.device).float()
+                    candidate_ids, candidate_logits[:, i, :].float()
                 )
                 if self.do_sample:
                     probs = nn.functional.softmax(next_token_logits, dim=-1, dtype=torch.float32)
@@ -1693,7 +1694,7 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
                 candidate_ids = torch.multinomial(probs.squeeze(0), num_samples=1)
             else:
                 candidate_ids = candidate_logits.argmax(dim=-1)
-            candidate_ids = torch.cat([input_ids, candidate_ids.to(input_ids.device)], dim=-1)
+            candidate_ids = torch.cat([input_ids, candidate_ids], dim=-1)
 
         return candidate_ids, candidate_logits
 

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1577,6 +1577,7 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
 
         # Get the assistant model and the embeddings of the main model
         self.assistant_model = assistant_model
+        self.device = self.assistant_model.device
         self.main_model_max_length = generation_config.max_length
         self.main_model_input_embeddings = main_model_input_embeddings
         self.main_model_output_embeddings = main_model_output_embeddings
@@ -1626,7 +1627,11 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
         # The hidden states hold all tokens from the last main model's forward on all the candidates. We need the
         # hidden states of only accepted tokens thus crop out the rest
         context_hidden_states: torch.Tensor = torch.cat(
-            [model_outputs.hidden_states[i + 1][:, :num_last_main_model_tokens] for i in self.target_layer_ids], dim=-1
+            [
+                model_outputs.hidden_states[i + 1][:, :num_last_main_model_tokens].to(self.device)
+                for i in self.target_layer_ids
+            ],
+            dim=-1,
         )
 
         # We need to tell the cache how many new states to expect into its k/v states, additional to the "noise" or "diffusion window"
@@ -1658,17 +1663,19 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
 
         # Get assistant model outputs
         outputs = self.assistant_model(
-            noise_embeds=noise_embeds,
+            noise_embeds=noise_embeds.to(self.device),
             context_hidden_states=context_hidden_states,
-            position_ids=position_ids,
-            attention_mask=attention_mask,
+            position_ids=position_ids.to(self.device),
+            attention_mask=attention_mask.to(self.device),
             past_key_values=self.cache,
         )
 
         # Once we arrive here the first time, it's no longer the case
         self.is_main_model_prefill = False
 
-        candidate_logits = self.main_model_output_embeddings(outputs.last_hidden_state)[:, 1:]
+        candidate_logits = self.main_model_output_embeddings(
+            outputs.last_hidden_state[:, 1:].to(self.main_model_output_embeddings.weight.device)
+        )
 
         # Potentially allow some logits manipulation and sampling - in this case we need to loop over new tokens to correctly apply processors
         if self.logits_processor is not None:

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1668,14 +1668,16 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
         # Once we arrive here the first time, it's no longer the case
         self.is_main_model_prefill = False
 
-        candidate_logits = self.main_model_output_embeddings(outputs.last_hidden_state)[:, 1:].to(input_ids.device)
+        candidate_logits = self.main_model_output_embeddings(outputs.last_hidden_state)[:, 1:]
 
         # Potentially allow some logits manipulation and sampling - in this case we need to loop over new tokens to correctly apply processors
         if self.logits_processor is not None:
             candidate_ids = input_ids
             # We need to sample 1 by 1 for the processors
             for i in range(candidate_logits.shape[1]):
-                next_token_logits = self.logits_processor(candidate_ids, candidate_logits[:, i, :].float())
+                next_token_logits = self.logits_processor(
+                    candidate_ids, candidate_logits[:, i, :].to(device=input_ids.device, dtype=torch.float32)
+                )
                 if self.do_sample:
                     probs = nn.functional.softmax(next_token_logits, dim=-1, dtype=torch.float32)
                     next_token = torch.multinomial(probs, num_samples=1)
@@ -1691,7 +1693,7 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
                 candidate_ids = torch.multinomial(probs.squeeze(0), num_samples=1)
             else:
                 candidate_ids = candidate_logits.argmax(dim=-1)
-            candidate_ids = torch.cat([input_ids, candidate_ids], dim=-1)
+            candidate_ids = torch.cat([input_ids, candidate_ids.to(input_ids.device)], dim=-1)
 
         return candidate_ids, candidate_logits
 

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1385,17 +1385,18 @@ class SinglePositionMultiTokenCandidateGenerator(AssistedCandidateGenerator):
                     use_cache=False,
                 )
 
-            logits = outputs.logits.to(input_ids.device)
-            last_token_id = logits.argmax(dim=-1)
-            last_hidden_state = outputs.last_hidden_state.to(input_ids.device)
+            last_token_id = outputs.logits.argmax(dim=-1)
+            last_hidden_state = outputs.last_hidden_state
 
             # For stopped sequences, replace drafted tokens with pad and logits with zeros.
             if sequence_stopped.any():
                 stopped = sequence_stopped.unsqueeze(1)  # (batch, 1) for broadcasting
                 last_token_id = torch.where(stopped, self.generation_config.pad_token_id, last_token_id)
-                drafted_logits.append(torch.where(stopped.unsqueeze(-1), torch.zeros_like(logits), logits))
+                drafted_logits.append(
+                    torch.where(stopped.unsqueeze(-1), torch.zeros_like(outputs.logits), outputs.logits)
+                )
             else:
-                drafted_logits.append(logits)
+                drafted_logits.append(outputs.logits)
 
             drafted_tokens.append(last_token_id)
 

--- a/src/transformers/modeling_layers.py
+++ b/src/transformers/modeling_layers.py
@@ -536,9 +536,9 @@ class MtpModel(PreTrainedModel):
             # Append the drafted logits
             drafted_logits.append(logits)
             # Decode one token
-            next_token_logits = logits[:, -1, :].to(device=input_ids.device, dtype=torch.float32)
+            next_token_logits = logits[:, -1, :].to(device=input_ids.device)
             if logits_processor is not None and full_input_ids is not None:
-                next_token_logits = logits_processor(full_input_ids, next_token_logits)
+                next_token_logits = logits_processor(full_input_ids, next_token_logits.to(dtype=torch.float32))
             if do_sample:
                 probs = nn.functional.softmax(next_token_logits, dim=-1, dtype=torch.float32)
                 next_mtp_token = torch.multinomial(probs, num_samples=1)

--- a/src/transformers/modeling_layers.py
+++ b/src/transformers/modeling_layers.py
@@ -534,17 +534,16 @@ class MtpModel(PreTrainedModel):
                 )
 
             # Append the drafted logits
-            logits = logits.to(input_ids.device)
             drafted_logits.append(logits)
             # Decode one token
-            next_token_logits = logits[:, -1, :]
+            next_token_logits = logits[:, -1, :].to(device=input_ids.device, dtype=torch.float32)
             if logits_processor is not None and full_input_ids is not None:
-                next_token_scores = logits_processor(full_input_ids, next_token_logits.to(torch.float32))
+                next_token_logits = logits_processor(full_input_ids, next_token_logits)
             if do_sample:
-                probs = nn.functional.softmax(next_token_scores, dim=-1, dtype=torch.float32)
+                probs = nn.functional.softmax(next_token_logits, dim=-1, dtype=torch.float32)
                 next_mtp_token = torch.multinomial(probs, num_samples=1)
             else:
-                next_mtp_token = torch.argmax(next_token_scores, dim=-1, keepdim=True)
+                next_mtp_token = torch.argmax(next_token_logits, dim=-1, keepdim=True)
             drafted_tokens.append(next_mtp_token)
 
             # Roll by 1 and append for next layer

--- a/src/transformers/modeling_layers.py
+++ b/src/transformers/modeling_layers.py
@@ -534,9 +534,10 @@ class MtpModel(PreTrainedModel):
                 )
 
             # Append the drafted logits
+            logits = logits.to(input_ids.device)
             drafted_logits.append(logits)
             # Decode one token
-            next_token_logits = logits[:, -1, :].to(device=input_ids.device)
+            next_token_logits = logits[:, -1, :]
             if logits_processor is not None and full_input_ids is not None:
                 next_token_scores = logits_processor(full_input_ids, next_token_logits.to(torch.float32))
             if do_sample:

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -24,7 +24,6 @@ import tempfile
 import unittest
 import warnings
 from pathlib import Path
-from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -112,7 +111,6 @@ if is_torch_available():
         AssistedCandidateGenerator,
         AssistedCandidateGeneratorDifferentTokenizers,
         DFlashTokenCandidateGenerator,
-        SinglePositionMultiTokenCandidateGenerator,
     )
     from transformers.generation.utils import ALL_CACHE_NAMES, _speculative_sampling
     from transformers.modeling_layers import MtpModel
@@ -3949,125 +3947,34 @@ class GenerationIntegrationTests(unittest.TestCase):
         self.assertTrue(out.shape[-1] <= (input_length + 7))
 
     @require_torch_multi_accelerator
-    def test_gemma_candidate_generator_keeps_ids_on_input_device(self):
-        """Regression test for Gemma4Assistant candidate generation with the assistant on a different device."""
-        input_device = torch.device(f"{torch_device}:0")
-        assistant_device = torch.device(f"{torch_device}:1")
-
-        assistant = AutoModelForCausalLM.from_pretrained("tiny-random/gemma-4-assistant").to(assistant_device).eval()
-        dtype = next(assistant.parameters()).dtype
-        text_config = assistant.config.get_text_config()
-        backbone_hidden_size = assistant.config.backbone_hidden_size
-        vocab_size = text_config.vocab_size
-
-        input_ids = torch.tensor([[1, 2, 3]], device=input_device)
-        target_embeddings = torch.nn.Embedding(vocab_size, backbone_hidden_size, device=input_device, dtype=dtype)
-        model_kwargs = {
-            "attention_mask": torch.ones_like(input_ids),
-            "position_ids": torch.arange(input_ids.shape[1], device=input_device).unsqueeze(0),
-        }
-        gemma_generator = SinglePositionMultiTokenCandidateGenerator(
-            input_ids=input_ids,
-            assistant_model=assistant,
-            target_model_input_embeddings=target_embeddings,
-            generation_config=GenerationConfig(eos_token_id=vocab_size - 1, pad_token_id=0, max_length=8),
-            model_kwargs=model_kwargs,
-        )
-        gemma_generator.num_assistant_tokens = 2
-
-        full_attention_head_dim = text_config.per_layer_config[
-            text_config.layer_types.index("full_attention")
-        ].head_dim
-        sliding_attention_head_dim = text_config.per_layer_config[
-            text_config.layer_types.index("sliding_attention")
-        ].head_dim
-        gemma_outputs = SimpleNamespace(
-            hidden_states=(
-                torch.zeros(1, input_ids.shape[1], backbone_hidden_size, device=input_device, dtype=dtype),
-            ),
-            shared_kv_states={
-                "full_attention": (
-                    torch.zeros(
-                        1,
-                        text_config.num_key_value_heads,
-                        input_ids.shape[1],
-                        full_attention_head_dim,
-                        device=input_device,
-                        dtype=dtype,
-                    ),
-                    torch.zeros(
-                        1,
-                        text_config.num_key_value_heads,
-                        input_ids.shape[1],
-                        full_attention_head_dim,
-                        device=input_device,
-                        dtype=dtype,
-                    ),
-                ),
-                "sliding_attention": (
-                    torch.zeros(
-                        1,
-                        text_config.num_key_value_heads,
-                        input_ids.shape[1],
-                        sliding_attention_head_dim,
-                        device=input_device,
-                        dtype=dtype,
-                    ),
-                    torch.zeros(
-                        1,
-                        text_config.num_key_value_heads,
-                        input_ids.shape[1],
-                        sliding_attention_head_dim,
-                        device=input_device,
-                        dtype=dtype,
-                    ),
-                ),
-            },
-        )
-        candidate_ids, candidate_logits = gemma_generator.get_candidates(
-            input_ids=input_ids,
-            model_kwargs=model_kwargs,
-            model_outputs=gemma_outputs,
-            is_first_iteration=False,
-            n_last_matches=0,
-        )
-        self.assertEqual(candidate_ids.device, input_device)
-        self.assertEqual(candidate_logits.device, input_device)
-
-    @require_torch_multi_accelerator
-    @require_accelerate
-    def test_mtp_candidate_generator_keeps_ids_on_input_device(self):
-        """Regression test for MTP draft logits being moved back to the input IDs device."""
-        from accelerate import dispatch_model
-
+    def test_mtp_use_correct_device_when_drafting(self):
+        """Test that when drafting the new token, mtp puts it back on the correct same device as `input_ids`"""
         input_device = torch.device(f"{torch_device}:0")
         assistant_device = torch.device(f"{torch_device}:1")
 
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-MistralForCausalLM")
         model.config.get_text_config().num_mtp_layers = 2
-        mtp_model = MtpModel(model, num_mtp_layers=2).eval()
-        device_map = {"embed_tokens": input_device, "layers": assistant_device, "shared_head": assistant_device}
-        if mtp_model.rotary_emb is not None:
-            device_map["rotary_emb"] = assistant_device
-        dispatch_model(mtp_model, device_map=device_map)
+        mtp_model = MtpModel(model, num_mtp_layers=2).to(assistant_device).eval()
+        # Mimics embedding being on 1st device, i.e. main model device
+        mtp_model.embed_tokens.to(input_device)
 
         input_ids = torch.tensor([[1, 2]], device=input_device)
-        mtp_candidate_ids, mtp_candidate_logits, _ = MtpModel.forward(
-            mtp_model,
+
+        # If the device is not correct, this will raise an error
+        mtp_candidate_ids, mtp_candidate_logits, _ = mtp_model.forward(
             input_ids=input_ids,
             last_hidden_states=torch.zeros(1, input_ids.shape[1], model.config.hidden_size, device=assistant_device),
             attention_mask=torch.ones_like(input_ids, device=assistant_device),
             position_ids=torch.arange(input_ids.shape[1], device=assistant_device).unsqueeze(0),
             mtp_cache=None,
-            logits_processor=LogitsProcessorList(),
             full_input_ids=input_ids,
         )
         self.assertEqual(mtp_candidate_ids.device, input_device)
-        self.assertEqual(mtp_candidate_logits.device, input_device)
+        self.assertEqual(mtp_candidate_logits.device, assistant_device)
 
     @require_torch_multi_accelerator
-    def test_dflash_candidate_generator_keeps_ids_on_input_device(self):
-        """Regression test for DFlash candidate logits being moved back to the input IDs device."""
+    def test_dflash_use_correct_device_when_drafting(self):
+        """Test that when drafting the new tokens, dflash puts them it back on the correct same device as `input_ids`"""
         from transformers.models.muse_glimmer.modeling_muse_glimmer import MuseGlimmerForConditionalGeneration
         from transformers.models.muse_glimmer_assistant.modeling_muse_glimmer_assistant import (
             MuseGlimmerAssistantModel,
@@ -4076,24 +3983,13 @@ class GenerationIntegrationTests(unittest.TestCase):
         input_device = torch.device(f"{torch_device}:0")
         assistant_device = torch.device(f"{torch_device}:1")
 
-        model = MuseGlimmerForConditionalGeneration.from_pretrained("hf-internal-testing/tiny-muse-glimmer").eval()
-        assistant = MuseGlimmerAssistantModel.from_pretrained("hf-internal-testing/tiny-muse-glimmer-assistant").eval()
+        model = MuseGlimmerForConditionalGeneration.from_pretrained(
+            "hf-internal-testing/tiny-muse-glimmer", device_map=input_device
+        )
+        assistant = MuseGlimmerAssistantModel.from_pretrained(
+            "hf-internal-testing/tiny-muse-glimmer-assistant", device_map=assistant_device
+        )
         assistant.config.target_layer_ids = list(range(model.config.text_config.num_hidden_layers))
-        model.model.to(input_device)
-        model.lm_head.to(assistant_device)
-        assistant.to(input_device)
-
-        class AssistantOutputOnDevice(torch.nn.Module):
-            def __init__(self, assistant, device):
-                super().__init__()
-                self.assistant = assistant
-                self.config = assistant.config
-                self.device = device
-
-            def forward(self, **kwargs):
-                outputs = self.assistant(**kwargs)
-                outputs.last_hidden_state = outputs.last_hidden_state.to(self.device)
-                return outputs
 
         input_ids = torch.tensor([[2, 3, 4]], device=input_device)
         main_model_input_ids = input_ids
@@ -4103,7 +3999,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         }
 
         dflash_generator = DFlashTokenCandidateGenerator(
-            assistant_model=AssistantOutputOnDevice(assistant, assistant_device),
+            assistant_model=assistant,
             main_model_input_embeddings=model.get_input_embeddings(),
             main_model_output_embeddings=model.get_output_embeddings(),
             generation_config=GenerationConfig(max_length=8, do_sample=False),
@@ -4121,6 +4017,7 @@ class GenerationIntegrationTests(unittest.TestCase):
                 is_first_iteration=False,
                 n_last_matches=0,
             )
+        # Both will live on `input_device` as the main model is there
         self.assertEqual(dflash_candidate_ids.device, input_device)
         self.assertEqual(dflash_candidate_logits.device, input_device)
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -24,6 +24,7 @@ import tempfile
 import unittest
 import warnings
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -110,6 +111,8 @@ if is_torch_available():
     from transformers.generation.candidate_generator import (
         AssistedCandidateGenerator,
         AssistedCandidateGeneratorDifferentTokenizers,
+        DFlashTokenCandidateGenerator,
+        SinglePositionMultiTokenCandidateGenerator,
     )
     from transformers.generation.utils import ALL_CACHE_NAMES, _speculative_sampling
     from transformers.modeling_layers import MtpModel
@@ -3944,6 +3947,161 @@ class GenerationIntegrationTests(unittest.TestCase):
             max_new_tokens=7,
         )
         self.assertTrue(out.shape[-1] <= (input_length + 7))
+
+    @require_torch_multi_accelerator
+    def test_gemma_candidate_generator_keeps_ids_on_input_device(self):
+        input_device = torch.device(f"{torch_device}:0")
+        assistant_device = torch.device(f"{torch_device}:1")
+        hidden_size = 4
+        vocab_size = 8
+
+        class Gemma4AssistantForCausalLM(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = SimpleNamespace(is_encoder_decoder=False)
+                self.generation_config = GenerationConfig(
+                    eos_token_id=vocab_size - 1,
+                    pad_token_id=0,
+                    max_length=8,
+                    num_assistant_tokens=2,
+                    num_assistant_tokens_schedule="constant",
+                )
+
+            @property
+            def device(self):
+                return assistant_device
+
+            def forward(self, **kwargs):
+                batch_size = kwargs["inputs_embeds"].shape[0]
+                logits = torch.zeros(batch_size, 1, vocab_size, device=assistant_device)
+                logits[..., 1] = 1
+                return SimpleNamespace(
+                    logits=logits,
+                    last_hidden_state=torch.zeros(batch_size, 1, hidden_size, device=assistant_device),
+                )
+
+        input_ids = torch.tensor([[1, 2, 3]], device=input_device)
+        target_embeddings = torch.nn.Embedding(vocab_size, hidden_size, device=input_device)
+        model_kwargs = {
+            "attention_mask": torch.ones_like(input_ids),
+            "position_ids": torch.arange(input_ids.shape[1], device=input_device).unsqueeze(0),
+        }
+        gemma_generator = SinglePositionMultiTokenCandidateGenerator(
+            input_ids=input_ids,
+            assistant_model=Gemma4AssistantForCausalLM(),
+            target_model_input_embeddings=target_embeddings,
+            generation_config=GenerationConfig(eos_token_id=vocab_size - 1, pad_token_id=0, max_length=8),
+            model_kwargs=model_kwargs,
+        )
+        gemma_outputs = SimpleNamespace(
+            hidden_states=(torch.zeros(1, input_ids.shape[1], hidden_size, device=input_device),),
+            shared_kv_states={
+                "layer": (
+                    torch.zeros(1, 1, input_ids.shape[1], hidden_size, device=input_device),
+                    torch.zeros(1, 1, input_ids.shape[1], hidden_size, device=input_device),
+                )
+            },
+        )
+        candidate_ids, candidate_logits = gemma_generator.get_candidates(
+            input_ids=input_ids,
+            model_kwargs=model_kwargs,
+            model_outputs=gemma_outputs,
+            is_first_iteration=False,
+            n_last_matches=0,
+        )
+        self.assertEqual(candidate_ids.device, input_device)
+        self.assertEqual(candidate_logits.device, input_device)
+
+    @require_torch_multi_accelerator
+    def test_mtp_candidate_generator_keeps_ids_on_input_device(self):
+        input_device = torch.device(f"{torch_device}:0")
+        assistant_device = torch.device(f"{torch_device}:1")
+        hidden_size = 4
+        vocab_size = 8
+        input_ids = torch.tensor([[1, 2, 3]], device=input_device)
+
+        class FakeMtpLayer(torch.nn.Module):
+            def forward(self, inputs_embeds, last_hidden_states, **kwargs):
+                return last_hidden_states + inputs_embeds
+
+        fake_mtp_model = SimpleNamespace(
+            layers=[FakeMtpLayer(), FakeMtpLayer()],
+            embed_tokens=torch.nn.Embedding(vocab_size, hidden_size, device=input_device),
+            rotary_emb=None,
+            use_shared_post_norm=False,
+            create_masks_for_mtp_layer=lambda *args, **kwargs: {},
+            _project_to_logits=lambda hidden_states: torch.zeros(
+                hidden_states.shape[0], hidden_states.shape[1], vocab_size, device=assistant_device
+            ),
+        )
+        mtp_candidate_ids, mtp_candidate_logits, _ = MtpModel.forward(
+            fake_mtp_model,
+            input_ids=input_ids[:, -1:],
+            last_hidden_states=torch.zeros(1, 1, hidden_size, device=assistant_device),
+            attention_mask=torch.ones(1, 1, device=input_device),
+            position_ids=torch.ones(1, 1, dtype=torch.long, device=input_device),
+            mtp_cache=None,
+            logits_processor=LogitsProcessorList(),
+            full_input_ids=input_ids,
+        )
+        self.assertEqual(mtp_candidate_ids.device, input_device)
+        self.assertEqual(mtp_candidate_logits.device, input_device)
+
+    @require_torch_multi_accelerator
+    def test_dflash_candidate_generator_keeps_ids_on_input_device(self):
+        input_device = torch.device(f"{torch_device}:0")
+        assistant_device = torch.device(f"{torch_device}:1")
+        hidden_size = 4
+        vocab_size = 8
+        input_ids = torch.tensor([[1, 2, 3]], device=input_device)
+        model_kwargs = {
+            "attention_mask": torch.ones_like(input_ids),
+            "position_ids": torch.arange(input_ids.shape[1], device=input_device).unsqueeze(0),
+        }
+
+        class FakeDFlashAssistant(torch.nn.Module):
+            def forward(self, **kwargs):
+                batch_size = kwargs["noise_embeds"].shape[0]
+                return SimpleNamespace(
+                    last_hidden_state=torch.zeros(batch_size, 3, hidden_size, device=assistant_device)
+                )
+
+        class FakeDFlashCache:
+            def set_previous_accepted_tokens(self, *args, **kwargs):
+                pass
+
+            def crop(self, *args, **kwargs):
+                pass
+
+        dflash_generator = DFlashTokenCandidateGenerator.__new__(DFlashTokenCandidateGenerator)
+        dflash_generator.assistant_model = FakeDFlashAssistant()
+        dflash_generator.main_model_max_length = 8
+        dflash_generator.main_model_input_embeddings = torch.nn.Embedding(vocab_size, hidden_size, device=input_device)
+        dflash_generator.main_model_output_embeddings = torch.nn.Linear(hidden_size, vocab_size, device=assistant_device)
+        dflash_generator.target_layer_ids = [0]
+        dflash_generator.block_size = 3
+        dflash_generator.mask_token_id = 0
+        dflash_generator.noise_ids_mask = torch.tensor([[0, 0]])
+        dflash_generator.cache = FakeDFlashCache()
+        dflash_generator.do_sample = False
+        dflash_generator.logits_processor = None
+        dflash_generator.is_main_model_prefill = True
+
+        dflash_outputs = SimpleNamespace(
+            hidden_states=(
+                torch.zeros(1, input_ids.shape[1], hidden_size, device=input_device),
+                torch.zeros(1, input_ids.shape[1], hidden_size, device=input_device),
+            )
+        )
+        dflash_candidate_ids, dflash_candidate_logits = dflash_generator.get_candidates(
+            input_ids=input_ids,
+            model_kwargs=model_kwargs,
+            model_outputs=dflash_outputs,
+            is_first_iteration=False,
+            n_last_matches=0,
+        )
+        self.assertEqual(dflash_candidate_ids.device, input_device)
+        self.assertEqual(dflash_candidate_logits.device, input_device)
 
     def test_model_kwarg_assisted_decoding_decoder_only(self):
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -4068,59 +4068,59 @@ class GenerationIntegrationTests(unittest.TestCase):
     @require_torch_multi_accelerator
     def test_dflash_candidate_generator_keeps_ids_on_input_device(self):
         """Regression test for DFlash candidate logits being moved back to the input IDs device."""
+        from transformers.models.muse_glimmer.modeling_muse_glimmer import MuseGlimmerForConditionalGeneration
+        from transformers.models.muse_glimmer_assistant.modeling_muse_glimmer_assistant import (
+            MuseGlimmerAssistantModel,
+        )
+
         input_device = torch.device(f"{torch_device}:0")
         assistant_device = torch.device(f"{torch_device}:1")
-        hidden_size = 4
-        vocab_size = 8
-        input_ids = torch.tensor([[1, 2, 3]], device=input_device)
+
+        model = MuseGlimmerForConditionalGeneration.from_pretrained("hf-internal-testing/tiny-muse-glimmer").eval()
+        assistant = MuseGlimmerAssistantModel.from_pretrained("hf-internal-testing/tiny-muse-glimmer-assistant").eval()
+        assistant.config.target_layer_ids = list(range(model.config.text_config.num_hidden_layers))
+        model.model.to(input_device)
+        model.lm_head.to(assistant_device)
+        assistant.to(input_device)
+
+        class AssistantOutputOnDevice(torch.nn.Module):
+            def __init__(self, assistant, device):
+                super().__init__()
+                self.assistant = assistant
+                self.config = assistant.config
+                self.device = device
+
+            def forward(self, **kwargs):
+                outputs = self.assistant(**kwargs)
+                outputs.last_hidden_state = outputs.last_hidden_state.to(self.device)
+                return outputs
+
+        input_ids = torch.tensor([[2, 3, 4]], device=input_device)
+        main_model_input_ids = input_ids
         model_kwargs = {
-            "attention_mask": torch.ones_like(input_ids),
-            "position_ids": torch.arange(input_ids.shape[1], device=input_device).unsqueeze(0),
+            "attention_mask": torch.ones_like(main_model_input_ids),
+            "position_ids": torch.arange(main_model_input_ids.shape[1], device=input_device).unsqueeze(0),
         }
 
-        class FakeDFlashAssistant(torch.nn.Module):
-            def forward(self, **kwargs):
-                batch_size = kwargs["noise_embeds"].shape[0]
-                return SimpleNamespace(
-                    last_hidden_state=torch.zeros(batch_size, 3, hidden_size, device=assistant_device)
-                )
-
-        class FakeDFlashCache:
-            def set_previous_accepted_tokens(self, *args, **kwargs):
-                pass
-
-            def crop(self, *args, **kwargs):
-                pass
-
-        dflash_generator = DFlashTokenCandidateGenerator.__new__(DFlashTokenCandidateGenerator)
-        dflash_generator.assistant_model = FakeDFlashAssistant()
-        dflash_generator.main_model_max_length = 8
-        dflash_generator.main_model_input_embeddings = torch.nn.Embedding(vocab_size, hidden_size, device=input_device)
-        dflash_generator.main_model_output_embeddings = torch.nn.Linear(
-            hidden_size, vocab_size, device=assistant_device
+        dflash_generator = DFlashTokenCandidateGenerator(
+            assistant_model=AssistantOutputOnDevice(assistant, assistant_device),
+            main_model_input_embeddings=model.get_input_embeddings(),
+            main_model_output_embeddings=model.get_output_embeddings(),
+            generation_config=GenerationConfig(max_length=8, do_sample=False),
         )
-        dflash_generator.target_layer_ids = [0]
-        dflash_generator.block_size = 3
-        dflash_generator.mask_token_id = 0
-        dflash_generator.noise_ids_mask = torch.tensor([[0, 0]])
-        dflash_generator.cache = FakeDFlashCache()
-        dflash_generator.do_sample = False
-        dflash_generator.logits_processor = None
-        dflash_generator.is_main_model_prefill = True
-
-        dflash_outputs = SimpleNamespace(
-            hidden_states=(
-                torch.zeros(1, input_ids.shape[1], hidden_size, device=input_device),
-                torch.zeros(1, input_ids.shape[1], hidden_size, device=input_device),
+        with torch.no_grad():
+            dflash_outputs = model.model(
+                input_ids=main_model_input_ids,
+                attention_mask=model_kwargs["attention_mask"],
+                output_hidden_states=True,
             )
-        )
-        dflash_candidate_ids, dflash_candidate_logits = dflash_generator.get_candidates(
-            input_ids=input_ids,
-            model_kwargs=model_kwargs,
-            model_outputs=dflash_outputs,
-            is_first_iteration=False,
-            n_last_matches=0,
-        )
+            dflash_candidate_ids, dflash_candidate_logits = dflash_generator.get_candidates(
+                input_ids=input_ids,
+                model_kwargs=model_kwargs,
+                model_outputs=dflash_outputs,
+                is_first_iteration=False,
+                n_last_matches=0,
+            )
         self.assertEqual(dflash_candidate_ids.device, input_device)
         self.assertEqual(dflash_candidate_logits.device, input_device)
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -3952,54 +3952,75 @@ class GenerationIntegrationTests(unittest.TestCase):
     def test_gemma_candidate_generator_keeps_ids_on_input_device(self):
         input_device = torch.device(f"{torch_device}:0")
         assistant_device = torch.device(f"{torch_device}:1")
-        hidden_size = 4
-        vocab_size = 8
 
-        class Gemma4AssistantForCausalLM(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.config = SimpleNamespace(is_encoder_decoder=False)
-                self.generation_config = GenerationConfig(
-                    eos_token_id=vocab_size - 1,
-                    pad_token_id=0,
-                    max_length=8,
-                    num_assistant_tokens=2,
-                    num_assistant_tokens_schedule="constant",
-                )
-
-            @property
-            def device(self):
-                return assistant_device
-
-            def forward(self, **kwargs):
-                batch_size = kwargs["inputs_embeds"].shape[0]
-                logits = torch.zeros(batch_size, 1, vocab_size, device=assistant_device)
-                logits[..., 1] = 1
-                return SimpleNamespace(
-                    logits=logits,
-                    last_hidden_state=torch.zeros(batch_size, 1, hidden_size, device=assistant_device),
-                )
+        assistant = AutoModelForCausalLM.from_pretrained("tiny-random/gemma-4-assistant").to(assistant_device).eval()
+        dtype = next(assistant.parameters()).dtype
+        text_config = assistant.config.get_text_config()
+        backbone_hidden_size = assistant.config.backbone_hidden_size
+        vocab_size = text_config.vocab_size
 
         input_ids = torch.tensor([[1, 2, 3]], device=input_device)
-        target_embeddings = torch.nn.Embedding(vocab_size, hidden_size, device=input_device)
+        target_embeddings = torch.nn.Embedding(vocab_size, backbone_hidden_size, device=input_device, dtype=dtype)
         model_kwargs = {
             "attention_mask": torch.ones_like(input_ids),
             "position_ids": torch.arange(input_ids.shape[1], device=input_device).unsqueeze(0),
         }
         gemma_generator = SinglePositionMultiTokenCandidateGenerator(
             input_ids=input_ids,
-            assistant_model=Gemma4AssistantForCausalLM(),
+            assistant_model=assistant,
             target_model_input_embeddings=target_embeddings,
             generation_config=GenerationConfig(eos_token_id=vocab_size - 1, pad_token_id=0, max_length=8),
             model_kwargs=model_kwargs,
         )
+        gemma_generator.num_assistant_tokens = 2
+
+        full_attention_head_dim = text_config.per_layer_config[
+            text_config.layer_types.index("full_attention")
+        ].head_dim
+        sliding_attention_head_dim = text_config.per_layer_config[
+            text_config.layer_types.index("sliding_attention")
+        ].head_dim
         gemma_outputs = SimpleNamespace(
-            hidden_states=(torch.zeros(1, input_ids.shape[1], hidden_size, device=input_device),),
+            hidden_states=(
+                torch.zeros(1, input_ids.shape[1], backbone_hidden_size, device=input_device, dtype=dtype),
+            ),
             shared_kv_states={
-                "layer": (
-                    torch.zeros(1, 1, input_ids.shape[1], hidden_size, device=input_device),
-                    torch.zeros(1, 1, input_ids.shape[1], hidden_size, device=input_device),
-                )
+                "full_attention": (
+                    torch.zeros(
+                        1,
+                        text_config.num_key_value_heads,
+                        input_ids.shape[1],
+                        full_attention_head_dim,
+                        device=input_device,
+                        dtype=dtype,
+                    ),
+                    torch.zeros(
+                        1,
+                        text_config.num_key_value_heads,
+                        input_ids.shape[1],
+                        full_attention_head_dim,
+                        device=input_device,
+                        dtype=dtype,
+                    ),
+                ),
+                "sliding_attention": (
+                    torch.zeros(
+                        1,
+                        text_config.num_key_value_heads,
+                        input_ids.shape[1],
+                        sliding_attention_head_dim,
+                        device=input_device,
+                        dtype=dtype,
+                    ),
+                    torch.zeros(
+                        1,
+                        text_config.num_key_value_heads,
+                        input_ids.shape[1],
+                        sliding_attention_head_dim,
+                        device=input_device,
+                        dtype=dtype,
+                    ),
+                ),
             },
         )
         candidate_ids, candidate_logits = gemma_generator.get_candidates(
@@ -4016,30 +4037,23 @@ class GenerationIntegrationTests(unittest.TestCase):
     def test_mtp_candidate_generator_keeps_ids_on_input_device(self):
         input_device = torch.device(f"{torch_device}:0")
         assistant_device = torch.device(f"{torch_device}:1")
-        hidden_size = 4
-        vocab_size = 8
-        input_ids = torch.tensor([[1, 2, 3]], device=input_device)
 
-        class FakeMtpLayer(torch.nn.Module):
-            def forward(self, inputs_embeds, last_hidden_states, **kwargs):
-                return last_hidden_states + inputs_embeds
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-MistralForCausalLM")
+        model.config.get_text_config().num_mtp_layers = 2
+        mtp_model = MtpModel(model, num_mtp_layers=2).eval()
+        mtp_model.layers.to(assistant_device)
+        mtp_model.embed_tokens.to(input_device)
+        mtp_model.shared_head.to(assistant_device)
+        if mtp_model.rotary_emb is not None:
+            mtp_model.rotary_emb.to(assistant_device)
 
-        fake_mtp_model = SimpleNamespace(
-            layers=[FakeMtpLayer(), FakeMtpLayer()],
-            embed_tokens=torch.nn.Embedding(vocab_size, hidden_size, device=input_device),
-            rotary_emb=None,
-            use_shared_post_norm=False,
-            create_masks_for_mtp_layer=lambda *args, **kwargs: {},
-            _project_to_logits=lambda hidden_states: torch.zeros(
-                hidden_states.shape[0], hidden_states.shape[1], vocab_size, device=assistant_device
-            ),
-        )
+        input_ids = torch.tensor([[1, 2]], device=input_device)
         mtp_candidate_ids, mtp_candidate_logits, _ = MtpModel.forward(
-            fake_mtp_model,
-            input_ids=input_ids[:, -1:],
-            last_hidden_states=torch.zeros(1, 1, hidden_size, device=assistant_device),
-            attention_mask=torch.ones(1, 1, device=input_device),
-            position_ids=torch.ones(1, 1, dtype=torch.long, device=input_device),
+            mtp_model,
+            input_ids=input_ids,
+            last_hidden_states=torch.zeros(1, input_ids.shape[1], model.config.hidden_size, device=assistant_device),
+            attention_mask=torch.ones_like(input_ids, device=assistant_device),
+            position_ids=torch.arange(input_ids.shape[1], device=assistant_device).unsqueeze(0),
             mtp_cache=None,
             logits_processor=LogitsProcessorList(),
             full_input_ids=input_ids,

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -3950,6 +3950,7 @@ class GenerationIntegrationTests(unittest.TestCase):
 
     @require_torch_multi_accelerator
     def test_gemma_candidate_generator_keeps_ids_on_input_device(self):
+        """Regression test for Gemma4Assistant candidate generation with the assistant on a different device."""
         input_device = torch.device(f"{torch_device}:0")
         assistant_device = torch.device(f"{torch_device}:1")
 
@@ -4034,18 +4035,21 @@ class GenerationIntegrationTests(unittest.TestCase):
         self.assertEqual(candidate_logits.device, input_device)
 
     @require_torch_multi_accelerator
+    @require_accelerate
     def test_mtp_candidate_generator_keeps_ids_on_input_device(self):
+        """Regression test for MTP draft logits being moved back to the input IDs device."""
+        from accelerate import dispatch_model
+
         input_device = torch.device(f"{torch_device}:0")
         assistant_device = torch.device(f"{torch_device}:1")
 
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-MistralForCausalLM")
         model.config.get_text_config().num_mtp_layers = 2
         mtp_model = MtpModel(model, num_mtp_layers=2).eval()
-        mtp_model.layers.to(assistant_device)
-        mtp_model.embed_tokens.to(input_device)
-        mtp_model.shared_head.to(assistant_device)
+        device_map = {"embed_tokens": input_device, "layers": assistant_device, "shared_head": assistant_device}
         if mtp_model.rotary_emb is not None:
-            mtp_model.rotary_emb.to(assistant_device)
+            device_map["rotary_emb"] = assistant_device
+        dispatch_model(mtp_model, device_map=device_map)
 
         input_ids = torch.tensor([[1, 2]], device=input_device)
         mtp_candidate_ids, mtp_candidate_logits, _ = MtpModel.forward(
@@ -4063,6 +4067,7 @@ class GenerationIntegrationTests(unittest.TestCase):
 
     @require_torch_multi_accelerator
     def test_dflash_candidate_generator_keeps_ids_on_input_device(self):
+        """Regression test for DFlash candidate logits being moved back to the input IDs device."""
         input_device = torch.device(f"{torch_device}:0")
         assistant_device = torch.device(f"{torch_device}:1")
         hidden_size = 4

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -4077,7 +4077,9 @@ class GenerationIntegrationTests(unittest.TestCase):
         dflash_generator.assistant_model = FakeDFlashAssistant()
         dflash_generator.main_model_max_length = 8
         dflash_generator.main_model_input_embeddings = torch.nn.Embedding(vocab_size, hidden_size, device=input_device)
-        dflash_generator.main_model_output_embeddings = torch.nn.Linear(hidden_size, vocab_size, device=assistant_device)
+        dflash_generator.main_model_output_embeddings = torch.nn.Linear(
+            hidden_size, vocab_size, device=assistant_device
+        )
         dflash_generator.target_layer_ids = [0]
         dflash_generator.block_size = 3
         dflash_generator.mask_token_id = 0


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47877)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47877)
<!-- ci-dashboard-badge:end -->

This PR fixes a device mismatch in DFlashTokenCandidateGenerator when models are split across devices with device_map="auto".

candidate_logits can be produced on the device of main_model_output_embeddings, while input_ids / candidate_ids may live on another device. In the logits-processor path, this could pass logits from a different device than candidate_ids into self.logits_processor. In the vectorized path, sampled or argmax candidate tokens could then be concatenated with input_ids across devices.

The fix keeps token-id construction device-consistent by:

moving each logits slice to candidate_ids.device before applying logits_processor moving vectorized generated candidate ids to input_ids.device before concatenation

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.

Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
for reviewers and other users and will almost certainly get you blocked.

For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @molbap @guarin
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @Abdennacer-Badaoui
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @IlyasMoutawwakil 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->