### PR TITLE
Fix ROCm SDPA-flash skip guard that crashes on RDNA GPUs

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3388,6 +3388,40 @@ def unpack_device_properties(
     return device_type, major, minor
 
 
+@functools.lru_cache(maxsize=1)
+def supports_sdpa_flash_backend() -> bool | None:
+    """Whether torch's SDPA flash backend can actually dispatch on this device.
+
+    Ask torch instead of guessing from the ROCm architecture number: CDNA
+    (flash-capable) reports major 9 while RDNA parts report 10/11/12, so a
+    ``major >= 9`` gate admits RDNA hardware that has no flash kernel. Returns
+    ``None`` when torch's capability API is unavailable.
+    """
+    import torch
+
+    if not torch.cuda.is_available():
+        return False
+    try:
+        from torch.backends.cuda import SDPAParams, can_use_flash_attention
+    except ImportError:
+        return None
+    try:
+        q = torch.empty(1, 1, 1, 16, device="cuda", dtype=torch.float16)
+        return bool(can_use_flash_attention(SDPAParams(q, q, q, None, 0.0, False, False), False))
+    except Exception:
+        return None
+
+
+def rocm_has_sdpa_flash_backend(major: int) -> bool:
+    """Whether this ROCm device can dispatch the SDPA flash backend, falling back
+    to the historical ``major >= 9`` heuristic when torch's query is unavailable.
+    """
+    supported = supports_sdpa_flash_backend()
+    if supported is None:
+        return major >= 9
+    return supported
+
+
 class Expectations(UserDict[PackedDeviceProperties, Any]):
     def get_expectation(self) -> Any:
         """

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3394,8 +3394,8 @@ def supports_sdpa_flash_backend() -> bool | None:
 
     Ask torch instead of guessing from the ROCm architecture number: CDNA
     (flash-capable) reports major 9 while RDNA parts report 10/11/12, so a
-    ``major >= 9`` gate admits RDNA hardware that has no flash kernel. Returns
-    ``None`` when torch's capability API is unavailable.
+    "major >= 9" gate admits RDNA hardware that has no flash kernel. Returns
+    None when torch's capability API is unavailable.
     """
     import torch
 
@@ -3414,7 +3414,7 @@ def supports_sdpa_flash_backend() -> bool | None:
 
 def rocm_has_sdpa_flash_backend(major: int) -> bool:
     """Whether this ROCm device can dispatch the SDPA flash backend, falling back
-    to the historical ``major >= 9`` heuristic when torch's query is unavailable.
+    to the historical "major >= 9" heuristic when torch's query is unavailable.
     """
     supported = supports_sdpa_flash_backend()
     if supported is None:

--- a/tests/models/musicgen/test_modeling_musicgen.py
+++ b/tests/models/musicgen/test_modeling_musicgen.py
@@ -40,6 +40,7 @@ from transformers.testing_utils import (
     require_torch,
     require_torch_accelerator,
     require_torch_fp16,
+    rocm_has_sdpa_flash_backend,
     slow,
     torch_device,
 )
@@ -917,8 +918,8 @@ class MusicgenTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
         device_type, major, _ = get_device_properties()
         if device_type == "cuda" and major < 8:
             self.skipTest(reason="This test requires an NVIDIA GPU with compute capability >= 8.0")
-        elif device_type == "rocm" and major < 9:
-            self.skipTest(reason="This test requires an AMD GPU with compute capability >= 9.0")
+        elif device_type == "rocm" and not rocm_has_sdpa_flash_backend(major):
+            self.skipTest(reason="This AMD GPU has no SDPA flash backend available")
         elif device_type not in ["cuda", "rocm", "xpu"]:
             self.skipTest(reason="This test requires a Nvidia or AMD GPU or an Intel XPU")
 

--- a/tests/models/musicgen_melody/test_modeling_musicgen_melody.py
+++ b/tests/models/musicgen_melody/test_modeling_musicgen_melody.py
@@ -42,6 +42,7 @@ from transformers.testing_utils import (
     require_torch_accelerator,
     require_torch_fp16,
     require_torchaudio,
+    rocm_has_sdpa_flash_backend,
     slow,
     torch_device,
 )
@@ -919,8 +920,8 @@ class MusicgenMelodyTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         device_type, major, _ = get_device_properties()
         if device_type == "cuda" and major < 8:
             self.skipTest(reason="This test requires an NVIDIA GPU with compute capability >= 8.0")
-        elif device_type == "rocm" and major < 9:
-            self.skipTest(reason="This test requires an AMD GPU with compute capability >= 9.0")
+        elif device_type == "rocm" and not rocm_has_sdpa_flash_backend(major):
+            self.skipTest(reason="This AMD GPU has no SDPA flash backend available")
         elif device_type not in ["cuda", "rocm", "xpu"]:
             self.skipTest(reason="This test requires a Nvidia or AMD GPU or an Intel XPU")
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -105,6 +105,7 @@ from transformers.testing_utils import (
     require_torch_mps,
     require_torch_multi_accelerator,
     require_torch_multi_gpu,
+    rocm_has_sdpa_flash_backend,
     run_first,
     run_test_using_subprocess,
     set_config_for_less_flaky_test,
@@ -3804,8 +3805,8 @@ class ModelTesterMixin(ExportTesterMixin):
         device_type, major, minor = get_device_properties()
         if device_type == "cuda" and major < 8:
             self.skipTest(reason="This test requires an NVIDIA GPU with compute capability >= 8.0")
-        elif device_type == "rocm" and major < 9:
-            self.skipTest(reason="This test requires an AMD GPU with compute capability >= 9.0")
+        elif device_type == "rocm" and not rocm_has_sdpa_flash_backend(major):
+            self.skipTest(reason="This AMD GPU has no SDPA flash backend available")
         elif device_type not in ["cuda", "rocm", "xpu"]:
             self.skipTest(reason="This test requires a Nvidia or AMD GPU, or an Intel XPU")
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47965)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47965)
<!-- ci-dashboard-badge:end -->

## What

`test_sdpa_can_dispatch_on_flash` gates AMD hardware with `major < 9` as a proxy for "no flash backend". That proxy is backwards: CDNA (flash-capable) reports major 9, while RDNA consumer/APU parts report *higher* majors (RDNA3.5/gfx1151 = 11). So the guard admits exactly the GPUs it meant to exclude, and the test fails with `RuntimeError: No available kernel` (verified on gfx1151).

## Fix

Ask torch whether SDPA-flash can actually dispatch (`can_use_flash_attention`) instead of guessing from the arch number, falling back to the historical `major >= 9` when that API is unavailable. Applied to the 3 affected sites (`test_modeling_common`, `musicgen`, `musicgen_melody`).

Verified on MI300 (CDNA): the test still runs and passes; behavior only changes on RDNA, which now skips instead of crashing.