### PR TITLE
fix(utils): include original cause in _LazyModule ModuleNotFoundError

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -2386,7 +2386,7 @@ class _LazyModule(ModuleType):
         super().__init__(name)
 
         self._object_missing_backend = {}
-        self._explicit_import_shortcut = explicit_import_shortcut if explicit_import_shortcut else {}
+        self._explicit_import_shortcut = explicit_import_shortcut or {}
 
         if any(isinstance(key, frozenset) for key in import_structure):
             self._modules = set()

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -2617,11 +2617,11 @@ class _LazyModule(ModuleType):
 
                         if value is None:
                             raise ModuleNotFoundError(
-                                f"Could not import module '{name}'. Are this object's requirements defined correctly?"
+                                f"Could not import module '{name}'. Are this object's requirements defined correctly? Caused by: {e}"
                             ) from e
                 else:
                     raise ModuleNotFoundError(
-                        f"Could not import module '{name}'. Are this object's requirements defined correctly?"
+                        f"Could not import module '{name}'. Are this object's requirements defined correctly? Caused by: {e}"
                     ) from e
 
         elif name in self._modules:
@@ -2629,7 +2629,7 @@ class _LazyModule(ModuleType):
                 value = self._get_module(name)
             except (ModuleNotFoundError, RuntimeError) as e:
                 raise ModuleNotFoundError(
-                    f"Could not import module '{name}'. Are this object's requirements defined correctly?"
+                    f"Could not import module '{name}'. Are this object's requirements defined correctly? Caused by: {e}"
                 ) from e
         else:
             # V5: If a *TokenizerFast symbol is requested but not present in the import structure,

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -353,3 +353,18 @@ def test_availability_helpers_are_compile_safe(helper_name: str, args: tuple):
         return x + 1 if helper(*args) else x - 1
 
     run(torch.zeros(3))  # a graph break inside the helper would raise here
+
+
+def test_lazy_module_error_message_includes_cause():
+    import pytest
+    from transformers.utils import _LazyModule
+
+    import_structure = {"fake_module": ["FakeClass"]}
+    lazy_mod = _LazyModule("fake_module", "/fake/file.py", import_structure)
+    lazy_mod._class_to_module = {"FakeClass": "transformers.models.fake.modeling_fake"}
+
+    with patch.object(lazy_mod, "_get_module", side_effect=ModuleNotFoundError("No module named 'fake_dep'")):
+        with pytest.raises(ModuleNotFoundError) as exc_info:
+            _ = lazy_mod.FakeClass
+        assert "Caused by: No module named 'fake_dep'" in str(exc_info.value)
+

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -357,6 +357,7 @@ def test_availability_helpers_are_compile_safe(helper_name: str, args: tuple):
 
 def test_lazy_module_error_message_includes_cause():
     import pytest
+
     from transformers.utils import _LazyModule
 
     import_structure = {"fake_module": ["FakeClass"]}
@@ -367,4 +368,3 @@ def test_lazy_module_error_message_includes_cause():
         with pytest.raises(ModuleNotFoundError) as exc_info:
             _ = lazy_mod.FakeClass
         assert "Caused by: No module named 'fake_dep'" in str(exc_info.value)
-


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47899)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47899)
<!-- ci-dashboard-badge:end -->

What is the purpose of this PR?

Fixes #47893

If an optional module like accelerate or sentencepiece is not installed in your system, and the import fails, for example when using MistralForSequenceClassification, then `_LazyModule.__getattr__` will catch the underlying ModuleNotFoundError and raise a generic error message. This obscures what is really needed from the user.

This PR enhances the `_LazyModule.__getattr__` function with the original exception information (`Caused by: {e}`). This provides instant, unmistakable diagnostic information of what package is missing.

I've also written a unit test in tests/utils/test_import_utils.py to make sure that exception causes are preserved.

## Code Agent Policy

- [x] (Only for the first time) I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Have read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Has a Github issue or the forum been consulted/approved? Please add a link to it if that's the case. (Fixes #47893)
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

- model loading / import_utils: @CyrilVallez @ArthurZucker