### PR TITLE
Fix NeMo conversion for Parakeet TDT checkpoints without a <pad> token (parakeet-tdt-0.6b-v2)

### DIFF
--- a/src/transformers/models/parakeet/convert_nemo_to_hf.py
+++ b/src/transformers/models/parakeet/convert_nemo_to_hf.py
@@ -158,7 +158,10 @@ def write_processor(
         tokenizer_converted_fast.add_tokens([AddedToken("<unk>", normalized=False, special=True)])
         print(f"Added <unk> token at ID: {tokenizer_converted_fast.convert_tokens_to_ids('<unk>')}")
 
-    if model_type == "rnnt":
+    # parakeet-tdt-0.6b-v2's NeMo vocab (unlike v3's) carries no <pad>, so its blank must land on
+    # `len(labels)` exactly like RNN-T's — take the RNN-T ordering for that case.
+    tdt_without_pad = model_type == "tdt" and tokenizer_converted_fast.convert_tokens_to_ids("<pad>") is None
+    if model_type == "rnnt" or tdt_without_pad:
         # RNN-T (unlike TDT) has no dedicated pad token in its NeMo vocab. NeMo's blank is the final vocab entry,
         # i.e. `config.blank_token_id == len(labels)`, and the joint head emits exactly `len(labels) + 1` logits.
         # Add `<blank>` *first* so it lands on that id (no `<pad>` is appended to push it past the model's vocab),
@@ -349,7 +352,7 @@ def convert_tdt_config(nemo_config, encoder_config):
         hidden_act="relu",
         max_symbols_per_step=10,
         encoder_config=encoder_config.to_dict(),
-        pad_token_id=labels.index("<pad>"),
+        pad_token_id=labels.index("<pad>") if "<pad>" in labels else blank_token_id,
         blank_token_id=blank_token_id,  # blank token is different from pad token for TDT
     )
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47891)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47891)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`src/transformers/models/parakeet/convert_nemo_to_hf.py` fails on NVIDIA's `parakeet-tdt-0.6b-v2` checkpoint, which matters because v2 is distributed only as a `.nemo` file and this converter is the sole path to an HF-format checkpoint for it. The failure has two parts, and the second one is silent.

**Bug 1, a crash.** v2's NeMo vocab has 1024 labels and, unlike v3's, contains no `<pad>` entry. `convert_tdt_config` calls `labels.index("<pad>")` unconditionally and raises `ValueError: '<pad>' is not in list`.

**Bug 2, silent corruption.** If the crash is papered over by simply appending a `<pad>` token, the TDT branch of `write_processor` places `<pad>` at id 1024 and `<blank>` at id 1025. The checkpoint's joint head emits 1030 logits (1025 token logits plus 5 duration logits) and its blank id is 1024. Decoding with blank at 1025 produces transcripts that look plausible but are subtly wrong, and nothing errors. This is the dangerous case, since a user would ship it without noticing.

## The fix

When a TDT vocab carries no `<pad>` entry, take the existing RNN-T ordering: add `<blank>` first so it lands on `len(labels)`, which is exactly where the checkpoint's blank id points, and reuse the blank id as `pad_token_id`. v3 checkpoints, which do carry `<pad>`, are unaffected and keep the current TDT path. The change is two small hunks and introduces no new configuration surface.

## Verification

After this fix, we converted `nvidia/parakeet-tdt-0.6b-v2` and validated the result against the NeMo/PyTorch reference implementation. A hand-rolled greedy TDT loop over the converted model matches `generate()` token for token on a 30 second probe (82 of 82 tokens), and end-to-end transcripts remained token-exact across a multi-hour audiobook validation corpus. Without the second fix, the same pipeline yields plausible but wrong transcripts, which is how we found the bug in the first place.

Converted config facts for reviewers who want to spot-check: `vocab_size=1025`, `blank_token_id=1024`, `durations=[0, 1, 2, 3, 4]`, and the encoder is identical to v3's, so only the tokenizer and vocab handling differ between the two releases.