### PR TITLE
Support `BatchFeature` in length-grouped samplers

### DIFF
--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -41,7 +41,6 @@ from torch.utils.data import Dataset, IterableDataset, RandomSampler, Sampler
 from torch.utils.data.distributed import DistributedSampler
 
 from .integrations.deepspeed import is_deepspeed_zero3_enabled
-from .tokenization_utils_base import BatchEncoding
 from .utils import (
     is_sagemaker_mp_enabled,
     is_torch_available,
@@ -538,7 +537,7 @@ class LengthGroupedSampler(Sampler):
         self.batch_size = batch_size
         if lengths is None:
             model_input_name = model_input_name if model_input_name is not None else "input_ids"
-            if not isinstance(dataset[0], (dict, BatchEncoding)) or model_input_name not in dataset[0]:
+            if not isinstance(dataset[0], Mapping) or model_input_name not in dataset[0]:
                 raise ValueError(
                     "Can only automatically infer lengths for datasets whose items are dictionaries with an "
                     f"'{model_input_name}' key."
@@ -598,7 +597,7 @@ class DistributedLengthGroupedSampler(DistributedSampler):
 
         if lengths is None:
             model_input_name = model_input_name if model_input_name is not None else "input_ids"
-            if not isinstance(dataset[0], (dict, BatchEncoding)) or model_input_name not in dataset[0]:
+            if not isinstance(dataset[0], Mapping) or model_input_name not in dataset[0]:
                 raise ValueError(
                     "Can only automatically infer lengths for datasets whose items are dictionaries with an "
                     f"'{model_input_name}' key."


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48034)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48034)
<!-- ci-dashboard-badge:end -->

Fixes #42760

`LengthGroupedSampler` and `DistributedLengthGroupedSampler` gate length inference on `isinstance(dataset[0], (dict, BatchEncoding))`. Multimodal processors (Qwen2.5-VL etc.) return `BatchFeature`, which subclasses `UserDict` and is therefore not a `dict`, so `group_by_length=True` raises `ValueError` even though the items are perfectly valid mappings.

This switches both checks to `isinstance(dataset[0], Mapping)`.


#42797 proposed the same fix by adding `BatchFeature` to the tuple; it was closed unmerged by its author. This PR differs in how the check is written:

- `Mapping` covers `dict`, `BatchEncoding`, `BatchFeature`, and any other mapping-like feature container, instead of enumerating classes that then need extending again.
- `Mapping` is already imported in `trainer_pt_utils.py` and used throughout it, so no new import is needed, and the now-unused `BatchEncoding` import is dropped, avoiding the new `feature_extraction_utils` import #42797 pulls into the trainer utils.


cc @zucchini-nlp who reviewed #42797