### PR TITLE
[Florence2] Fix dtype mismatch in test_large_model_inference_eager

### DIFF
--- a/tests/models/florence2/test_modeling_florence2.py
+++ b/tests/models/florence2/test_modeling_florence2.py
@@ -448,9 +448,9 @@ class Florence2ForConditionalGenerationIntegrationTest(unittest.TestCase):
     def test_large_model_inference_eager(self):
         model_name = "florence-community/Florence-2-large"
         processor = AutoProcessor.from_pretrained(model_name)
-        model = Florence2ForConditionalGeneration.from_pretrained(model_name, attn_implementation="eager").to(
-            torch_device
-        )
+        model = Florence2ForConditionalGeneration.from_pretrained(
+            model_name, attn_implementation="eager", torch_dtype=torch.float32
+        ).to(torch_device)
 
         prompt = "<DETAILED_CAPTION>"
         inputs = processor(images=self.image1, text=prompt, return_tensors="pt")


### PR DESCRIPTION
## Root cause

`florence-community/Florence-2-large` weights are stored in **float16** on the Hub. PR #34919 (Dec 11 2025) changed the default dtype to `torch_dtype="auto"`, which causes the model to load in float16.

The test then passes float32 processor outputs (default dtype) to a float16 model, crashing with:

```
RuntimeError: Input type (float) and bias type (c10::Half) should be the same
```

This regression first appeared in CI on **Dec 12 2025**.

## Fix

Pass `torch_dtype=torch.float32` explicitly in the `from_pretrained` call for `test_large_model_inference_eager`. This keeps both the model weights and input tensors in float32, matching the original test intent (the base model tests use float32 weights and are unaffected).

## Verification

Test confirmed **PASSED** on A10 runner (torch 2.13.0+cu130):

```
tests/models/florence2/test_modeling_florence2.py::Florence2ForConditionalGenerationIntegrationTest::test_large_model_inference_eager PASSED 10.72s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)