### PR TITLE
[Init] Guard nn.Embedding branch in generic _init_weights against packed weights

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2400,10 +2400,11 @@ class PreTrainedModel(
                 elif "bias" in name:
                     init.constant_(param, 0.0)
         elif isinstance(module, nn.Embedding):
-            init.normal_(module.weight, mean=0.0, std=std)
-            # Here we need the check explicitly, as we slice the weight in the `zeros_` call, so it looses the flag
-            if module.padding_idx is not None and not getattr(module.weight, "_is_hf_initialized", False):
-                init.zeros_(module.weight[module.padding_idx])
+            if getattr(module, "weight", None) is not None:
+                init.normal_(module.weight, mean=0.0, std=std)
+                # Here we need the check explicitly, as we slice the weight in the `zeros_` call, so it looses the flag
+                if module.padding_idx is not None and not getattr(module.weight, "_is_hf_initialized", False):
+                    init.zeros_(module.weight[module.padding_idx])
         elif isinstance(module, nn.MultiheadAttention):
             # This uses torch's original init
             module._reset_parameters()

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -437,6 +437,34 @@ class ModelUtilsTest(TestCasePlus):
         self.assertIn(torch.device("cpu"), total_byte_count)
         self.assertGreater(total_byte_count[torch.device("cpu")], 0)
 
+    @require_torch
+    def test_initialize_missing_keys_skips_packed_embeddings(self):
+        config = BertConfig(
+            vocab_size=99,
+            hidden_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            intermediate_size=37,
+            max_position_embeddings=64,
+        )
+        model = BertModel(config)
+        for module in model.modules():
+            if isinstance(module, nn.Embedding):
+                num_embeddings, embedding_dim = module.weight.shape
+                del module._parameters["weight"]
+                module.register_parameter(
+                    "weight_packed",
+                    nn.Parameter(
+                        torch.zeros(num_embeddings, embedding_dim // 8, dtype=torch.int32), requires_grad=False
+                    ),
+                )
+        for param in model.parameters():
+            param._is_hf_initialized = True
+        for module in model.modules():
+            if hasattr(module, "_is_hf_initialized"):
+                del module._is_hf_initialized
+        model._initialize_missing_keys(is_quantized=True)
+
     def test_hub_retry(self):
         @hub_retry(max_attempts=2)
         def test_func():


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47959)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47959)
<!-- ci-dashboard-badge:end -->

## Summary

`PreTrainedModel._init_weights` dereferenced `module.weight` on
`nn.Embedding` unconditionally — the last unguarded branch of the generic
initializer. Checkpoints with quantized embeddings (packed tensors replacing
`weight`) crash at load with `AttributeError: 'Embedding' object has no
attribute 'weight'`. This guards the branch exactly like the existing
Linear/Conv and norm guards.

## Why

Follow-up piece of #47920 (explicitly left open there): quantizers replace
`weight` on `Embedding` with packed tensors (`weight_packed` / `qweight`),
so the finalization init pass must skip them. Mirrors the merged pattern
from #38013.

## Changes

- `src/transformers/modeling_utils.py`: wrap `init.normal_` / `padding_idx`
  handling in `if getattr(module, "weight", None) is not None`, matching
  the `nn.Linear`/`nn.Conv*` branch.
- `tests/utils/test_modeling_utils.py`: CPU-only regression test that packs
  every embedding of a tiny `BertModel` and runs
  `_initialize_missing_keys(is_quantized=True)`; raises `AttributeError`
  without the fix, passes with it.

## Verification

- `.venv/bin/python -m pytest tests/utils/test_modeling_utils.py -q -p no:randomly -k initialize_missing_keys_skips_packed_embeddings` — 1 passed (fails on unpatched source)
- `ruff check` / `ruff format` clean on both files.

Part of #47920

## AI disclosure

Drafted with assistance from an AI coding agent (Crush); the human submitter
reviewed all changed lines and ran the verification above.
