### PR TITLE
[GPTNeoX] Fix post_processor not overridden when loading from pretrained (OLMo garbage generation)

### DIFF
--- a/src/transformers/models/gpt_neox/tokenization_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/tokenization_gpt_neox.py
@@ -139,6 +139,13 @@ class GPTNeoXTokenizer(TokenizersBackend):
             trim_offsets=trim_offsets,
             **kwargs,
         )
+        # See https://github.com/huggingface/transformers/pull/47988 for more details.
+        # `_from_pretrained` strips `add_bos_token`/`add_eos_token` from init_kwargs when a
+        # tokenizer.json is present (assuming the post_processor is authoritative). But GPTNeoX
+        # rebuilds its backend tokenizer from scratch, so the post_processor baked into
+        # tokenizer.json may not match the desired add_bos/eos settings. Call
+        # update_post_processor() here to ensure they stay in sync.
+        self.update_post_processor()
 
 
 __all__ = ["GPTNeoXTokenizer"]


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47988)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47988)
<!-- ci-dashboard-badge:end -->

## Root cause

`GPTNeoXTokenizer` has a custom `__init__` that rebuilds the Rust backend tokenizer from scratch using vocab/merges, rather than loading it directly from `tokenizer.json`. Because of this, `convert_to_native_format` extracts the post_processor from `tokenizer.json` and passes it to `__init__` so it can be applied to the rebuilt tokenizer — this is how the serialized post_processor settings are preserved.

However, `_from_pretrained` also strips `add_bos_token`/`add_eos_token` from `init_kwargs` whenever a `tokenizer.json` is present, on the assumption that the post_processor inside is the source of truth and should not be overridden. This causes `TokenizersBackend.__init__` to never see those kwargs → `explicit_bos_eos_in_kwargs = False` → `_should_update_post_processor = False` → `update_post_processor()` is never called. The net result: the post_processor from `tokenizer.json` is applied to the rebuilt tokenizer and then **never overridden**, even when `tokenizer_config.json` says `add_eos_token: false`.

For OLMo-7B, the `tokenizer.json` was saved with a `TemplateProcessing` post_processor that appends `<|endoftext|>` (EOS, ID 50279) after every sequence. It is unclear why the repo has it — it was never actually in effect before the regression, since `update_post_processor()` was always called and overrode it (and the model worked correctly). After the regression, it is applied as-is and silently corrupts every input.

## Regression introduced

Commit `73a13f86f6` ("Refactor-tokenization-more", #42563, Dec 9 2025) removed the explicit `self.update_post_processor()` call that was at the end of the old `GPTNeoXTokenizer.__init__`. That call was the only thing ensuring the Rust post_processor matched `add_bos_token=False, add_eos_token=False`.

## Fix

Restore `self.update_post_processor()` at the end of `GPTNeoXTokenizer.__init__` with an explanatory comment.

## Verification

Tested on A10G runner across all 4 relevant states:

**`9a6df2ce9c`** (last good commit, before regression):
```
input_ids: [[4749, 2881, 1691, 13, 253, 3762, 273, 39241, 3054, 326, 209]]
output:    "Simply put, the theory of relativity states that \nthe speed of light is
            the same for all observers.\n\nThe theory of relativity is a theory of
            physics that describes the \nmovement of objects in space and time.\n\n"
```
✅ PASS

**`73a13f86f6`** (regression commit, #42563):
```
input_ids: [[4749, 2881, 1691, 13, 253, 3762, 273, 39241, 3054, 326, 209, 50279]]
                                                                            ^^^^^ spurious EOS
output:    "Simply put, the theory of relativity states that  .1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1"
```
❌ FAIL (same bug present on `main`)

**`main`** (same bug as `73a13f86f6`):
```
input_ids: [[4749, 2881, 1691, 13, 253, 3762, 273, 39241, 3054, 326, 209, 50279]]
                                                                            ^^^^^ spurious EOS
output:    "Simply put, the theory of relativity states that  .1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1"
```
❌ FAIL

**`main` + this fix**:
```
input_ids: [[4749, 2881, 1691, 13, 253, 3762, 273, 39241, 3054, 326, 209]]
output:    "Simply put, the theory of relativity states that \nthe speed of light is
            the same for all observers.\n\nThe theory of relativity is a theory of
            physics that describes the \nmovement of objects in space and time.\n\n"
```
✅ PASS

## Impact on GPT-NeoX models

This change does **not** affect the GPT-NeoX models themselves (e.g. `EleutherAI/gpt-neox-20b`, `EleutherAI/pythia-410m-deduped`). Their `tokenizer.json` uses a `ByteLevel` post_processor (which adds no tokens), so calling `update_post_processor()` with `add_bos_token=False, add_eos_token=False` produces the same token IDs as before.

The full `tests/models/gpt_neox/` test suite passes with `RUN_SLOW=1` (223 passed, 109 skipped).

## Notes

This fix was discovered because `allenai/OLMo-7B-hf`'s `tokenizer.json` has an unusual `TemplateProcessing` post_processor that adds EOS — which the canonical GPT-NeoX repos (e.g. `EleutherAI/gpt-neox-20b`) do not have. For those, the regression in `73a13f86f6` was a silent no-op.

There are arguably two sides to the fix:
1. **Transformers side (this PR)**: the regression removed `update_post_processor()` unintentionally; restoring it is correct regardless of OLMo.
2. **Hub repo side**: `allenai/OLMo-7B-hf`'s `tokenizer.json` has a `TemplateProcessing` post_processor that adds EOS while `tokenizer_config.json` says `add_eos_token: false` — an inconsistency that only became observable after the regression removed the override. Ideally the Hub repo should also be corrected to keep things consistent.

Related: #47986 (OLMo OOM fix — separate issue in same test file)