### PR TITLE
docs: fix malformed link to custom models section in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ There are four timelines for model additions depending on the model contributor 
 
   Open issues tagged ["New model"](https://github.com/huggingface/transformers/issues?q=is%3Aopen+is%3Aissue+label%3A%22New+model%22) are the entry point for outside contributors. Start with the most-requested architectures to maximize impact. We'll review and guide you through it.
 
-- Hub-first release: ship your model directly on the Hub via Transformers' [remote-code](./docs/source/en/models#custom-models.md) support, with no upstream PR required.
+- Hub-first release: ship your model directly on the Hub via Transformers' [remote-code](./docs/source/en/models.md#custom-models) support, with no upstream PR required.
 
   Popular Hub-first models often get integrated into Transformers later, which unlocks first-class docs, maintenance, and optimization. Hub-first is the lowest-friction way to add a model. However, it can be more fragile if a model requires weight conversion or other backward compatibility issues.
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47984)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47984)
<!-- ci-dashboard-badge:end -->

the link to the remote-code docs in CONTRIBUTING.md had the .md extension on the anchor instead of the file path. this broke the link and pointed to a directory instead of models.md. i fixed it to go to models.md#custom-models.