### PR TITLE
fix(deps): bump tokenizers upper bound to <0.24.0 (#47429)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ _deps = [
     "tomli",
     "tiktoken",
     "timm>=1.0.23",
-    "tokenizers>=0.22.0,<=0.23.0",
+    "tokenizers>=0.22.0,<0.24.0",
     "torch>=2.5",
     "torchaudio",
     "torchvision",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -73,7 +73,7 @@ deps = {
     "tomli": "tomli",
     "tiktoken": "tiktoken",
     "timm": "timm>=1.0.23",
-    "tokenizers": "tokenizers>=0.22.0,<=0.23.0",
+    "tokenizers": "tokenizers>=0.22.0,<0.24.0",
     "torch": "torch>=2.5",
     "torchaudio": "torchaudio",
     "torchvision": "torchvision",


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47978&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47978) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47978&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47978)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47429

`tokenizers==0.23.0` was never published, and the release series jumped directly from `0.22.x` to `0.23.1`. The upper bound constraint `<=0.23.0` unintentionally blocked users from installing `tokenizers==0.23.1`, which contains a security fix for an XSS vulnerability in `EncodingVisualizer` (AIKIDO-2026-10636).

This PR updates the upper bound in `dependency_versions_table.py` from `<=0.23.0` to `<0.24.0`.

Both `setup.py` and `src/transformers/dependency_versions_table.py` have been updated and formatted to bump `tokenizers` upper bound to `<0.24.0` (#47429). 

Because `setup.py` was modified, CI security gate approval from a maintainer is required to run the workflow.