### PR TITLE
Fix CpmAnt loading: size lm_head to vocab_size

### DIFF
--- a/src/transformers/models/cpmant/modeling_cpmant.py
+++ b/src/transformers/models/cpmant/modeling_cpmant.py
@@ -685,10 +685,8 @@ class CpmAntModel(CpmAntPreTrainedModel):
     """
 )
 class CpmAntForCausalLM(CpmAntPreTrainedModel, GenerationMixin):
-    # `lm_head.weight` is a vocab-sized slice of `input_embedding.weight`, whose trailing
-    # `prompt_types * prompt_length` rows are soft-prompt embeddings and never decoding
-    # targets. A whole-tensor tie would be shape-mismatched, so the checkpoint ships the
-    # head explicitly and nothing is tied here.
+    # The head is a vocab-sized slice of `input_embedding.weight`, so a whole-tensor tie
+    # would be shape-mismatched; the checkpoint ships `lm_head.weight` explicitly.
     _tied_weights_keys = {}
 
     def __init__(self, config: CpmAntConfig):

--- a/src/transformers/models/cpmant/modeling_cpmant.py
+++ b/src/transformers/models/cpmant/modeling_cpmant.py
@@ -680,20 +680,22 @@ class CpmAntModel(CpmAntPreTrainedModel):
 
 @auto_docstring(
     custom_intro="""
-    The CPMAnt Model with a language modeling head on top (linear layer with weights tied to the input embeddings).
+    The CPMAnt Model with a language modeling head on top (linear layer whose weights are a
+    vocabulary-sized slice of the input embeddings).
     """
 )
 class CpmAntForCausalLM(CpmAntPreTrainedModel, GenerationMixin):
-    _tied_weights_keys = {"lm_head.weight": "cpmant.input_embedding.weight"}
+    # `lm_head.weight` is a vocab-sized slice of `input_embedding.weight`, whose trailing
+    # `prompt_types * prompt_length` rows are soft-prompt embeddings and never decoding
+    # targets. A whole-tensor tie would be shape-mismatched, so the checkpoint ships the
+    # head explicitly and nothing is tied here.
+    _tied_weights_keys = {}
 
     def __init__(self, config: CpmAntConfig):
         super().__init__(config)
         self.cpmant = CpmAntModel(config)
 
-        # lm_head.weight is tied to cpmant.input_embedding.weight
-        self.lm_head = nn.Linear(
-            config.hidden_size, config.vocab_size + config.prompt_types * config.prompt_length, bias=False
-        )
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
         self.post_init()
 
     @auto_docstring

--- a/tests/models/cpmant/test_modeling_cpmant.py
+++ b/tests/models/cpmant/test_modeling_cpmant.py
@@ -124,7 +124,7 @@ class CpmAntModelTester:
         model_output = model(**input_ids)
         self.parent.assertEqual(
             model_output.logits.shape,
-            (self.batch_size, self.seq_length, config.vocab_size + config.prompt_types * config.prompt_length),
+            (self.batch_size, self.seq_length, config.vocab_size),
         )
 
     def prepare_config_and_inputs_for_common(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48012)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48012)
<!-- ci-dashboard-badge:end -->

`openbmb/cpm-ant-10b` cannot be loaded on `main`.

## Repro

```python
import torch
from transformers import AutoModelForCausalLM, CpmAntTokenizer

MODEL_ID = "openbmb/cpm-ant-10b"  # tokenizer needs the `rjieba` backend

tok = CpmAntTokenizer.from_pretrained(MODEL_ID)
model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype=torch.bfloat16).eval()

print("config.vocab_size    :", model.config.vocab_size)
print("lm_head.out_features :", model.lm_head.out_features)

inputs = tok(["Today is a good day"], return_tensors="pt")
with torch.no_grad():
    print("logits width         :", model(**inputs).logits.shape[-1])
```

**Before** (`a93de5e1f4`):

```
lm_head.weight | MISMATCH | Reinit due to size mismatch - ckpt: torch.Size([30720, 4096]) vs model:torch.Size([31744, 4096])

  File "src/transformers/modeling_utils.py", line 2645, in tie_weights
    if not torch.equal(source_param, target_param):
NotImplementedError: aten::equal: attempted to run this operator with Meta tensors, ...

During handling of the above exception, another exception occurred:

  File "src/transformers/utils/loading_report.py", line 278, in log_state_dict_report
    raise RuntimeError(
RuntimeError: You set `ignore_mismatched_sizes` to `False`, thus raising an error. For details look at the above report!
```

`ignore_mismatched_sizes=True` is not a workaround — it reinitializes the head
and then still dies in `tie_weights` on the same `aten::equal` meta-tensor call.

**After**:

```
config.vocab_size    : 30720
lm_head.out_features : 30720
logits width         : 30720
```

## Cause

The checkpoint ships `lm_head.weight` at `(vocab_size, hidden) = (30720, 4096)`,
while `input_embedding.weight` is `(31744, 4096)`. The extra
`prompt_types * prompt_length = 32 * 32 = 1024` rows are soft-prompt embeddings
and are never decoding targets. Verified against the released weights:

```python
sd = torch.load("pytorch_model-00013-of-00013.bin", weights_only=True)
sd["input_embedding.weight"].shape                          # (31744, 4096)
sd["lm_head.weight"].shape                                  # (30720, 4096)
torch.equal(sd["lm_head.weight"], sd["input_embedding.weight"][:30720])  # True
```

The model instead built a 31744-wide head and declared a whole-tensor tie:

```python
_tied_weights_keys = {"lm_head.weight": "cpmant.input_embedding.weight"}
self.lm_head = nn.Linear(hidden, vocab_size + prompt_types * prompt_length, bias=False)
```

Nothing about that mapping is satisfiable: the two tensors have different shapes,
so they can never be the same storage. The old loader tolerated the mismatch by
reinitializing; the meta-device loader raises.

## Fix

`modeling_cpmant.py`: size the head to `config.vocab_size`, which is what the
checkpoint contains, and drop the tie mapping.

## Tests

`create_and_check_lm_head_model` now expects `config.vocab_size`-wide logits
(was `vocab_size + prompt_types * prompt_length`).

```
$ pytest tests/models/cpmant/ -q
112 passed, 152 skipped, 53 warnings
```

## Note

`generate` still fails with `use_cache=True` on this checkpoint. That is an
unrelated regression and is fixed separately.