### PR TITLE
[DeepSeekV2] Fix integration tests OOM: use device_map=auto instead of 8-bit quantization

### DIFF
--- a/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
+++ b/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
@@ -173,10 +173,10 @@ class DeepseekV2IntegrationTest(unittest.TestCase):
         with torch.no_grad():
             out = model(torch.tensor([input_ids]).to(torch_device))
 
-        EXPECTED_MEAN = torch.tensor([[-6.177091121673584, -5.0334978103637695, -3.9929561614990234, -2.515228509902954, -2.128833770751953, -2.458101511001587, -3.771824598312378, -3.6901206970214844]], device=torch_device)  # fmt: skip
+        EXPECTED_MEAN = torch.tensor([[-6.1771, -5.0335, -3.9930, -2.5152, -2.1288, -2.4581, -3.7718, -3.6901]], device=torch_device)  # fmt: skip
         torch.testing.assert_close(out.logits.float().mean(-1), EXPECTED_MEAN, atol=1e-3, rtol=1e-3)
 
-        EXPECTED_SLICE = torch.tensor([-1.21875, -0.7421875, -0.0201416015625, -2.828125, 1.25, -2.609375, -0.7265625, -2.921875, -2.53125, -0.546875, -0.322265625, -1.828125, -2.109375, -0.8125, -3.78125], device=torch_device)  # fmt: skip
+        EXPECTED_SLICE = torch.tensor([-1.2188, -0.7422, -0.0201, -2.8281, 1.2500, -2.6094, -0.7266, -2.9219, -2.5313, -0.5469, -0.3223, -1.8281, -2.1094, -0.8125, -3.7813], device=torch_device)  # fmt: skip
         torch.testing.assert_close(out.logits[0, 0, :15].float(), EXPECTED_SLICE, atol=1e-3, rtol=1e-3)
 
     def test_batch_fa2(self):

--- a/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
+++ b/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
@@ -139,7 +139,7 @@ class DeepseekV2ModelTest(CausalLMModelTest, unittest.TestCase):
 @require_torch_accelerator
 class DeepseekV2IntegrationTest(unittest.TestCase):
     def test_deepseek_v2_lite(self):
-        EXPECTED_TEXT = ['An attention function can be described as mapping a query and a set of key-value pairs to an output, where the query, keys, values, and output are all vectors.\n\nAttention functions are used in a variety of applications, including natural language processing, computer vision, and reinforcement learning.\n\nThe attention function is a function that takes a query and a set of key-value pairs as input and outputs a vector']  # fmt: skip
+        EXPECTED_TEXT = ['An attention function can be described as mapping a query and a set of key-value pairs to an output, where the query, keys, values, and output are all vectors. The query and keys are used to compute a similarity score between each key and the query, and the values are used to compute a weighted sum of the similarity scores. The output is a vector that represents the attention score for each key-value pair.']  # fmt: skip
 
         tokenizer = AutoTokenizer.from_pretrained("deepseek-ai/DeepSeek-V2-Lite")
         model = DeepseekV2ForCausalLM.from_pretrained(
@@ -178,8 +178,8 @@ class DeepseekV2IntegrationTest(unittest.TestCase):
 
     def test_batch_fa2(self):
         EXPECTED_TEXT = [
-            "Simply put, the theory of relativity states that \nthe laws of physics are the same for all observers, regardless of their \nrelative motion.\nThe theory of relativity is a theory of space, time, and gravity.\nThe theory of",  # fmt: skip
-            "My favorite all time favorite condiment is ketchup. I love ketchup. I love ketchup on my hot dogs, hamburgers, french fries, and even on my eggs. I love ketchup. I love ketchup so much that I",  # fmt: skip
+            "Simply put, the theory of relativity states that , the theory of relativity is a theory of space and time. It is a theory that explains the relationship between space and time. It is a theory that explains how space and time are related to each",  # fmt: skip
+            "My favorite all time favorite condiment is ketchup. I love it on everything. I also love mustard, but I don't like it on hot dogs. I like it on hamburgers, and I like it on sandwiches. I like it",  # fmt: skip
         ]
 
         prompts = [

--- a/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
+++ b/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
@@ -17,7 +17,7 @@ import math
 import unittest
 
 from transformers import is_torch_available
-from transformers.testing_utils import require_torch, require_torch_accelerator, slow, torch_device
+from transformers.testing_utils import cleanup, require_torch, require_torch_accelerator, slow, torch_device
 
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
 
@@ -138,6 +138,9 @@ class DeepseekV2ModelTest(CausalLMModelTest, unittest.TestCase):
 @slow
 @require_torch_accelerator
 class DeepseekV2IntegrationTest(unittest.TestCase):
+    def tearDown(self):
+        cleanup(torch_device, gc_collect=True)
+
     def test_deepseek_v2_lite(self):
         EXPECTED_TEXT = ['An attention function can be described as mapping a query and a set of key-value pairs to an output, where the query, keys, values, and output are all vectors. The query and keys are used to compute a similarity score between each key and the query, and the values are used to compute a weighted sum of the similarity scores. The output is a vector that represents the attention score for each key-value pair.']  # fmt: skip
 
@@ -179,7 +182,7 @@ class DeepseekV2IntegrationTest(unittest.TestCase):
     def test_batch_fa2(self):
         EXPECTED_TEXT = [
             "Simply put, the theory of relativity states that , the theory of relativity is a theory of space and time. It is a theory that explains the relationship between space and time. It is a theory that explains how space and time are related to each",  # fmt: skip
-            "My favorite all time favorite condiment is ketchup. I love it on everything. I also love mustard, but I don't like it on hot dogs. I like it on hamburgers, and I like it on sandwiches. I like it",  # fmt: skip
+            "My favorite all time favorite condiment is ketchup. I love it on everything. I also love mustard, but I don\u2019t like it on hot dogs. I like it on hamburgers, and I like it on sandwiches. I like it",  # fmt: skip
         ]
 
         prompts = [

--- a/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
+++ b/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
@@ -16,7 +16,7 @@
 import math
 import unittest
 
-from transformers import BitsAndBytesConfig, is_torch_available
+from transformers import is_torch_available
 from transformers.testing_utils import require_torch, require_torch_accelerator, slow, torch_device
 
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
@@ -144,15 +144,14 @@ class DeepseekV2IntegrationTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained("deepseek-ai/DeepSeek-V2-Lite")
         model = DeepseekV2ForCausalLM.from_pretrained(
             "deepseek-ai/DeepSeek-V2-Lite",
-            device_map=torch_device,
+            device_map="auto",
             dtype=torch.bfloat16,
-            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
 
         input_text = [
             "An attention function can be described as mapping a query and a set of key-value pairs to an output, where the query, keys, values, and output are all vectors."  # fmt: skip
         ]
-        model_inputs = tokenizer(input_text, return_tensors="pt").to(model.device)
+        model_inputs = tokenizer(input_text, return_tensors="pt").to(torch_device)
 
         generated_ids = model.generate(**model_inputs, max_new_tokens=50, do_sample=False)
         generated_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
@@ -163,19 +162,18 @@ class DeepseekV2IntegrationTest(unittest.TestCase):
 
         model = DeepseekV2ForCausalLM.from_pretrained(
             "deepseek-ai/DeepSeek-V2-Lite",
-            device_map=torch_device,
+            device_map="auto",
             dtype=torch.bfloat16,
-            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             attn_implementation="eager",
         )
 
         with torch.no_grad():
             out = model(torch.tensor([input_ids]).to(torch_device))
 
-        EXPECTED_MEAN = torch.tensor([[-6.1232, -5.0952, -4.4493, -2.6536, -2.0608, -2.3991, -3.8013, -2.8681]], device=torch_device)  # fmt: skip
+        EXPECTED_MEAN = torch.tensor([[-6.177091121673584, -5.0334978103637695, -3.9929561614990234, -2.515228509902954, -2.128833770751953, -2.458101511001587, -3.771824598312378, -3.6901206970214844]], device=torch_device)  # fmt: skip
         torch.testing.assert_close(out.logits.float().mean(-1), EXPECTED_MEAN, atol=1e-3, rtol=1e-3)
 
-        EXPECTED_SLICE = torch.tensor([-1.2500, -0.9961, -0.0194, -3.1562,  1.2812, -2.7656, -0.8438, -3.0469, -2.7812, -0.6328, -0.4160, -1.9688, -2.4219, -1.0391, -3.8906], device=torch_device)  # fmt: skip
+        EXPECTED_SLICE = torch.tensor([-1.21875, -0.7421875, -0.0201416015625, -2.828125, 1.25, -2.609375, -0.7265625, -2.921875, -2.53125, -0.546875, -0.322265625, -1.828125, -2.109375, -0.8125, -3.78125], device=torch_device)  # fmt: skip
         torch.testing.assert_close(out.logits[0, 0, :15].float(), EXPECTED_SLICE, atol=1e-3, rtol=1e-3)
 
     def test_batch_fa2(self):
@@ -194,11 +192,10 @@ class DeepseekV2IntegrationTest(unittest.TestCase):
 
         model = DeepseekV2ForCausalLM.from_pretrained(
             "deepseek-ai/DeepSeek-V2-Lite",
-            device_map=torch_device,
+            device_map="auto",
             dtype=torch.bfloat16,
-            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
-        inputs = tokenizer(prompts, return_tensors="pt", padding=True).to(model.device)
+        inputs = tokenizer(prompts, return_tensors="pt", padding=True).to(torch_device)
 
         generated_ids = model.generate(**inputs, max_new_tokens=40, do_sample=False)
         generated_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47991)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47991)
<!-- ci-dashboard-badge:end -->

## Summary

The 3 `DeepseekV2IntegrationTest` slow tests (`test_logits_eager`, `test_deepseek_v2_lite`, `test_batch_fa2`) fail with OOM on the A10G runner (22.30 GiB) because loading `deepseek-ai/DeepSeek-V2-Lite` with `device_map=torch_device` + 8-bit quantization requires ~22 GiB — the model OOMs at 82% of weight loading even in complete isolation.

## Fix

- Replace `device_map=torch_device` + `BitsAndBytesConfig(load_in_8bit=True)` with `device_map="auto"` + bfloat16 (no quantization). With `device_map="auto"`, the model loads ~19.3 GiB on GPU and offloads the rest to CPU, fitting the A10G.
- Fix input placement: `.to(model.device)` → `.to(torch_device)` (with `device_map="auto"`, `model.device` resolves to CPU which is wrong for inputs).
- Add `tearDown` with `cleanup()` to free VRAM between tests. Without it, the 3rd test (`test_logits_eager`) OOMs because prior tests leave models in VRAM, forcing disk offload which requires an `offload_folder`.
- Update all expected values (logits + generation text) captured fresh on A10G with the new bfloat16 loading. The new values are reasonably close to the old ones (same sign and order of magnitude for logits; coherent, on-topic continuations for generation text) — giving confidence that the modeling code has not regressed during the period these tests were broken.

## Timings (A10G)

| Test | Time |
|------|------|
| `test_deepseek_v2_lite` | 72.5s |
| `test_batch_fa2` | 61.7s |
| `test_logits_eager` | 9.4s |
| **Total** | **148s** |

All 3 tests pass: `3 passed in 148.27s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)