### PR TITLE
[Whisper] Fix batch decode_with_timestamps in WhisperTokenizer.decode()

### DIFF
--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -495,9 +495,18 @@ class WhisperTokenizer(TokenizersBackend):
         )
         if decode_with_timestamps:
             # legacy method to decode timestamps when not included in the tokenizer vocabulary
-            text = self._decode_with_timestamps(
-                filtered_ids, time_precision=time_precision, skip_special_tokens=skip_special_tokens
-            )
+            if isinstance(filtered_ids, list) and filtered_ids and isinstance(filtered_ids[0], list):
+                # batched input: process each sequence individually
+                text = [
+                    self._decode_with_timestamps(
+                        seq, time_precision=time_precision, skip_special_tokens=skip_special_tokens
+                    )
+                    for seq in filtered_ids
+                ]
+            else:
+                text = self._decode_with_timestamps(
+                    filtered_ids, time_precision=time_precision, skip_special_tokens=skip_special_tokens
+                )
         else:
             # Handle both single string and batch (list of strings) outputs
             if isinstance(text, list):


### PR DESCRIPTION
## Summary

Continuation of #47995 ([Whisper] Fix integration test failures on A10G).

Fixes `test_whisper_longform_single_batch`, one of the 5 tests left in Group 5 of that PR as requiring changes outside the test file.

---

## Why the test passed before PR #40936 (commit `05c0e1d390`)

Before `05c0e1d390`, the base class `PreTrainedTokenizerBase.batch_decode` iterated per-sequence, calling `decode()` once per sequence with a single 1D list of token ids. `decode()` in `WhisperTokenizer` therefore always received a 1D input, so both `decode_with_timestamps=True` and `False` worked correctly for both single and batch inputs.

## Root cause

PR #40936 (commit `05c0e1d390`, "rm slow tokenizers", Nov 27 2025) changed the base class `batch_decode` to pass the full 2D batch (list of token id lists) to `decode()` in one call instead of iterating per-sequence. `decode()` in `WhisperTokenizer` was partially updated to handle the 2D input:
- ✅ The `else` branch (non-timestamp path) got `isinstance(text, list)` handling for `_filter_timestamp_ids`
- ❌ The `decode_with_timestamps=True` branch was missed — it still calls `_decode_with_timestamps(filtered_ids, ...)` unconditionally

When `batch_decode(decode_with_timestamps=True)` is called with a batch, `filtered_ids` is now a list of lists. `_decode_with_timestamps` iterates over it and immediately hits `token >= timestamp_begin` where `token` is a list → `TypeError: '>=' not supported between instances of 'list' and 'int'`.

**Bisect confirmed:** parent commit `01c51596ec` passes, `05c0e1d390` fails. First seen in CI on 2025-11-28 (the day after the commit landed).

## Why only this one test is affected

`decode_with_timestamps=True` is used in exactly **one** integration test in the entire whisper test file — `test_whisper_longform_single_batch` (line 2348). All other tests use either:
- `output_offsets=True` — the newer structured return format, a different code path entirely
- Plain `batch_decode(skip_special_tokens=True)` — no timestamp decoding

The other 4 tests remaining in Group 5 of #47995 have completely unrelated root causes and are not addressed here.

## Fix

Add the same `isinstance` batch check to the `decode_with_timestamps` branch that was already applied to the `else` branch: detect a 2D input and process each sequence individually.

```python
if isinstance(filtered_ids, list) and filtered_ids and isinstance(filtered_ids[0], list):
    # batched input: process each sequence individually
    text = [
        self._decode_with_timestamps(seq, ...)
        for seq in filtered_ids
    ]
else:
    text = self._decode_with_timestamps(filtered_ids, ...)
```

## Test

`WhisperModelIntegrationTests::test_whisper_longform_single_batch` — verified passing on runner (A10G, torch 2.13 / CUDA 13.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)