### PR TITLE
Let the GPU verify caller turn on the memory probe

### DIFF
--- a/.github/workflows/serge-verify-caller.yml
+++ b/.github/workflows/serge-verify-caller.yml
@@ -58,6 +58,11 @@ on:
         required: false
         type: string
         default: main
+      memory_probe:
+        description: "Diagnostic: record per-test device memory, including how much survives a gc.collect(), and upload it as an artifact. Off by default — the collect frees memory, so it can stop a memory-related failure from reproducing."
+        required: false
+        type: boolean
+        default: false
       correlation_id:
         description: "Opaque id echoed into the run name so serge can find this run"
         required: false
@@ -86,4 +91,5 @@ jobs:
       machine_type: ${{ inputs.machine_type }}
       run_collateral: ${{ inputs.run_collateral }}
       transformersci_ref: ${{ inputs.transformersci_ref }}
+      memory_probe: ${{ inputs.memory_probe }}
     secrets: inherit


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48001)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48001)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

transformers-ci#75 added a `memory_probe` input to the reusable serge-verify-slow workflow: it installs the resource plugin, sets PYTEST_RESOURCE_METRICS_FILE / PYTEST_RESOURCE_GC_PROBE and uploads a per-test JSONL saying how much device memory each test leaves behind and how much of that survives a gc.collect(). This caller is the only dispatchable entry point, so without the passthrough the input is unreachable.

Off by default, and the reusable workflow reads an empty string as off, so serge's normal dispatches are unchanged. It stays opt-in on purpose: the probe's collect frees memory and can stop a memory-related failure from reproducing.