### PR TITLE
Remove stale (None, None) fallback in qwen2_5_vl batch_different_resolutions test

### DIFF
--- a/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
@@ -636,10 +636,6 @@ class Qwen2_5_VLIntegrationTest(unittest.TestCase):
 
         expected_decoded_texts = Expectations(
             {
-                (None, None): [
-                    "system\nYou are a helpful assistant.\nuser\nWhat kind of dog is this?\nassistant\nThe dog in the picture appears to be a Labrador Retriever. Labradors are known for their friendly and energetic nature, which is evident in",
-                    "system\nYou are a helpful assistant.\nuser\nWhat kind of dog is this?\nassistant\n addCriterion\nThe dog in the picture appears to be a Labrador Retriever. Labradors are known for their friendly and gentle nature, which is",
-                ],
                 ("cuda", (8, 6)): [
                     'system\nYou are a helpful assistant.\nuser\nWhat kind of dog is this?\nassistant\nThe dog in the picture appears to be a Labrador Retriever. Labradors are known for their friendly and energetic nature, which is evident in',
                     'system\nYou are a helpful assistant.\nuser\nWhat kind of dog is this?\nassistant\nThe dog in the picture appears to be a Labrador Retriever. Labradors are known for their friendly and gentle nature, which is evident in',


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47972)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47972)
<!-- ci-dashboard-badge:end -->

## Summary

The `(None, None)` fallback in `test_small_model_integration_test_batch_different_resolutions` contained a stale expected value: the second batch item started with `' addCriterion\n'` — a garbage token that was measured at commit c61ca64 on CUDA 8.6 hardware but no longer matches any current hardware's output.

All hardware-specific keys (`("cuda", (8, 6))`, `("rocm", None)`, `("xpu", None)`) already have clean, correct expected values. The `(None, None)` fallback is removed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>