### PR TITLE
Added device validation function, function call in main pipeline, and unit tests

### DIFF
--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -303,6 +303,48 @@ def get_supported_tasks() -> list[str]:
     return PIPELINE_REGISTRY.get_supported_tasks()
 
 
+def _validate_device(device):
+    """Validates device input early before model loading."""
+    if device is None:
+        return
+
+    # Integer ordinals (e.g., device=0)
+    if isinstance(device, int):
+        if device < -1:
+            raise ValueError(f"Invalid device ordinal '{device}'. Must be >= -1.")
+        return
+
+    # torch.device instances
+    if isinstance(device, torch.device):
+        return
+
+    # String device types
+    if isinstance(device, str):
+        device_str = device.strip().lower()
+        
+        # If passed as a numeric string (e.g., device="0" or device="-1")
+        if device_str.isdigit() or (device_str.startswith("-") and device_str[1:].isdigit()):
+            if int(device_str) < -1:
+                raise ValueError(f"Invalid device ordinal '{device}'. Must be >= -1.")
+            return
+
+        base_device = device_str.split(":")[0]
+        valid_devices = {
+            "cpu", "cuda", "mps", "npu", "xpu", "hpu", 
+            "ipu", "meta", "vulkan", "opencl", "directml"
+        }
+        if base_device not in valid_devices:
+            raise ValueError(
+                f"Invalid device string '{device}'. Expected a valid device string "
+                f"(e.g., 'cpu', 'cuda', 'mps', 'npu'), an integer device ordinal, or a `torch.device` instance."
+            )
+        return
+
+    raise TypeError(
+        f"Invalid device type '{type(device).__name__}'. Expected `str`, `int`, `torch.device`, or `None`."
+    )
+
+
 def get_task(model: str, token: str | None = None, **deprecated_kwargs) -> str:
     if is_offline_mode():
         raise RuntimeError("You cannot infer task automatically within `pipeline` when using offline mode")
@@ -838,6 +880,7 @@ def pipeline(
     >>> tokenizer = AutoTokenizer.from_pretrained("google-bert/bert-base-cased")
     >>> recognizer = pipeline("ner", model=model, tokenizer=tokenizer)
     ```"""
+    _validate_device(device)
     if model_kwargs is None:
         model_kwargs = {}
 

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -57,7 +57,7 @@ from transformers.testing_utils import (
 from transformers.utils import direct_transformers_import, is_torch_available
 from transformers.utils import logging as transformers_logging
 from transformers.utils.chat_template_utils import Chat
-
+from transformers.pipelines import _validate_device
 
 sys.path.append(str(Path(__file__).parent.parent.parent / "utils"))
 
@@ -114,6 +114,23 @@ class CommonPipelineTest(unittest.TestCase):
         pipe = pipeline(model="hf-internal-testing/tiny-random-distilbert")
 
         self.assertIsInstance(pipe, TextClassificationPipeline)
+
+    @require_torch
+    def test_pipeline_invalid_device_raises_early(self):
+        """Verify that an invalid device string raises a ValueError immediately before model loading."""
+        with self.assertRaises(ValueError):
+            _validate_device("mpx")
+        with self.assertRaises(ValueError):
+            _validate_device(-5)
+
+    @require_torch
+    def test_pipeline_valid_devices_pass(self):
+        """Verify that standard valid device configurations pass validation cleanly."""
+        _validate_device("cpu")
+        _validate_device("cuda:0")
+        _validate_device("mps")
+        _validate_device(0)
+        _validate_device(None)
 
     @require_torch
     def test_pipeline_batch_size_global(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47898)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47898)
<!-- ci-dashboard-badge:end -->

…ests

# What does this PR do?

This PR added an early device validation function in the pipeline, which prevents code failure caused by a misspelled "device" argument value, only after the entire model download is completed.

The current validate helper function runs before the model download execution and throws ValueError if an invalid device type is passed. The included unit tests check the required behavior as well.

Fixes #47869

- [x] (First-time contributors only): I confirm that this PR description is not written by an LLM or code agent; I have used external LLM help to fix issues with the validation function, and that is all.


## Who can review?

Anyone in the community. Kindly suggest improvements