### PR TITLE
[GPT2] Fix encoder_attention_mask being silently discarded in cross-attention

### DIFF
--- a/src/transformers/models/decision_transformer/modeling_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/modeling_decision_transformer.py
@@ -413,7 +413,6 @@ class DecisionTransformerGPT2Model(DecisionTransformerGPT2PreTrainedModel):
             position_ids=position_ids,
         )
 
-        encoder_attention_mask = None
         if encoder_hidden_states is not None:
             encoder_attention_mask = create_bidirectional_mask(
                 config=self.config,

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -588,7 +588,6 @@ class GPT2Model(GPT2PreTrainedModel):
             position_ids=position_ids,
         )
 
-        encoder_attention_mask = None
         if encoder_hidden_states is not None:
             encoder_attention_mask = create_bidirectional_mask(
                 config=self.config,

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -321,7 +321,7 @@ class GPT2ModelTest(CausalLMModelTest, unittest.TestCase):
             self.model_tester.prepare_config_and_inputs_for_decoder()
         )
         config.add_cross_attention = True
-        model = GPT2Model(config).eval()
+        model = GPT2Model(config).to(device=torch_device).eval()
 
         # Mark the second half of encoder sequence as padding
         padding = encoder_attention_mask.shape[1] // 2

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -315,6 +315,39 @@ class GPT2ModelTest(CausalLMModelTest, unittest.TestCase):
         )
         result.loss.backward()
 
+    def test_cross_attention_respects_encoder_padding_mask(self):
+        torch.manual_seed(0)
+        config, input_ids, _, _, _, _, _, encoder_hidden_states, encoder_attention_mask = (
+            self.model_tester.prepare_config_and_inputs_for_decoder()
+        )
+        config.add_cross_attention = True
+        model = GPT2Model(config).eval()
+
+        # Mark the second half of encoder sequence as padding
+        padding = encoder_attention_mask.shape[1] // 2
+        encoder_attention_mask = encoder_attention_mask.clone()
+        encoder_attention_mask[:, padding:] = 0
+
+        # Fill the padded encoder positions with garbage
+        corrupted_encoder_states = encoder_hidden_states.clone()
+        corrupted_encoder_states[:, padding:] = 1e6
+
+        # Corrupted encoder states should be ignored via mask
+        with torch.no_grad():
+            output = model(
+                input_ids=input_ids,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+            ).last_hidden_state
+
+            output_corrupted = model(
+                input_ids=input_ids,
+                encoder_hidden_states=corrupted_encoder_states,
+                encoder_attention_mask=encoder_attention_mask,
+            ).last_hidden_state
+
+        self.assertTrue(torch.equal(output, output_corrupted))
+
     def test_training_gradient_checkpointing(self):
         # overwritten: GPT2DoubleHeadsModel fails this test, non-standard class
         self.original_all_model_classes = self.all_model_classes


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47946)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47946)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

On line 591 (`encoder_attention_mask = None`) in `GPT2Model` in `src/transformers/models/gpt2/modeling_gpt2.py` appears to be a bug. The user defined `encoder_attention_mask` is overwritten and set to None before it is passed to `create_bidirectional_mask`. This has a knock on effect on the creation of an `encoder_attention_mask` in the case that there are padding tokens present in the input. This causes padding tokens not be ignored during the cross attention calculation with `attention_mask=None` (since encoder_attention_mask=None) when calling `torch.nn.functional.scaled_dot_product_attention`.

This bug was introduced in the recent masking refactor `[Attn] New attn mask interface everywhere (#42848)` (4b8ba25aea). I appreciate that this is not the default use case for GPT2 but seemed wrong to not highlight/fix when reviewing GPT2 model code.

## What's implemented

The fix involves simply removing this line of code from the GPT2Model in addition to removing the same bug from the `DecisionTransformer` model which copies code from the GPT2 model. Additionally, to ensure that this type of error does not re-occur I have added a regression test to the GPT2 tests. This test assigns some of the input tokens as padding tokens which should be removed, a copy of the encoder hidden states is also generated with their padded tokens assigned corrupted values. A comparison is made between the last hidden state of the clean and corrupted encoder hidden states. The idea being that these tokens will never be output due to the mask fix, however, when the mask was set to None these output values would be different due to the addition of the corrupted data.

## AI assistance
I identified the bug, wrote the fix and created the test. Claude Code was used as a review and feedback tool during development.

## Before submitting
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?
@Rocketknight1 @qgallouedec @vasqu