### PR TITLE
Fix gemma4 video to device

### DIFF
--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -2341,7 +2341,7 @@ class Gemma4Model(Gemma4PreTrainedModel):
             video_features = self.get_video_features(
                 pixel_values_videos, video_position_ids, return_dict=True
             ).pooler_output
-            video_features = video_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            video_features = torch.cat(video_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
 
             # Confirm the number of soft tokens from the vision tower matches the number of slots in the embeddings.
             n_video_tokens = video_mask.sum()

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -2066,7 +2066,7 @@ class Gemma4Model(Gemma3nModel):
             video_features = self.get_video_features(
                 pixel_values_videos, video_position_ids, return_dict=True
             ).pooler_output
-            video_features = video_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            video_features = torch.cat(video_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
 
             # Confirm the number of soft tokens from the vision tower matches the number of slots in the embeddings.
             n_video_tokens = video_mask.sum()

--- a/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py
+++ b/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py
@@ -933,13 +933,14 @@ class Gemma4UnifiedModel(Gemma4UnifiedPreTrainedModel):
         # Strip padding patches before scattering into text sequence.
         # Padding patches have position_ids == -1 on both axes.
         # We only scatter non-padding patches into the placeholder token positions.
-        padding_mask = (image_position_ids == -1).all(dim=-1).to(vision_outputs.device)  # (batch, num_patches)
+        non_pad_mask = (image_position_ids != -1).all(dim=-1).to(vision_outputs.device)  # (batch, num_patches)
 
         # Flatten valid patches: keep only non-padding patches across the batch
-        vision_outputs = vision_outputs[~padding_mask]  # (total_valid_patches, text_hidden_size)
+        vision_outputs = vision_outputs[non_pad_mask]  # (total_valid_patches, text_hidden_size)
 
+        split_sizes = non_pad_mask.sum(dim=-1).tolist()
         return Gemma4UnifiedVisionModelOutput(
-            pooler_output=vision_outputs,
+            pooler_output=torch.split(vision_outputs, split_sizes),
         )
 
     def get_placeholder_mask(
@@ -1033,7 +1034,7 @@ class Gemma4UnifiedModel(Gemma4UnifiedPreTrainedModel):
         # Merge text and images
         if pixel_values is not None:
             image_features = self.get_image_features(pixel_values, image_position_ids, return_dict=True).pooler_output
-            image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            image_features = torch.cat(image_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
 
             # Confirm the number of soft tokens from the vision tower matches the number of slots in the embeddings.
             n_image_tokens = image_mask.sum()
@@ -1050,7 +1051,7 @@ class Gemma4UnifiedModel(Gemma4UnifiedPreTrainedModel):
             video_features = self.get_video_features(
                 pixel_values_videos, video_position_ids, return_dict=True
             ).pooler_output
-            video_features = video_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            video_features = torch.cat(video_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
 
             # Confirm the number of soft tokens from the vision tower matches the number of slots in the embeddings.
             n_video_tokens = video_mask.sum()
@@ -1175,12 +1176,18 @@ class Gemma4UnifiedModel(Gemma4UnifiedPreTrainedModel):
         video_position_ids (`torch.LongTensor` of shape `(num_videos, num_frames, max_patches, 2)`, *optional*):
             2D patch position coordinates from the video processor, with `(-1, -1)` indicating padding.
         """
-        # Flatten video frames: (num_videos, num_frames, ...) → (num_videos*num_frames, ...)
-        pixel_values_videos = pixel_values_videos.flatten(0, 1)
-        video_position_ids = video_position_ids.flatten(0, 1)
+        vision_outputs = self.embed_vision(pixel_values_videos.flatten(0, 1), video_position_ids.flatten(0, 1))
 
-        # Use the same unified pipeline as images
-        return self.get_image_features(pixel_values_videos, video_position_ids, **kwargs)
+        # Strip padding patches before scattering into text sequence.
+        non_pad_mask = (video_position_ids != -1).all(dim=-1).to(vision_outputs.device)
+
+        # Flatten valid patches: keep only non-padding patches across all frames
+        vision_outputs = vision_outputs[non_pad_mask.flatten(0, 1)]  # (total_valid_patches, text_hidden_size)
+
+        split_sizes = non_pad_mask.sum(dim=(-2, -1)).tolist()
+        return Gemma4UnifiedVisionModelOutput(
+            pooler_output=torch.split(vision_outputs, split_sizes),
+        )
 
 
 def create_masks_for_vision_model(

--- a/src/transformers/models/gemma4_unified/modular_gemma4_unified.py
+++ b/src/transformers/models/gemma4_unified/modular_gemma4_unified.py
@@ -944,13 +944,14 @@ class Gemma4UnifiedModel(Gemma4Model):
         # Strip padding patches before scattering into text sequence.
         # Padding patches have position_ids == -1 on both axes.
         # We only scatter non-padding patches into the placeholder token positions.
-        padding_mask = (image_position_ids == -1).all(dim=-1).to(vision_outputs.device)  # (batch, num_patches)
+        non_pad_mask = (image_position_ids != -1).all(dim=-1).to(vision_outputs.device)  # (batch, num_patches)
 
         # Flatten valid patches: keep only non-padding patches across the batch
-        vision_outputs = vision_outputs[~padding_mask]  # (total_valid_patches, text_hidden_size)
+        vision_outputs = vision_outputs[non_pad_mask]  # (total_valid_patches, text_hidden_size)
 
+        split_sizes = non_pad_mask.sum(dim=-1).tolist()
         return Gemma4UnifiedVisionModelOutput(
-            pooler_output=vision_outputs,
+            pooler_output=torch.split(vision_outputs, split_sizes),
         )
 
     @can_return_tuple
@@ -965,12 +966,18 @@ class Gemma4UnifiedModel(Gemma4Model):
         video_position_ids (`torch.LongTensor` of shape `(num_videos, num_frames, max_patches, 2)`, *optional*):
             2D patch position coordinates from the video processor, with `(-1, -1)` indicating padding.
         """
-        # Flatten video frames: (num_videos, num_frames, ...) → (num_videos*num_frames, ...)
-        pixel_values_videos = pixel_values_videos.flatten(0, 1)
-        video_position_ids = video_position_ids.flatten(0, 1)
+        vision_outputs = self.embed_vision(pixel_values_videos.flatten(0, 1), video_position_ids.flatten(0, 1))
 
-        # Use the same unified pipeline as images
-        return self.get_image_features(pixel_values_videos, video_position_ids, **kwargs)
+        # Strip padding patches before scattering into text sequence.
+        non_pad_mask = (video_position_ids != -1).all(dim=-1).to(vision_outputs.device)
+
+        # Flatten valid patches: keep only non-padding patches across all frames
+        vision_outputs = vision_outputs[non_pad_mask.flatten(0, 1)]  # (total_valid_patches, text_hidden_size)
+
+        split_sizes = non_pad_mask.sum(dim=(-2, -1)).tolist()
+        return Gemma4UnifiedVisionModelOutput(
+            pooler_output=torch.split(vision_outputs, split_sizes),
+        )
 
     @can_return_tuple
     @auto_docstring(
@@ -1045,7 +1052,7 @@ class Gemma4UnifiedModel(Gemma4Model):
         # Merge text and images
         if pixel_values is not None:
             image_features = self.get_image_features(pixel_values, image_position_ids, return_dict=True).pooler_output
-            image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            image_features = torch.cat(image_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
 
             # Confirm the number of soft tokens from the vision tower matches the number of slots in the embeddings.
             n_image_tokens = image_mask.sum()
@@ -1062,7 +1069,7 @@ class Gemma4UnifiedModel(Gemma4Model):
             video_features = self.get_video_features(
                 pixel_values_videos, video_position_ids, return_dict=True
             ).pooler_output
-            video_features = video_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            video_features = torch.cat(video_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
 
             # Confirm the number of soft tokens from the vision tower matches the number of slots in the embeddings.
             n_video_tokens = video_mask.sum()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47896)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47896)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes `video_features.to(device)` which failed because `video_features` is now a tuple and not a tensor (since https://github.com/huggingface/transformers/pull/46405).

I also aligned gemma4 unified to follow the new the new shapes for image and video features.

@zucchini-nlp I noticed that diffusion gemma doesn't follow the expected shapes either but didn't change it as https://github.com/huggingface/transformers/pull/46405 explicitly added it that way. 

<!-- Remove if not applicable -->

Fixes https://github.com/huggingface/transformers/issues/47879