### PR TITLE
Revert "[Quantization]: Refactor is_quantization_compressed for format-based detection"

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -1284,13 +1284,10 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
 
     @property
     def is_quantization_compressed(self):
+        from compressed_tensors.quantization import QuantizationStatus
+
         qc = self.quantization_config
-        return (
-            self.is_quantized
-            and qc is not None
-            and qc.quant_method == QuantizationMethod.COMPRESSED_TENSORS
-            and qc.format != "dense"
-        )
+        return self.is_quantized and (qc is not None and qc.quantization_status == QuantizationStatus.COMPRESSED)
 
 
 @dataclass


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48072)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48072)
<!-- ci-dashboard-badge:end -->

Reverts #47152, as requested in https://github.com/huggingface/transformers/pull/47152#issuecomment-5328783119.

`is_quantization_compressed` goes back to reading `quantization_status`, which fixes the case @kylesayrs reported: a checkpoint declaring a packed `format` while storing dense weights was given the compressed module layout, which its weights cannot fill.

This brings back #47145 for checkpoints that declare `frozen` but store compressed weights (e.g. `RedHatAI/Llama-3.2-1B-FP8`). I'll follow up in the original thread.

cc @SunMarc @kylesayrs