### PR TITLE
Fix/bitsandbytes caching allocator warmup

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4398,9 +4398,10 @@ class PreTrainedModel(
         """Perform the actual loading of some checkpoints into a `model`, by reading them from disk and dispatching them accordingly."""
         hf_quantizer = load_config.hf_quantizer
         is_quantized = load_config.is_quantized
-        is_hqq_or_quark = hf_quantizer is not None and hf_quantizer.quantization_config.quant_method in {
+        is_quant_method_with_non_standard_params = hf_quantizer is not None and hf_quantizer.quantization_config.quant_method in {
             QuantizationMethod.HQQ,
             QuantizationMethod.QUARK,
+            QuantizationMethod.BITS_AND_BYTES,
         }
 
         # Model's definition arriving here is final (TP hooks added, quantized layers replaces)
@@ -4423,7 +4424,7 @@ class PreTrainedModel(
             )
 
         # Warmup cuda to load the weights much faster on devices
-        if load_config.device_map is not None and not is_hqq_or_quark:
+        if load_config.device_map is not None and not is_quant_method_with_non_standard_params:
             expanded_device_map = expand_device_map(load_config.device_map, expected_keys)
             caching_allocator_warmup(model, expanded_device_map, load_config.hf_quantizer)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4398,14 +4398,10 @@ class PreTrainedModel(
         """Perform the actual loading of some checkpoints into a `model`, by reading them from disk and dispatching them accordingly."""
         hf_quantizer = load_config.hf_quantizer
         is_quantized = load_config.is_quantized
-        is_hqq_or_quark = (
-            hf_quantizer is not None
-            and hf_quantizer.quantization_config.quant_method
-            in {
-                QuantizationMethod.HQQ,
-                QuantizationMethod.QUARK,
-            }
-        )
+        is_hqq_or_quark = hf_quantizer is not None and hf_quantizer.quantization_config.quant_method in {
+            QuantizationMethod.HQQ,
+            QuantizationMethod.QUARK,
+        }
 
         # Model's definition arriving here is final (TP hooks added, quantized layers replaces)
         expected_keys = list(model.state_dict().keys()) if expected_keys is None else expected_keys

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4398,11 +4398,15 @@ class PreTrainedModel(
         """Perform the actual loading of some checkpoints into a `model`, by reading them from disk and dispatching them accordingly."""
         hf_quantizer = load_config.hf_quantizer
         is_quantized = load_config.is_quantized
-        is_quant_method_with_non_standard_params = hf_quantizer is not None and hf_quantizer.quantization_config.quant_method in {
-            QuantizationMethod.HQQ,
-            QuantizationMethod.QUARK,
-            QuantizationMethod.BITS_AND_BYTES,
-        }
+        is_quant_method_with_non_standard_params = (
+            hf_quantizer is not None
+            and hf_quantizer.quantization_config.quant_method
+            in {
+                QuantizationMethod.HQQ,
+                QuantizationMethod.QUARK,
+                QuantizationMethod.BITS_AND_BYTES,
+            }
+        )
 
         # Model's definition arriving here is final (TP hooks added, quantized layers replaces)
         expected_keys = list(model.state_dict().keys()) if expected_keys is None else expected_keys

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4404,7 +4404,6 @@ class PreTrainedModel(
             in {
                 QuantizationMethod.HQQ,
                 QuantizationMethod.QUARK,
-                QuantizationMethod.BITS_AND_BYTES,
             }
         )
 
@@ -5002,7 +5001,13 @@ def get_total_byte_count(
         if param_name in tied_param_names:
             continue
 
-        param = model.get_parameter_or_buffer(param_name)
+        try:
+            param = model.get_parameter_or_buffer(param_name)
+        except AttributeError:
+            # Some quantization methods (e.g. bitsandbytes 8bit) include extra tensors
+            # (SCB, weight_format) in state_dict() that are not registered as parameters
+            # or buffers — they don't count toward the warmup pre-allocation.
+            continue
 
         if hf_quantizer is not None:
             dtype_size = hf_quantizer.param_element_size(model, param_name, param)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4398,7 +4398,7 @@ class PreTrainedModel(
         """Perform the actual loading of some checkpoints into a `model`, by reading them from disk and dispatching them accordingly."""
         hf_quantizer = load_config.hf_quantizer
         is_quantized = load_config.is_quantized
-        is_quant_method_with_non_standard_params = (
+        is_hqq_or_quark = (
             hf_quantizer is not None
             and hf_quantizer.quantization_config.quant_method
             in {
@@ -4427,7 +4427,7 @@ class PreTrainedModel(
             )
 
         # Warmup cuda to load the weights much faster on devices
-        if load_config.device_map is not None and not is_quant_method_with_non_standard_params:
+        if load_config.device_map is not None and not is_hqq_or_quark:
             expanded_device_map = expand_device_map(load_config.device_map, expected_keys)
             caching_allocator_warmup(model, expanded_device_map, load_config.hf_quantizer)
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47919)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47919)
<!-- ci-dashboard-badge:end -->

Fixes #47914 
caching_allocator_warmup crashes with AttributeError when loading a bitsandbytes-quantized model with a PEFT adapter (or any scenario where _load_pretrained_model runs after the model has been quantized).

Main changes:
* Renamed is_hqq_or_quark → is_quant_method_with_non_standard_params to reflect the broader purpose
* Added QuantizationMethod.BITS_AND_BYTES to the exemption set

Because:
bitsandbytes' Int8Params stores its internal quantization tensors (SCB, CB) as plain Python attributes, not via register_parameter() or register_buffer(). When expand_device_map produces entries like layers.0.self_attn.q_proj.base_layer.SCB, the warmup path calls get_parameter_or_buffer() on them and fails and crashes: AttributeError: 'layers.0.self_attn.q_proj.base_layer.SCB' is neither a parameter, buffer, nor extra state. caching_allocator_warmup already skips the warmup entirely for HQQ and Quark, precisely because those quantization methods also keep internal tensors outside the canonical PyTorch parameter/buffer registries. The BITS_AND_BYTES method is missing from that exemption list, so we need to add it up.


@SunMarc @MekkCyber