### PR TITLE
Add `CI_CPU_MEMORY_LIMIT_GB` to check_failed_tests workflow

### DIFF
--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -44,8 +44,9 @@ env:
   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   TF_FORCE_GPU_ALLOW_GROWTH: true
   CUDA_VISIBLE_DEVICES: 0,1
-  # K8S instance-sharing makes each runner report the full machine's CPU RAM (~750 GB). Cap it to the
-  # amount a dedicated A10 instance would see, so `device_map="auto"` produces a sane device map.
+  # Cap the CPU RAM that psutil reports to pytest so device_map="auto" offloads some layers to disk
+  # instead of packing everything into CPU RAM (K8S runners share a ~750 GB host, causing GPU OOM).
+  # See huggingface/transformers#46539 for details.
   CI_CPU_MEMORY_LIMIT_GB: 60
 
 

--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -44,6 +44,9 @@ env:
   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   TF_FORCE_GPU_ALLOW_GROWTH: true
   CUDA_VISIBLE_DEVICES: 0,1
+  # K8S instance-sharing makes each runner report the full machine's CPU RAM (~750 GB). Cap it to the
+  # amount a dedicated A10 instance would see, so `device_map="auto"` produces a sane device map.
+  CI_CPU_MEMORY_LIMIT_GB: 60
 
 
 permissions:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47884)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47884)
<!-- ci-dashboard-badge:end -->

## Summary

- The `check_failed_tests` workflow re-runs failing tests on the same K8S instance-sharing runners as the daily CI model job, where each runner sees the full machine CPU RAM (~750 GB) instead of its allocated share
- Without `CI_CPU_MEMORY_LIMIT_GB`, `device_map="auto"` in the re-run produces a different device map than in the original CI run, making the comparison inconsistent
- Adds `CI_CPU_MEMORY_LIMIT_GB: 60` to match the value set in [daily-ci_reusable_model_job.yml](https://github.com/huggingface/transformers-ci/blob/89df54a3fb1882cd5cec5a3c19da3ff3b1166fbd/.github/workflows/daily-ci_reusable_model_job.yml#L69) so both workflows cap CPU RAM identically

The env var propagates through the full subprocess chain in `check_bad_commit.py` (Python → `target_script.py` → pytest → conftest.py) since no subprocess call overrides `env=`.

Related: #46539, huggingface/transformers-ci#59