### PR TITLE
Scan a diff in trufflehog, not the whole repo history

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -18,4 +18,15 @@ jobs:
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51  # main
         with:
-          extra_args: --results=verified,unknown
+          # Always scan a DIFF, never the whole history. The action derives its
+          # base from `github.event.before`, which is all-zeros on the push that
+          # CREATES a branch — trufflehog then walks every commit ever made
+          # (415k chunks / 230 MB, ~2 min) instead of the pushed changes. Fall
+          # back to the default branch in that case so a new branch is scanned
+          # against main.
+          base: ${{ github.event.before != '0000000000000000000000000000000000000000' && github.event.before || github.event.repository.default_branch }}
+          # Lob's detector matches `(live|test)_<35 hex>` and "verifies" a hit by
+          # POSTing to api.lob.com, where a 422 counts as a valid key — that
+          # endpoint 422s on a bad body whatever the key, so every candidate came
+          # back "verified" (397 of them on a full-history scan, all false).
+          extra_args: --results=verified,unknown --exclude-detectors=lob


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47945)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47945)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

The Secret Leaks job fails on any push that CREATES a branch, and passes on every later push to it. The action derives its scan base from github.event.before, which is all-zeros for a new branch, so trufflehog walks the entire history instead of the pushed changes:

  new branch: scanning repo {"head": "..."}            415676 chunks, 230 MB
  later push: scanning repo {"base": "...", "head": ...}    11 chunks, 8 KB

The 230 MB scan reports 397 "verified" secrets, all from Lob's detector, all false. That detector matches `(live|test)_<35 hex>` and verifies a hit by POSTing to api.lob.com/v1/us_verifications, where 422 is taken to mean "key is valid, body is bad" — the endpoint 422s on a bad body regardless of the key, so every candidate string is "verified" and the job exits 183.

Pass an explicit base (falling back to the default branch when there is no before-SHA) so a new branch is scanned against main, and exclude the lob detector so a future full scan cannot resurrect the same 397 hits. Every push is now a diff scan, which also drops ~2 min of CI per new branch.

Example: https://github.com/huggingface/transformers/actions/runs/31648156289/job/94286396401?pr=47938