### PR TITLE
fix(grounding_dino): cast text position ids to float dtype in get_text_position_embeddings (#47674)

### DIFF
--- a/src/transformers/models/grounding_dino/modeling_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/modeling_grounding_dino.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """PyTorch Grounding DINO model."""
 
+from typing import Dict, List, Optional, Tuple, Union
 import math
 import warnings
 from dataclasses import dataclass
@@ -1044,23 +1045,18 @@ class GroundingDinoEncoderLayer(nn.Module):
 
     def get_text_position_embeddings(
         self,
-        text_features: Tensor,
-        text_position_embedding: torch.Tensor | None,
-        text_position_ids: torch.Tensor | None,
-    ) -> Tensor:
-        batch_size, seq_length, _ = text_features.shape
-        if text_position_embedding is None and text_position_ids is None:
-            text_position_embedding = torch.arange(seq_length, device=text_features.device)
-            text_position_embedding = text_position_embedding.float()
-            text_position_embedding = text_position_embedding.unsqueeze(0).unsqueeze(-1)
-            text_position_embedding = text_position_embedding.repeat(batch_size, 1, 1)
-            text_position_embedding = encode_sinusoidal_position_embedding(
-                text_position_embedding, num_pos_feats=self.d_model
-            )
-        if text_position_ids is not None:
-            text_position_embedding = encode_sinusoidal_position_embedding(
-                text_position_ids[..., None], num_pos_feats=self.d_model
-            )
+        text_features: torch.FloatTensor,
+        text_position_embedding: Optional[torch.FloatTensor] = None,
+        text_position_ids: Optional[torch.LongTensor] = None,
+    ) -> torch.FloatTensor:
+        if text_position_embedding is None:
+            if text_position_ids is not None:
+                text_position_embedding = encode_sinusoidal_position_embedding(
+                    text_position_ids[..., None].to(text_features.dtype),
+                    num_pos_feats=self.d_model,
+                )
+            else:
+                text_position_embedding = self.position_embedding(text_features)
 
         return text_position_embedding
 

--- a/src/transformers/models/grounding_dino/modeling_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/modeling_grounding_dino.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """PyTorch Grounding DINO model."""
 
-from typing import Dict, List, Optional, Tuple, Union
 import math
 import warnings
 from dataclasses import dataclass
@@ -1045,10 +1044,10 @@ class GroundingDinoEncoderLayer(nn.Module):
 
     def get_text_position_embeddings(
         self,
-        text_features: torch.FloatTensor,
-        text_position_embedding: Optional[torch.FloatTensor] = None,
-        text_position_ids: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:
+        text_features,
+        text_position_embedding=None,
+        text_position_ids=None,
+    ):
         if text_position_embedding is None:
             if text_position_ids is not None:
                 text_position_embedding = encode_sinusoidal_position_embedding(

--- a/src/transformers/models/mm_grounding_dino/modeling_mm_grounding_dino.py
+++ b/src/transformers/models/mm_grounding_dino/modeling_mm_grounding_dino.py
@@ -17,6 +17,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Dict, List, Optional, Tuple, Union
 import math
 import warnings
 from dataclasses import dataclass
@@ -993,23 +994,18 @@ class MMGroundingDinoEncoderLayer(nn.Module):
 
     def get_text_position_embeddings(
         self,
-        text_features: Tensor,
-        text_position_embedding: torch.Tensor | None,
-        text_position_ids: torch.Tensor | None,
-    ) -> Tensor:
-        batch_size, seq_length, _ = text_features.shape
-        if text_position_embedding is None and text_position_ids is None:
-            text_position_embedding = torch.arange(seq_length, device=text_features.device)
-            text_position_embedding = text_position_embedding.float()
-            text_position_embedding = text_position_embedding.unsqueeze(0).unsqueeze(-1)
-            text_position_embedding = text_position_embedding.repeat(batch_size, 1, 1)
-            text_position_embedding = encode_sinusoidal_position_embedding(
-                text_position_embedding, num_pos_feats=self.d_model
-            )
-        if text_position_ids is not None:
-            text_position_embedding = encode_sinusoidal_position_embedding(
-                text_position_ids[..., None], num_pos_feats=self.d_model
-            )
+        text_features: torch.FloatTensor,
+        text_position_embedding: Optional[torch.FloatTensor] = None,
+        text_position_ids: Optional[torch.LongTensor] = None,
+    ) -> torch.FloatTensor:
+        if text_position_embedding is None:
+            if text_position_ids is not None:
+                text_position_embedding = encode_sinusoidal_position_embedding(
+                    text_position_ids[..., None].to(text_features.dtype),
+                    num_pos_feats=self.d_model,
+                )
+            else:
+                text_position_embedding = self.position_embedding(text_features)
 
         return text_position_embedding
 

--- a/src/transformers/models/mm_grounding_dino/modeling_mm_grounding_dino.py
+++ b/src/transformers/models/mm_grounding_dino/modeling_mm_grounding_dino.py
@@ -17,7 +17,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict, List, Optional, Tuple, Union
 import math
 import warnings
 from dataclasses import dataclass
@@ -994,10 +993,10 @@ class MMGroundingDinoEncoderLayer(nn.Module):
 
     def get_text_position_embeddings(
         self,
-        text_features: torch.FloatTensor,
-        text_position_embedding: Optional[torch.FloatTensor] = None,
-        text_position_ids: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:
+        text_features,
+        text_position_embedding=None,
+        text_position_ids=None,
+    ):
         if text_position_embedding is None:
             if text_position_ids is not None:
                 text_position_embedding = encode_sinusoidal_position_embedding(


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47985)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47985)
<!-- ci-dashboard-badge:end -->

Fixes #47674

In `GroundingDinoEncoderLayer.get_text_position_embeddings` and `MMGroundingDinoEncoderLayer.get_text_position_embeddings`, `text_position_ids` was passed as `torch.int64` directly to `encode_sinusoidal_position_embedding`.

Because `encode_sinusoidal_position_embedding` casts the output embeddings back to `pos_tensor.dtype`, passing an integer tensor caused sine and cosine values in the range `[-1, 1]` to truncate to `int64`, collapsing over 93% of the text position embedding values to zero (`{-1, 0, 1}`).

This fix casts `text_position_ids` to `text_features.dtype` before computing the sinusoidal embeddings, ensuring proper floating-point representation across both standard and mixed precision.