### PR TITLE
[Quantization] Anchor should_convert_module regex to stop prefix-matching siblings

### DIFF
--- a/src/transformers/quantizers/quantizers_utils.py
+++ b/src/transformers/quantizers/quantizers_utils.py
@@ -36,7 +36,7 @@ def should_convert_module(full_name, patterns: list[str] | None = None):
     #    (e.g., "fc1" matches "model.decoder.layers.23.fc1").
 
     should_not_convert = any(
-        re.match(f"{key}\\.", full_name) or re.match(f"{key}", full_name) or full_name.endswith(key)
+        re.match(f"{key}\\.", full_name) or re.match(f"{key}$", full_name) or full_name.endswith(key)
         for key in patterns
     )
     return not should_not_convert

--- a/tests/quantization/mxfp4/test_mxfp4.py
+++ b/tests/quantization/mxfp4/test_mxfp4.py
@@ -337,6 +337,11 @@ class Mxfp4IntegrationTest(unittest.TestCase):
         self.assertFalse(should_convert_module("lm_head", patterns))
         self.assertTrue(should_convert_module("experts", patterns))
 
+        # A literal pattern must not skip a longer name that only shares its prefix
+        # (regression: `mlp.gate` used to also match `mlp.gate_proj`).
+        self.assertTrue(should_convert_module("model.layers.0.mlp.gate_proj", ["model.layers.0.mlp.gate"]))
+        self.assertFalse(should_convert_module("model.layers.0.mlp.gate", ["model.layers.0.mlp.gate"]))
+
     @require_torch
     def test_convert_moe_packed_tensors(self):
         """Test unpacking of quantized tensors"""


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47990)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47990)
<!-- ci-dashboard-badge:end -->

## What

`should_convert_module` in `src/transformers/quantizers/quantizers_utils.py` matches each `modules_to_not_convert` entry against the module's full name with an **unanchored** `re.match(f"{key}", full_name)`.

Because `re.match` anchors at the *start* but not the *end*, a literal pattern such as `...mlp.gate` also matches `...mlp.gate_proj`. When `gate_proj` is not supposed to be converted, the result is inverted: `gate_proj` gets skipped when `gate` was the intended target (or vice versa), so the quantizer leaves it as a plain `nn.Linear` while its weight is FP8 — a BF16 × FP8 matmul then dies at forward with `mat1 BFloat16 != mat2 Float8_e4m3fn`.

## Repro

Real checkpoint: `Qwen/Qwen3.8-27B-FP8` (quant_method `"fp8"`), whose config lists `model.language_model.layers.N.mlp.gate` among 882 `modules_to_not_convert` entries. The MoE router `mlp.gate` must not be quantized, but `mlp.gate_proj` must be.

- `re.match("model.language_model.layers.0.mlp.gate", "model.language_model.layers.0.mlp.gate_proj.weight")` → `True` (bug: skips `gate_proj`)
- After anchoring: `re.match(f"{key}$", full_name)` → `False`, `gate_proj` converts correctly.

## Fix

Anchor the regex to exact match, preserving the existing `layer.*` wildcard semantics:

```python
re.match(f"{key}\\.", full_name) or re.match(f"{key}$", full_name) or full_name.endswith(key)
```

A regression test is added to `tests/quantization/mxfp4/test_mxfp4.py::test_should_convert_module` asserting that a literal pattern does not skip a longer sibling that only shares its prefix.

## Why this matters

It is not a niche cosmetic issue: any finegrained-FP8 MoE checkpoint whose config names a router submodule that is a prefix of another module (e.g. `mlp.gate` vs `mlp.gate_proj`) either fails to load or silently mis-quantizes. The current logic has no way to express "exactly this module" for such names.