### PR TITLE
Fix Gemma `sliding_window` being halved on every config save/reload

### DIFF
--- a/src/transformers/models/diffusion_gemma/configuration_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/configuration_diffusion_gemma.py
@@ -144,6 +144,15 @@ class DiffusionGemmaTextConfig(PreTrainedConfig):
 
         super().__post_init__(**kwargs)
 
+    def to_dict(self) -> dict[str, Any]:
+        output = super().to_dict()
+        # Serialize the value `__post_init__` converted *from*, so that a reload converts once more
+        # instead of halving the already-halved window. Configs that inherit this one without the
+        # flag never convert, hence the `None` fallback.
+        if getattr(self, "use_bidirectional_attention", None) == "all":
+            output["sliding_window"] = (self.sliding_window - 1) * 2
+        return output
+
     def convert_rope_params_to_dict(self, **kwargs):
         # No need to handle BC for new models, because they have no old-format `rope_scaling`
         return kwargs

--- a/src/transformers/models/gemma3/configuration_gemma3.py
+++ b/src/transformers/models/gemma3/configuration_gemma3.py
@@ -124,6 +124,15 @@ class Gemma3TextConfig(PreTrainedConfig):
                 f"heads ({self.num_attention_heads})."
             )
 
+    def to_dict(self) -> dict[str, Any]:
+        output = super().to_dict()
+        # Serialize the value `__post_init__` converted *from*, so that a reload converts once more
+        # instead of halving the already-halved window. Configs that inherit this one without the
+        # flag never convert, hence the `False` fallback.
+        if getattr(self, "use_bidirectional_attention", False):
+            output["sliding_window"] = (self.sliding_window - 1) * 2
+        return output
+
     def convert_rope_params_to_dict(self, **kwargs):
         rope_scaling = kwargs.pop("rope_scaling", None)
 

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -127,6 +127,15 @@ class Gemma3TextConfig(Gemma2Config, PreTrainedConfig):
 
         PreTrainedConfig.__post_init__(**kwargs)
 
+    def to_dict(self) -> dict[str, Any]:
+        output = super().to_dict()
+        # Serialize the value `__post_init__` converted *from*, so that a reload converts once more
+        # instead of halving the already-halved window. Configs that inherit this one without the
+        # flag never convert, hence the `False` fallback.
+        if getattr(self, "use_bidirectional_attention", False):
+            output["sliding_window"] = (self.sliding_window - 1) * 2
+        return output
+
     def convert_rope_params_to_dict(self, **kwargs):
         rope_scaling = kwargs.pop("rope_scaling", None)
 

--- a/src/transformers/models/gemma3n/configuration_gemma3n.py
+++ b/src/transformers/models/gemma3n/configuration_gemma3n.py
@@ -167,6 +167,15 @@ class Gemma3nTextConfig(PreTrainedConfig):
                 f"heads ({self.num_attention_heads})."
             )
 
+    def to_dict(self) -> dict[str, Any]:
+        output = super().to_dict()
+        # Serialize the value `__post_init__` converted *from*, so that a reload converts once more
+        # instead of halving the already-halved window. Configs that inherit this one without the
+        # flag never convert, hence the `False` fallback.
+        if getattr(self, "use_bidirectional_attention", False):
+            output["sliding_window"] = (self.sliding_window - 1) * 2
+        return output
+
     def convert_rope_params_to_dict(self, **kwargs):
         rope_scaling = kwargs.pop("rope_scaling", None)
 

--- a/src/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/transformers/models/gemma4/configuration_gemma4.py
@@ -224,6 +224,15 @@ class Gemma4TextConfig(PreTrainedConfig):
 
         super().__post_init__(**kwargs)
 
+    def to_dict(self) -> dict[str, Any]:
+        output = super().to_dict()
+        # Serialize the value `__post_init__` converted *from*, so that a reload converts once more
+        # instead of halving the already-halved window. Configs that inherit this one without the
+        # flag never convert, hence the `None` fallback.
+        if getattr(self, "use_bidirectional_attention", None) == "all":
+            output["sliding_window"] = (self.sliding_window - 1) * 2
+        return output
+
     def convert_rope_params_to_dict(self, **kwargs):
         # No need to handle BC for new models, because they have no old-format `rope_scaling`
         return kwargs

--- a/src/transformers/models/gemma4_unified/configuration_gemma4_unified.py
+++ b/src/transformers/models/gemma4_unified/configuration_gemma4_unified.py
@@ -191,6 +191,15 @@ class Gemma4UnifiedTextConfig(PreTrainedConfig):
 
         super().__post_init__(**kwargs)
 
+    def to_dict(self) -> dict[str, Any]:
+        output = super().to_dict()
+        # Serialize the value `__post_init__` converted *from*, so that a reload converts once more
+        # instead of halving the already-halved window. Configs that inherit this one without the
+        # flag never convert, hence the `None` fallback.
+        if getattr(self, "use_bidirectional_attention", None) == "all":
+            output["sliding_window"] = (self.sliding_window - 1) * 2
+        return output
+
     def convert_rope_params_to_dict(self, **kwargs):
         # No need to handle BC for new models, because they have no old-format `rope_scaling`
         return kwargs

--- a/src/transformers/models/t5gemma2/configuration_t5gemma2.py
+++ b/src/transformers/models/t5gemma2/configuration_t5gemma2.py
@@ -106,6 +106,15 @@ class T5Gemma2TextConfig(PreTrainedConfig):
                 f"heads ({self.num_attention_heads})."
             )
 
+    def to_dict(self) -> dict[str, Any]:
+        output = super().to_dict()
+        # Serialize the value `__post_init__` converted *from*, so that a reload converts once more
+        # instead of halving the already-halved window. Configs that inherit this one without the
+        # flag never convert, hence the `False` fallback.
+        if getattr(self, "use_bidirectional_attention", False):
+            output["sliding_window"] = (self.sliding_window - 1) * 2
+        return output
+
     def convert_rope_params_to_dict(self, **kwargs):
         rope_scaling = kwargs.pop("rope_scaling", None)
 
@@ -280,6 +289,15 @@ class T5Gemma2DecoderConfig(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+
+    def to_dict(self) -> dict[str, Any]:
+        output = super().to_dict()
+        # Serialize the value `__post_init__` converted *from*, so that a reload converts once more
+        # instead of halving the already-halved window. Configs that inherit this one without the
+        # flag never convert, hence the `False` fallback.
+        if getattr(self, "use_bidirectional_attention", False):
+            output["sliding_window"] = (self.sliding_window - 1) * 2
+        return output
 
     def convert_rope_params_to_dict(self, **kwargs):
         rope_scaling = kwargs.pop("rope_scaling", None)

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -114,6 +114,16 @@ class Gemma3TextModelTest(CausalLMModelTest, unittest.TestCase):
     def test_load_with_mismatched_shapes(self):
         pass
 
+    def test_bidirectional_sliding_window_survives_save_and_reload(self):
+        config = Gemma3TextConfig(sliding_window=512, use_bidirectional_attention=True)
+        self.assertEqual(config.sliding_window, 257)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config.save_pretrained(tmpdirname)
+            reloaded = Gemma3TextConfig.from_pretrained(tmpdirname)
+
+        self.assertEqual(reloaded.sliding_window, config.sliding_window)
+
     def test_generation_beyond_sliding_window_tiny_model(self):
         """Test generation with a tiny randomly initialised model whose input length is larger than the `sliding_window`.
         The model is configured with both `full_attention` and `sliding_attention` layers to make sure the hybrid cache

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Testing suite for the PyTorch Gemma4 model."""
 
+import tempfile
 import unittest
 from contextlib import contextmanager
 
@@ -110,6 +111,16 @@ class Gemma4TextModelTest(CausalLMModelTest, unittest.TestCase):
     @unittest.skip("We need 4 layers to correctly test cache sharing.")
     def test_num_layers_is_small(self):
         pass
+
+    def test_bidirectional_sliding_window_survives_save_and_reload(self):
+        config = Gemma4TextConfig(sliding_window=512, use_bidirectional_attention="all")
+        self.assertEqual(config.sliding_window, 257)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config.save_pretrained(tmpdirname)
+            reloaded = Gemma4TextConfig.from_pretrained(tmpdirname)
+
+        self.assertEqual(reloaded.sliding_window, config.sliding_window)
 
     @unittest.skip(
         "Gemma4 cannot use random inputs_embeds, as it needs to reverse them when input_ids is not provided"


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47940)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47940)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`Gemma3TextConfig.__post_init__` converts the declared sliding window into the exclusive
half-window the attention kernels use, and writes the result back into the field it read from:

```python
if self.use_bidirectional_attention:
    self.sliding_window = (self.sliding_window // 2) + 1  # due to fa we set exclusive bounds
```

`save_pretrained` then persists the converted value, and the next load converts it again, so the
window halves on every save/load round trip. No model download is needed to reproduce it:

```python
from transformers import Gemma3TextConfig

config = Gemma3TextConfig(sliding_window=512, use_bidirectional_attention=True)
print(config.sliding_window)                                          # 257
config.save_pretrained("/tmp/cfg")                                    # writes "sliding_window": 257
print(Gemma3TextConfig.from_pretrained("/tmp/cfg").sliding_window)    # 129
```

Repeating the cycle gives `512 -> 257 -> 129 -> 65 -> 33 -> 17 -> 9 -> 5 -> 3 -> 2`, and 2 is a
fixed point, so the window keeps shrinking until attention is effectively local to one token.

`google/embeddinggemma-300m` ships `"sliding_window": 512` in its `config.json`, so the value
`save_pretrained` writes back is not the convention the checkpoint itself uses.

## Where it comes from

Introduced in #40700 (`948bc0fa`). Before it, #40694 divided in the mask overlay
(`abs(q_idx - kv_idx) <= sliding_window // 2`) and left the config untouched. #40700 moved the
division to config init so that flash-attention — which reads `config.sliding_window` for its
`window_size` and never builds a mask — agrees with eager/sdpa/flex. That consolidation is
correct and this PR keeps it; the only problem is that the converted value is also the one that
gets serialized.

## Impact

Every `save_pretrained` / `from_pretrained` cycle on a bidirectional Gemma config is affected:
fine-tuning checkpoints, PEFT merges, quantization exports, and re-uploads to the Hub, which then
carry the halved window permanently.

Measured on a `google/embeddinggemma-300m` checkpoint round-tripped through `save_pretrained`,
with its weights verified bit-identical to the source (314/314 tensors), evaluated with
`sentence-transformers` on NanoBEIR:

| | mean nDCG@10 | nfcorpus | scifact |
|---|---|---|---|
| source checkpoint | 0.6271558738396297 | 0.3929820955134049 | 0.8613296521658544 |
| after one round trip | 0.6184786921356261 | — | — |
| round trip, `sliding_window` patched back to 512 | 0.6271558738396297 | 0.3929820955134049 | 0.8613296521658544 |

The weights are identical in all three rows, so the 0.87 pp is the config scalar alone; patching
only that field reproduces the baseline exactly to 16 significant digits on both datasets.

## Fix

`to_dict()` serializes the value `__post_init__` converted *from*, so a saved config reloads to
the in-memory window instead of being halved a second time.

This mirrors `ModernBertConfig`, which keeps the declared window in the serialized field and
exposes the converted one as a
[`sliding_window` property](https://github.com/huggingface/transformers/blob/main/src/transformers/models/modernbert/modular_modernbert.py#L181-L189).
Gemma cannot use that split because its checkpoints already serialize the key as
`sliding_window`, so the conversion is undone at serialization time instead.

`(sliding_window - 1) * 2` is an exact pre-image of `v // 2 + 1`, since `((2c - 2) // 2) + 1 == c`
for every integer `c`. For an even declared window — every released Gemma checkpoint — it
recovers the original value exactly (`512 -> 257 -> 512`). An odd declared window comes back one
lower, which reloads to the same in-memory value.

In-memory behaviour is unchanged: masking, attention and cache still see the converted window.
Configs that do not convert (`use_bidirectional_attention` false / `None` / `"vision"`) serialize
byte-for-byte as before.

The guard uses `getattr` because `Gemma3nTextConfig`, `T5Gemma2TextConfig` and
`T5Gemma2DecoderConfig` inherit `Gemma3TextConfig` through modular while overriding
`__post_init__` to drop the conversion, and do not define the flag at all — the same reason
`Gemma4TextConfig.__post_init__` already reads `getattr(self, "attention_k_eq_v", True)`. Their
regenerated files carry the method as a no-op.

## Compatibility

- A newly saved config stores the declared window (`512`) where it previously stored the
  converted one (`257`). Loading it through `transformers` yields `257` either way.
- Configs already saved with the converted value cannot be repaired: `257` as a declared window
  and `257` as a converted one are indistinguishable. They still load as `129`, but they no
  longer decay further on subsequent saves.

Happy to add the 🚨 prefix to the title if you consider the changed serialized value breaking.

## Alternatives considered

- Moving the division back to the mask overlay would reintroduce the flash-attention / mask
  divergence that #40700 fixed.
- Making `__post_init__` idempotent needs extra state, and private attributes are serialized too
  (`_sliding_window_pattern` ends up in `config.json`), so it would add a key to every file.

Happy to move this into `PreTrainedConfig` instead if you would prefer a general mechanism for
`__post_init__` normalisations that are not idempotent.

## Tests

`test_bidirectional_sliding_window_survives_save_and_reload` in the Gemma3 and Gemma4 text model
tests, one per hand-written config source. Both fail on `main` with `AssertionError: 129 != 257`.

`Gemma4UnifiedTextConfig` and `DiffusionGemmaTextConfig` carry the same `__post_init__` line
through modular inheritance from `Gemma4TextConfig`; their configuration files were regenerated.
All seven config classes that end up with the new method — the four that convert and the three
that inherit it inert — were checked for save/reload stability over three consecutive round trips.

## Before submitting

- [x] This PR fixes a bug.
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing)?
- [x] Did you write any new necessary tests? Yes, one per affected config source.
- [x] The generated configuration files were regenerated from their modular files.

## Who can review?

@vasqu (author of #40700) and @Cyrilvallez.