### PR TITLE
Fix compressed-tensors loading for KV-cache-only quantized models

### DIFF
--- a/src/transformers/quantizers/quantizer_compressed_tensors.py
+++ b/src/transformers/quantizers/quantizer_compressed_tensors.py
@@ -106,9 +106,6 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
                 modules_to_not_convert=self.modules_to_not_convert,
             )
 
-        if not remaining_groups:
-            return
-
         from compressed_tensors.quantization import apply_quantization_config
 
         remaining_config = deepcopy(ct_config)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47904)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47904)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes loading of KV-cache-only quantized models (e.g. `inference-optimization/tinysmokeqwen3-fp8-kv-only`) with the compressed-tensors quantizer.

## Problem

In `_process_model_before_weight_loading`, the early return `if not remaining_groups: return` was added to skip `apply_quantization_config` when all config groups were already handled by the FP8 kernel path. However, `apply_quantization_config` is also responsible for setting up KV-cache quantization observers and scales. For models that **only** have KV-cache quantization (no weight quantization groups), `remaining_groups` is empty and the early return skips KV-cache setup entirely, causing the model to load without any quantization applied.

## Fix

Remove the early return so that `apply_quantization_config` always runs. When `remaining_groups` is empty, it receives an empty `config_groups` dict — this is a no-op for weight quantization but still correctly processes KV-cache quantization config.

## Example

Loading `inference-optimization/tinysmokeqwen3-fp8-kv-only`:

**Before (broken):** `apply_quantization_config` is skipped, KV-cache quantization is not applied, and the model behaves as if unquantized.

**After (fixed):** `apply_quantization_config` runs, KV-cache quantization observers/scales are correctly initialized, and the model loads as expected.

## Follow-up

- Add a dedicated test for KV-cache-only model loading in the compressed-tensors test suite
- Refactor compressed-tensors tests to use modern models and more robust test metrics

## Before submitting
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?

## Who can review?

@SunMarc @MekkCyber