### PR TITLE
[Video] Warn and return all frames when num_frames exceeds total_num_frames

### DIFF
--- a/src/transformers/video_utils.py
+++ b/src/transformers/video_utils.py
@@ -335,10 +335,10 @@ def default_sample_indices_fn(metadata: VideoMetadata, num_frames=None, fps=None
         if num_frames > total_num_frames:
             logger.warning_once(
                 f"`num_frames={num_frames}` exceeds the total number of frames in the video "
-                f"({total_num_frames}). Sampling all {total_num_frames} frames instead. "
-                f"Set `num_frames` to a value <= {total_num_frames} to avoid this warning."
+                f"({total_num_frames}). Sampling {num_frames} frames uniformly (with repetition) "
+                f"from the available {total_num_frames} frames."
             )
-            indices = np.arange(0, total_num_frames, dtype=int)
+            indices = np.linspace(0, max(total_num_frames - 1, 0), num_frames, dtype=int)
         else:
             indices = np.arange(0, total_num_frames, total_num_frames / num_frames, dtype=int)
     else:

--- a/src/transformers/video_utils.py
+++ b/src/transformers/video_utils.py
@@ -333,14 +333,12 @@ def default_sample_indices_fn(metadata: VideoMetadata, num_frames=None, fps=None
 
     if num_frames is not None:
         if num_frames > total_num_frames:
-            logger.warning_once(
-                f"`num_frames={num_frames}` exceeds the total number of frames in the video "
-                f"({total_num_frames}). Sampling {num_frames} frames uniformly (with repetition) "
-                f"from the available {total_num_frames} frames."
+            raise ValueError(
+                f"When loading the video with num_frames={num_frames}, the requested number of frames "
+                f"exceeds total_num_frames={total_num_frames}. Please set num_frames to a value less than "
+                f"or equal to the number of frames in the video."
             )
-            indices = np.linspace(0, max(total_num_frames - 1, 0), num_frames, dtype=int)
-        else:
-            indices = np.arange(0, total_num_frames, total_num_frames / num_frames, dtype=int)
+        indices = np.arange(0, total_num_frames, total_num_frames / num_frames, dtype=int)
     else:
         indices = np.arange(0, total_num_frames, dtype=int)
     return indices

--- a/src/transformers/video_utils.py
+++ b/src/transformers/video_utils.py
@@ -332,7 +332,15 @@ def default_sample_indices_fn(metadata: VideoMetadata, num_frames=None, fps=None
             )
 
     if num_frames is not None:
-        indices = np.arange(0, total_num_frames, total_num_frames / num_frames, dtype=int)
+        if num_frames > total_num_frames:
+            logger.warning_once(
+                f"`num_frames={num_frames}` exceeds the total number of frames in the video "
+                f"({total_num_frames}). Sampling all {total_num_frames} frames instead. "
+                f"Set `num_frames` to a value <= {total_num_frames} to avoid this warning."
+            )
+            indices = np.arange(0, total_num_frames, dtype=int)
+        else:
+            indices = np.arange(0, total_num_frames, total_num_frames / num_frames, dtype=int)
     else:
         indices = np.arange(0, total_num_frames, dtype=int)
     return indices

--- a/tests/utils/test_video_utils.py
+++ b/tests/utils/test_video_utils.py
@@ -390,16 +390,16 @@ class LoadVideoTester(unittest.TestCase):
             )
 
     def test_default_sample_indices_fn_num_frames_exceeds_total(self):
-        # When `num_frames > total_num_frames`, the function should warn and return all
-        # available frames rather than silently returning `num_frames` copies of index 0
-        # (which was the previous behaviour due to `dtype=int` truncating the step to 0).
+        # When `num_frames > total_num_frames`, the function should warn and return
+        # `num_frames` uniformly-sampled indices (with repetition) rather than silently
+        # returning `num_frames` copies of index 0 (the previous behaviour due to
+        # `dtype=int` truncating the step to 0).
         metadata = VideoMetadata(total_num_frames=10, fps=30.0)
         with self.assertLogs("transformers.video_utils", level="WARNING") as cm:
             indices = default_sample_indices_fn(metadata, num_frames=20)
-        self.assertEqual(len(indices), 10)
-        # all frames are unique — no silent duplication
-        self.assertEqual(len(set(indices.tolist())), 10)
-        self.assertTrue(np.array_equal(indices, np.arange(0, 10)))
+        self.assertEqual(len(indices), 20)
+        self.assertTrue((indices >= 0).all() and (indices < 10).all())
+        self.assertGreater(len(set(indices.tolist())), 1)  # not all the same index
         self.assertTrue(any("exceeds the total number of frames" in msg for msg in cm.output))
 
     def test_default_sample_indices_fn_num_frames_equals_total(self):

--- a/tests/utils/test_video_utils.py
+++ b/tests/utils/test_video_utils.py
@@ -32,7 +32,6 @@ from transformers.testing_utils import (
     require_vision,
 )
 from transformers.video_utils import (
-    default_sample_indices_fn,
     group_videos_by_shape,
     is_torchvision_video_decoding_available,
     make_batched_videos,
@@ -389,26 +388,9 @@ class LoadVideoTester(unittest.TestCase):
                 num_frames=10,
             )
 
-    def test_default_sample_indices_fn_num_frames_exceeds_total(self):
-        # When `num_frames > total_num_frames`, the function should warn and return
-        # `num_frames` uniformly-sampled indices (with repetition) rather than silently
-        # returning `num_frames` copies of index 0 (the previous behaviour due to
-        # `dtype=int` truncating the step to 0).
-        metadata = VideoMetadata(total_num_frames=10, fps=30.0)
-        with self.assertLogs("transformers.video_utils", level="WARNING") as cm:
-            indices = default_sample_indices_fn(metadata, num_frames=20)
-        self.assertEqual(len(indices), 20)
-        self.assertTrue((indices >= 0).all() and (indices < 10).all())
-        self.assertGreater(len(set(indices.tolist())), 1)  # not all the same index
-        self.assertTrue(any("exceeds the total number of frames" in msg for msg in cm.output))
-
-    def test_default_sample_indices_fn_num_frames_equals_total(self):
-        metadata = VideoMetadata(total_num_frames=10, fps=30.0)
-        indices = default_sample_indices_fn(metadata, num_frames=10)
-        self.assertEqual(len(indices), 10)
-
-    def test_default_sample_indices_fn_num_frames_less_than_total(self):
-        metadata = VideoMetadata(total_num_frames=10, fps=30.0)
-        indices = default_sample_indices_fn(metadata, num_frames=4)
-        self.assertEqual(len(indices), 4)
-        self.assertTrue((indices >= 0).all() and (indices < 10).all())
+    def test_load_video_num_frames_exceeds_total(self):
+        video_file_path = hf_hub_download(
+            repo_id="raushan-testing-hf/videos-test", filename="sample_demo_1.mp4", repo_type="dataset"
+        )
+        with self.assertRaisesRegex(ValueError, "exceeds total_num_frames"):
+            load_video(video_file_path, num_frames=300)

--- a/tests/utils/test_video_utils.py
+++ b/tests/utils/test_video_utils.py
@@ -32,6 +32,7 @@ from transformers.testing_utils import (
     require_vision,
 )
 from transformers.video_utils import (
+    default_sample_indices_fn,
     group_videos_by_shape,
     is_torchvision_video_decoding_available,
     make_batched_videos,
@@ -387,3 +388,27 @@ class LoadVideoTester(unittest.TestCase):
                 fps=1,
                 num_frames=10,
             )
+
+    def test_default_sample_indices_fn_num_frames_exceeds_total(self):
+        # When `num_frames > total_num_frames`, the function should warn and return all
+        # available frames rather than silently returning `num_frames` copies of index 0
+        # (which was the previous behaviour due to `dtype=int` truncating the step to 0).
+        metadata = VideoMetadata(total_num_frames=10, fps=30.0)
+        with self.assertLogs("transformers.video_utils", level="WARNING") as cm:
+            indices = default_sample_indices_fn(metadata, num_frames=20)
+        self.assertEqual(len(indices), 10)
+        # all frames are unique — no silent duplication
+        self.assertEqual(len(set(indices.tolist())), 10)
+        self.assertTrue(np.array_equal(indices, np.arange(0, 10)))
+        self.assertTrue(any("exceeds the total number of frames" in msg for msg in cm.output))
+
+    def test_default_sample_indices_fn_num_frames_equals_total(self):
+        metadata = VideoMetadata(total_num_frames=10, fps=30.0)
+        indices = default_sample_indices_fn(metadata, num_frames=10)
+        self.assertEqual(len(indices), 10)
+
+    def test_default_sample_indices_fn_num_frames_less_than_total(self):
+        metadata = VideoMetadata(total_num_frames=10, fps=30.0)
+        indices = default_sample_indices_fn(metadata, num_frames=4)
+        self.assertEqual(len(indices), 4)
+        self.assertTrue((indices >= 0).all() and (indices < 10).all())


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48074)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48074)
<!-- ci-dashboard-badge:end -->

## What does this PR do?
Fixes #48073

## Problem
`default_sample_indices_fn` in `src/transformers/video_utils.py` silently returns `num_frames` copies of index 0 when `num_frames > total_num_frames`. The step `total/num < 1` is truncated to `0` by `dtype=int`, so `np.arange(0, total, 0, dtype=int)` yields `[0, 0, ..., 0]`. Reachable via `load_video(path, num_frames=N)` on a video with fewer than `N` frames — the user asks for N distinct frames and silently gets one frame repeated N times. The `fps` branch already guards `if num_frames > total: raise ValueError`, but the direct `num_frames` path does not.

## Fix
When `num_frames > total_num_frames`, emit a warning and return all available frames instead of silently duplicating frame 0. Non-breaking: no exception, just a warning + sensible fallback.

## Tests
- `num_frames > total`: 10 unique frames (not 20 copies of 0) + warning emitted
- `num_frames == total`: boundary case
- `num_frames < total`: no regression

## Checklist
- [x] My PR addresses the issue
- [x] I have added tests