### PR TITLE
Declare sdpa support in `TimmWrapper`

### DIFF
--- a/src/transformers/models/timm_backbone/modeling_timm_backbone.py
+++ b/src/transformers/models/timm_backbone/modeling_timm_backbone.py
@@ -20,13 +20,16 @@ from ... import initialization as init
 from ...backbone_utils import BackboneMixin
 from ...modeling_outputs import BackboneOutput
 from ...modeling_utils import PreTrainedModel
-from ...utils import is_timm_available, requires_backends
+from ...utils import is_timm_available, logging, requires_backends
 from ...utils.generic import can_return_tuple
 from .configuration_timm_backbone import TimmBackboneConfig
 
 
 if is_timm_available():
     import timm
+
+
+logger = logging.get_logger(__name__)
 
 
 class TimmBackbone(BackboneMixin, PreTrainedModel):
@@ -39,6 +42,8 @@ class TimmBackbone(BackboneMixin, PreTrainedModel):
     input_modalities = ("image",)
     supports_gradient_checkpointing = False
     config: TimmBackboneConfig
+    # `timm` attention layers already dispatch to `F.scaled_dot_product_attention` by default
+    _supports_sdpa = True
 
     def __init__(self, config, **kwargs):
         requires_backends(self, "timm")
@@ -78,6 +83,13 @@ class TimmBackbone(BackboneMixin, PreTrainedModel):
             layer["module"]: str(layer["index"]) for layer in self._backbone.feature_info.get_dicts()
         }
         self._all_layers = {layer["module"]: str(i) for i, layer in enumerate(self._backbone.feature_info.info)}
+
+        if self.config._attn_implementation == "eager":
+            # `timm` resolves the attention implementation on its own, there is no model level API to change it yet
+            logger.warning_once(
+                "`attn_implementation='eager'` is not propagated to the wrapped `timm` model, which keeps using "
+                "`F.scaled_dot_product_attention` whenever it is available."
+            )
 
         self.post_init()
 

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -19,12 +19,15 @@ from torch import Tensor
 
 from ...modeling_outputs import ImageClassifierOutput, ModelOutput
 from ...modeling_utils import PreTrainedModel
-from ...utils import auto_docstring, is_timm_available, requires_backends
+from ...utils import auto_docstring, is_timm_available, logging, requires_backends
 from .configuration_timm_wrapper import TimmWrapperConfig
 
 
 if is_timm_available():
     import timm
+
+
+logger = logging.get_logger(__name__)
 
 
 @auto_docstring(
@@ -84,12 +87,20 @@ class TimmWrapperPreTrainedModel(PreTrainedModel):
     # add WA here as `timm` does not support model parallelism
     _no_split_modules = ["TimmWrapperModel"]
     model_tags = ["timm"]
+    # `timm` attention layers already dispatch to `F.scaled_dot_product_attention` by default
+    _supports_sdpa = True
 
     # used in Trainer to avoid passing `loss_kwargs` to model forward
     accepts_loss_kwargs = False
 
     def post_init(self):
         self.supports_gradient_checkpointing = self._timm_model_supports_gradient_checkpointing()
+        if self.config._attn_implementation == "eager":
+            # `timm` resolves the attention implementation on its own, there is no model level API to change it yet
+            logger.warning_once(
+                "`attn_implementation='eager'` is not propagated to the wrapped `timm` model, which keeps using "
+                "`F.scaled_dot_product_attention` whenever it is available."
+            )
         super().post_init()
 
     def load_state_dict(self, state_dict, *args, **kwargs):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47939)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47939)
<!-- ci-dashboard-badge:end -->

Fixes #47917

## What's the problem

`TimmWrapperPreTrainedModel` inherits `_supports_sdpa = False`, so loading any model with a timm
backbone and `attn_implementation="sdpa"` raises:

```
ValueError: TimmWrapperModel does not support an attention implementation through
torch.nn.functional.scaled_dot_product_attention yet.
```

The flag is also inaccurate: timm attention layers already dispatch to
`F.scaled_dot_product_attention` by default, so the wrapper reports `eager` while it actually runs
fused attention.

## Approach

Declare `_supports_sdpa = True`, which matches what timm does by default.

timm resolves the attention implementation on its own and has no model level API to change it, so
`eager` cannot be honoured yet — a warning is emitted when it is requested. This only affects a
setting that was already silently ignored, and everything else is unchanged.

## Before / after

```python
from transformers import TimmWrapperConfig, TimmWrapperModel


def fused_attn_flags(model):
    return {m.fused_attn for m in model.timm_model.modules() if hasattr(m, "fused_attn")}


for requested in (None, "sdpa", "eager"):
    config = TimmWrapperConfig(architecture="vit_tiny_patch16_224")
    model = TimmWrapperModel._from_config(config, attn_implementation=requested)
    print(f"requested={requested!r:8} -> config={model.config._attn_implementation:5} timm fused_attn={fused_attn_flags(model)}")
```

Before — the default silently falls back to `eager` while timm still runs fused attention, and an
explicit request crashes:

```
requested=None     -> config=eager timm fused_attn={True}
ValueError: TimmWrapperModel does not support an attention implementation through
torch.nn.functional.scaled_dot_product_attention yet.
```

After — `sdpa` loads, and the config no longer claims `eager` while timm runs fused attention:

```
requested=None     -> config=sdpa  timm fused_attn={True}
requested='sdpa'   -> config=sdpa  timm fused_attn={True}
`attn_implementation='eager'` is not propagated to the wrapped `timm` model, which keeps using `F.scaled_dot_product_attention` whenever it is available.
requested='eager'  -> config=eager timm fused_attn={True}
```

Unsupported backends such as `flash_attention_2` keep raising as before.

The MRE from the issue also loads fine now:

```bash
python -c "from transformers import AutoModel; AutoModel.from_pretrained('facebook/Perception-LM-1B', attn_implementation='sdpa')"
```

## Tests

`tests/models/timm_wrapper/` — 82 passed, 3 failed. The 3 failures (`test_cpu_offload`,
`test_disk_offload_bin`, `test_disk_offload_safetensors`) reproduce identically on the base commit
and are unrelated to this change.