### PR TITLE
[Pipelines] Add early device validation in pipeline() (Fixes #47869)

### DIFF
--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -838,6 +838,25 @@ def pipeline(
     >>> tokenizer = AutoTokenizer.from_pretrained("google-bert/bert-base-cased")
     >>> recognizer = pipeline("ner", model=model, tokenizer=tokenizer)
     ```"""
+    if device is not None:
+        if not (isinstance(device, int) and device == -1):
+            try:
+                if isinstance(device, int):
+                    if device < 0:
+                        raise ValueError(
+                            f"Invalid device ordinal {device}. Expected a non-negative integer or -1 for CPU."
+                        )
+                    torch.device(device)
+                elif isinstance(device, str):
+                    torch.device(device)
+                elif not isinstance(device, torch.device):
+                    torch.device(device)
+            except RuntimeError as e:
+                raise ValueError(
+                    f"Invalid device '{device}'. Expected a valid device string (e.g. 'cpu', 'cuda', 'mps'), "
+                    f"an integer device ordinal, or a `torch.device` instance."
+                ) from e
+
     if model_kwargs is None:
         model_kwargs = {}
 

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -616,6 +616,15 @@ class PipelineUtilsTest(unittest.TestCase):
         actual_output = classifier("Test input.")
         self.assertEqual(expected_output, actual_output)
 
+    def test_pipeline_invalid_device_raises_early(self):
+        with self.assertRaises(ValueError) as ctx:
+            pipeline("text-classification", model="hf-internal-testing/tiny-random-bert", device="invalid_device_name")
+        self.assertIn("Invalid device", str(ctx.exception))
+
+        with self.assertRaises(ValueError) as ctx:
+            pipeline("text-classification", model="hf-internal-testing/tiny-random-bert", device=-5)
+        self.assertIn("Invalid device", str(ctx.exception))
+
     @require_torch_accelerator
     def test_pipeline_no_device(self):
         # Test when no device is passed to pipeline


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47881)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47881)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47869 by adding early device validation at the entry point of `pipeline()` in `src/transformers/pipelines/__init__.py` before downloading or loading model weights into memory.

### Motivation & Problem
Previously, when a user passed a misspelled or invalid device (e.g. `device="mpx"` or `device="cuka"` or `device=-5`), `pipeline()` proceeded to download and load gigabytes of model weights into RAM *before* crashing at tensor placement.

### Solution
1. Validate `device` parameter immediately inside `pipeline()` using `torch.device(device)` or checking valid non-negative integer ordinals (and preserving `device=-1` CPU convention).
2. Fail fast with a clear `ValueError` before downloading or instantiating models.
3. Added `test_pipeline_invalid_device_raises_early` in `tests/pipelines/test_pipelines_common.py`.

- [x] This PR fixes #47869.
- [x] Included unit tests.