### PR TITLE
Align logit distributions for CandidateGenerators using sampling

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1680,11 +1680,11 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
 
         candidate_logits = self.main_model_output_embeddings(
             outputs.last_hidden_state[:, 1:].to(self.main_model_output_embeddings.weight.device)
-        )
+        ).to(input_ids.device)
 
         # Potentially allow some logits manipulation and sampling - in this case we need to loop over new tokens to correctly apply processors
         if self.logits_processor is not None:
-            candidate_ids = input_ids.to(device=candidate_logits.device)
+            candidate_ids = input_ids
             # Upcast for logit manipulations
             candidate_logits = candidate_logits.to(dtype=torch.float32)
             # We need to sample 1 by 1 for the processors
@@ -1698,8 +1698,6 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
                     next_token = torch.argmax(candidate_logits[:, i, :], dim=-1, keepdim=True)
                 # Append it to the full sequence to be used by the next round of `self.logits_processor`
                 candidate_ids = torch.cat([candidate_ids, next_token], dim=-1)
-            # Put back to `input_ids.device` as we performed all computations on `candidate_logits.device`
-            candidate_ids = candidate_ids.to(input_ids.device)
         # Here we can vectorize as we don't have any processors
         else:
             if self.do_sample:
@@ -1708,7 +1706,7 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
                 candidate_ids = torch.multinomial(probs.squeeze(0), num_samples=1)
             else:
                 candidate_ids = candidate_logits.argmax(dim=-1)
-            candidate_ids = torch.cat([input_ids, candidate_ids.to(input_ids.device)], dim=-1)
+            candidate_ids = torch.cat([input_ids, candidate_ids], dim=-1)
 
         return candidate_ids, candidate_logits
 

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1684,19 +1684,22 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
 
         # Potentially allow some logits manipulation and sampling - in this case we need to loop over new tokens to correctly apply processors
         if self.logits_processor is not None:
-            candidate_ids = input_ids
+            candidate_ids = input_ids.to(device=candidate_logits.device)
+            # Upcast for logit manipulations
+            candidate_logits = candidate_logits.to(dtype=torch.float32)
             # We need to sample 1 by 1 for the processors
             for i in range(candidate_logits.shape[1]):
-                next_token_logits = self.logits_processor(
-                    candidate_ids, candidate_logits[:, i, :].to(device=input_ids.device, dtype=torch.float32)
-                )
+                # Re-assign so we later return the correct logits
+                candidate_logits[:, i, :] = self.logits_processor(candidate_ids, candidate_logits[:, i, :])
                 if self.do_sample:
-                    probs = nn.functional.softmax(next_token_logits, dim=-1, dtype=torch.float32)
+                    probs = nn.functional.softmax(candidate_logits[:, i, :], dim=-1, dtype=torch.float32)
                     next_token = torch.multinomial(probs, num_samples=1)
                 else:
-                    next_token = torch.argmax(next_token_logits, dim=-1, keepdim=True)
-                # Append it to the full sequence
+                    next_token = torch.argmax(candidate_logits[:, i, :], dim=-1, keepdim=True)
+                # Append it to the full sequence to be used by the next round of `self.logits_processor`
                 candidate_ids = torch.cat([candidate_ids, next_token], dim=-1)
+            # Put back to `input_ids.device` as we performed all computations on `candidate_logits.device`
+            candidate_ids = candidate_ids.to(input_ids.device)
         # Here we can vectorize as we don't have any processors
         else:
             if self.do_sample:

--- a/src/transformers/modeling_layers.py
+++ b/src/transformers/modeling_layers.py
@@ -538,7 +538,7 @@ class MtpModel(PreTrainedModel):
             if logits_processor is not None and full_input_ids is not None:
                 next_token_logits = logits_processor(full_input_ids, next_token_logits.to(dtype=torch.float32))
             # Append the drafted logits AFTER logits processors if any
-            drafted_logits.append(next_token_logits)
+            drafted_logits.append(next_token_logits[:, None, :])
             if do_sample:
                 probs = nn.functional.softmax(next_token_logits, dim=-1, dtype=torch.float32)
                 next_mtp_token = torch.multinomial(probs, num_samples=1)

--- a/src/transformers/modeling_layers.py
+++ b/src/transformers/modeling_layers.py
@@ -533,12 +533,12 @@ class MtpModel(PreTrainedModel):
                     logits, labels, vocab_size=self.config.vocab_size, shift_labels=shift_labels, **kwargs
                 )
 
-            # Append the drafted logits
-            drafted_logits.append(logits)
             # Decode one token
             next_token_logits = logits[:, -1, :].to(device=input_ids.device)
             if logits_processor is not None and full_input_ids is not None:
                 next_token_logits = logits_processor(full_input_ids, next_token_logits.to(dtype=torch.float32))
+            # Append the drafted logits AFTER logits processors if any
+            drafted_logits.append(next_token_logits)
             if do_sample:
                 probs = nn.functional.softmax(next_token_logits, dim=-1, dtype=torch.float32)
                 next_mtp_token = torch.multinomial(probs, num_samples=1)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48007)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48007)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

As per the title. Let's return the logits AFTER we apply the `logits_processors` to them, to allow coherent redistribution with the main model's outputs