### PR TITLE
Fix IndexError in is_valid_audio for an empty list or tuple

### DIFF
--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -391,7 +391,7 @@ def is_valid_audio(audio):
     return (
         is_numpy_array(audio)
         or is_torch_tensor(audio)
-        or (isinstance(audio, (list, tuple)) and isinstance(audio[0], float))
+        or (isinstance(audio, (list, tuple)) and len(audio) > 0 and isinstance(audio[0], float))
     )
 
 

--- a/tests/utils/test_audio_utils.py
+++ b/tests/utils/test_audio_utils.py
@@ -31,9 +31,11 @@ from transformers.audio_utils import (
     chroma_filter_bank,
     get_audio_filetype,
     hertz_to_mel,
+    is_valid_audio,
     load_audio,
     load_audio_librosa,
     load_audio_torchcodec,
+    make_list_of_audio,
     mel_filter_bank,
     mel_to_hertz,
     power_to_db,
@@ -1990,3 +1992,25 @@ class LoadAudioTester(unittest.TestCase):
     def test_unknown_backend_raises(self):
         with self.assertRaises(ValueError):
             load_audio(self._path("audio.wav"), sampling_rate=16000, backend="not_a_backend")
+
+
+class AudioInputValidationTest(unittest.TestCase):
+    def test_is_valid_audio_empty_sequence(self):
+        # An empty list/tuple used to raise IndexError from audio[0] instead of
+        # being reported as not valid audio.
+        self.assertFalse(is_valid_audio([]))
+        self.assertFalse(is_valid_audio(()))
+
+    def test_is_valid_audio_accepts_valid_inputs(self):
+        self.assertTrue(is_valid_audio([1.0, 2.0]))
+        self.assertTrue(is_valid_audio((1.0,)))
+        self.assertTrue(is_valid_audio(np.zeros(3)))
+
+    def test_is_valid_audio_rejects_non_audio(self):
+        self.assertFalse(is_valid_audio([1, 2]))
+        self.assertFalse(is_valid_audio("not audio"))
+
+    def test_make_list_of_audio_empty_sequence_raises_value_error(self):
+        for empty in ([], ()):
+            with self.assertRaises(ValueError):
+                make_list_of_audio(empty)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48008)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48008)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`is_valid_audio` indexes `audio[0]` to check the element type, so an empty list or tuple raises `IndexError` instead of returning `False`:

```python
>>> from transformers.audio_utils import is_valid_audio
>>> is_valid_audio([])
IndexError: list index out of range
>>> is_valid_audio(())
IndexError: tuple index out of range
```

```python
return (
    is_numpy_array(audio)
    or is_torch_tensor(audio)
    or (isinstance(audio, (list, tuple)) and isinstance(audio[0], float))   # audio[0] on []
)
```

This reaches the public API through `make_list_of_audio`, which exists to reject invalid input with a clear error:

```python
>>> from transformers.audio_utils import make_list_of_audio
>>> make_list_of_audio([])
IndexError: list index out of range     # expected: ValueError("Invalid input type...")
```

An empty audio list is an easy thing to end up with — a filtered batch, a caller building inputs in a loop — and the `IndexError` gives no hint about what was wrong with the input.

`is_valid_list_of_audio` is unaffected: it already short-circuits on `audio and ...`, which is why this only shows up through the single-audio path.

## Fix

Guard the index with a length check. Valid inputs behave exactly as before, and an empty sequence is now correctly reported as not audio, so `make_list_of_audio` raises its intended `ValueError`.

```
is_valid_audio([1.0, 2.0])   True     (unchanged)
is_valid_audio((1.0,))       True     (unchanged)
is_valid_audio(np.zeros(3))  True     (unchanged)
is_valid_audio([1, 2])       False    (unchanged)
is_valid_audio("not audio")  False    (unchanged)
is_valid_audio([])           False    (was IndexError)
is_valid_audio(())           False    (was IndexError)

make_list_of_audio([])       ValueError: Invalid input type. Must be a single audio or a list of audio
```

## Tests

Added `AudioInputValidationTest` to `tests/utils/test_audio_utils.py`, covering the empty sequences, the valid inputs, the non-audio rejections, and the `make_list_of_audio` behaviour.

```
$ pytest tests/utils/test_audio_utils.py -k AudioInputValidation
4 passed, 38 deselected
```

Two of them fail on `main` with the `IndexError`. `ruff check` and `ruff format --check` are clean.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Did you make sure to update the documentation with your changes? — no user-facing docs affected
- [x] Did you write any new necessary tests?

## Who can review?

@eustlb @ylacombe — audio utils