### PR TITLE
fix: prevent silent discard of `additional_special_tokens` when `extra_special_tokens` is already present

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1165,10 +1165,8 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         # V5: Allowed keys are SPECIAL_TOKENS_ATTRIBUTES + "extra_special_tokens"
         # Backward compatibility: convert "additional_special_tokens" to "extra_special_tokens"
         special_tokens_dict = dict(special_tokens_dict)
-        if "additional_special_tokens" in special_tokens_dict:
-            special_tokens_dict.setdefault(
-                "extra_special_tokens", special_tokens_dict.pop("additional_special_tokens")
-            )
+        if "additional_special_tokens" in special_tokens_dict and "extra_special_tokens" not in special_tokens_dict:
+            special_tokens_dict["extra_special_tokens"] = special_tokens_dict.pop("additional_special_tokens")
 
         allowed_keys = set(self.SPECIAL_TOKENS_ATTRIBUTES) | {"extra_special_tokens"}
         tokens_to_add = []
@@ -1809,8 +1807,8 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         init_kwargs.update(kwargs)
 
         # V5: Convert deprecated additional_special_tokens to extra_special_tokens
-        if "additional_special_tokens" in init_kwargs:
-            init_kwargs.setdefault("extra_special_tokens", init_kwargs.pop("additional_special_tokens"))
+        if "additional_special_tokens" in init_kwargs and "extra_special_tokens" not in init_kwargs:
+            init_kwargs["extra_special_tokens"] = init_kwargs.pop("additional_special_tokens")
 
         # V5: Collect model-specific tokens (custom *_token keys not in standard attributes)
         default_attrs = set(cls.SPECIAL_TOKENS_ATTRIBUTES)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48040)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48040)
<!-- ci-dashboard-badge:end -->

## Problem

Fixes #47838.

When `tokenizer_config.json` contains both `additional_special_tokens` and `extra_special_tokens`, the deprecated `additional_special_tokens` was being silently discarded. This happens because Python evaluates call arguments **before** the call itself — so `.pop("additional_special_tokens")` always runs eagerly, removing the value from the dict, and then `setdefault` declines to overwrite the already-present `extra_special_tokens` key, causing the popped list to be lost entirely.

This affects:
1. **`_from_pretrained`** (line ~1813): every `from_pretrained()` load of a checkpoint whose config has both keys
2. **`add_special_tokens`** (line ~1169): the public `add_special_tokens()` API

**Minimal reproduction** (no model download required):
```python
d = {"additional_special_tokens": ["<|im_end|>", "<|media_placeholder|>"],
     "extra_special_tokens": {}}
d.setdefault("extra_special_tokens", d.pop("additional_special_tokens"))
print(d)  # {'extra_special_tokens': {}}  <-- both tokens GONE
```

## Root Cause

The regression was introduced in `b76caaa88d9d` (#43230, v5.1.0) which replaced the explicit `... and "extra_special_tokens" not in init_kwargs` guard with the buggy `setdefault` pattern. The `__init__` method at line ~997 already uses the correct explicit guard.

## Fix

Replace the two buggy `setdefault` calls with the same explicit guard pattern already used correctly in `__init__`:

```python
# Before (buggy): always pops, then setdefault silently does nothing
if "additional_special_tokens" in init_kwargs:
    init_kwargs.setdefault("extra_special_tokens", init_kwargs.pop("additional_special_tokens"))

# After (correct): only pops when there's a safe destination
if "additional_special_tokens" in init_kwargs and "extra_special_tokens" not in init_kwargs:
    init_kwargs["extra_special_tokens"] = init_kwargs.pop("additional_special_tokens")
```

This makes all three conversion sites consistent and matches the already-correct behaviour in `__init__`.

## Impact

- **Hard failure**: tokenizers whose `__init__` branches on `additional_special_tokens is None` (e.g. `trust_remote_code` tokenizers) would raise on a normal load because the stripped kwarg triggers their "no special tokens supplied" code path.  
- **Silent correctness bug**: for everyone else, tokens declared as special in the checkpoint config would no longer appear in `all_special_tokens` / `all_special_ids`, while `encode()` and `len(tokenizer)` remain unchanged (so the bug passes unnoticed in most test suites).

Affects ~40 of 185 cached checkpoints in a local corpus, including `allenai/Molmo2-8B`, `mistralai/Mistral-Large-3-675B`, `moonshotai/Kimi-VL-A3B-Instruct`, `tiiuae/Falcon-H1-34B`, and `xlangai/OpenCUA-7B`.

Fixes #47838