### PR TITLE
Potential fix for code scanning alert no. 267: Artifact poisoning

### DIFF
--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mlinter-findings
+          path: ${{ runner.temp }}/mlinter-findings
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47949)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47949)
<!-- ci-dashboard-badge:end -->

Potential fix for [https://github.com/huggingface/transformers/security/code-scanning/267](https://github.com/huggingface/transformers/security/code-scanning/267)

The safest fix is to **download the artifact into an isolated temporary directory** (for example `${{ runner.temp }}/mlinter-findings`) so it cannot overwrite repository files or executable scripts in `$GITHUB_WORKSPACE`. This preserves existing behavior while removing the overwrite primitive that enables poisoning.

In `.github/workflows/pr-ci-post-dashboard-link.yml`, update the `Download mlinter findings artifact` step (lines around 46–54) to set the `path` input to a temp folder. Optionally, downstream script logic can read from that folder explicitly, but since only this snippet is provided, the minimal non-breaking fix is to isolate extraction path only.

No new imports, methods, or dependencies are needed in YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._