### PR TITLE
[PE] Skip test_sdpa_can_dispatch_on_flash for TimmWrapper-backed models

### DIFF
--- a/tests/models/pe_audio_video/test_modeling_pe_audio_video.py
+++ b/tests/models/pe_audio_video/test_modeling_pe_audio_video.py
@@ -233,6 +233,13 @@ class PeAudioVideoEncoderTest(ModelTesterMixin, unittest.TestCase):
     def test_model_get_set_embeddings(self):
         pass
 
+    @unittest.skip(
+        "TimmWrapper sets _supports_sdpa=True (timm uses F.scaled_dot_product_attention internally) but does not "
+        "support flash-only dispatch via sdpa_kernel(enable_flash=True, enable_math=False, enable_mem_efficient=False)."
+    )
+    def test_sdpa_can_dispatch_on_flash(self):
+        pass
+
     @unittest.skip("PeAudioVideoEncoder does not have language_model, vision_tower, multi_modal_projector.")
     def test_sdpa_can_dispatch_composite_models(self):
         pass

--- a/tests/models/pe_video/test_modeling_pe_video.py
+++ b/tests/models/pe_video/test_modeling_pe_video.py
@@ -334,7 +334,7 @@ class PeVideoModelTest(ModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
-@unittest.skip(reason="The model has TimmWrapper backbone but doesn't apply any conversion")
+    @unittest.skip(reason="The model has TimmWrapper backbone but doesn't apply any conversion")
     def test_reverse_loading_mapping(self, check_keys_were_modified=True):
         pass
 

--- a/tests/models/pe_video/test_modeling_pe_video.py
+++ b/tests/models/pe_video/test_modeling_pe_video.py
@@ -149,6 +149,13 @@ class PeVideoEncoderTest(ModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
+    @unittest.skip(
+        "TimmWrapper sets _supports_sdpa=True (timm uses F.scaled_dot_product_attention internally) but does not "
+        "support flash-only dispatch via sdpa_kernel(enable_flash=True, enable_math=False, enable_mem_efficient=False)."
+    )
+    def test_sdpa_can_dispatch_on_flash(self):
+        pass
+
     @unittest.skip(reason="The model has TimmWrapper backbone but doesn't apply any conversion")
     def test_reverse_loading_mapping(self, check_keys_were_modified=True):
         pass
@@ -326,6 +333,13 @@ class PeVideoModelTest(ModelTesterMixin, unittest.TestCase):
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
+
+    @unittest.skip(
+        "TimmWrapper sets _supports_sdpa=True (timm uses F.scaled_dot_product_attention internally) but does not "
+        "support flash-only dispatch via sdpa_kernel(enable_flash=True, enable_math=False, enable_mem_efficient=False)."
+    )
+    def test_sdpa_can_dispatch_on_flash(self):
+        pass
 
     @unittest.skip(reason="The model has TimmWrapper backbone but doesn't apply any conversion")
     def test_reverse_loading_mapping(self, check_keys_were_modified=True):

--- a/tests/models/pe_video/test_modeling_pe_video.py
+++ b/tests/models/pe_video/test_modeling_pe_video.py
@@ -334,14 +334,7 @@ class PeVideoModelTest(ModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
-    @unittest.skip(
-        "TimmWrapper sets _supports_sdpa=True (timm uses F.scaled_dot_product_attention internally) but does not "
-        "support flash-only dispatch via sdpa_kernel(enable_flash=True, enable_math=False, enable_mem_efficient=False)."
-    )
-    def test_sdpa_can_dispatch_on_flash(self):
-        pass
-
-    @unittest.skip(reason="The model has TimmWrapper backbone but doesn't apply any conversion")
+@unittest.skip(reason="The model has TimmWrapper backbone but doesn't apply any conversion")
     def test_reverse_loading_mapping(self, check_keys_were_modified=True):
         pass
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48064)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48064)
<!-- ci-dashboard-badge:end -->

## Summary

Skips `test_sdpa_can_dispatch_on_flash` in `PeAudioVideoEncoderTest`, `PeVideoEncoderTest`, and `PeVideoModelTest`.

## Root cause

PR #47939 (`1cdaf598`) declared `_supports_sdpa = True` on `TimmWrapper` and `TimmBackbone` because timm models internally use `F.scaled_dot_product_attention`. However, this caused a regression:

`test_sdpa_can_dispatch_on_flash` checks `_supports_sdpa` across all `PreTrainedModel` submodules. Before #47939, `TimmWrapper._supports_sdpa` was `False` (default), so the test skipped for `PeAudioVideoEncoder`/`PeVideoEncoder` (which embed `TimmWrapperForImageClassification`). After #47939, all submodules report `True`, so the test runs — and forces:

```python
with sdpa_kernel(enable_flash=True, enable_math=False, enable_mem_efficient=False):
    _ = model(**inputs_dict)
```

timm has no external API to restrict attention to flash-only, so this raises:
```
RuntimeError: No available kernel. Aborting execution.
```

This is confirmed by bisect: the failure appears exactly at `1cdaf598` and is absent at its parent `00e8e49e`.

## Question for @jiqing-feng and @zucchini-nlp

This PR skips the test as a minimal fix. But the deeper question is: **should `_supports_sdpa = True` be reverted on `TimmWrapper`/`TimmBackbone`?**

Arguments for reverting:
- `_supports_sdpa = True` in transformers implies controllable SDPA dispatch (flash-only, eager, etc.), which timm does not support — there is no model-level API to change it
- PR #47939 itself adds a warning saying `attn_implementation` is **not propagated** to the wrapped timm model. This is self-contradictory with declaring SDPA support
- The existing skip in the test file already says: *"TimmWrapperForImageClassification does not support an attention implementation through torch.nn.functional.scaled_dot_product_attention yet."*

If `_supports_sdpa` is reverted to `False`, this skip PR would be unnecessary. Keeping `_supports_sdpa = True` is only correct if timm ever exposes an API to control the attention backend externally.