### PR TITLE
[bitnet] Support use_sub_norms=False (weight-quant-only BitLinear checkpoints)

### DIFF
--- a/src/transformers/models/bitnet/configuration_bitnet.py
+++ b/src/transformers/models/bitnet/configuration_bitnet.py
@@ -59,6 +59,7 @@ class BitNetConfig(PreTrainedConfig):
     attention_bias: bool = False
     attention_dropout: float | int | None = 0.0
     rope_parameters: RopeParameters | dict | None = None
+    use_sub_norms: bool = True
 
     def __post_init__(self, **kwargs):
         # for backward compatibility

--- a/src/transformers/models/bitnet/configuration_bitnet.py
+++ b/src/transformers/models/bitnet/configuration_bitnet.py
@@ -27,8 +27,12 @@ class BitNetConfig(PreTrainedConfig):
         Whether to use per-projection sub-layer RMSNorm modules
         (`attn_sub_norm` / `ffn_sub_norm`). Set to `False` for
         weight-quant-only BitLinear checkpoints, whose forward skips the
-        sub-layer normalisations entirely (they must be absent, not neutral —
-        an RMSNorm initialised to ones still normalises).
+        sub-layer normalisations entirely (they are replaced by `nn.Identity`
+        modules without parameters, so no `*_sub_norm.*` weights appear in the
+        state dict — an RMSNorm initialised to ones would still normalise).
+        Loading a checkpoint that *does* contain sub-norm weights with
+        `use_sub_norms=False` simply leaves them unused; transformers reports
+        them as unused weights at load time.
 
     ```python
     >>> from transformers import BitNetModel, BitNetConfig

--- a/src/transformers/models/bitnet/configuration_bitnet.py
+++ b/src/transformers/models/bitnet/configuration_bitnet.py
@@ -23,6 +23,13 @@ from ...utils import auto_docstring
 @strict
 class BitNetConfig(PreTrainedConfig):
     r"""
+    use_sub_norms (`bool`, *optional*, defaults to `True`):
+        Whether to use per-projection sub-layer RMSNorm modules
+        (`attn_sub_norm` / `ffn_sub_norm`). Set to `False` for
+        weight-quant-only BitLinear checkpoints, whose forward skips the
+        sub-layer normalisations entirely (they must be absent, not neutral —
+        an RMSNorm initialised to ones still normalises).
+
     ```python
     >>> from transformers import BitNetModel, BitNetConfig
 

--- a/src/transformers/models/bitnet/modeling_bitnet.py
+++ b/src/transformers/models/bitnet/modeling_bitnet.py
@@ -61,6 +61,19 @@ class BitNetRMSNorm(nn.Module):
         return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
 
 
+def _make_sub_norm(config: BitNetConfig, hidden_size: int):
+    """
+    Build a per-projection sub-layer RMSNorm, or `nn.Identity` when `use_sub_norms=False`.
+
+    `use_sub_norms=False` describes checkpoints trained through a weight-quant-only BitLinear, where the
+    sub-layer normalisations are absent rather than set to a neutral value. They cannot be neutralised by
+    initialising the weight to one, because RMSNorm still normalises; the normalisation has to be removed
+    from the forward entirely. `nn.Identity` does exactly that while keeping the module graph uniform and
+    the state dict identical (it has no parameters, so no `*_sub_norm.*` keys appear either way).
+    """
+    return BitNetRMSNorm(hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity()
+
+
 class BitNetMLP(nn.Module):
     def __init__(self, config: BitNetConfig):
         super().__init__()
@@ -71,20 +84,10 @@ class BitNetMLP(nn.Module):
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         self.act_fn = ACT2FN[config.hidden_act]
-        # `use_sub_norms=False` describes checkpoints trained through a
-        # weight-quant-only BitLinear, where the sub-layer normalisations are
-        # absent rather than set to a neutral value. They cannot be neutralised
-        # by initialising the weight to one, because RMSNorm still normalises;
-        # the module has to not exist. See BitNetAttention for the same case.
-        self.ffn_sub_norm = (
-            BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else None
-        )
+        self.ffn_sub_norm = _make_sub_norm(config, config.intermediate_size)
 
-    def forward(self, x):
-        hidden = self.act_fn(self.gate_proj(x)) * self.up_proj(x)
-        if self.ffn_sub_norm is not None:
-            hidden = self.ffn_sub_norm(hidden)
-        return self.down_proj(hidden)
+    def forward(self, x) -> torch.Tensor:
+        return self.down_proj(self.ffn_sub_norm(self.act_fn(self.gate_proj(x)) * self.up_proj(x)))
 
 
 def rotate_half(x):
@@ -183,11 +186,7 @@ class BitNetAttention(nn.Module):
         self.o_proj = nn.Linear(
             config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
         )
-        # See BitNetMLP: absent, not neutral, when the checkpoint was trained
-        # without the sub-layer normalisation.
-        self.attn_sub_norm = (
-            BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else None
-        )
+        self.attn_sub_norm = _make_sub_norm(config, config.hidden_size)
 
     def forward(
         self,
@@ -226,8 +225,7 @@ class BitNetAttention(nn.Module):
         )
 
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
-        if self.attn_sub_norm is not None:
-            attn_output = self.attn_sub_norm(attn_output)  # diff with Llama
+        attn_output = self.attn_sub_norm(attn_output)  # diff with Llama
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights
 

--- a/src/transformers/models/bitnet/modeling_bitnet.py
+++ b/src/transformers/models/bitnet/modeling_bitnet.py
@@ -71,11 +71,20 @@ class BitNetMLP(nn.Module):
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         self.act_fn = ACT2FN[config.hidden_act]
-        self.ffn_sub_norm = BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps)
+        # `use_sub_norms=False` describes checkpoints trained through a
+        # weight-quant-only BitLinear, where the sub-layer normalisations are
+        # absent rather than set to a neutral value. They cannot be neutralised
+        # by initialising the weight to one, because RMSNorm still normalises;
+        # the module has to not exist. See BitNetAttention for the same case.
+        self.ffn_sub_norm = (
+            BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else None
+        )
 
     def forward(self, x):
-        down_proj = self.down_proj(self.ffn_sub_norm(self.act_fn(self.gate_proj(x)) * self.up_proj(x)))
-        return down_proj
+        hidden = self.act_fn(self.gate_proj(x)) * self.up_proj(x)
+        if self.ffn_sub_norm is not None:
+            hidden = self.ffn_sub_norm(hidden)
+        return self.down_proj(hidden)
 
 
 def rotate_half(x):
@@ -174,7 +183,11 @@ class BitNetAttention(nn.Module):
         self.o_proj = nn.Linear(
             config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
         )
-        self.attn_sub_norm = BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        # See BitNetMLP: absent, not neutral, when the checkpoint was trained
+        # without the sub-layer normalisation.
+        self.attn_sub_norm = (
+            BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else None
+        )
 
     def forward(
         self,
@@ -213,7 +226,8 @@ class BitNetAttention(nn.Module):
         )
 
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
-        attn_output = self.attn_sub_norm(attn_output)  # diff with Llama
+        if self.attn_sub_norm is not None:
+            attn_output = self.attn_sub_norm(attn_output)  # diff with Llama
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights
 

--- a/src/transformers/models/bitnet/modular_bitnet.py
+++ b/src/transformers/models/bitnet/modular_bitnet.py
@@ -45,17 +45,30 @@ class BitNetRMSNorm(LlamaRMSNorm):
 class BitNetMLP(GemmaMLP):
     def __init__(self, config: BitNetConfig):
         super().__init__(config)
-        self.ffn_sub_norm = BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps)
+        # `use_sub_norms=False` describes checkpoints trained through a
+        # weight-quant-only BitLinear, where the sub-layer normalisations are
+        # absent rather than set to a neutral value. They cannot be neutralised
+        # by initialising the weight to one, because RMSNorm still normalises;
+        # the module has to not exist. See BitNetAttention for the same case.
+        self.ffn_sub_norm = (
+            BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else None
+        )
 
     def forward(self, x):
-        down_proj = self.down_proj(self.ffn_sub_norm(self.act_fn(self.gate_proj(x)) * self.up_proj(x)))
-        return down_proj
+        hidden = self.act_fn(self.gate_proj(x)) * self.up_proj(x)
+        if self.ffn_sub_norm is not None:
+            hidden = self.ffn_sub_norm(hidden)
+        return self.down_proj(hidden)
 
 
 class BitNetAttention(LlamaAttention):
     def __init__(self, config: BitNetConfig, layer_idx: int):
         super().__init__(config, layer_idx)
-        self.attn_sub_norm = BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        # See BitNetMLP: absent, not neutral, when the checkpoint was trained
+        # without the sub-layer normalisation.
+        self.attn_sub_norm = (
+            BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else None
+        )
 
     def forward(
         self,
@@ -94,7 +107,8 @@ class BitNetAttention(LlamaAttention):
         )
 
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
-        attn_output = self.attn_sub_norm(attn_output)  # diff with Llama
+        if self.attn_sub_norm is not None:
+            attn_output = self.attn_sub_norm(attn_output)  # diff with Llama
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights
 

--- a/src/transformers/models/bitnet/modular_bitnet.py
+++ b/src/transformers/models/bitnet/modular_bitnet.py
@@ -15,6 +15,7 @@
 from collections.abc import Callable
 
 import torch
+from torch import nn
 
 from ...cache_utils import Cache
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
@@ -42,33 +43,32 @@ class BitNetRMSNorm(LlamaRMSNorm):
     pass
 
 
+def _make_sub_norm(config: BitNetConfig, hidden_size: int):
+    """
+    Build a per-projection sub-layer RMSNorm, or `nn.Identity` when `use_sub_norms=False`.
+
+    `use_sub_norms=False` describes checkpoints trained through a weight-quant-only BitLinear, where the
+    sub-layer normalisations are absent rather than set to a neutral value. They cannot be neutralised by
+    initialising the weight to one, because RMSNorm still normalises; the normalisation has to be removed
+    from the forward entirely. `nn.Identity` does exactly that while keeping the module graph uniform and
+    the state dict identical (it has no parameters, so no `*_sub_norm.*` keys appear either way).
+    """
+    return BitNetRMSNorm(hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity()
+
+
 class BitNetMLP(GemmaMLP):
     def __init__(self, config: BitNetConfig):
         super().__init__(config)
-        # `use_sub_norms=False` describes checkpoints trained through a
-        # weight-quant-only BitLinear, where the sub-layer normalisations are
-        # absent rather than set to a neutral value. They cannot be neutralised
-        # by initialising the weight to one, because RMSNorm still normalises;
-        # the module has to not exist. See BitNetAttention for the same case.
-        self.ffn_sub_norm = (
-            BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else None
-        )
+        self.ffn_sub_norm = _make_sub_norm(config, config.intermediate_size)
 
-    def forward(self, x):
-        hidden = self.act_fn(self.gate_proj(x)) * self.up_proj(x)
-        if self.ffn_sub_norm is not None:
-            hidden = self.ffn_sub_norm(hidden)
-        return self.down_proj(hidden)
+    def forward(self, x) -> torch.Tensor:
+        return self.down_proj(self.ffn_sub_norm(self.act_fn(self.gate_proj(x)) * self.up_proj(x)))
 
 
 class BitNetAttention(LlamaAttention):
     def __init__(self, config: BitNetConfig, layer_idx: int):
         super().__init__(config, layer_idx)
-        # See BitNetMLP: absent, not neutral, when the checkpoint was trained
-        # without the sub-layer normalisation.
-        self.attn_sub_norm = (
-            BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else None
-        )
+        self.attn_sub_norm = _make_sub_norm(config, config.hidden_size)
 
     def forward(
         self,
@@ -107,8 +107,7 @@ class BitNetAttention(LlamaAttention):
         )
 
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
-        if self.attn_sub_norm is not None:
-            attn_output = self.attn_sub_norm(attn_output)  # diff with Llama
+        attn_output = self.attn_sub_norm(attn_output)  # diff with Llama
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights
 

--- a/tests/models/bitnet/test_modeling_bitnet.py
+++ b/tests/models/bitnet/test_modeling_bitnet.py
@@ -15,6 +15,7 @@
 
 import gc
 import unittest
+from dataclasses import replace
 
 from transformers import AutoTokenizer, BitNetConfig, is_torch_available
 from transformers.testing_utils import (
@@ -165,6 +166,31 @@ class BitNetModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
+
+    def test_model_without_sub_norms(self):
+        config, input_ids, input_mask = self.model_tester.prepare_config_and_inputs()
+        config = replace(config, use_sub_norms=False)
+        model = BitNetForCausalLM(config=config).to(torch_device)
+        model.eval()
+
+        # Sub-norms are `nn.Identity`, so they do not normalise and carry no
+        # weights in the state dict.
+        for layer in model.model.layers:
+            self.assertIsInstance(layer.mlp.ffn_sub_norm, torch.nn.Identity)
+            self.assertIsInstance(layer.self_attn.attn_sub_norm, torch.nn.Identity)
+        self.assertFalse(any("sub_norm" in key for key in model.state_dict()))
+
+        result = model(input_ids, attention_mask=input_mask)
+        self.assertEqual(
+            result.logits.shape,
+            (self.model_tester.batch_size, self.model_tester.seq_length, self.model_tester.vocab_size),
+        )
+
+    def test_config_use_sub_norms_roundtrip(self):
+        config = BitNetConfig(use_sub_norms=False)
+        config_dict = config.to_dict()
+        self.assertIs(config_dict["use_sub_norms"], False)
+        self.assertIs(BitNetConfig.from_dict(config_dict).use_sub_norms, False)
 
 
 @require_torch


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47955)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47955)
<!-- ci-dashboard-badge:end -->

## Summary

Adds the `use_sub_norms` flag to `BitNetConfig` and honours it in
`BitNetMLP`/`BitNetAttention`. When `False`, the per-projection sub-layer
RMSNorm modules are replaced by `nn.Identity` (a shared `_make_sub_norm`
helper builds either), which is what weight-quant-only BitLinear
checkpoints require.

## Why

BitNet checkpoints come in two forward variants:

1. **Full BitNet** (`use_sub_norms=True`, default): per-projection RMSNorm
   (attn_sub_norm / ffn_sub_norm) applied before the projection bias and the
   residual — the `microsoft/bitnet-b1.58-2B-4T` shape.
2. **Weight-quant-only** (`use_sub_norms=False`): trained through a BitLinear
   that skips the per-projection RMSNorm and activation quant entirely; the
   weights are already ternary `{-1, 0, +1}` and the forward is a plain
   `nn.Linear`. The sub-norm must not normalise: an RMSNorm initialised to
   ones still normalises, so it cannot be neutralised by `weight=ones`.
   `nn.Identity` removes the normalisation from the forward while keeping the
   module graph and the state dict uniform (it has no parameters, so no
   `*_sub_norm.*` weights appear either way).

Today `BitNetMLP.forward` always runs `self.ffn_sub_norm(...)` and
`BitNetAttention.forward` always runs `self.attn_sub_norm(...)` on modules
unconditionally constructed in `__init__`. A weight-quant-only checkpoint
therefore loads with the sub-norms applied, producing logits that differ
from the trained/deployed forward by ~10 in max-abs and flip the argmax.

## Changes

- `configuration_bitnet.py`: add `use_sub_norms: bool = True` (docstring
  notes that loading a checkpoint *with* sub-norm weights into a
  `use_sub_norms=False` model leaves them unused and reported as such).
- `modular_bitnet.py`: `_make_sub_norm` helper + `nn.Identity` fallback; the
  forward paths stay branch-free.
- `modeling_bitnet.py`: generated mirror of the modular change.
- `tests/models/bitnet/test_modeling_bitnet.py`: new
  `test_model_without_sub_norms` (Identity modules, no `*_sub_norm.*` state
  dict keys, forward shapes) and `test_config_use_sub_norms_roundtrip`.

Backward compatible: the default stays `True`, so existing `bitnet` model
cards (which don't set `use_sub_norms`) are unchanged.

## Verification

A continued-trained Qwen2.5-0.5B weight-quant-only BitNet (ternary export,
`PeetPedro/quantal-ternary`) loaded into `BitNetForCausalLM` with
`use_sub_norms=False`, compared against a golden reference (the deployed
forward the Rust runner reproduces to 1e-5):

```
prompt 1: max_abs 6.497e-06  argmax 71703 = 71703  PASS
prompt 2: max_abs 6.676e-06  argmax 71703 = 71703  PASS
```

Before the fix (sub-norms forced on): max_abs ~10-20, argmax off.

Local: `pytest tests/models/bitnet/test_modeling_bitnet.py` — 146 passed,
132 skipped; ruff and modular-conversion checks pass.

## AI disclosure

This PR was drafted with assistance from an AI coding agent (opencode), and
further refined with an AI assistant (Crush). The human submitter reviewed
all changed lines and ran the verification above.
Coordination: https://huggingface.co/PeetPedro/quantal-ternary (the model
this enables). No overlapping open PR found for `use_sub_norms`.

Fixes #47957
