### PR TITLE
[AXK1] Fix expected logits for CUDA A10G

### DIFF
--- a/tests/models/axk1/test_modeling_axk1.py
+++ b/tests/models/axk1/test_modeling_axk1.py
@@ -107,14 +107,14 @@ class AXK1IntegrationTest(unittest.TestCase):
         # Last-3x3 logits slice, left-padded (batch 0) and unpadded (batch 1) rows.
         EXPECTED_LOGITS_LEFT_PADDED = Expectations(
             {
-                ("cuda", (8, 6)): [[-0.2910, 1.8047, 0.4121], [0.4277, -0.3027, -1.0000], [-0.3535, 0.1221, 0.9961]],
+                ("cuda", (8, 6)): [[-0.1895, 1.7656, 0.8828], [0.2637, -0.1377, -1.0078], [-0.4648, 0.2031, 1.0391]],
                 ("xpu", None): [[-0.1934, 1.7266, 0.9141], [0.2393, -0.2363, -1.0156], [-0.4062, 0.1309, 1.0234]],
             }
         )
         expected_left_padded = torch.tensor(EXPECTED_LOGITS_LEFT_PADDED.get_expectation(), device=torch_device)
         EXPECTED_LOGITS_UNPADDED = Expectations(
             {
-                ("cuda", (8, 6)): [[-0.5234, -0.0388, -0.3574], [-0.4980, -0.2119, -0.0713], [-0.8359, 0.0669, -0.4219]],
+                ("cuda", (8, 6)): [[-0.5703, -0.0099, -0.3477], [-0.3613, -0.3008, 0.1836], [-0.8008, 0.0840, -0.4453]],
                 ("xpu", None): [[-0.5469, -0.0574, -0.3691], [-0.3301, -0.3770, 0.2012], [-0.8320, 0.0732, -0.4492]],
             }
         )  # fmt: skip


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47980)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47980)
<!-- ci-dashboard-badge:end -->

## Summary

- `test_model_logits_batched` has been failing on A10G (CUDA compute capability 8.6) since the model was added in #46867
- The `("cuda", (8, 6))` expected values for both `EXPECTED_LOGITS_LEFT_PADDED` and `EXPECTED_LOGITS_UNPADDED` were incorrect (all 9 elements mismatched, greatest absolute diff ~0.47)
- Updated to values measured on A10G with PyTorch on the CI runner

## Test plan
- [x] `test_model_logits_batched` passes on A10G (verified on SSH CI runner)