### PR TITLE
[Whisper] Fix decoder position IDs for left-padded batches in longform generation

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -577,6 +577,22 @@ class GenerationMixin(ContinuousMixin):
         attention_mask = (
             kwargs.pop("decoder_attention_mask", None) if self.config.is_encoder_decoder else attention_mask
         )
+        # When processing encoder-decoder models with condition_on_prev_tokens=True (e.g. Whisper
+        # longform), shorter sequences in a batch are left-padded. Without explicit position_ids,
+        # WhisperDecoder falls back to `past_kv.get_seq_length()` which counts padding positions,
+        # giving wrong embeddings for padded items. Compute per-item position_ids from the
+        # decoder_attention_mask via cumsum so each item gets correct positions regardless of padding.
+        if (
+            self.config.is_encoder_decoder
+            and attention_mask is not None
+            and model_inputs.get(position_ids_key) is None
+            and position_ids_key in set(inspect.signature(self.forward).parameters.keys())
+        ):
+            decoder_position_ids = attention_mask.long().cumsum(-1) - 1
+            decoder_position_ids = decoder_position_ids.masked_fill(attention_mask == 0, 0)
+            model_inputs[position_ids_key] = decoder_position_ids[..., -sequence_length:].clone(
+                memory_format=torch.contiguous_format
+            )
         if (
             isinstance(past_key_values, Cache)
             and past_key_values.is_compileable

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -577,22 +577,6 @@ class GenerationMixin(ContinuousMixin):
         attention_mask = (
             kwargs.pop("decoder_attention_mask", None) if self.config.is_encoder_decoder else attention_mask
         )
-        # When processing encoder-decoder models with condition_on_prev_tokens=True (e.g. Whisper
-        # longform), shorter sequences in a batch are left-padded. Without explicit position_ids,
-        # WhisperDecoder falls back to `past_kv.get_seq_length()` which counts padding positions,
-        # giving wrong embeddings for padded items. Compute per-item position_ids from the
-        # decoder_attention_mask via cumsum so each item gets correct positions regardless of padding.
-        if (
-            self.config.is_encoder_decoder
-            and attention_mask is not None
-            and model_inputs.get(position_ids_key) is None
-            and position_ids_key in set(inspect.signature(self.forward).parameters.keys())
-        ):
-            decoder_position_ids = attention_mask.long().cumsum(-1) - 1
-            decoder_position_ids = decoder_position_ids.masked_fill(attention_mask == 0, 0)
-            model_inputs[position_ids_key] = decoder_position_ids[..., -sequence_length:].clone(
-                memory_format=torch.contiguous_format
-            )
         if (
             isinstance(past_key_values, Cache)
             and past_key_values.is_compileable

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1018,10 +1018,13 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
         # During Whisper longform generation with condition_on_prev_tokens=True, shorter sequences
         # in a batch are left-padded. Compute decoder_position_ids from decoder_attention_mask so
         # each item gets correct positions regardless of padding, before the base class processes it.
-        if "decoder_position_ids" not in kwargs and (decoder_attention_mask := kwargs.get("decoder_attention_mask")) is not None:
+        if (
+            "decoder_position_ids" not in kwargs
+            and (decoder_attention_mask := kwargs.get("decoder_attention_mask")) is not None
+        ):
             position_ids = decoder_attention_mask.long().cumsum(-1) - 1
             position_ids = position_ids.masked_fill(decoder_attention_mask == 0, 0)
-            kwargs["decoder_position_ids"] = position_ids[..., -input_ids.shape[1]:]
+            kwargs["decoder_position_ids"] = position_ids[..., -input_ids.shape[1] :]
         return super().prepare_inputs_for_generation(
             input_ids, past_key_values=past_key_values, attention_mask=attention_mask, **kwargs
         )

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1014,6 +1014,18 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
     def get_input_embeddings(self) -> nn.Module:
         return self.model.get_input_embeddings()
 
+    def prepare_inputs_for_generation(self, input_ids, past_key_values=None, attention_mask=None, **kwargs):
+        # During Whisper longform generation with condition_on_prev_tokens=True, shorter sequences
+        # in a batch are left-padded. Compute decoder_position_ids from decoder_attention_mask so
+        # each item gets correct positions regardless of padding, before the base class processes it.
+        if "decoder_position_ids" not in kwargs and (decoder_attention_mask := kwargs.get("decoder_attention_mask")) is not None:
+            position_ids = decoder_attention_mask.long().cumsum(-1) - 1
+            position_ids = position_ids.masked_fill(decoder_attention_mask == 0, 0)
+            kwargs["decoder_position_ids"] = position_ids[..., -input_ids.shape[1]:]
+        return super().prepare_inputs_for_generation(
+            input_ids, past_key_values=past_key_values, attention_mask=attention_mask, **kwargs
+        )
+
     def freeze_encoder(self):
         """
         Calling this function will disable the gradient computation for the Whisper encoder so that its parameters will

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -1090,7 +1090,6 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     def test_longform_generate_multi_batch(self):
         self._check_longform_generate_multi_batch(condition_on_prev_tokens=False)
 
-    @unittest.skip("Broken by #44130, to be checked asap")
     def test_longform_generate_multi_batch_cond_prev(self):
         self._check_longform_generate_multi_batch(condition_on_prev_tokens=True)
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48028)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48028)
<!-- ci-dashboard-badge:end -->

## What this fixes

`test_whisper_longform_multi_batch_hard_prev_cond` and `test_whisper_longform_no_speech_detection` have been failing since PR #44130 (Feb 20 2026). Also re-enables `test_longform_generate_multi_batch_cond_prev` which was explicitly skipped in #44130 with _"Broken by #44130, to be checked asap"_.

## Root cause

PR #44130 refactored `prepare_inputs_for_generation` to stop using `cache_position` for input slicing, but inadvertently dropped the cumsum-based `decoder_position_ids` computation from `decoder_attention_mask`.

Without it, `WhisperDecoder.forward` falls back to `arange(0, seq_len)` — the same sequential positions for every batch item, ignoring padding. With `condition_on_prev_tokens=True` and a heterogeneous batch (shape `(8, 140)`), shorter sequences are left-padded. Item 0 has 28 padding tokens followed by 112 real tokens:

```
# decoder_attention_mask for item 0:
[0, 0, ..., 0,  1, 1, ..., 1]
 ←— 28 ——→   ←——— 112 ———→

# Good commit (708d3e1251) — cumsum from mask:
[0, 0, ..., 0,  0, 1, ..., 111]   ✓ padding → pos 0, real tokens → pos 0..111

# Bad commit (ecf79eb2f6) — arange(0, 140) for all items:
[0, 1, ..., 27, 28, 29, ..., 139] ✗ padding → pos 0..27, real tokens → pos 28..139
```

Every real token for item 0 gets a position 28 too high. Item 5 (no padding, 140 real tokens) is unaffected and gets correct positions — matching the test result where item 5 always passes.

**Runtime evidence** (actual test run, verified on runner):

**Good commit `708d3e1251`** — cumsum fires (`mask_has_zeros=1`), per-item last positions:
```
item=0  pos[-3:]=[109, 110, 111]  mask[:3]=[0, 0, 0]  (padding → wrong pos avoided)
item=1  pos[-3:]=[125, 126, 127]  mask[:3]=[0, 0, 0]
item=2  pos[-3:]=[90,  91,  92 ]  mask[:3]=[0, 0, 0]
item=3  pos[-3:]=[128, 129, 130]  mask[:3]=[0, 0, 0]
item=4  pos[-3:]=[120, 121, 122]  mask[:3]=[0, 0, 0]
item=5  pos[-3:]=[137, 138, 139]  mask[:3]=[1, 1, 1]  (no padding — longest item)
item=6  pos[-3:]=[122, 123, 124]  mask[:3]=[0, 0, 0]
item=7  pos[-3:]=[132, 133, 134]  mask[:3]=[0, 0, 0]
```

**Bad commit `ecf79eb2f6`** — no cumsum, all items get `arange(0, 140)`:
```
item=0  pos[-3:]=[137, 138, 139]  ✗ real tokens shifted by +28 (padding count)
item=1  pos[-3:]=[137, 138, 139]  ✗ real tokens shifted by +12
item=2  pos[-3:]=[137, 138, 139]  ✗ real tokens shifted by +47
item=3  pos[-3:]=[137, 138, 139]  ✗ real tokens shifted by +9
item=4  pos[-3:]=[137, 138, 139]  ✗ real tokens shifted by +17
item=5  pos[-3:]=[137, 138, 139]  ✓ no padding, positions correct
item=6  pos[-3:]=[137, 138, 139]  ✗ real tokens shifted by +15
item=7  pos[-3:]=[137, 138, 139]  ✗ real tokens shifted by +5
```

Wrong positional embeddings for 7 of 8 items → wrong logits → wrong tokens. The errors cascade through `condition_on_prev_tokens=True` into hallucination.

## Fix

### Original approach (superseded)

Restored the cumsum computation in the base `prepare_inputs_for_generation` in `generation/utils.py`, scoped to encoder-decoder models only when `decoder_attention_mask` is present and `position_ids` haven't already been set:

```python
if (
    self.config.is_encoder_decoder
    and attention_mask is not None
    and model_inputs.get(position_ids_key) is None
    and position_ids_key in set(inspect.signature(self.forward).parameters.keys())
):
    decoder_position_ids = attention_mask.long().cumsum(-1) - 1
    decoder_position_ids = decoder_position_ids.masked_fill(attention_mask == 0, 0)
    model_inputs[position_ids_key] = decoder_position_ids[..., -sequence_length:].clone(
        memory_format=torch.contiguous_format
    )
```

### Updated approach (per @zucchini-nlp's review)

Instead of patching the generic base method, override `prepare_inputs_for_generation` in `WhisperForConditionalGeneration` directly. This keeps the fix model-specific and avoids any risk of unintended side effects on other encoder-decoder models.

**Why `prepare_inputs_for_generation` and not `_prepare_position_ids_for_generation`?** The base `_prepare_position_ids_for_generation` can't be used here for two reasons: (1) it always stores to `model_kwargs["position_ids"]`, but encoder-decoder models use `"decoder_position_ids"` as the key — writing to the wrong key is silently ignored; (2) it reads `model_kwargs.get("attention_mask")` (the encoder mask), not `decoder_attention_mask`. All existing custom `_prepare_position_ids_for_generation` overrides in the codebase (`qwen2_vl`, `qwen3_vl`, `glm4v`, `cosmos3_omni`, etc.) are decoder-only VLMs needing 3D position IDs — none are encoder-decoder, confirming it's the wrong hook for Whisper.

```python
def prepare_inputs_for_generation(self, input_ids, past_key_values=None, attention_mask=None, **kwargs):
    # During Whisper longform generation with condition_on_prev_tokens=True, shorter sequences
    # in a batch are left-padded. Compute decoder_position_ids from decoder_attention_mask so
    # each item gets correct positions regardless of padding, before the base class processes it.
    if "decoder_position_ids" not in kwargs and (decoder_attention_mask := kwargs.get("decoder_attention_mask")) is not None:
        position_ids = decoder_attention_mask.long().cumsum(-1) - 1
        position_ids = position_ids.masked_fill(decoder_attention_mask == 0, 0)
        kwargs["decoder_position_ids"] = position_ids[..., -input_ids.shape[1]:]
    return super().prepare_inputs_for_generation(
        input_ids, past_key_values=past_key_values, attention_mask=attention_mask, **kwargs
    )
```

## Test results

Full whisper test suite run on A10 (torch 2.13) with this fix:

```
1 failed, 460 passed, 254 skipped in 9:56
```

The one remaining failure (`test_speculative_decoding_non_distil`) is a pre-existing regression from PR #42702, unrelated to this fix. `test_longform_generate_multi_batch_cond_prev` (previously skipped) now **passes**.

cc @Cyrilvallez @eustlb
