### PR TITLE
Fix MTP config when mlp_layer_types is absent

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -1413,6 +1413,10 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin, Heterogeneous
         # This is needed to be correct in several places, e.g. when creating the cache
         text_config.num_hidden_layers = num_mtp_layers
 
+        # If this exist, the MTP layers always use a MoE, so we artificially set to 0
+        if hasattr(text_config, "first_k_dense_replace"):
+            text_config.first_k_dense_replace = 0
+
         return text_config
 
 

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -1413,7 +1413,7 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin, Heterogeneous
         # This is needed to be correct in several places, e.g. when creating the cache
         text_config.num_hidden_layers = num_mtp_layers
 
-        # If this exist, the MTP layers always use a MoE, so we artificially set to 0
+        # In some models this is used to discriminate between MLP or MoE layers, but MTP layers always use MoE -> artifically set to 0
         if hasattr(text_config, "first_k_dense_replace"):
             text_config.first_k_dense_replace = 0
 


### PR DESCRIPTION
# What does this PR do?

As per the title. This is true e.g. for glm4_moe and deepseek_v3