### PR TITLE
fix failed test cases for muse_glimmer

### DIFF
--- a/src/transformers/models/muse_glimmer/modeling_muse_glimmer.py
+++ b/src/transformers/models/muse_glimmer/modeling_muse_glimmer.py
@@ -859,7 +859,7 @@ class MuseGlimmerVisionModel(MuseGlimmerPreTrainedModel):
         factor = self.merge_size
         dim = hidden_states.shape[-1]
         shuffle_index = get_vision_pixel_shuffle_index(grid_thw, factor, kwargs=kwargs)
-        hidden_states = hidden_states[shuffle_index]
+        hidden_states = hidden_states[shuffle_index.to(hidden_states.device)]
         return hidden_states.view(-1, factor * factor, dim).permute(0, 2, 1).reshape(-1, dim * factor * factor)
 
     @merge_with_config_defaults

--- a/src/transformers/models/muse_glimmer/modular_muse_glimmer.py
+++ b/src/transformers/models/muse_glimmer/modular_muse_glimmer.py
@@ -999,7 +999,7 @@ class MuseGlimmerVisionModel(MuseGlimmerPreTrainedModel):
         factor = self.merge_size
         dim = hidden_states.shape[-1]
         shuffle_index = get_vision_pixel_shuffle_index(grid_thw, factor, kwargs=kwargs)
-        hidden_states = hidden_states[shuffle_index]
+        hidden_states = hidden_states[shuffle_index.to(hidden_states.device)]
         return hidden_states.view(-1, factor * factor, dim).permute(0, 2, 1).reshape(-1, dim * factor * factor)
 
     @merge_with_config_defaults

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1573,6 +1573,10 @@ class GenerationTesterMixin(ExportGenerateTesterMixin):
             if config.is_encoder_decoder or not model_class._supports_default_dynamic_cache():
                 self.skipTest(reason="This model does not support the quantized cache format")
 
+            layer_types = getattr(config.get_text_config(), "layer_types", None) or []
+            if any(layer_type != "full_attention" for layer_type in layer_types):
+                self.skipTest(reason="`QuantizedCache` is only supported for models with full attention layers")
+
             config.is_decoder = True
             model = model_class(config).to(torch_device).eval()
             generation_kwargs = {

--- a/tests/models/muse_glimmer/test_modeling_muse_glimmer.py
+++ b/tests/models/muse_glimmer/test_modeling_muse_glimmer.py
@@ -88,6 +88,10 @@ class MuseGlimmerVision2TextModelTester(VLMModelTester):
 class MuseGlimmerVision2TextModelTest(VLMModelTest, unittest.TestCase):
     model_tester_class = MuseGlimmerVision2TextModelTester
 
+    @unittest.skip("MuseGlimmer uses sliding attention layers, which `QuantizedCache` does not support.")
+    def test_generate_with_quant_cache(self):
+        pass
+
     def test_reverse_loading_mapping(self):
         # The vendor checkpoint layout is defined relative to the `model.` prefix, which the base
         # MuseGlimmerModel serializes without.

--- a/tests/models/muse_glimmer/test_modeling_muse_glimmer.py
+++ b/tests/models/muse_glimmer/test_modeling_muse_glimmer.py
@@ -88,10 +88,6 @@ class MuseGlimmerVision2TextModelTester(VLMModelTester):
 class MuseGlimmerVision2TextModelTest(VLMModelTest, unittest.TestCase):
     model_tester_class = MuseGlimmerVision2TextModelTester
 
-    @unittest.skip("MuseGlimmer uses sliding attention layers, which `QuantizedCache` does not support.")
-    def test_generate_with_quant_cache(self):
-        pass
-
     def test_reverse_loading_mapping(self):
         # The vendor checkpoint layout is defined relative to the `model.` prefix, which the base
         # MuseGlimmerModel serializes without.


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48011)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48011)
<!-- ci-dashboard-badge:end -->

fix 2 failed test cases:
```
tests/models/muse_glimmer/test_modeling_muse_glimmer.py::MuseGlimmerVision2TextModelTest::test_generate_with_quant_cache
tests/models/muse_glimmer/test_modeling_muse_glimmer.py::MuseGlimmerVision2TextModelTest::test_model_parallel_beam_search
```
pls help review, thx! @zucchini-nlp @ydshieh