### PR TITLE
[tests] Fix expected output for Qwen2.5-VL batch_wo_image on CUDA

### DIFF
--- a/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
@@ -598,7 +598,7 @@ class Qwen2_5_VLIntegrationTest(unittest.TestCase):
             {
                 (None, None): [
                     'system\nYou are a helpful assistant.\nuser\nWhat kind of dog is this?\nassistant\nThe dog in the picture appears to be a Labrador Retriever. Labradors are known for their friendly and energetic nature, which is evident in',
-                    'system\nYou are a helpful assistant.\nuser\nWho are you?\nassistant\nI am Qwen, an AI language model created by Alibaba Cloud. I am designed to assist with various tasks such as answering questions, providing information,'
+                    'system\nYou are a helpful assistant.\nuser\nWho are you?\nassistant\nI am Qwen, a large language model created by Alibaba Cloud. I am designed to assist with a wide range of tasks, from answering questions and'
                 ],
                 ("rocm", (9, 4)): [
                     'system\nYou are a helpful assistant.\nuser\nWhat kind of dog is this?\nassistant\nThe dog in the picture appears to be a Labrador Retriever. Labradors are known for their friendly and energetic nature, which is evident in',


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47968)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47968)
<!-- ci-dashboard-badge:end -->

## Summary

Fixes a stale expected string in `test_small_model_integration_test_batch_wo_image` for `Qwen2_5_VLIntegrationTest`.

The `(None, None)` CUDA expected value was outdated:
- **Before**: `"an AI language model"` / `"various tasks such as answering questions, providing information,"`
- **After**: `"a large language model"` / `"a wide range of tasks, from answering questions and"`

The rocm and xpu entries already had the correct value. Verified passing on an A10G GPU runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)