### PR TITLE
Fix out_indices validation letting an out-of-range 0 through

### DIFF
--- a/src/transformers/backbone_utils.py
+++ b/src/transformers/backbone_utils.py
@@ -99,7 +99,9 @@ class BackboneConfigMixin:
                 raise ValueError(f"out_indices must be a list, got {type(self._out_indices)}")
             # Convert negative indices to their positive equivalent: [-1,] -> [len(stage_names) - 1,]
             positive_indices = tuple(idx % len(self.stage_names) if idx < 0 else idx for idx in self._out_indices)
-            if any(idx for idx in positive_indices if idx not in range(len(self.stage_names))):
+            # `any(idx for ...)` tested the truthiness of each out-of-range index, so an
+            # out-of-range 0 was falsy and slipped through; test the condition instead.
+            if any(idx not in range(len(self.stage_names)) for idx in positive_indices):
                 raise ValueError(
                     f"out_indices must be valid indices for stage_names {self.stage_names}, got {self._out_indices}"
                 )

--- a/tests/utils/test_backbone_utils.py
+++ b/tests/utils/test_backbone_utils.py
@@ -132,6 +132,18 @@ class BackboneUtilsTester(unittest.TestCase):
         AnyBackboneConfig(stage_names=["a", "b", "c", "d"], out_features=["a", "b", "d"], out_indices=[0, 1, -1])
 
     @require_torch
+    def test_config_verify_out_indices_rejects_out_of_range_zero(self):
+        # `any(idx for ...)` tested the truthiness of each out-of-range index, so an
+        # out-of-range 0 was falsy and passed validation while 1 was rejected.
+        with pytest.raises(ValueError, match="out_indices must be valid indices for stage_names"):
+            AnyBackboneConfig(stage_names=[], out_features=None, out_indices=[0])
+
+        with pytest.raises(ValueError, match="out_indices must be valid indices for stage_names"):
+            AnyBackboneConfig(stage_names=[], out_features=None, out_indices=[1])
+
+        # a valid 0 for non-empty stage_names is still accepted
+        AnyBackboneConfig(stage_names=["a", "b"], out_features=None, out_indices=[0])
+
     def test_backbone_mixin(self):
         config = AnyBackboneConfig(stage_names=["a", "b", "c"], out_features=["a", "c"], out_indices=[0, 2])
         backbone = AnyBackbone(config)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48010)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48010)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`BackboneConfigMixin.verify_out_features_out_indices` checks the index range with:

```python
if any(idx for idx in positive_indices if idx not in range(len(self.stage_names))):
```

That tests the **truthiness of each out-of-range index** rather than the condition itself. `0` is falsy, so an out-of-range `0` passes validation while `1` in the same position is rejected:

```python
stage_names=[], out_indices=[0]   ->  accepted   (should raise)
stage_names=[], out_indices=[1]   ->  ValueError (correct)
```

The generator only yields indices that are already out of range, so every value it produces should trigger the error — `any()` is being asked the wrong question.

## Reachability

To be straight about severity: with a non-empty `stage_names`, `0` is always a valid index, so this only bites when `stage_names` is empty. I don't have a model config that does that, so I'd call this a correctness fix in validation logic rather than a bug users are hitting today. Flagging it because the expression is wrong regardless of whether a caller currently exercises it, and it's the kind of thing that silently starts mattering the day some config passes an empty stage list.

## Fix

Test the condition rather than the value:

```python
if any(idx not in range(len(self.stage_names)) for idx in positive_indices):
```

Valid indices are unaffected, including negative ones (they're normalised to positive before this check):

```
stage_names=["a","b"], out_indices=[0]      -> ok
stage_names=["a","b"], out_indices=[0, 1]   -> ok
stage_names=["a","b"], out_indices=[-1]     -> ok
stage_names=["a","b"], out_indices=[5]      -> ValueError
```

## Tests

Added `test_config_verify_out_indices_rejects_out_of_range_zero` to `tests/utils/test_backbone_utils.py`, asserting both `[0]` and `[1]` are rejected for an empty `stage_names` and that a valid `0` is still accepted.

One disclosure: `tests/utils/test_backbone_utils.py` doesn't collect in my environment — it needs `PreTrainedModel`, so it requires torch, which I don't have installed. That collection error reproduces identically before and after this change. I verified the three assertions directly against `BackboneConfigMixin` instead, and confirmed the `[0]` case is accepted without the fix and rejected with it. CI is the authority for the file as a whole.

`ruff check` and `ruff format --check` are clean.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Did you write any new necessary tests?

## Who can review?

@amyeroberts @qubvel — backbone utils