### PR TITLE
Fix CLIP _init_weights when a child module carries quantized weights

### DIFF
--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -383,6 +383,18 @@ class CLIPEncoderLayer(GradientCheckpointingLayer):
         return hidden_states
 
 
+def _init_child_weight(child: nn.Module, std: float) -> None:
+    """Initialize `child.weight` if the child module still carries one.
+
+    `CLIPPreTrainedModel._init_weights` initializes the parameters of child modules by name, and a quantized
+    checkpoint replaces `weight` on those children with packed tensors (`weight_packed` for compressed-tensors,
+    `qweight` for GPTQ/AWQ). Reading `.weight` unconditionally would then raise an `AttributeError` while
+    `from_pretrained` initializes the keys that are missing from the checkpoint.
+    """
+    if getattr(child, "weight", None) is not None:
+        init.normal_(child.weight, std=std)
+
+
 @auto_docstring
 class CLIPPreTrainedModel(PreTrainedModel):
     config: CLIPConfig
@@ -406,50 +418,35 @@ class CLIPPreTrainedModel(PreTrainedModel):
         super()._init_weights(module)
         factor = self.config.initializer_factor
         if isinstance(module, CLIPTextEmbeddings):
-            init.normal_(module.token_embedding.weight, mean=0.0, std=factor * 0.02)
-            init.normal_(module.position_embedding.weight, mean=0.0, std=factor * 0.02)
+            _init_child_weight(module.token_embedding, factor * 0.02)
+            _init_child_weight(module.position_embedding, factor * 0.02)
             init.copy_(module.position_ids, torch.arange(module.position_ids.shape[-1]).expand((1, -1)))
         elif isinstance(module, CLIPVisionEmbeddings):
             init.normal_(module.class_embedding, mean=0.0, std=module.embed_dim**-0.5 * factor)
-            init.normal_(module.patch_embedding.weight, std=module.config.initializer_range * factor)
-            init.normal_(module.position_embedding.weight, std=module.config.initializer_range * factor)
+            _init_child_weight(module.patch_embedding, module.config.initializer_range * factor)
+            _init_child_weight(module.position_embedding, module.config.initializer_range * factor)
             init.copy_(module.position_ids, torch.arange(module.num_positions).expand((1, -1)))
         elif isinstance(module, CLIPAttention):
             in_proj_std = (module.embed_dim**-0.5) * ((2 * module.config.num_hidden_layers) ** -0.5) * factor
             out_proj_std = (module.embed_dim**-0.5) * factor
-            init.normal_(module.q_proj.weight, std=in_proj_std)
-            init.normal_(module.k_proj.weight, std=in_proj_std)
-            init.normal_(module.v_proj.weight, std=in_proj_std)
-            init.normal_(module.out_proj.weight, std=out_proj_std)
+            _init_child_weight(module.q_proj, in_proj_std)
+            _init_child_weight(module.k_proj, in_proj_std)
+            _init_child_weight(module.v_proj, in_proj_std)
+            _init_child_weight(module.out_proj, out_proj_std)
         elif isinstance(module, CLIPMLP):
             in_proj_std = (module.config.hidden_size**-0.5) * ((2 * module.config.num_hidden_layers) ** -0.5) * factor
             fc_std = (2 * module.config.hidden_size) ** -0.5 * factor
-            init.normal_(module.fc1.weight, std=fc_std)
-            init.normal_(module.fc2.weight, std=in_proj_std)
+            _init_child_weight(module.fc1, fc_std)
+            _init_child_weight(module.fc2, in_proj_std)
         elif isinstance(module, CLIPModel):
-            init.normal_(
-                module.text_projection.weight,
-                std=module.text_embed_dim**-0.5 * factor,
-            )
-            init.normal_(
-                module.visual_projection.weight,
-                std=module.vision_embed_dim**-0.5 * factor,
-            )
+            _init_child_weight(module.text_projection, module.text_embed_dim**-0.5 * factor)
+            _init_child_weight(module.visual_projection, module.vision_embed_dim**-0.5 * factor)
         elif isinstance(module, CLIPVisionModelWithProjection):
-            init.normal_(
-                module.visual_projection.weight,
-                std=self.config.hidden_size**-0.5 * factor,
-            )
+            _init_child_weight(module.visual_projection, self.config.hidden_size**-0.5 * factor)
         elif isinstance(module, CLIPTextModelWithProjection):
-            init.normal_(
-                module.text_projection.weight,
-                std=self.config.hidden_size**-0.5 * factor,
-            )
+            _init_child_weight(module.text_projection, self.config.hidden_size**-0.5 * factor)
         elif isinstance(module, CLIPForImageClassification):
-            init.normal_(
-                module.classifier.weight,
-                std=self.config.vision_config.hidden_size**-0.5 * factor,
-            )
+            _init_child_weight(module.classifier, self.config.vision_config.hidden_size**-0.5 * factor)
 
 
 class CLIPEncoder(nn.Module):

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -384,12 +384,7 @@ class CLIPEncoderLayer(GradientCheckpointingLayer):
 
 
 def _init_child_weight(child: nn.Module, std: float) -> None:
-    """Initialize `child.weight` if the child module still carries one.
-
-    `CLIPPreTrainedModel._init_weights` initializes the parameters of child modules by name, and a quantized
-    checkpoint replaces `weight` on those children with packed tensors (`weight_packed` for compressed-tensors,
-    `qweight` for GPTQ/AWQ). Reading `.weight` unconditionally would then raise an `AttributeError` while
-    `from_pretrained` initializes the keys that are missing from the checkpoint.
+    """Initialize `child.weight` if the child module still carries one. Guards against quantization methods that set `weight` to `None`.
     """
     if getattr(child, "weight", None) is not None:
         init.normal_(child.weight, std=std)

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -384,8 +384,7 @@ class CLIPEncoderLayer(GradientCheckpointingLayer):
 
 
 def _init_child_weight(child: nn.Module, std: float) -> None:
-    """Initialize `child.weight` if the child module still carries one. Guards against quantization methods that set `weight` to `None`.
-    """
+    """Initialize `child.weight` if the child module still carries one. Guards against quantization methods that set `weight` to `None`."""
     if getattr(child, "weight", None) is not None:
         init.normal_(child.weight, std=std)
 

--- a/src/transformers/models/metaclip_2/modeling_metaclip_2.py
+++ b/src/transformers/models/metaclip_2/modeling_metaclip_2.py
@@ -288,8 +288,7 @@ class MetaClip2EncoderLayer(GradientCheckpointingLayer):
 
 
 def _init_child_weight(child: nn.Module, std: float) -> None:
-    """Initialize `child.weight` if the child module still carries one. Guards against quantization methods that set `weight` to `None`.
-    """
+    """Initialize `child.weight` if the child module still carries one. Guards against quantization methods that set `weight` to `None`."""
     if getattr(child, "weight", None) is not None:
         init.normal_(child.weight, std=std)
 

--- a/src/transformers/models/metaclip_2/modeling_metaclip_2.py
+++ b/src/transformers/models/metaclip_2/modeling_metaclip_2.py
@@ -288,12 +288,7 @@ class MetaClip2EncoderLayer(GradientCheckpointingLayer):
 
 
 def _init_child_weight(child: nn.Module, std: float) -> None:
-    """Initialize `child.weight` if the child module still carries one.
-
-    `MetaClip2PreTrainedModel._init_weights` initializes the parameters of child modules by name, and a quantized
-    checkpoint replaces `weight` on those children with packed tensors (`weight_packed` for compressed-tensors,
-    `qweight` for GPTQ/AWQ). Reading `.weight` unconditionally would then raise an `AttributeError` while
-    `from_pretrained` initializes the keys that are missing from the checkpoint.
+    """Initialize `child.weight` if the child module still carries one. Guards against quantization methods that set `weight` to `None`.
     """
     if getattr(child, "weight", None) is not None:
         init.normal_(child.weight, std=std)

--- a/src/transformers/models/metaclip_2/modeling_metaclip_2.py
+++ b/src/transformers/models/metaclip_2/modeling_metaclip_2.py
@@ -287,6 +287,18 @@ class MetaClip2EncoderLayer(GradientCheckpointingLayer):
         return hidden_states
 
 
+def _init_child_weight(child: nn.Module, std: float) -> None:
+    """Initialize `child.weight` if the child module still carries one.
+
+    `MetaClip2PreTrainedModel._init_weights` initializes the parameters of child modules by name, and a quantized
+    checkpoint replaces `weight` on those children with packed tensors (`weight_packed` for compressed-tensors,
+    `qweight` for GPTQ/AWQ). Reading `.weight` unconditionally would then raise an `AttributeError` while
+    `from_pretrained` initializes the keys that are missing from the checkpoint.
+    """
+    if getattr(child, "weight", None) is not None:
+        init.normal_(child.weight, std=std)
+
+
 @auto_docstring
 class MetaClip2PreTrainedModel(PreTrainedModel):
     config: MetaClip2Config
@@ -310,50 +322,35 @@ class MetaClip2PreTrainedModel(PreTrainedModel):
         super()._init_weights(module)
         factor = self.config.initializer_factor
         if isinstance(module, MetaClip2TextEmbeddings):
-            init.normal_(module.token_embedding.weight, mean=0.0, std=factor * 0.02)
-            init.normal_(module.position_embedding.weight, mean=0.0, std=factor * 0.02)
+            _init_child_weight(module.token_embedding, factor * 0.02)
+            _init_child_weight(module.position_embedding, factor * 0.02)
             init.copy_(module.position_ids, torch.arange(module.position_ids.shape[-1]).expand((1, -1)))
         elif isinstance(module, MetaClip2VisionEmbeddings):
             init.normal_(module.class_embedding, mean=0.0, std=module.embed_dim**-0.5 * factor)
-            init.normal_(module.patch_embedding.weight, std=module.config.initializer_range * factor)
-            init.normal_(module.position_embedding.weight, std=module.config.initializer_range * factor)
+            _init_child_weight(module.patch_embedding, module.config.initializer_range * factor)
+            _init_child_weight(module.position_embedding, module.config.initializer_range * factor)
             init.copy_(module.position_ids, torch.arange(module.num_positions).expand((1, -1)))
         elif isinstance(module, MetaClip2Attention):
             in_proj_std = (module.embed_dim**-0.5) * ((2 * module.config.num_hidden_layers) ** -0.5) * factor
             out_proj_std = (module.embed_dim**-0.5) * factor
-            init.normal_(module.q_proj.weight, std=in_proj_std)
-            init.normal_(module.k_proj.weight, std=in_proj_std)
-            init.normal_(module.v_proj.weight, std=in_proj_std)
-            init.normal_(module.out_proj.weight, std=out_proj_std)
+            _init_child_weight(module.q_proj, in_proj_std)
+            _init_child_weight(module.k_proj, in_proj_std)
+            _init_child_weight(module.v_proj, in_proj_std)
+            _init_child_weight(module.out_proj, out_proj_std)
         elif isinstance(module, MetaClip2MLP):
             in_proj_std = (module.config.hidden_size**-0.5) * ((2 * module.config.num_hidden_layers) ** -0.5) * factor
             fc_std = (2 * module.config.hidden_size) ** -0.5 * factor
-            init.normal_(module.fc1.weight, std=fc_std)
-            init.normal_(module.fc2.weight, std=in_proj_std)
+            _init_child_weight(module.fc1, fc_std)
+            _init_child_weight(module.fc2, in_proj_std)
         elif isinstance(module, MetaClip2Model):
-            init.normal_(
-                module.text_projection.weight,
-                std=module.text_embed_dim**-0.5 * factor,
-            )
-            init.normal_(
-                module.visual_projection.weight,
-                std=module.vision_embed_dim**-0.5 * factor,
-            )
+            _init_child_weight(module.text_projection, module.text_embed_dim**-0.5 * factor)
+            _init_child_weight(module.visual_projection, module.vision_embed_dim**-0.5 * factor)
         elif isinstance(module, MetaClip2VisionModelWithProjection):
-            init.normal_(
-                module.visual_projection.weight,
-                std=self.config.hidden_size**-0.5 * factor,
-            )
+            _init_child_weight(module.visual_projection, self.config.hidden_size**-0.5 * factor)
         elif isinstance(module, MetaClip2TextModelWithProjection):
-            init.normal_(
-                module.text_projection.weight,
-                std=self.config.hidden_size**-0.5 * factor,
-            )
+            _init_child_weight(module.text_projection, self.config.hidden_size**-0.5 * factor)
         elif isinstance(module, MetaClip2ForImageClassification):
-            init.normal_(
-                module.classifier.weight,
-                std=self.config.vision_config.hidden_size**-0.5 * factor,
-            )
+            _init_child_weight(module.classifier, self.config.vision_config.hidden_size**-0.5 * factor)
         if hasattr(module, "logit_scale"):
             init.constant_(module.logit_scale, self.config.logit_scale_init_value)
 

--- a/tests/models/clip/test_modeling_clip.py
+++ b/tests/models/clip/test_modeling_clip.py
@@ -58,6 +58,7 @@ if is_torch_available():
         CLIPVisionModel,
         CLIPVisionModelWithProjection,
     )
+    from transformers.models.clip.modeling_clip import CLIPMLP, CLIPAttention
 
 if is_vision_available():
     from PIL import Image
@@ -563,6 +564,33 @@ class CLIPModelTest(CLIPModelTesterMixin, PipelineTesterMixin, unittest.TestCase
             config.save_pretrained(tmp_dir_name)
             text_config = CLIPTextConfig.from_pretrained(tmp_dir_name)
             self.assertDictEqual(config.text_config.to_dict(), text_config.to_dict())
+
+    def test_init_weights_with_quantized_children(self):
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        model = CLIPModel(config)
+
+        # A quantized checkpoint carries packed tensors instead of `weight` on the modules it targets:
+        # `weight_packed` for compressed-tensors, `qweight` for GPTQ/AWQ. `_init_weights` initializes the
+        # attention and MLP projections by name, so it must tolerate children without a `weight`.
+        for module in model.modules():
+            if isinstance(module, (CLIPAttention, CLIPMLP)):
+                for child in module.children():
+                    if isinstance(child, nn.Linear):
+                        out_features, in_features = child.weight.shape
+                        del child._parameters["weight"]
+                        child.register_parameter(
+                            "weight_packed",
+                            nn.Parameter(
+                                torch.zeros(out_features, in_features // 8, dtype=torch.int32),
+                                requires_grad=False,
+                            ),
+                        )
+            # Undo the flags set while `__init__` initialized the model, so that the init pass runs again
+            # over the whole module tree, as it does at the end of `from_pretrained`.
+            if hasattr(module, "_is_hf_initialized"):
+                del module._is_hf_initialized
+
+        model.initialize_weights()
 
     @slow
     def test_model_from_pretrained(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47921)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47921)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47920

`CLIPPreTrainedModel._init_weights` initializes the parameters of **child** modules by name —
`module.q_proj.weight`, `module.fc1.weight`, `module.text_projection.weight`, and so on. A quantized
checkpoint replaces `weight` on those children with packed tensors (`weight_packed` for
compressed-tensors, `qweight` for GPTQ/AWQ), so loading one raises

```
AttributeError: 'Linear' object has no attribute 'weight'
```

from the initialization pass that runs at the end of loading: `_finalize_model_loading` →
`_initialize_missing_keys` → `initialize_weights` → `smart_apply` → `_init_weights`
(`modeling_utils.py:4517`, `:2476-2491`). For a packed format the packed layout is installed **before**
the weights are loaded, by `transformers` itself —
`CompressedTensorsHfQuantizer._process_model_before_weight_loading` calls
`self.compressor.compress_model(model)` (`quantizers/quantizer_compressed_tensors.py:117-121`).

A container such as `CLIPAttention` owns no parameter of its own, so `_initialize_weights`' skip
conditions never apply to it for a class living in `transformers.*`, and it always reaches
`_init_weights`.

This PR routes every child-weight initialization in `CLIPPreTrainedModel._init_weights` through a
small helper that skips a child with no `weight`, which is the guard the generic
`PreTrainedModel._init_weights` already applies to `nn.Linear`/`nn.Conv*` (`modeling_utils.py:2392`)
and to the norms (`:2418-2421`, *"Norms can exist without weights"*). It is the same shape as the
merged #38013, which fixed this class of failure in `modeling_qwen2_5_omni.py` for AutoAWQ
checkpoints.

`MetaClip2PreTrainedModel` inherits this method through modular and the converter inlines the body,
so `models/metaclip_2/modeling_metaclip_2.py` is regenerated in the same commit
(`python utils/modular_model_converter.py --files_to_parse src/transformers/models/metaclip_2/modular_metaclip_2.py`);
MetaCLIP-2 gets the fix with it.

Initialization of a non-quantized model is unchanged: the seeded `state_dict` of a tiny `CLIPModel`
hashes to the same SHA-256 before and after the patch (`a6808d27…`). The change also removes a
pre-existing crash for `CLIPForImageClassification` with `num_labels == 0`, where `classifier` is an
`nn.Identity`.

### Verification

```
# the new regression test
pytest tests/models/clip/test_modeling_clip.py -k init_weights_with_quantized
  -> 1 passed          (with the patch)
  -> 1 failed, AttributeError: 'Linear' object has no attribute 'weight'   (with the patch reverted)

# the test files utils/tests_fetcher.py selects for this diff
pytest tests/models/clip/test_modeling_clip.py tests/models/metaclip_2/test_modeling_metaclip_2.py \
       tests/models/sam3/test_modeling_sam3.py tests/models/sam3_video/test_modeling_sam3_video.py \
       tests/models/vision_text_dual_encoder/test_modeling_vision_text_dual_encoder.py
  -> 869 passed, 960 skipped, 6 xfailed, 8 failed in 6m18s

# repo checks
python utils/checkers.py ruff_check, ruff_format, init_isort, sort_auto_mappings, modeling_structure
  -> all OK (ruff over the whole tree)
python utils/checkers.py <all REPO_CONSISTENCY_CHECKERS>
  -> All 17 checks passed
```

The 8 failures are all `test_multi_gpu_data_parallel_forward` (4 in the CLIP file, 4 in the MetaCLIP-2
file). They are pre-existing on this machine: the same 8 fail on the parent commit, and nothing else in
those five files fails.

The `types` checker fails identically on the parent commit with the `ty` version I have installed, so
it is not affected by this diff.

### Scope

The same pattern — `_init_weights` dereferencing a child module's `.weight`/`.bias` — is present in 83
of 488 `modeling_*.py` files on `main`, and I measured the identical `AttributeError` for `T5`,
`Mamba2`, `LLaVA` (CLIP vision tower) and `Gemma3` (SigLIP vision tower). The issue linked above has
the full analysis, including why marking the quantized modules `_is_hf_initialized` (as the
bitsandbytes/torchao/quanto/mxfp4/sinq integrations do) does not fix it, and why the 4.x
"skip a fully loaded subtree" rule does not either. I kept this PR to CLIP; happy to extend the guard
to the other families in whatever batching you prefer.

## Code Agent Policy

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

Not applicable — I am not a first-time contributor (#46277, #47940). Per the *Agentic contributions*
section of `CONTRIBUTING.md`: this change was prepared with AI assistance (Claude Code). I have
reviewed every changed line, the analysis and every number above come from runs against the installed
packages, the test commands and results are quoted above, the coordination link is #47920, and I am
not aware of another open PR touching CLIP's `_init_weights`. I opened this alongside the issue so the
diff is concrete rather than hypothetical -- if you would rather settle the scope there first (one
model vs. the 83 files that share the pattern), say so and I will hold this PR until then.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. — see the linked issue
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)? — no documented behavior changes
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?
      `tests/models/clip/test_modeling_clip.py::CLIPModelTest::test_init_weights_with_quantized_children`

## Who can review?

@CyrilVallez (the failure is in the `from_pretrained` initialization pass), @molbap (CLIP)
