### PR TITLE
[Trainer] Exempt PEFT-wrapped models from quant-method training guard

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -106,7 +106,7 @@ def validate_quantization_for_training(model):
     Raises `ValueError` when:
     - A quantized + compiled model is used (torch.compile is not supported with PEFT fine-tuning).
     - A purely quantized model has no trainable adapters attached (unless it supports QAT).
-    - The quantization method does not support training.
+    - The quantization method does not support training, unless trainable adapters are attached via PEFT.
 
     Args:
         model: The model to validate.
@@ -134,7 +134,7 @@ def validate_quantization_for_training(model):
             " the quantized model to correctly perform fine-tuning. Please see: https://huggingface.co/docs/transformers/peft"
             " for more details"
         )
-    elif _is_quantized_and_base_model and not _quantization_method_supports_training:
+    elif _is_quantized_and_base_model and not _is_peft_model(model) and not _quantization_method_supports_training:
         raise ValueError(
             f"The model you are trying to fine-tune is quantized with {model.hf_quantizer.quantization_config.quant_method}"
             " but that quantization method do not support training. Please open an issue on GitHub: https://github.com/huggingface/transformers"

--- a/tests/trainer/test_trainer_utils.py
+++ b/tests/trainer/test_trainer_utils.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import patch
+
+from transformers.trainer_utils import validate_quantization_for_training
+
+
+class DummyQuantizationConfig:
+    def __init__(self, quant_method="fp8"):
+        self.quant_method = quant_method
+
+
+class DummyQuantizer:
+    def __init__(self, is_trainable=False, is_qat_trainable=False):
+        self._is_trainable = is_trainable
+        self._is_qat_trainable = is_qat_trainable
+
+    @property
+    def is_trainable(self):
+        return self._is_trainable
+
+    @property
+    def is_qat_trainable(self):
+        return self._is_qat_trainable
+
+    @property
+    def quantization_config(self):
+        return DummyQuantizationConfig()
+
+
+class DummyQuantizedModel:
+    def __init__(self, is_trainable=False, hf_peft_config_loaded=False):
+        self.is_quantized = True
+        self._hf_peft_config_loaded = hf_peft_config_loaded
+        self.hf_quantizer = DummyQuantizer(is_trainable=is_trainable)
+
+
+class ValidateQuantizationForTrainingTest(unittest.TestCase):
+    def test_unquantized_model_passes(self):
+        model = DummyQuantizedModel()
+        model.is_quantized = False
+        validate_quantization_for_training(model)
+
+    def test_untrainable_quantized_base_model_raises(self):
+        with self.assertRaisesRegex(ValueError, "purely quantized models"):
+            validate_quantization_for_training(DummyQuantizedModel())
+
+    def test_qat_flagged_but_untrainable_method_raises(self):
+        model = DummyQuantizedModel()
+        model.hf_quantizer = DummyQuantizer(is_trainable=False, is_qat_trainable=True)
+        with self.assertRaisesRegex(ValueError, "do not support training"):
+            validate_quantization_for_training(model)
+
+    def test_trainable_quantized_base_model_without_adapters_raises(self):
+        with self.assertRaisesRegex(ValueError, "purely quantized models"):
+            validate_quantization_for_training(DummyQuantizedModel(is_trainable=True))
+
+    def test_compiled_quantized_model_raises(self):
+        model = DummyQuantizedModel()
+        model._orig_mod = object()
+        with self.assertRaisesRegex(ValueError, "torch.compile"):
+            validate_quantization_for_training(model)
+
+    def test_qat_trainable_model_passes(self):
+        model = DummyQuantizedModel(is_trainable=True)
+        model.hf_quantizer = DummyQuantizer(is_trainable=True, is_qat_trainable=True)
+        validate_quantization_for_training(model)
+
+    def test_native_peft_adapters_passes(self):
+        validate_quantization_for_training(DummyQuantizedModel(hf_peft_config_loaded=True))
+
+    def test_peft_wrapped_model_with_trainable_quant_method_passes(self):
+        with patch("transformers.trainer_utils._is_peft_model", return_value=True):
+            validate_quantization_for_training(DummyQuantizedModel(is_trainable=True))
+
+    def test_peft_wrapped_model_with_untrainable_quant_method_passes(self):
+        with patch("transformers.trainer_utils._is_peft_model", return_value=True):
+            validate_quantization_for_training(DummyQuantizedModel())


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47958)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47958)
<!-- ci-dashboard-badge:end -->

## Summary

`validate_quantization_for_training` rejected any PEFT-wrapped model whose
quantizer reports `is_trainable=False` (e.g. `fp8` / `fbgemm_fp8`), blocking
the documented LoRA-on-quantized flow: `get_peft_model` attaches trainable
adapters to a frozen quantized base, yet `Trainer.__init__` raised.

## Why

The guard's first branch already exempts PEFT models ("attach trainable
adapters on top of the quantized model"), but the `elif` for untrainable
quant methods did not. Whether the quantized base is trainable is irrelevant
when only the bf16 LoRA adapters receive gradients — the base is frozen. The
bitsandbytes LoRA workflow only passed because the bnb quantizer reports
`is_trainable=True`; FP8 quantizers correctly report `False`, which made LoRA
on FP8-only checkpoints (e.g. DeepSeek-V4-Flash) impossible through the
standard `get_peft_model` path.

## Changes

- `src/transformers/trainer_utils.py`: added `not _is_peft_model(model)` to
  the `elif` branch, mirroring the first branch's exemption; docstring
  updated. The `elif` remains live for the contradictory
  QAT-flagged-but-untrainable case.
- `tests/trainer/test_trainer_utils.py`: new CPU-only unit tests for the
  guard (9 cases: bare / PEFT / QAT / compiled / native-adapters × trainable
  and untrainable quant methods), no GPU or peft install needed.

## Verification

- `.venv/bin/python -m pytest tests/trainer/test_trainer_utils.py -q -p no:randomly` — 9 passed
- `ruff check` / `ruff format` clean on both files.

Fixes #46736

## AI disclosure

Drafted with assistance from an AI coding agent (Crush); the human submitter
reviewed all changed lines and ran the verification above.
