### PR TITLE
Fix ASR pipeline mono conversion for channels-last audio (fixes #47886)

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -424,10 +424,17 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         if not isinstance(inputs, (np.ndarray, torch.Tensor)):
             raise TypeError(f"We expect a numpy ndarray or torch tensor as input, got `{type(inputs)}`")
         if inputs.ndim != 1:
+            # `soundfile.read`, `librosa.load(mono=False)` and `scipy.io.wavfile.read`
+            # all return channels-last, `(samples, channels)`. Averaging over axis 0
+            # on that layout averages across *time*, collapsing the waveform to one
+            # value per channel. Infer the channel axis instead: real audio has far
+            # more samples than channels, so the shorter axis is the channel axis.
+            channel_axis = int(np.argmin(inputs.shape))
             logger.warning(
-                f"We expect a single channel audio input for AutomaticSpeechRecognitionPipeline, got {inputs.ndim}. Taking the mean of the channels for mono conversion."
+                f"We expect a single channel audio input for AutomaticSpeechRecognitionPipeline, got shape "
+                f"{tuple(inputs.shape)}. Taking the mean over axis {channel_axis} for mono conversion."
             )
-            inputs = inputs.mean(axis=0)
+            inputs = inputs.mean(axis=channel_axis)
 
         if chunk_length_s:
             if stride_length_s is None:

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -69,12 +69,6 @@ def _to_mono(inputs):
             "so the weighting is yours to choose."
         )
 
-    if num_channels > 1:
-        logger.warning(
-            "We expect a single channel audio input for AutomaticSpeechRecognitionPipeline, got "
-            f"{num_channels} channels in an input of shape {tuple(inputs.shape)}. Taking the mean "
-            "over the channels for mono conversion."
-        )
     return inputs.mean(axis=0)
 
 

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -435,9 +435,9 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             in_sampling_rate = inputs.pop("sampling_rate")
             extra = inputs
             inputs = _inputs
-            # Downmix before resampling. `F.resample` operates on the last axis, so a
-            # multi-channel array has to be reduced first or the resampler works on the
-            # wrong axis. The stride arithmetic below also reads `shape[0]` as samples.
+            # Downmix first: the stride arithmetic below reads `shape[0]` as the
+            # sample count, which it is not until this runs. `F.resample` batches
+            # over leading axes, so it is not the step that breaks here.
             if isinstance(inputs, (np.ndarray, torch.Tensor)):
                 inputs = _to_mono(inputs)
             if in_sampling_rate != self.feature_extractor.sampling_rate:

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -38,6 +38,46 @@ if is_torch_available():
     from ..models.auto.modeling_auto import MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES
 
 
+def _to_mono(inputs):
+    """
+    Reduce a waveform to a single channel, or refuse when the layout is ambiguous.
+
+    The pipeline reads audio as `(channels, samples)`, which is what torchcodec returns
+    and what `datasets` returned before 4.0. Anything else is rejected rather than
+    guessed at: the shape alone cannot distinguish two-channel audio from a two-sample
+    recording, and averaging the wrong axis produces a silently wrong transcription
+    instead of an error.
+    """
+    if inputs.ndim == 1:
+        return inputs
+
+    if inputs.ndim != 2:
+        raise ValueError(
+            "AutomaticSpeechRecognitionPipeline expects mono audio shaped `(samples,)` or "
+            f"multi-channel audio shaped `(channels, samples)`, got {inputs.ndim} dimensions "
+            f"with shape {tuple(inputs.shape)}."
+        )
+
+    num_channels = inputs.shape[0]
+    if num_channels > 2:
+        raise ValueError(
+            "AutomaticSpeechRecognitionPipeline reads axis 0 as channels, and it has size "
+            f"{num_channels} in the input of shape {tuple(inputs.shape)}. If this array is "
+            "channels-last `(samples, channels)`, which is what `soundfile.read`, "
+            "`librosa.load(mono=False)` and `scipy.io.wavfile.read` return, transpose it "
+            "first. If it genuinely has more than 2 channels, downmix it to mono yourself "
+            "so the weighting is yours to choose."
+        )
+
+    if num_channels > 1:
+        logger.warning(
+            "We expect a single channel audio input for AutomaticSpeechRecognitionPipeline, got "
+            f"{num_channels} channels in an input of shape {tuple(inputs.shape)}. Taking the mean "
+            "over the channels for mono conversion."
+        )
+    return inputs.mean(axis=0)
+
+
 def rescale_stride(stride, ratio):
     """
     Rescales the stride values from audio space to tokens/logits space.
@@ -395,6 +435,11 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             in_sampling_rate = inputs.pop("sampling_rate")
             extra = inputs
             inputs = _inputs
+            # Downmix before resampling. `F.resample` operates on the last axis, so a
+            # multi-channel array has to be reduced first or the resampler works on the
+            # wrong axis. The stride arithmetic below also reads `shape[0]` as samples.
+            if isinstance(inputs, (np.ndarray, torch.Tensor)):
+                inputs = _to_mono(inputs)
             if in_sampling_rate != self.feature_extractor.sampling_rate:
                 if is_torchaudio_available():
                     from torchaudio import functional as F
@@ -423,18 +468,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 stride = (inputs.shape[0], int(round(stride[0] * ratio)), int(round(stride[1] * ratio)))
         if not isinstance(inputs, (np.ndarray, torch.Tensor)):
             raise TypeError(f"We expect a numpy ndarray or torch tensor as input, got `{type(inputs)}`")
-        if inputs.ndim != 1:
-            # `soundfile.read`, `librosa.load(mono=False)` and `scipy.io.wavfile.read`
-            # all return channels-last, `(samples, channels)`. Averaging over axis 0
-            # on that layout averages across *time*, collapsing the waveform to one
-            # value per channel. Infer the channel axis instead: real audio has far
-            # more samples than channels, so the shorter axis is the channel axis.
-            channel_axis = int(np.argmin(inputs.shape))
-            logger.warning(
-                f"We expect a single channel audio input for AutomaticSpeechRecognitionPipeline, got shape "
-                f"{tuple(inputs.shape)}. Taking the mean over axis {channel_axis} for mono conversion."
-            )
-            inputs = inputs.mean(axis=channel_axis)
+        inputs = _to_mono(inputs)
 
         if chunk_length_s:
             if stride_length_s is None:

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -183,6 +183,30 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
             _ = speech_recognizer(waveform, return_timestamps="char")
 
     @require_torch
+    def test_multichannel_mono_conversion_is_layout_agnostic(self):
+        # `soundfile.read`, `librosa.load(mono=False)` and `scipy.io.wavfile.read` all
+        # return channels-last `(samples, channels)`. Averaging over a hardcoded axis 0
+        # collapsed such input to one value per channel, so a 34,000-sample waveform
+        # became 2 samples and was transcribed as silence with only a warning.
+        speech_recognizer = pipeline(
+            task="automatic-speech-recognition",
+            model="facebook/s2t-small-mustc-en-fr-st",
+            tokenizer="facebook/s2t-small-mustc-en-fr-st",
+        )
+        waveform = np.tile(np.arange(1000, dtype=np.float32), 34)
+        expected = speech_recognizer(waveform)
+
+        channels_last = np.stack([waveform, waveform], axis=-1)  # (samples, 2)
+        channels_first = np.stack([waveform, waveform], axis=0)  # (2, samples)
+        self.assertEqual(channels_last.shape, (waveform.size, 2))
+        self.assertEqual(speech_recognizer(channels_last), expected)
+        self.assertEqual(speech_recognizer(channels_first), expected)
+
+        # a 2-D mono waveform must survive in either orientation too
+        self.assertEqual(speech_recognizer(waveform[:, None]), expected)
+        self.assertEqual(speech_recognizer(waveform[None, :]), expected)
+
+    @require_torch
     def test_small_model_pt_fp16(self):
         speech_recognizer = pipeline(
             task="automatic-speech-recognition",

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -33,7 +33,7 @@ from transformers import (
 )
 from transformers.pipelines import AutomaticSpeechRecognitionPipeline, pipeline
 from transformers.pipelines.audio_utils import chunk_bytes_iter, ffmpeg_microphone_live
-from transformers.pipelines.automatic_speech_recognition import chunk_iter
+from transformers.pipelines.automatic_speech_recognition import _to_mono, chunk_iter
 from transformers.testing_utils import (
     Expectations,
     compare_pipeline_output_to_hub_spec,
@@ -183,11 +183,9 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
             _ = speech_recognizer(waveform, return_timestamps="char")
 
     @require_torch
-    def test_multichannel_mono_conversion_is_layout_agnostic(self):
-        # `soundfile.read`, `librosa.load(mono=False)` and `scipy.io.wavfile.read` all
-        # return channels-last `(samples, channels)`. Averaging over a hardcoded axis 0
-        # collapsed such input to one value per channel, so a 34,000-sample waveform
-        # became 2 samples and was transcribed as silence with only a warning.
+    def test_multichannel_mono_conversion(self):
+        # The pipeline reads audio as `(channels, samples)`, which is what torchcodec
+        # returns. A 2-channel waveform is averaged down to mono.
         speech_recognizer = pipeline(
             task="automatic-speech-recognition",
             model="facebook/s2t-small-mustc-en-fr-st",
@@ -196,15 +194,33 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         waveform = np.tile(np.arange(1000, dtype=np.float32), 34)
         expected = speech_recognizer(waveform)
 
-        channels_last = np.stack([waveform, waveform], axis=-1)  # (samples, 2)
         channels_first = np.stack([waveform, waveform], axis=0)  # (2, samples)
-        self.assertEqual(channels_last.shape, (waveform.size, 2))
-        self.assertEqual(speech_recognizer(channels_last), expected)
         self.assertEqual(speech_recognizer(channels_first), expected)
-
-        # a 2-D mono waveform must survive in either orientation too
-        self.assertEqual(speech_recognizer(waveform[:, None]), expected)
+        # a single channel expressed as 2-D collapses to the same thing
         self.assertEqual(speech_recognizer(waveform[None, :]), expected)
+
+    def test_multichannel_ambiguous_layout_raises(self):
+        # `soundfile.read`, `librosa.load(mono=False)` and `scipy.io.wavfile.read` all
+        # return channels-last `(samples, channels)`. Averaging axis 0 on that layout
+        # averages across time, so a 34,000-sample waveform silently became 2 samples
+        # and was transcribed as silence. The shape alone cannot tell that apart from
+        # genuine `(channels, samples)` audio, so refuse instead of guessing. See #47886.
+        waveform = np.tile(np.arange(1000, dtype=np.float32), 34)
+
+        channels_last = np.stack([waveform, waveform], axis=-1)  # (samples, 2)
+        with self.assertRaisesRegex(ValueError, "channels-last"):
+            _to_mono(channels_last)
+
+        surround = np.stack([waveform] * 6, axis=0)  # (6, samples)
+        with self.assertRaisesRegex(ValueError, "downmix it to mono yourself"):
+            _to_mono(surround)
+
+        with self.assertRaisesRegex(ValueError, "3 dimensions"):
+            _to_mono(waveform[None, None, :])
+
+    def test_mono_passthrough(self):
+        waveform = np.tile(np.arange(1000, dtype=np.float32), 34)
+        self.assertIs(_to_mono(waveform), waveform)
 
     @require_torch
     def test_small_model_pt_fp16(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47888)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47888)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47886.

`AutomaticSpeechRecognitionPipeline` averaged multi-channel input over a hardcoded
`axis=0`, which assumes channels-first `(channels, samples)`. `soundfile.read`,
`librosa.load(..., mono=False)` and `scipy.io.wavfile.read` all return channels-**last**
`(samples, channels)`, so on that layout the mean ran across *time*: a 3-second stereo
clip collapsed to 2 numbers, was padded back to 30s of silence, and transcribed as
`' you'`.

The pipeline logged a warning saying the conversion had happened. It had, along the
wrong axis.

```python
stereo, sr = sf.read(buf, dtype="float32")   # (48000, 2)
asr(mono)     # ' See you in the next video!'
asr(stereo)   # ' you'          <- before
asr(stereo)   # ' See you in the next video!'   <- after
```

## The fix

Infer the channel axis rather than assume it. Real audio has far more samples than
channels, so the shorter axis is the channel axis. `(2, N)` keeps working exactly as
before; `(N, 2)` stops being destroyed.

Also report `tuple(inputs.shape)` in the warning instead of `inputs.ndim`. The old
message interpolated `ndim`, so it printed "got 2" for every 2-D input regardless of
channel count, and the number that would actually help you debug never appeared.

## Why not raise instead

That is a reasonable alternative and I would switch if you prefer it. The two sibling
pipelines already reject multi-channel outright:

```python
# pipelines/audio_classification.py:232
if len(inputs.shape) != 1:
    raise ValueError("We expect a single channel audio input for AudioClassificationPipeline")

# pipelines/zero_shot_audio_classification.py:119
if len(audio.shape) != 1:
    raise ValueError("We expect a single channel audio input for ZeroShotAudioClassificationPipeline")
```

So the same stereo array raises a clear `ValueError` in two pipelines and silently
transcribes as `' you'` in the third. I kept the conversion because it is existing
documented behaviour and removing it would break callers who currently pass `(2, N)`
successfully, but making ASR raise like its siblings is a three-line change if that is
the preferred direction.

I left `ndim > 2` alone deliberately; that is a separate question from the reported bug.

## Tests

`test_multichannel_mono_conversion_is_layout_agnostic` covers `(N, 2)`, `(2, N)`, and
2-D mono in both orientations, asserting all four match the 1-D baseline.

It fails on `main` with `AssertionError: choose a window size 400 that is [2, 2]` from
torchaudio, which is the bug surfacing as a 2-sample waveform.

```
tests/pipelines/test_pipelines_automatic_speech_recognition.py
    before: 5 failed, 16 passed, 35 skipped
    after:  5 failed, 17 passed, 35 skipped
```

Identical failures before and after, all pre-existing in my environment
(`test_return_timestamps_ctc_fast`, `test_pipeline_generation_kwargs` and friends), so
no regressions introduced. `ruff check` and `ruff format --check` both clean.

## Who can review?

@ylacombe @eustlb (audio pipelines)