### PR TITLE
Fix CANINE torch.export with dynamic sequence length

### DIFF
--- a/src/transformers/models/canine/modeling_canine.py
+++ b/src/transformers/models/canine/modeling_canine.py
@@ -433,6 +433,11 @@ class CanineAttention(nn.Module):
         if not self.local:
             self_outputs = self.self(hidden_states, hidden_states, attention_mask, output_attentions)
             attention_output = self_outputs[0]
+        elif self._use_blocked_local_attention(output_attentions):
+            # `range(seq_len)` is specialized by torch.export/dynamo, which freezes the
+            # example sequence length. The default CANINE encoder uses equal-stride
+            # local windows, so we can run the same attention as blocked tensors.
+            attention_output = self._local_attention_blocked(hidden_states, attention_mask)
         else:
             from_seq_length = to_seq_length = hidden_states.shape[1]
             from_tensor = to_tensor = hidden_states
@@ -493,9 +498,27 @@ class CanineAttention(nn.Module):
         outputs = (attention_output,)
         if not self.local:
             outputs = outputs + self_outputs[1:]  # add attentions if we output them
-        else:
-            outputs = outputs + tuple(attention_probs_chunks)  # add attentions if we output them
+        elif output_attentions:
+            outputs = outputs + tuple(attention_probs_chunks)
         return outputs
+
+    def _use_blocked_local_attention(self, output_attentions: bool) -> bool:
+        return (
+            self.attend_from_chunk_width == self.attend_from_chunk_stride
+            and self.attend_to_chunk_width == self.attend_to_chunk_stride
+            and self.attend_from_chunk_width == self.attend_to_chunk_width
+            and not self.always_attend_to_first_position
+            and not self.first_position_attends_to_all
+            and not output_attentions
+        )
+
+    def _local_attention_blocked(self, hidden_states: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+        seq_length = hidden_states.shape[1]
+        chunk_size = self.attend_from_chunk_stride
+        positions = torch.arange(seq_length, device=hidden_states.device)
+        local_chunks = (positions // chunk_size).unsqueeze(0) == (positions // chunk_size).unsqueeze(1)
+        local_attention_mask = attention_mask.masked_fill(~local_chunks.unsqueeze(0), 0)
+        return self.self(hidden_states, hidden_states, local_attention_mask, output_attentions=False)[0]
 
 
 class CanineIntermediate(nn.Module):
@@ -787,19 +810,12 @@ class CanineModel(CaninePreTrainedModel):
         return mask
 
     def _downsample_attention_mask(self, char_attention_mask: torch.Tensor, downsampling_rate: int):
-        """Downsample 2D character attention mask to 2D molecule attention mask using MaxPool1d layer."""
-
-        # first, make char_attention_mask 3D by adding a channel dim
+        """Downsample 2D character attention mask to 2D molecule attention mask."""
         batch_size, char_seq_len = char_attention_mask.shape
-        poolable_char_mask = torch.reshape(char_attention_mask, (batch_size, 1, char_seq_len))
-
-        # next, apply MaxPool1d to get pooled_molecule_mask of shape (batch_size, 1, mol_seq_len)
-        pooled_molecule_mask = torch.nn.MaxPool1d(kernel_size=downsampling_rate, stride=downsampling_rate)(
-            poolable_char_mask.float()
-        )
-
-        # drop the channel dim added for MaxPool1d to get tensor of shape (batch_size, mol_seq_len)
-        return pooled_molecule_mask.squeeze(dim=1)
+        molecule_seq_len = char_seq_len // downsampling_rate
+        complete_char_seq_len = molecule_seq_len * downsampling_rate
+        poolable_char_mask = char_attention_mask[:, :complete_char_seq_len].to(dtype=torch.float32)
+        return poolable_char_mask.reshape(batch_size, molecule_seq_len, downsampling_rate).amax(dim=-1)
 
     def _repeat_molecules(self, molecules: torch.Tensor, char_seq_length: int) -> torch.Tensor:
         """Repeats molecules to make them the same length as the char sequence."""

--- a/tests/models/canine/test_modeling_canine.py
+++ b/tests/models/canine/test_modeling_canine.py
@@ -18,7 +18,7 @@ import unittest
 import pytest
 
 from transformers import CanineConfig, is_torch_available
-from transformers.testing_utils import require_torch, slow, torch_device
+from transformers.testing_utils import require_torch, require_torch_greater_or_equal, slow, torch_device
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, ids_tensor, random_attention_mask
@@ -35,6 +35,7 @@ if is_torch_available():
         CanineForTokenClassification,
         CanineModel,
     )
+    from transformers.models.canine.modeling_canine import CanineAttention
 
 
 class CanineModelTester:
@@ -263,6 +264,100 @@ class CanineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
         self.assertEqual(output.dtype, torch.float16)
         self.assertFalse(torch.isnan(output).any())
+
+    def test_local_attention_blocked_matches_loop(self):
+        config = self.model_tester.get_config()
+        config.hidden_dropout_prob = 0.0
+        config.attention_probs_dropout_prob = 0.0
+        attention = CanineAttention(
+            config,
+            local=True,
+            attend_from_chunk_width=4,
+            attend_from_chunk_stride=4,
+            attend_to_chunk_width=4,
+            attend_to_chunk_stride=4,
+        ).to(torch_device)
+        attention.eval()
+
+        for sequence_length in (4, 8, 9, 12, 13):
+            hidden_states = torch.randn(2, sequence_length, config.hidden_size, device=torch_device)
+            # Match CANINE's 3D mask: broadcast a 2D padding mask across query positions.
+            for padding_mask in (
+                torch.ones(2, sequence_length, device=torch_device),
+                torch.cat(
+                    [
+                        torch.ones(2, max(sequence_length - 3, 1), device=torch_device),
+                        torch.zeros(2, sequence_length - max(sequence_length - 3, 1), device=torch_device),
+                    ],
+                    dim=1,
+                ),
+            ):
+                if padding_mask[:, -1].eq(0).all():
+                    padding_mask[:, -1] = 1
+                attention_mask = padding_mask[:, None, :].expand(2, sequence_length, sequence_length)
+
+                with torch.no_grad():
+                    blocked_output = attention(hidden_states, attention_mask, output_attentions=False)[0]
+                    loop_output = attention(hidden_states, attention_mask, output_attentions=True)[0]
+
+                self.assertTrue(torch.allclose(blocked_output, loop_output, atol=1e-5, rtol=1e-5))
+
+    def test_downsample_attention_mask_matches_max_pool(self):
+        model = CanineModel(self.model_tester.get_config())
+        downsampling_rate = 4
+
+        for sequence_length in (4, 5, 8, 9, 12, 13):
+            attention_mask = torch.randint(0, 2, (2, sequence_length))
+            expected = torch.nn.functional.max_pool1d(
+                attention_mask[:, None, :].float(), kernel_size=downsampling_rate, stride=downsampling_rate
+            ).squeeze(1)
+            actual = model._downsample_attention_mask(attention_mask, downsampling_rate)
+
+            self.assertTrue(torch.equal(actual, expected))
+
+    @require_torch_greater_or_equal("2.6")
+    def test_torch_export_with_dynamic_sequence_length(self):
+        config = CanineConfig(
+            hidden_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            intermediate_size=64,
+            max_position_embeddings=64,
+            num_hash_functions=4,
+            num_hash_buckets=64,
+            downsampling_rate=4,
+            upsampling_kernel_size=4,
+            local_transformer_stride=4,
+            hidden_dropout_prob=0.0,
+            attention_probs_dropout_prob=0.0,
+        )
+        model = CanineModel(config).eval()
+        example_input_ids = torch.ones(2, 12, dtype=torch.long)
+
+        class ExportableCanine(torch.nn.Module):
+            def __init__(self, canine_model):
+                super().__init__()
+                self.canine_model = canine_model
+
+            def forward(self, input_ids, attention_mask):
+                return self.canine_model(input_ids=input_ids, attention_mask=attention_mask).last_hidden_state
+
+        sequence_length = 4 * torch.export.Dim("molecule_sequence_length", min=3, max=8)
+        exported = torch.export.export(
+            ExportableCanine(model),
+            (example_input_ids, example_input_ids),
+            dynamic_shapes={
+                "input_ids": {1: sequence_length},
+                "attention_mask": {1: sequence_length},
+            },
+            strict=True,
+        )
+
+        exported_module = exported.module()
+        for length in (12, 16):
+            input_ids = torch.ones(2, length, dtype=torch.long)
+            output = exported_module(input_ids, input_ids)
+            self.assertEqual(tuple(output.shape), (2, length, config.hidden_size))
 
     def test_for_multiple_choice(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47987)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47987)
<!-- ci-dashboard-badge:end -->

Fixes #47491

CANINE local attention loops with `range(seq_len)`. Dynamo freezes that length at export time, so an example of 12 can not run another length.

For the default equal stride local encoder I replaced that loop with a block diagonal mask. The old loop still works for CLS / unequal-stride / output_attentions. Char-mask downsampling is done using reshape + amax, not MaxPool1d.

I reproduced the range() issue, compared against the current loop path, and kept the fallback for the special cases.

Tests:
- test_local_attention_blocked_matches_loop
- test_downsample_attention_mask_matches_max_pool
- test_torch_export_with_dynamic_sequence_length (export 12, run 16)

Issue: https://github.com/huggingface/transformers/issues/47491