### PR TITLE
[Whisper] Fix speculative decoding: UnboundLocalError, cache corruption, and speed regression

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -278,6 +278,8 @@ class AssistedCandidateGenerator(CandidateGenerator):
                 best_threshold = thresholds[optimal_threshold_index]
 
                 self.assistant_generation_config.assistant_confidence_threshold = best_threshold
+                # Sync to generation_config so ConfidenceCriteria picks up the updated threshold on the next round
+                self.generation_config.assistant_confidence_threshold = best_threshold
 
     def _calculate_new_tokens(self, input_ids: torch.LongTensor) -> tuple[int, int]:
         """Calculate the minimum and maximum number of new tokens to generate."""

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -292,8 +292,15 @@ class AssistedCandidateGenerator(CandidateGenerator):
         """Update past key values and attention masks for subsequent generation rounds."""
         has_past_key_values = self.assistant_kwargs.get("past_key_values", None) is not None
         if has_past_key_values:
-            tokens_to_remove = remove_from_pkv + num_added_tokens
-            self.assistant_kwargs["past_key_values"].crop(-tokens_to_remove)
+            # Crop the cache to align with the next round's input_ids. The target size is
+            # input_ids.shape[-1] - 1 - remove_from_pkv - num_added_tokens (= num_added_tokens worth
+            # of tokens are the "bonus" token added by the main model and processed next round).
+            # We compute how many tokens to remove rather than cropping to an absolute index to
+            # comply with the current Cache.crop() API (negative = remove from end).
+            target_size = input_ids.shape[-1] - 1 - remove_from_pkv - num_added_tokens
+            current_size = self.assistant_kwargs["past_key_values"].get_seq_length()
+            if current_size > target_size:
+                self.assistant_kwargs["past_key_values"].crop(target_size - current_size)
             self.assistant_kwargs = _prepare_attention_mask(
                 self.assistant_kwargs, input_ids.shape[-1], self.assistant_model.config.is_encoder_decoder
             )

--- a/src/transformers/models/audioflamingo3/modeling_audioflamingo3.py
+++ b/src/transformers/models/audioflamingo3/modeling_audioflamingo3.py
@@ -142,6 +142,7 @@ class AudioFlamingo3Attention(nn.Module):
         query_states = (self.q_proj(hidden_states) * self.scaling).view(hidden_shape).transpose(1, 2).contiguous()
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
+        is_updated = False
         if past_key_values is not None and isinstance(past_key_values, EncoderDecoderCache):
             is_updated = past_key_values.is_updated.get(self.layer_idx)
             if is_cross_attention:

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -749,7 +749,9 @@ class WhisperDecoder(WhisperPreTrainedModel):
             decoder_cache_config = copy.deepcopy(self.config)
             decoder_cache_config.num_hidden_layers = self.config.decoder_layers
             past_key_values = (
-                EncoderDecoderCache(DynamicCache(config=decoder_cache_config), DynamicCache(config=decoder_cache_config))
+                EncoderDecoderCache(
+                    DynamicCache(config=decoder_cache_config), DynamicCache(config=decoder_cache_config)
+                )
                 if encoder_hidden_states is not None or self.config.is_encoder_decoder
                 else DynamicCache(config=decoder_cache_config)
             )

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """PyTorch Whisper model."""
 
+import copy
 import math
 from collections.abc import Callable
 
@@ -309,6 +310,7 @@ class WhisperAttention(nn.Module):
         query_states = (self.q_proj(hidden_states) * self.scaling).view(hidden_shape).transpose(1, 2).contiguous()
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
+        is_updated = False
         if past_key_values is not None and isinstance(past_key_values, EncoderDecoderCache):
             is_updated = past_key_values.is_updated.get(self.layer_idx)
             if is_cross_attention:
@@ -737,10 +739,38 @@ class WhisperDecoder(WhisperPreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if use_cache and past_key_values is None:
+            # Build a config that DynamicCache can use to pre-allocate the right number of layers.
+            # DynamicCache(config=...) reads config.num_hidden_layers via get_text_config(decoder=True),
+            # but WhisperConfig maps num_hidden_layers → encoder_layers (e.g. 32 for distil-whisper-large-v2
+            # even though the decoder only has 2 layers). Pre-allocating 32 cache slots for a 2-layer
+            # decoder wastes memory and, with crop(-n), causes crop() to iterate uninitialized layers
+            # and crash. We deepcopy the config and override num_hidden_layers with decoder_layers so
+            # DynamicCache allocates exactly the right number of slots.
+            decoder_cache_config = copy.deepcopy(self.config)
+            decoder_cache_config.num_hidden_layers = self.config.decoder_layers
             past_key_values = (
-                EncoderDecoderCache(DynamicCache(config=self.config), DynamicCache(config=self.config))
+                EncoderDecoderCache(DynamicCache(config=decoder_cache_config), DynamicCache(config=decoder_cache_config))
                 if encoder_hidden_states is not None or self.config.is_encoder_decoder
-                else DynamicCache(config=self.config)
+                else DynamicCache(config=decoder_cache_config)
+            )
+        elif (
+            use_cache
+            and encoder_hidden_states is not None
+            and isinstance(past_key_values, DynamicCache)
+            and not isinstance(past_key_values, EncoderDecoderCache)
+            and past_key_values.get_seq_length() == 0
+        ):
+            # generate() (since PR #43679) pre-initializes the cache with DynamicCache based on
+            # config.is_encoder_decoder. WhisperForCausalLM sets is_encoder_decoder=False, so
+            # generate() creates a plain DynamicCache. But when encoder_hidden_states are present,
+            # both self-attention and cross-attention write to the same layer_idx in DynamicCache,
+            # overwriting each other. Convert the empty DynamicCache to EncoderDecoderCache here.
+            # Use the same decoder_cache_config approach: override num_hidden_layers with decoder_layers
+            # so only the actual decoder layers are pre-allocated.
+            decoder_cache_config = copy.deepcopy(self.config)
+            decoder_cache_config.num_hidden_layers = self.config.decoder_layers
+            past_key_values = EncoderDecoderCache(
+                DynamicCache(config=decoder_cache_config), DynamicCache(config=decoder_cache_config)
             )
 
         past_key_values_length = past_key_values.get_seq_length() if past_key_values is not None else 0


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48000)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48000)
<!-- ci-dashboard-badge:end -->

## Summary

Continuation of #47997 / #47995. Fixes four bugs in `test_speculative_decoding_distil`, each introduced by a separate commit:

1. `UnboundLocalError: is_updated referenced before assignment` — introduced by PR #43679 (Feb 2026)
2. `RuntimeError: cannot reshape tensor of 0 elements` from wrong cache type and wrong layer count — introduced by PR #43679 (Feb 2026)
3. `RuntimeError: cannot reshape tensor of 0 elements` from cache size accumulation — introduced by commit `5ec7b73615` (Jul 2026)
4. `AssertionError: Make sure that assistant decoding is faster` — introduced by PR #42702 (Dec 2025)

---

## Fix 1 — `is_updated` UnboundLocalError (`WhisperAttention.forward()`)

**History:** PR #39956 (Aug 2025) refactored `past_key_values` naming and wrapped the `is_updated` assignment in an `isinstance(past_key_values, EncoderDecoderCache)` guard, but left it consumed unconditionally below:

```python
if past_key_values is not None and isinstance(past_key_values, EncoderDecoderCache):
    is_updated = past_key_values.is_updated.get(self.layer_idx)  # only set here

if is_cross_attention and past_key_values and is_updated:  # always reached
    ...
```

This same bug hit 55 other encoder-decoder models in Sep 2025 and was fixed by PR #40517 (`is_updated = False` before the guard). Whisper escaped that fix because it was still receiving an `EncoderDecoderCache` at the time, keeping the bug dormant.

**What activated it:** PR #43679 (Feb 2026) changed `generate()` to pre-initialize a plain `DynamicCache` for `WhisperForCausalLM` (which has `config.is_encoder_decoder=False`). The guard now never triggers, `is_updated` is never assigned, and the cross-attention path raises `UnboundLocalError`.

**Fix:** Initialize `is_updated = False` before the guard, identical to PR #40517:

```python
is_updated = False
if past_key_values is not None and isinstance(past_key_values, EncoderDecoderCache):
    is_updated = past_key_values.is_updated.get(self.layer_idx)
```

---

## Fix 2 — Wrong cache type and wrong layer count (`WhisperDecoder.forward()`)

### 2a. Wrong cache type: `DynamicCache` instead of `EncoderDecoderCache`

**Root cause:** `generate()` decides the cache type from `config.is_encoder_decoder`. `WhisperForCausalLM` sets `is_encoder_decoder=False` (to behave as a causal LM for speculative decoding), so PR #43679 made `generate()` pre-initialize a plain `DynamicCache`. But `WhisperForCausalLM` uses cross-attention — with a plain `DynamicCache`, self-attention and cross-attention share the same `layer_idx` slots and overwrite each other, corrupting the cache.

**Before PR #43679:** `generate()` passed `past_key_values=None`, so `WhisperDecoder.forward()` always created the cache itself and correctly detected `encoder_hidden_states is not None` → `EncoderDecoderCache`.

**Fix:** When `generate()` passes a pre-initialized empty `DynamicCache` and `encoder_hidden_states` are present, convert it to `EncoderDecoderCache` before the first forward pass:

```python
elif (
    use_cache
    and encoder_hidden_states is not None
    and isinstance(past_key_values, DynamicCache)
    and not isinstance(past_key_values, EncoderDecoderCache)
    and past_key_values.get_seq_length() == 0
):
    past_key_values = EncoderDecoderCache(...)
```

### 2b. Wrong layer count: 32 slots pre-allocated for a 2-layer decoder

**Root cause:** `DynamicCache(config=self.config)` calls `config.get_text_config(decoder=True)` to determine how many layers to pre-allocate. For `WhisperConfig`, `get_text_config(decoder=True)` returns `self` unchanged — Whisper uses a flat config with no nested decoder sub-config, so the `decoder=True` hint has no effect. It then reads `config.num_hidden_layers`, which `WhisperConfig` maps via `attribute_map` to `encoder_layers`:

```python
attribute_map = {"num_hidden_layers": "encoder_layers"}
```

For distil-whisper-large-v2, `encoder_layers=32` (the full encoder is kept) but `decoder_layers=2` (distilled). So `DynamicCache` pre-allocates 32 slots for a decoder with only 2 layers. Slots 2–31 are uninitialized, and iterating them in `crop(-n)` crashes with `TypeError` on `keys=None`.

**Fix:** Deepcopy the config and override `num_hidden_layers` with `decoder_layers` before passing it to `DynamicCache`, so exactly 2 slots are pre-allocated:

```python
decoder_cache_config = copy.deepcopy(self.config)
decoder_cache_config.num_hidden_layers = self.config.decoder_layers
past_key_values = EncoderDecoderCache(
    DynamicCache(config=decoder_cache_config),
    DynamicCache(config=decoder_cache_config),
)
```

---

## Fix 3 — Cache size accumulation (`candidate_generator.py`)

**Root cause:** Commit `5ec7b73615` (Jul 2026, "crop with negative always") changed `_update_past_and_masks` from cropping to an absolute target to always removing a fixed number of tokens:

```python
# before 5ec7b73615 — crops to absolute target
new_cache_size = input_ids.shape[-1] - 1 - remove_from_pkv
self.assistant_kwargs["past_key_values"].crop(new_cache_size - num_added_tokens)

# after 5ec7b73615 — always removes exactly 1 token regardless of how many candidates were rejected
self.assistant_kwargs["past_key_values"].crop(-remove_from_pkv - num_added_tokens)  # = crop(-1)
```

When multiple speculative candidates are rejected in a round, the assistant cache grows by several tokens but only 1 is trimmed. Over successive rounds, `cache.get_seq_length()` exceeds `input_ids.shape[1]`. On the next call, `_prefill` computes:

```python
next_sequence_length = input_ids.shape[1] - cache.get_seq_length()  # goes negative
```

`input_ids[:, -n:]` with negative `n` slices incorrectly, producing a `[1, 0]` empty tensor that crashes in `WhisperAttention.forward()` at the reshape.

**Fix:** Restore the absolute crop logic — compute the intended target size from `input_ids` and only crop if the cache exceeds it, using a negative delta to comply with the current `Cache.crop(negative)` API:

```python
target_size = input_ids.shape[-1] - 1 - remove_from_pkv - num_added_tokens
current_size = self.assistant_kwargs["past_key_values"].get_seq_length()
if current_size > target_size:
    self.assistant_kwargs["past_key_values"].crop(target_size - current_size)
```

---

## Fix 4 — Speed regression: adaptive threshold not fed back to `ConfidenceCriteria`

**Root cause:** PR #42702 (Dec 2025) introduced `self.assistant_generation_config` — a deepcopy of the assistant model's config with global defaults applied — to decouple the assistant config from `assistant_model.generation_config`. It moved the adaptive threshold update (ROC-curve optimization in `update_candidate_strategy`) to write to `self.assistant_generation_config.assistant_confidence_threshold`, but left `self.generation_config.assistant_confidence_threshold` (set once in `__init__` to the initial 0.4) untouched.

`ConfidenceCriteria` is constructed fresh on each inner `generate()` call for the assistant, reading `generation_config.assistant_confidence_threshold`. Since `self.generation_config` was never updated, every round used the initial threshold of 0.4 — ignoring the ROC curve's computed optimal threshold.

**Effect:** With the threshold stuck at 0.4 (as `ConfidenceCriteria` always reads `assistant_confidence_threshold` from `self.generation_config`, which is never updated), `ConfidenceCriteria` only stops generation when the assistant's confidence drops below 0.4. Distil-whisper's token probabilities are typically 0.7–0.99, so this almost never happens — the assistant generates all 20 speculative candidates every round. The ROC curve correctly identifies that 0.84 would be the better threshold (stopping when confidence is not high enough), but that value never reaches `ConfidenceCriteria`. Combined with a ~22% candidate acceptance rate, the overhead of generating and verifying 20 candidates per round exceeded the savings from fewer main-model passes, making assisted generation slower than greedy:

```
# bad commit (a81e04a923) — ConfidenceCriteria always reads 0.4 from self.generation_config, never stops early
round 1:  candidates=2,  threshold=0.4
round 2:  candidates=20, threshold=0.4   ← ROC fires: best=0.84 written to assistant_generation_config only
round 3:  candidates=20, threshold=0.4   ← ROC fires: best=0.84, ConfidenceCriteria still reads 0.4
round 4:  candidates=17, threshold=0.4   ← ROC fires: best=0.84, ConfidenceCriteria still reads 0.4
round 5:  candidates=14, threshold=0.4   ← ROC fires: best=0.74, ConfidenceCriteria still reads 0.4
round 6:  candidates=10, threshold=0.4   ← ROC fires: best=0.74, ConfidenceCriteria still reads 0.4
round 7:  candidates=5,  threshold=0.4   ← ROC fires: best=0.74, ConfidenceCriteria still reads 0.4
FAILED: AssertionError: Make sure that assistant decoding is faster
```

**Before PR #42702:** The adaptive update wrote to `self.assistant_model.generation_config.assistant_confidence_threshold` (the live model object) rather than to a deepcopy. Verified empirically: after ~6 rounds the threshold did propagate to `self.generation_config`, and `ConfidenceCriteria` eventually started cutting candidates short. It is unclear why the threshold propagated only at round 8 (reading 0.74) and not earlier at round 2 (when 0.84 was first computed):

```
# parent commit (bdaddb6f58) — threshold propagates after a ~6-round lag
round 1:  candidates=2,  threshold=0.4
round 2:  candidates=20, threshold=0.4   ← ROC fires: best=0.84; round 3 ConfidenceCriteria still reads 0.4
round 3:  candidates=20, threshold=0.4
round 4:  candidates=17, threshold=0.4
round 5:  candidates=14, threshold=0.4
round 6:  candidates=10, threshold=0.4
round 7:  candidates=5,  threshold=0.4   ← ROC fires: best=0.74
round 8:  candidates=2,  threshold=0.74  ← ConfidenceCriteria now reads 0.74, cuts candidates short each round
round 9:  candidates=6,  threshold=0.74
round 10: candidates=4,  threshold=0.74
...
PASSED
```

**Verified:** After fix, the threshold propagates immediately after the first ROC convergence, skipping the ~6-round warmup:

```
# this PR (all 4 fixes) — threshold propagates immediately after ROC convergence
round 1:  candidates=2,  threshold=0.4
round 2:  candidates=20, threshold=0.4   ← ROC fires: best=0.84; round 3 ConfidenceCriteria reads 0.84
round 3:  candidates=1,  threshold=0.84  ← ConfidenceCriteria reads 0.84, cuts candidates short each round
round 4:  candidates=2,  threshold=0.84
round 5:  candidates=1,  threshold=0.84
round 6:  candidates=6,  threshold=0.74
round 7:  candidates=4,  threshold=0.74
...
PASSED (3/3 runs)
```

**Fix:** One line — sync the updated threshold to `self.generation_config` so each round's `ConfidenceCriteria` reflects the current best:

```python
self.assistant_generation_config.assistant_confidence_threshold = best_threshold
self.generation_config.assistant_confidence_threshold = best_threshold  # ← added
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)