### PR TITLE
[OLMo] Fix OOM in logits tests by adding torch.no_grad()

### DIFF
--- a/tests/models/olmo/test_modeling_olmo.py
+++ b/tests/models/olmo/test_modeling_olmo.py
@@ -208,7 +208,8 @@ class OlmoIntegrationTest(unittest.TestCase):
     def test_model_7b_logits(self):
         input_ids = [[1, 306, 4658, 278, 6593, 310, 2834, 338]]
         model = OlmoForCausalLM.from_pretrained("allenai/OLMo-7B-hf", device_map="auto")
-        out = model(torch.tensor(input_ids)).logits.float()
+        with torch.no_grad():
+            out = model(torch.tensor(input_ids)).logits.float()
         # Expected mean on dim = -1
         EXPECTED_MEAN = torch.tensor([[0.0271, 0.0249, -0.0578, -0.0870, 0.0167, 0.0710, 0.1002, 0.0677]])
         torch.testing.assert_close(out.mean(-1), EXPECTED_MEAN, rtol=1e-2, atol=1e-2)
@@ -220,7 +221,8 @@ class OlmoIntegrationTest(unittest.TestCase):
     def test_model_7b_twin_2t_logits(self):
         input_ids = [[1, 306, 4658, 278, 6593, 310, 2834, 338]]
         model = OlmoForCausalLM.from_pretrained("allenai/OLMo-7B-Twin-2T-hf", device_map="auto")
-        out = model(torch.tensor(input_ids)).logits.float()
+        with torch.no_grad():
+            out = model(torch.tensor(input_ids)).logits.float()
         # Expected mean on dim = -1
         EXPECTED_MEAN = torch.tensor([[-0.3636, -0.3825, -0.4800, -0.3696, -0.8388, -0.9737, -0.9849, -0.8356]])
         torch.testing.assert_close(out.mean(-1), EXPECTED_MEAN, rtol=1e-2, atol=1e-2)

--- a/tests/models/olmo/test_modeling_olmo.py
+++ b/tests/models/olmo/test_modeling_olmo.py
@@ -196,7 +196,8 @@ class OlmoIntegrationTest(unittest.TestCase):
     def test_model_1b_logits(self):
         input_ids = [[1, 306, 4658, 278, 6593, 310, 2834, 338]]
         model = OlmoForCausalLM.from_pretrained("allenai/OLMo-1B-hf", device_map="auto")
-        out = model(torch.tensor(input_ids)).logits.float()
+        with torch.no_grad():
+            out = model(torch.tensor(input_ids).to(model.device)).logits.float().cpu()
         # Expected mean on dim = -1
         EXPECTED_MEAN = torch.tensor([[2.2869, 0.3315, 0.9876, 1.4146, 1.8804, 2.0430, 1.7055, 1.2065]])
         torch.testing.assert_close(out.mean(-1), EXPECTED_MEAN, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47986)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47986)
<!-- ci-dashboard-badge:end -->

## Summary

`test_model_7b_logits` and `test_model_7b_twin_2t_logits` call `model()` directly without `torch.no_grad()`, causing PyTorch to retain intermediate activations for potential backward passes. On A10G (22 GB VRAM), OLMo-7B loads with some layers CPU-offloaded via accelerate (`device_map="auto"`). The extra memory pressure from gradient tracking causes OOM when accelerate tries to move those CPU-offloaded layers to GPU during the forward pass.

Adding `torch.no_grad()` resolves the issue — this is consistent with how `generate()` handles inference internally, which is why `test_model_7b_greedy_generation` (which loads the same model) never hits OOM.

`test_model_1b_logits` had a separate issue: OLMo-1B fits entirely on GPU with `device_map="auto"` (no CPU offloading), so accelerate does not automatically dispatch a CPU input tensor to GPU. This caused a device mismatch `RuntimeError`. Fixed by moving the input to `model.device` and adding `torch.no_grad()` + `.cpu()` on the output for consistency.

## Test plan
- [x] `test_model_7b_logits` passes on A10G (verified on SSH CI runner)
- [x] `test_model_7b_twin_2t_logits` passes on A10G (verified on SSH CI runner)
- [x] `test_model_1b_logits` passes on A10G (verified on SSH CI runner)
- [x] Full `tests/models/olmo/` with `RUN_SLOW=1`: 166 passed, 106 skipped, 0 failed