### PR TITLE
Prevent path traversal via sharded-checkpoint index filenames

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -888,6 +888,18 @@ def get_checkpoint_shard_files(
         index = json.loads(f.read())
 
     shard_filenames = sorted(set(index["weight_map"].values()))
+    # The shard filenames come from the (untrusted) index file and are joined to the model
+    # directory below. A value containing a path separator, a `..` component, or an absolute path
+    # would escape that directory and let a malicious checkpoint read arbitrary files off disk
+    # (path traversal). Legitimate shards are always plain filenames sitting next to the index, so
+    # reject anything else.
+    for shard_filename in shard_filenames:
+        if os.path.basename(shard_filename) != shard_filename or shard_filename in (os.curdir, os.pardir):
+            raise ValueError(
+                f"The checkpoint index {index_filename} contains an unexpected shard filename "
+                f"{shard_filename!r}. Shard filenames must be plain filenames located in the same "
+                "directory as the index."
+            )
     sharded_metadata = index["metadata"]
     sharded_metadata["all_checkpoint_keys"] = list(index["weight_map"].keys())
     sharded_metadata["weight_map"] = index["weight_map"].copy()

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -22,6 +22,7 @@ from huggingface_hub import constants, hf_hub_download
 from huggingface_hub.errors import HfHubHTTPError, LocalEntryNotFoundError, OfflineModeIsEnabled
 
 from transformers.utils import CONFIG_NAME, WEIGHTS_NAME, cached_file, has_file, list_repo_templates
+from transformers.utils.hub import get_checkpoint_shard_files
 
 
 RANDOM_BERT = "hf-internal-testing/tiny-random-bert"
@@ -205,3 +206,41 @@ class OfflineModeTests(unittest.TestCase):
                 side_effect=LocalEntryNotFoundError("no snapshot found"),
             ):
                 self.assertEqual(list_repo_templates(RANDOM_BERT, local_files_only=False), [])
+
+
+class GetCheckpointShardFilesTest(unittest.TestCase):
+    def _write_index(self, tmp_dir, weight_map):
+        index_filename = os.path.join(tmp_dir, "model.safetensors.index.json")
+        index = {"metadata": {"total_size": 0}, "weight_map": weight_map}
+        with open(index_filename, "w") as f:
+            json.dump(index, f)
+        return index_filename
+
+    def test_get_checkpoint_shard_files_accepts_plain_filenames(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            index_filename = self._write_index(
+                tmp_dir, {"a": "model-00001-of-00002.safetensors", "b": "model-00002-of-00002.safetensors"}
+            )
+            shard_files, _ = get_checkpoint_shard_files(tmp_dir, index_filename)
+            self.assertEqual(
+                sorted(shard_files),
+                [
+                    os.path.join(tmp_dir, "model-00001-of-00002.safetensors"),
+                    os.path.join(tmp_dir, "model-00002-of-00002.safetensors"),
+                ],
+            )
+
+    def test_get_checkpoint_shard_files_rejects_path_traversal(self):
+        # A malicious index whose weight_map escapes the model directory must be rejected rather
+        # than joined and read (path traversal / arbitrary file read).
+        for malicious in ["../secret.safetensors", "sub/dir/shard.safetensors", "..", os.path.join("..", "x")]:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                index_filename = self._write_index(tmp_dir, {"w": malicious})
+                with self.assertRaises(ValueError):
+                    get_checkpoint_shard_files(tmp_dir, index_filename)
+
+    def test_get_checkpoint_shard_files_rejects_absolute_path(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            index_filename = self._write_index(tmp_dir, {"w": os.path.abspath(os.sep + "etc" + os.sep + "passwd")})
+            with self.assertRaises(ValueError):
+                get_checkpoint_shard_files(tmp_dir, index_filename)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=47996)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=47996)
<!-- ci-dashboard-badge:end -->

Fixes #47176.

## Diagnosis

When `from_pretrained` loads a sharded checkpoint, `get_checkpoint_shard_files` (`src/transformers/utils/hub.py`) reads the shard filenames straight from the model-supplied index (`model.safetensors.index.json` / `pytorch_model.bin.index.json`) and joins each to the model directory with `os.path.join` and **no validation**:

```python
shard_filenames = sorted(set(index["weight_map"].values()))  # attacker-controlled
...
shard_filenames = [os.path.join(pretrained_model_name_or_path, subfolder, f) for f in shard_filenames]
```

The `weight_map` values are arbitrary strings from the checkpoint. `os.path.join` does not neutralize `..`, and an absolute value discards the directory prefix entirely, so a malicious index escapes the model directory. The returned paths then flow into `safe_open(...)` / `torch.load(...)`, so a plain `AutoModel.from_pretrained("/untrusted/model/dir")`:

- reads arbitrary files as an existence/error oracle (e.g. `weight_map = {"w": "/etc/passwd"}`), and
- for a safetensors-format target, **fully exfiltrates its tensor bytes** through the load path (e.g. another model's weights on a shared host) — `weight_map = {"stolen": "../victim/private.safetensors"}`.

This is the "load a model someone gave me" threat model (a downloaded repo, a shared directory on a multi-tenant host). No auth required beyond getting the victim to load the directory.

## Fix

Reject any shard filename that isn't a plain filename sitting next to the index, before it is joined:

```python
for shard_filename in shard_filenames:
    if os.path.basename(shard_filename) != shard_filename or shard_filename in (os.curdir, os.pardir):
        raise ValueError(...)
```

Placed right after the `weight_map` values are read, so it guards both the local-directory and the Hub-download paths. Legitimate index files are always produced with sibling shard filenames (`model-00001-of-0000N.safetensors`), confirmed against the sharded-save code in `modeling_utils.py`, so normal loading is unaffected.

## Tests

`tests/utils/test_hub_utils.py::GetCheckpointShardFilesTest`:
- plain sibling filenames still resolve and load;
- `../`, `sub/dir/...`, `..`, and absolute (`/etc/passwd`) `weight_map` values raise `ValueError`.

Verified locally: the traversal test fails on `main` (`ValueError not raised`) and passes with the fix. `ruff check`/`ruff format` clean on the changed lines; the diff is a single guard plus the test.