### PR TITLE
[docs] torchcodec + vision processor features

### DIFF
--- a/docs/source/en/chat_templating_multimodal.md
+++ b/docs/source/en/chat_templating_multimodal.md
@@ -114,8 +114,11 @@ The decoded output contains the full conversation so far, including the user mes
 Some vision models also support video inputs. The message format is very similar to the format for [image inputs](#image-inputs).
 
 - The content `"type"` should be `"video"` to indicate the content is a video.
-- For videos, it can be a link to the video (`"url"`) or it could be a file path (`"path"`). Videos loaded from a URL can be decoded with [torchcodec](https://meta-pytorch.org/torchcodec/stable/index.html), [PyAV](https://pyav.basswood-io.com/docs/stable/), or [Decord](https://github.com/dmlc/decord), but not with OpenCV.
-- In addition to loading videos from a URL or file path, you can also pass decoded video data directly. This is useful if you've already preprocessed or decoded video frames elsewhere in memory (using torchcodec, OpenCV, or decord). You don't need to save to files or store it in an URL.
+- For videos, it can be a link to the video (`"url"`) or it could be a file path (`"path"`). Videos are decoded with [torchcodec](https://meta-pytorch.org/torchcodec/stable/index.html). If torchcodec isn't available and you're on an older torchvision version, decoding falls back to torchvision.
+- In addition to loading videos from a URL or file path, you can also pass decoded video data directly. This is useful if you've already preprocessed or decoded video frames elsewhere in memory. You don't need to save to files or store it in an URL.
+
+> [!TIP]
+> [PyAV](https://pyav.basswood-io.com/docs/stable/) and [Decord](https://github.com/dmlc/decord) are available, but only if you decode the video yourself and request the backend explicitly with `load_video(backend=...)`.
 
 ```python
 from transformers import AutoProcessor, LlavaOnevisionForConditionalGeneration

--- a/docs/source/en/chat_templating_multimodal.md
+++ b/docs/source/en/chat_templating_multimodal.md
@@ -114,11 +114,8 @@ The decoded output contains the full conversation so far, including the user mes
 Some vision models also support video inputs. The message format is very similar to the format for [image inputs](#image-inputs).
 
 - The content `"type"` should be `"video"` to indicate the content is a video.
-- For videos, it can be a link to the video (`"url"`) or it could be a file path (`"path"`). Videos loaded from a URL can only be decoded with [PyAV](https://pyav.basswood-io.com/docs/stable/) or [Decord](https://github.com/dmlc/decord).
-- In addition to loading videos from a URL or file path, you can also pass decoded video data directly. This is useful if you've already preprocessed or decoded video frames elsewhere in memory (e.g., using OpenCV, decord, or torchvision). You don't need to save to files or store it in an URL.
-
-> [!WARNING]
-> Loading a video from `"url"` is only supported by the PyAV or Decord backends.
+- For videos, it can be a link to the video (`"url"`) or it could be a file path (`"path"`). Videos loaded from a URL can be decoded with [torchcodec](https://meta-pytorch.org/torchcodec/stable/index.html), [PyAV](https://pyav.basswood-io.com/docs/stable/), or [Decord](https://github.com/dmlc/decord), but not with OpenCV.
+- In addition to loading videos from a URL or file path, you can also pass decoded video data directly. This is useful if you've already preprocessed or decoded video frames elsewhere in memory (using torchcodec, OpenCV, or decord). You don't need to save to files or store it in an URL.
 
 ```python
 from transformers import AutoProcessor, LlavaOnevisionForConditionalGeneration
@@ -168,7 +165,7 @@ You can also use existing (`"load_video()"`) function to load a video, edit the 
 
 ```python
 
-# Make sure a video backend library (pyav, decord, or torchvision) is available.
+# Make sure a video backend library (torchcodec, pyav, or decord) is available.
 from transformers.video_utils import load_video
 
 # load a video file in memory for testing

--- a/docs/source/en/image_processors.md
+++ b/docs/source/en/image_processors.md
@@ -143,6 +143,33 @@ The benchmarks are obtained from an [AWS EC2 g5.2xlarge](https://aws.amazon.com/
 </div>
 </details>
 
+## Dynamic resolution
+
+Most image processors resize every image to one fixed resolution. Qwen-format processors, such as the ones for [Qwen2-VL](./model_doc/qwen2_vl) and [GLM-4V](./model_doc/glm4v), keep the original aspect ratio and resize each image to fit a pixel budget instead. A detailed photo gets more patches than a small icon, so the model spends its compute where there's something to look at.
+
+The budget is the `shortest_edge` and `longest_edge` keys of `size`, and both are counts of pixels rather than edge lengths. Qwen2-VL defaults to a floor of `56 * 56` pixels and a ceiling of `28 * 28 * 1280` pixels. Three more parameters describe the vision encoder and decide how the resized image is cut up.
+
+| Parameter | Default | What it controls |
+|---|---|---|
+| `patch_size` | 14 | Height and width in pixels of a single patch. |
+| `merge_size` | 2 | How many patches per side are merged into one token before the language model sees them. |
+| `temporal_patch_size` | 2 | How many frames a patch spans. Still images are repeated to fill the temporal dimension. |
+
+Resizing snaps both dimensions to a multiple of `patch_size * merge_size` so the patch grid divides evenly, which means the image you get back is rarely the exact size you asked for. Pass a smaller `longest_edge` to trade detail for a shorter sequence.
+
+```py
+from transformers import AutoImageProcessor
+from transformers.image_utils import load_image
+
+image_processor = AutoImageProcessor.from_pretrained("Qwen/Qwen2-VL-7B-Instruct")
+image = load_image("https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg")
+
+inputs = image_processor(image, size={"shortest_edge": 56 * 56, "longest_edge": 28 * 28 * 256}, return_tensors="pt")
+print(inputs.pixel_values.shape, inputs.image_grid_thw)
+```
+
+The output layout differs from a fixed-resolution processor too. Rather than a `(batch_size, num_channels, height, width)` tensor, `pixel_values` is a 2D tensor of shape `(total_patches, patch_dim)` holding the flattened patches of every image in the batch end to end, and `image_grid_thw` is a `(num_images, 3)` tensor of the temporal, height, and width grid dimensions that says where each image starts and stops. Use `get_number_of_image_patches` to work out the patch count for a given image size without running preprocessing.
+
 ## Preprocess
 
 Transformers' vision models expects the input as PyTorch tensors of pixel values. An image processor handles the conversion of images to pixel values, which is represented by the batch size, number of channels, height, and width. To achieve this, an image is resized (center cropped) and the pixel values are normalized and rescaled to the models expected values.

--- a/docs/source/en/image_processors.md
+++ b/docs/source/en/image_processors.md
@@ -145,30 +145,11 @@ The benchmarks are obtained from an [AWS EC2 g5.2xlarge](https://aws.amazon.com/
 
 ## Dynamic resolution
 
-Most image processors resize every image to one fixed resolution. Qwen-format processors, such as the ones for [Qwen2-VL](./model_doc/qwen2_vl) and [GLM-4V](./model_doc/glm4v), keep the original aspect ratio and resize each image to fit a pixel budget instead. A detailed photo gets more patches than a small icon, so the model spends its compute where there's something to look at.
+Most image processors resize every image to one fixed resolution. Dynamic resolution allows some models to preserve the original aspect ratio and let the amount of preprocessed data grow with the image, so a detailed photo gets more patches than a small icon and the model spends its compute where there's something to look at.
 
-The budget is the `shortest_edge` and `longest_edge` keys of `size`, and both are counts of pixels rather than edge lengths. Qwen2-VL defaults to a floor of `56 * 56` pixels and a ceiling of `28 * 28 * 1280` pixels. Three more parameters describe the vision encoder and decide how the resized image is cut up.
+How the image is divided up is model-specific. Some models crop the image into a variable number of fixed-size patches, bounded by parameters like `min_patches` and `max_patches`. Other models resize the image to whichever resolution fits it best, either picked from a predefined list of aspect ratios or derived from a pixel budget.
 
-| Parameter | Default | What it controls |
-|---|---|---|
-| `patch_size` | 14 | Height and width in pixels of a single patch. |
-| `merge_size` | 2 | How many patches per side are merged into one token before the language model sees them. |
-| `temporal_patch_size` | 2 | How many frames a patch spans. Still images are repeated to fill the temporal dimension. |
-
-Resizing snaps both dimensions to a multiple of `patch_size * merge_size` so the patch grid divides evenly, which means the image you get back is rarely the exact size you asked for. Pass a smaller `longest_edge` to trade detail for a shorter sequence.
-
-```py
-from transformers import AutoImageProcessor
-from transformers.image_utils import load_image
-
-image_processor = AutoImageProcessor.from_pretrained("Qwen/Qwen2-VL-7B-Instruct")
-image = load_image("https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg")
-
-inputs = image_processor(image, size={"shortest_edge": 56 * 56, "longest_edge": 28 * 28 * 256}, return_tensors="pt")
-print(inputs.pixel_values.shape, inputs.image_grid_thw)
-```
-
-The output layout differs from a fixed-resolution processor too. Rather than a `(batch_size, num_channels, height, width)` tensor, `pixel_values` is a 2D tensor of shape `(total_patches, patch_dim)` holding the flattened patches of every image in the batch end to end, and `image_grid_thw` is a `(num_images, 3)` tensor of the temporal, height, and width grid dimensions that says where each image starts and stops. Use `get_number_of_image_patches` to work out the patch count for a given image size without running preprocessing.
+Refer to a model's doc page for its parameters, defaults, and output shapes.
 
 ## Preprocess
 

--- a/docs/source/en/video_processors.md
+++ b/docs/source/en/video_processors.md
@@ -59,12 +59,9 @@ A video processor decodes a video and picks the frames the model actually sees. 
 Pass a path or URL and the processor decodes the video for you with [torchcodec](https://meta-pytorch.org/torchcodec/stable/index.html), which is the default decoder and must be installed. Add `return_metadata=True` to get back the sampled frame indices, original dimensions, duration, and fps.
 
 ```python
-import torch
 from transformers import AutoVideoProcessor
 
-device = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
-
-processor = AutoVideoProcessor.from_pretrained("Qwen/Qwen3-VL-4B-Instruct", device=device)
+processor = AutoVideoProcessor.from_pretrained("Qwen/Qwen3-VL-4B-Instruct")
 inputs = processor(videos=["video.mp4"], do_sample_frames=True, fps=1, return_metadata=True, return_tensors="pt")
 
 print(inputs.pixel_values_videos.shape, inputs.video_grid_thw)

--- a/docs/source/en/video_processors.md
+++ b/docs/source/en/video_processors.md
@@ -56,7 +56,9 @@ A video processor decodes a video and picks the frames the model actually sees. 
 - `num_frames` asks for a fixed count spread uniformly across the video.
 - `fps` asks for a rate in frames per second.
 
-Pass a path or URL and the processor decodes the video for you with [torchcodec](https://meta-pytorch.org/torchcodec/stable/index.html), which is the default decoder and must be installed. Add `return_metadata=True` to get back the sampled frame indices, original dimensions, duration, and fps.
+Pass a path or URL and the processor decodes the video for you with [torchcodec](https://meta-pytorch.org/torchcodec/stable/index.html), the default decoder. If torchcodec isn't available and you're on an older torchvision version, decoding falls back to torchvision.
+
+Add `return_metadata=True` to get back the sampled frame indices, original dimensions, duration, and fps.
 
 ```python
 from transformers import AutoVideoProcessor

--- a/docs/source/en/video_processors.md
+++ b/docs/source/en/video_processors.md
@@ -48,3 +48,45 @@ processor = AutoVideoProcessor.from_pretrained("llava-hf/llava-onevision-qwen2-0
 processor = torch.compile(processor)
 processed_video = processor(video, return_tensors="pt")
 ```
+
+## Frame sampling
+
+A video processor decodes a video and picks the frames the model actually sees. Set `do_sample_frames=True` to turn sampling on, then pick the frames in one of two ways.
+
+- `num_frames` asks for a fixed count spread uniformly across the video.
+- `fps` asks for a rate in frames per second.
+
+Pass a path or URL and the processor decodes the video for you with [torchcodec](https://meta-pytorch.org/torchcodec/stable/index.html), which is the default decoder and must be installed. Add `return_metadata=True` to get back the sampled frame indices, original dimensions, duration, and fps.
+
+```python
+import torch
+from transformers import AutoVideoProcessor
+
+device = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"
+
+processor = AutoVideoProcessor.from_pretrained("Qwen/Qwen3-VL-4B-Instruct", device=device)
+inputs = processor(videos=["video.mp4"], do_sample_frames=True, fps=1, return_metadata=True, return_tensors="pt")
+
+print(inputs.pixel_values_videos.shape, inputs.video_grid_thw)
+print(inputs["video_metadata"][0].total_num_frames)
+```
+
+Sampling defaults are per model, and a request for `num_frames` or `fps` is a starting point rather than a guarantee. Qwen3-VL samples at `fps=2` and clamps the result to between `min_frames=4` and `max_frames=768`, so a one-second clip still yields 4 frames and a long recording is capped well below its real frame count.
+
+Models with a `temporal_patch_size` add a second constraint where frames are grouped into patches of that many frames along the time axis, and the final frame is repeated until the count divides evenly.
+
+If you pass an already decoded video array and still want model-specific sampling, provide `video_metadata` as well. Without it, the sampler doesn't know the original duration or fps, and sampling by `fps` warns and assumes the video was recorded at 24 fps.
+
+```python
+import torch
+from transformers import AutoVideoProcessor
+from transformers.video_utils import VideoMetadata
+
+processor = AutoVideoProcessor.from_pretrained("Qwen/Qwen3-VL-4B-Instruct")
+video = torch.randint(0, 255, size=(100, 3, 1280, 1280))  # short video of 100 frames
+video_metadata = VideoMetadata(total_num_frames=100, fps=24, duration=4.1)
+
+inputs = processor(
+    videos=[video], video_metadata=[video_metadata], do_sample_frames=True, num_frames=16, return_tensors="pt"
+)
+```


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47935)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47935)
<!-- ci-dashboard-badge:end -->

Adds docs for some vision related things in #47850 and #47573

- Remove mention of torchvision from the docs.
- Document dynamic resolution and frame sampling