### PR TITLE
Fix HfArgumentParser to parse dict-typed fields from CLI using json.loads

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -224,6 +224,14 @@ class HfArgumentParser(ArgumentParser):
                 kwargs["default"] = field.default_factory()
             elif field.default is dataclasses.MISSING:
                 kwargs["required"] = True
+        elif isclass(origin_type) and issubclass(origin_type, dict):
+            kwargs["type"] = json.loads
+            if field.default is not dataclasses.MISSING:
+                kwargs["default"] = field.default
+            elif field.default_factory is not dataclasses.MISSING:
+                kwargs["default"] = field.default_factory()
+            else:
+                kwargs["required"] = True
         else:
             kwargs["type"] = field.type
             if field.default is not dataclasses.MISSING:

--- a/tests/utils/test_hf_argparser.py
+++ b/tests/utils/test_hf_argparser.py
@@ -62,6 +62,11 @@ class WithDefaultBoolExample:
     opt: bool | None = None
 
 
+@dataclass
+class DictCliExample:
+    kw: dict | None = field(default=None)
+
+
 class BasicEnum(Enum):
     titi = "titi"
     toto = "toto"
@@ -490,3 +495,13 @@ class HfArgumentParserTest(unittest.TestCase):
         parser = HfArgumentParser(TrainingArguments)
         training_args = parser.parse_args_into_dataclasses()[0]
         self.assertEqual(training_args.accelerator_config.gradient_accumulation_kwargs["num_steps"], 2)
+
+    def test_17_cli_parse_dict_field(self):
+        # Regression test for #48030: dict-typed dataclass fields were registered with `type=dict`,
+        # which makes argparse reject JSON values (e.g. '{"a": false}'). They must use `json.loads`.
+        parser = HfArgumentParser((DictCliExample,))
+        args = parser.parse_args_into_dataclasses(["--kw", '{"a": false}'])[0]
+        self.assertEqual(args.kw, {"a": False})
+
+        args = parser.parse_args_into_dataclasses(["--kw", '{"x": [1, 2]}'])[0]
+        self.assertEqual(args.kw, {"x": [1, 2]})


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48033)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48033)
<!-- ci-dashboard-badge:end -->

Fixes #48030

Adds special case for dict fields in HfArgumentParser._parse_dataclass_field using json.loads.