### PR TITLE
unpin `pytest` in the `examples_torch` deps

### DIFF
--- a/examples/pytorch/_tests_requirements.txt
+++ b/examples/pytorch/_tests_requirements.txt
@@ -15,7 +15,6 @@ nltk
 pandas
 datasets >= 1.13.3
 fire
-pytest<8.0.1
 conllu
 sentencepiece != 0.1.92
 protobuf

--- a/examples/pytorch/_tests_requirements.txt
+++ b/examples/pytorch/_tests_requirements.txt
@@ -15,6 +15,7 @@ nltk
 pandas
 datasets >= 1.13.3
 fire
+pytest
 conllu
 sentencepiece != 0.1.92
 protobuf

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1039,6 +1039,11 @@ def infer_tests_to_run(output_file: str, diff_with_last_commit: bool = False, te
             if f in test_map:
                 test_files_to_run.extend(test_map[f])
 
+    # TEMPORARY - DO NOT MERGE: force the examples_torch job to run so we can verify the
+    # pytest unpin in examples/pytorch/_tests_requirements.txt. The fetcher only selects
+    # examples tests on the full-CI path, so a requirements-only diff never exercises them.
+    test_files_to_run.extend(glob.glob("examples/pytorch/*test_*.py"))
+
     if should_run_repo_utils_tests(modified_files):
         test_files_to_run.extend(get_repo_utils_tests())
 

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1039,11 +1039,6 @@ def infer_tests_to_run(output_file: str, diff_with_last_commit: bool = False, te
             if f in test_map:
                 test_files_to_run.extend(test_map[f])
 
-    # TEMPORARY - DO NOT MERGE: force the examples_torch job to run so we can verify the
-    # pytest unpin in examples/pytorch/_tests_requirements.txt. The fetcher only selects
-    # examples tests on the full-CI path, so a requirements-only diff never exercises them.
-    test_files_to_run.extend(glob.glob("examples/pytorch/*test_*.py"))
-
     if should_run_repo_utils_tests(modified_files):
         test_files_to_run.extend(get_repo_utils_tests())
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48023)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48023)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Per https://github.com/huggingface/transformers/actions/runs/32013375246/job/95337862026?pr=48015

the `pytest-timeout` 2.5.0 release yesterday, that added `Requires-Dist: pytest>=8.4.0` and we have `pytest<8.0.1` just for `examples_torch`

This patch unpins it from the requirements and let `examples_torch` run with the pytest that is already in the docker image