### PR TITLE
Fix Qwen3.5 BF16 gated delta initialization

### DIFF
--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -814,7 +814,10 @@ class Qwen3_5PreTrainedModel(PreTrainedModel):
         super()._init_weights(module)
         if isinstance(module, Qwen3_5GatedDeltaNet):
             init.ones_(module.dt_bias)
-            init.copy_(module.A_log, torch.empty_like(module.A_log).uniform_(0, 16).log_())
+            init.copy_(
+                module.A_log,
+                torch.empty_like(module.A_log, dtype=torch.float32).uniform_(0, 16).log_(),
+            )
         # We initialize with 0s to be 1 centered as the RMSNorm here does (1 + weight)
         elif isinstance(module, Qwen3_5RMSNorm):
             init.zeros_(module.weight)

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -418,7 +418,10 @@ class Qwen3_5PreTrainedModel(Qwen3NextPreTrainedModel):
         PreTrainedModel._init_weights(self, module)
         if isinstance(module, Qwen3_5GatedDeltaNet):
             init.ones_(module.dt_bias)
-            init.copy_(module.A_log, torch.empty_like(module.A_log).uniform_(0, 16).log_())
+            init.copy_(
+                module.A_log,
+                torch.empty_like(module.A_log, dtype=torch.float32).uniform_(0, 16).log_(),
+            )
         # We initialize with 0s to be 1 centered as the RMSNorm here does (1 + weight)
         elif isinstance(module, Qwen3_5RMSNorm):
             init.zeros_(module.weight)

--- a/tests/models/qwen3_5/test_modeling_qwen3_5.py
+++ b/tests/models/qwen3_5/test_modeling_qwen3_5.py
@@ -146,6 +146,28 @@ class Qwen3_5TextModelTest(CausalLMModelTest, unittest.TestCase):
             self.assertEqual(len(self_attentions), sum(layer == "full_attention" for layer in config.layer_types))
             self.assertListEqual(list(self_attentions[0].shape[-3:]), [config.num_attention_heads, seq_len, seq_len])
 
+    def test_gated_delta_net_a_log_initialization_uses_float32_sampling(self):
+        previous_dtype = torch.get_default_dtype()
+        try:
+            torch.manual_seed(3)
+            torch.set_default_dtype(torch.bfloat16)
+
+            config = self.model_tester.get_config()
+            model = Qwen3_5TextModel(config)
+
+            a_logs = [
+                module.A_log
+                for module in model.modules()
+                if hasattr(module, "A_log")
+            ]
+
+            self.assertTrue(a_logs)
+            for a_log in a_logs:
+                self.assertEqual(a_log.dtype, torch.bfloat16)
+                self.assertTrue(torch.isfinite(a_log).all())
+        finally:
+            torch.set_default_dtype(previous_dtype)
+
     @unittest.skip("The specific cache format cannot be instantiated from dp/ddp data.")
     def test_multi_gpu_data_parallel_forward(self):
         pass

--- a/tests/models/qwen3_5/test_modeling_qwen3_5.py
+++ b/tests/models/qwen3_5/test_modeling_qwen3_5.py
@@ -155,11 +155,7 @@ class Qwen3_5TextModelTest(CausalLMModelTest, unittest.TestCase):
             config = self.model_tester.get_config()
             model = Qwen3_5TextModel(config)
 
-            a_logs = [
-                module.A_log
-                for module in model.modules()
-                if hasattr(module, "A_log")
-            ]
+            a_logs = [module.A_log for module in model.modules() if hasattr(module, "A_log")]
 
             self.assertTrue(a_logs)
             for a_log in a_logs:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47962)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47962)
<!-- ci-dashboard-badge:end -->

### Summary
- initialize Qwen3.5 `A_log` from an FP32 temporary tensor before copying into the parameter
- add a regression test covering BF16 `A_log` initialization

### Validation
- `python -m pytest tests/models/qwen3_5/test_modeling_qwen3_5.py -q -k "init_weights"` — 2 passed
- `python -m pytest tests/models/qwen3_5/test_modeling_qwen3_5.py -q -k "gated_delta_net_a_log_initialization_uses_float32_sampling"` — 1 passed
- `git diff --check` — clean

The full Qwen3.5 suite was also attempted locally; unrelated Windows `WinError 5` safetensors cleanup/file-lock failures and a missing MSVC `cl` compiler prevented a clean full-suite result.