### PR TITLE
Fix unquoted-key JSON repair skipping keys preceded by whitespace

### DIFF
--- a/src/transformers/utils/chat_parsing/content_parsers.py
+++ b/src/transformers/utils/chat_parsing/content_parsers.py
@@ -70,7 +70,7 @@ def _json(text: str, args: dict) -> Any:
         working = re.sub(pattern, _capture, working, flags=re.DOTALL)
 
     if unquoted_keys:
-        working = re.sub(r"(?<=[{,])(\w+):", r'"\1":', working)
+        working = re.sub(r"([{,]\s*)(\w+):", r'\1"\2":', working)
 
     for i, s in enumerate(captured):
         working = working.replace(f"{_LAX_OPEN}{i}{_LAX_CLOSE}", json.dumps(s))

--- a/tests/utils/test_chat_parsing.py
+++ b/tests/utils/test_chat_parsing.py
@@ -545,6 +545,31 @@ class ChatResponseTemplateParserTest(unittest.TestCase):
             },
         )
 
+    def test_gemma4_tool_call_with_spaces_between_args(self):
+        # Models often emit ", " (or newlines) between arguments; unquoted key
+        # detection must tolerate whitespace before the key
+        model_out = (
+            "<|channel>thought\nThe user is asking for the current temperature in Paris.<channel|>"
+            '<|tool_call>call:get_current_temperature{detail_level: 0, location: <|"|>Paris, France<|"|>,\n'
+            'unit: <|"|>celsius<|"|>}<tool_call|><|tool_response>'
+        )
+        self.assertEqual(
+            parse_response(model_out, gemma4_template, prefix=""),
+            {
+                "role": "assistant",
+                "thinking": "The user is asking for the current temperature in Paris.",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_current_temperature",
+                            "arguments": {"detail_level": 0, "location": "Paris, France", "unit": "celsius"},
+                        },
+                    }
+                ],
+            },
+        )
+
     def test_gemma4_complex_tool_call(self):
         model_out = (
             "<|channel>thought\nLet me call the tool.<channel|>"


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47967)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47967)
<!-- ci-dashboard-badge:end -->

# What's broken

`_json()` in `chat_parsing/content_parsers.py` repairs lax JSON emitted by models. Its unquoted-key pass uses a lookbehind:

```python
working = re.sub(r"(?<=[{,])(\w+):", r'"\1":', working)
```

The lookbehind requires the key to sit *immediately* after `{` or `,`. Models routinely put a space or newline there — `{"a": 1, b: 2}` — and those keys are left unquoted, so `json.loads` fails and the whole tool call is dropped.

# Fix

Match the delimiter plus any following whitespace and preserve it:

```python
working = re.sub(r"([{,]\s*)(\w+):", r'\1"\2":', working)
```

# Test

Added `test_gemma4_tool_call_with_spaces_between_args`, a Gemma4 tool call with `, ` and a newline between arguments. It fails on `main` and passes with the fix. Full file: 51 passed, 1 skipped, 337 subtests passed.