### PR TITLE
Crop MTP drafts at the first EOS

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1450,6 +1450,9 @@ class MTPCandidateGenerator(AssistedCandidateGenerator):
         self.do_sample = generation_config.do_sample
         self.logits_processor = logits_processor
 
+        # Same tensor the stopping criteria are built from, so a draft cropped here stops generation
+        self.eos_token_id = getattr(generation_config, "_eos_token_tensor", None)
+
         self.is_main_model_prefill = True
 
     def get_candidates(
@@ -1532,6 +1535,17 @@ class MTPCandidateGenerator(AssistedCandidateGenerator):
 
         # Once we arrive here the first time, it's no longer the case
         self.is_main_model_prefill = False
+
+        # Crop the draft after the first EOS, otherwise the target model may accept eos and the rest as valid,
+        # thus not stopping generation after "eos" -- the block is committed before the stopping criteria run,
+        # and they only look at the last committed token. Cropping leaves EOS last, so they fire unchanged.
+        if self.eos_token_id is not None:
+            drafted_tokens = candidate_ids[0]
+            eos_positions = (torch.isin(drafted_tokens, self.eos_token_id.to(drafted_tokens.device))).nonzero()
+            if eos_positions.numel() > 0:
+                num_drafted = eos_positions[0].item() + 1
+                candidate_ids = candidate_ids[:, :num_drafted]
+                candidate_logits = candidate_logits[:, :num_drafted]
 
         # cat everything back together (we need to return the full ids here)
         candidate_ids = torch.cat([input_ids, candidate_ids], dim=-1)

--- a/tests/generation/test_candidate_generator.py
+++ b/tests/generation/test_candidate_generator.py
@@ -1,16 +1,29 @@
 import gc
 import unittest
 import weakref
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
+from torch import nn
 
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GenerationConfig, pipeline
+from transformers import (
+    AutoConfig,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    DeepseekV3Config,
+    DeepseekV3ForCausalLM,
+    GenerationConfig,
+    pipeline,
+)
 from transformers.generation.candidate_generator import (
     AssistantToTargetTranslator,
     AssistantVocabTranslatorCache,
+    MTPCandidateGenerator,
     UniversalSpeculativeDecodingGenerator,
 )
+from transformers.generation.logits_process import LogitsProcessorList
+from transformers.modeling_layers import MtpModel
+from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.testing_utils import require_torch, torch_device
 
 
@@ -336,3 +349,99 @@ class TestUniversalSpeculativeDecoding(unittest.TestCase):
 
         # Assert that the outputs match
         cls.assertEqual(usd_text, vanilla_text)
+
+
+@require_torch
+class TestMTPCandidateGenerator(unittest.TestCase):
+    """`_assisted_decoding` commits `n_matches + 1` tokens before checking whether to stop, and that check
+    reads only the last of them, so an EOS earlier in the drafted block is committed along with everything
+    after it. Reachable only with more than one mtp layer: with a single layer the drafted EOS is already
+    last, and the `is_done_candidate` guard in `_assisted_decoding` covers it.
+    """
+
+    vocab_size = 50
+    hidden_size = 32
+    prompt_length = 6
+    draft = [11, 12, 7, 13, 14]  # one drafted token per mtp layer
+
+    def setUp(self):
+        torch.manual_seed(0)
+        config = DeepseekV3Config(
+            vocab_size=self.vocab_size, hidden_size=self.hidden_size, intermediate_size=37,
+            moe_intermediate_size=12, num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=4,
+            n_routed_experts=4, n_shared_experts=1, num_experts_per_tok=2, first_k_dense_replace=1,
+            n_group=1, topk_group=1, q_lora_rank=8, kv_lora_rank=8, qk_rope_head_dim=4, v_head_dim=8,
+            qk_nope_head_dim=4, num_mtp_layers=len(self.draft), pad_token_id=2,
+        )  # fmt: skip
+        self.model = DeepseekV3ForCausalLM(config).to(torch_device).eval()
+        self.input_ids = torch.randint(5, self.vocab_size, (1, self.prompt_length), device=torch_device)
+        self.model_kwargs = {
+            "position_ids": torch.arange(self.prompt_length, device=torch_device)[None],
+            "attention_mask": torch.ones(1, self.prompt_length, dtype=torch.long, device=torch_device),
+        }
+        self.model_outputs = BaseModelOutputWithPast(
+            last_hidden_state=torch.randn(1, self.prompt_length, self.hidden_size, device=torch_device),
+            hidden_states=tuple(
+                torch.randn(1, self.prompt_length, self.hidden_size, device=torch_device) for _ in range(3)
+            ),
+        )
+
+    def _get_drafted_tokens(self, eos_token_id, draft=None):
+        """Drafts one block, pinning the shared vocab projection so the drafted tokens are exactly `draft`."""
+        draft = self.draft if draft is None else draft
+        vocab_size = self.vocab_size
+
+        class _PinnedHead(nn.Module):
+            """Each mtp layer asks the head, which the drafter shares with the main model, for one token."""
+
+            layer = 0
+
+            def forward(self, hidden_states):
+                logits = torch.zeros(*hidden_states.shape[:2], vocab_size, device=hidden_states.device)
+                logits[:, -1, draft[self.layer]] = 1.0
+                self.layer += 1
+                return logits
+
+        self.model.lm_head = _PinnedHead()
+        generation_config = GenerationConfig(do_sample=False, max_length=1024)
+        generation_config._eos_token_tensor = (
+            None if eos_token_id is None else torch.tensor([eos_token_id], device=torch_device)
+        )
+        # The drafter is normally read out of the checkpoint; its weights do not matter here, as the pinned
+        # head is what decides the drafted tokens
+        with patch.object(
+            MtpModel, "from_pretrained", lambda model, **kwargs: MtpModel(model, len(draft)).to(torch_device)
+        ):
+            candidate_generator = MTPCandidateGenerator(
+                main_model=self.model,
+                generation_config=generation_config,
+                model_kwargs=self.model_kwargs,
+                logits_processor=LogitsProcessorList(),
+            )
+        candidate_ids, candidate_logits = candidate_generator.get_candidates(
+            input_ids=self.input_ids,
+            model_kwargs=self.model_kwargs,
+            model_outputs=self.model_outputs,
+            is_first_iteration=False,
+            n_last_matches=0,
+        )
+        drafted = candidate_ids[0, self.prompt_length :].tolist()
+        # `_speculative_sampling` reads the logits per token, so they have to be cropped alongside them --
+        # matching lengths alone would not catch logits cropped from the wrong end
+        self.assertEqual(candidate_logits.argmax(-1)[0].tolist(), drafted)
+        return drafted
+
+    def test_draft_is_cropped_at_the_first_eos(self):
+        for eos_token_id, draft, expected in (
+            (7, None, [11, 12, 7]),
+            # a drafter repeats tokens, and only a repeated EOS tells "first" apart from "last"
+            (7, [11, 7, 12, 7, 13], [11, 7]),
+            (11, None, [11]),
+        ):
+            with self.subTest(eos_token_id=eos_token_id, draft=draft):
+                self.assertEqual(self._get_drafted_tokens(eos_token_id, draft), expected)
+
+    def test_draft_without_an_eos_before_the_end_is_untouched(self):
+        for eos_token_id in (None, 42, 14):  # unset, not drafted, already the last drafted token
+            with self.subTest(eos_token_id=eos_token_id):
+                self.assertEqual(self._get_drafted_tokens(eos_token_id), self.draft)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48002)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48002)
<!-- ci-dashboard-badge:end -->

# Crop MTP drafts at the first EOS

Fixes #47912. Companion to #47931, per @zucchini-nlp's
[request](https://github.com/huggingface/transformers/issues/47912#issuecomment-5292013856) to fix this for
MTP as well as dflash by cropping. Same crop, same place: inside the candidate generator, mirroring
`PromptLookupCandidateGenerator` (`candidate_generator.py:1129`).

## The bug

`_assisted_decoding` commits `n_matches + 1` tokens per round. It appends and streams the whole block
*before* running the stopping criteria, and `EosTokenCriteria` only inspects the last `new_token_length=1`
tokens. So an EOS accepted anywhere but the end of a committed block is missed, and generation runs past it.

## Scope: it needs more than one mtp layer

The defect fires only when the accepted EOS is *not* the final drafted token, so `num_mtp_layers == 1`
cannot reach it—the single draft position is also the last, and the `is_done_candidate` guard at
`utils.py:3777` already covers that. Every released one-layer checkpoint is therefore unaffected:
DeepSeek-V3, V3.1, GLM-4.5, 4.5-Air and 4.6 all ship exactly one. `thinkingmachines/Inkling` and
`Inkling-Small` ship eight and are reachable today.

I have no MTP checkpoint I can run (Inkling-Small is 532 GB), so the numbers below are on a tiny randomly
initialised `DeepseekV3ForCausalLM`, not on real weights.

## Why cropping the draft is sufficient

`n_matches` is the length of the leading run where the target model's argmax equals the drafted token
(`utils.py:3774`), and `valid_tokens = selected_tokens[:, : n_matches + 1]` (`:3779`). So every committed
position before the last is provably a drafted token, and only the final one—the correction/bonus token—can
be an EOS that was not in the draft. That one is already fine: it lands last, so the criteria fire. Cropping
the draft at its first EOS makes an EOS-before-the-end impossible.

The gating is exact: `EosTokenCriteria` is installed iff `generation_config._eos_token_tensor is not None`
(`utils.py:1383-1384`), and this crop fires on that same tensor, so a block can never be shortened for a
token that would not have stopped generation.

Both commit paths are covered, because both drop the bonus token once EOS lands last: greedy at
`utils.py:3777` and sampling at the matching `is_done_candidate and n_matches == candidate_length` guard in
`_speculative_sampling`. `candidate_logits` is cropped alongside `candidate_ids`—`_speculative_sampling`
indexes it positionally.

Reading `candidate_ids[0]` is safe rather than merely conventional: `_assisted_decoding` raises
`ValueError("assisted generate is only supported for batch_size = 1")` at `utils.py:3669`. The crop also
runs *before* the block is concatenated onto `input_ids`, so it only ever scans drafted tokens—an EOS in the
prompt cannot truncate a draft.

The mtp cache is untouched: the crop applies to the returned block rather than exiting the drafting loop
early, so every layer has still run and recorded its position, and the next call's
`mtp_cache.crop(-num_mtp_layers)` is driven by the layer count, never by how many candidates came back.

## Why not the `SinglePosition` shape

@zucchini-nlp suggested copying `SinglePositionMultiTokenCandidateGenerator`. That one pads post-EOS drafted
tokens with `pad_token_id` and zeroes their logits, but under the `batch_size = 1` guard its
`if sequence_stopped.all(): break` fires on the first drafted EOS, so in practice it simply stops drafting
there and the pad/zero branch is unreachable.

Ending MTP's drafting loop early would not be safe. The cache-correction path crops a fixed
`self.mtp_cache.crop(-self.num_mtp_layers)`, so a block that drafted fewer positions than there are layers
would over-crop and desync. Cropping the returned block instead leaves every layer having run and recorded
its position. Checked directly: drafting the same block with the crop firing and with
`_eos_token_tensor = None` leaves identical per-layer mtp cache lengths.

## Measured

Tiny random `DeepseekV3ForCausalLM`, `max_new_tokens=40`, on macOS/CPU/torch 2.11 and on Linux/CUDA (RTX
A2000)/torch 2.8 with identical results. A random mtp head never agrees with the main model—not one draft
accepted in 39 rounds—so these pin the shared vocab projection to make drafts accepted, which is the
precondition for the bug. Tokens committed after the first EOS, before this change:

| `num_mtp_layers` | EOS at draft index | committed after the first EOS |
|---|---|---|
| 1 | 0 (also last) | 0 |
| 2 | 0 / 1 (last) | **38** / 0 |
| 3 | 0 / 1 / 2 (last) | **38** / **37** / 0 |

Every row is 0 after it. For `num_mtp_layers=3` with the EOS at draft index 1: plain greedy emits 3 tokens
and stops at EOS, `use_mtp=True` emitted 40—37 of them after the EOS—and now emits the same 3 as greedy.
`do_sample=True` is 37 past on each of 3 seeds before and 0 after. With a draft that is cropped and then
*rejected*, generation runs 28 further rounds behind a shortened block and stays token-for-token identical
to plain greedy, which is what says the cache stays in sync.

Separately, an end-to-end A/B sweep through `generate()` (a crafted deterministic drafter, 80 CPU / 60 CUDA
cases) shows the same picture: with the crop, past-EOS is 0 and the output equals plain greedy token for
token on every case; without it, mid-block cases run 13–56 tokens past the EOS, and every
`num_mtp_layers == 1` case stays at 0 even unpatched.

## Tests

Two, in a new `TestMTPCandidateGenerator`: a tiny `DeepseekV3ForCausalLM` with five mtp layers and a pinned
`lm_head`, so the drafted tokens are exactly what each case asks for and the drafter's own weights don't
matter.

- `test_draft_is_cropped_at_the_first_eos`—EOS mid-draft, EOS *repeated* in the draft (only a repeat
  distinguishes "first" from "last"), and EOS as the very first drafted token.
- `test_draft_without_an_eos_before_the_end_is_untouched`—`_eos_token_tensor` unset, an EOS that is never
  drafted, and an EOS that is already the last drafted token.

Both assert `candidate_logits.argmax(-1)` still equals the drafted tokens, so logits cropped from the wrong
end fail; matching lengths alone would not catch that.

---

*AI-assisted contribution, per CONTRIBUTING.md: the patch, the tests and the measurements were drafted with
Claude Code, and the numbers above are from actual local runs. The changed lines and the behaviour have been
reviewed by me before submitting.*