### PR TITLE
Fix nemotron_h save_pretrained emitting singular backbone.embedding.weight

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -1223,7 +1223,6 @@ def _build_checkpoint_conversion_mapping():
         ],
         "nemotron_h": [
             WeightRenaming("backbone.", "model."),
-            WeightRenaming("embedding.weight", "embeddings.weight"),
             WeightConverter(
                 source_patterns=[
                     "mixer.experts.*.up_proj.weight",


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48075&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48075) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48075&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48075)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

The `nemotron_h` conversion mapping contains
`WeightRenaming("embedding.weight", "embeddings.weight")` (added in #44390 together with the rest of the mapping). This rule assumes original NemotronH checkpoints store the **singular** `backbone.embedding.weight`, but every published `nemotron_h` checkpoint stores the **plural** form. Checked against the safetensors index of all eight released models:

| Checkpoint | embedding key |
|---|---|
| nvidia/Nemotron-H-8B-Base-8K, -47B-, -56B- | `backbone.embeddings.weight` |
| nvidia/NVIDIA-Nemotron-Nano-12B-v2 | `backbone.embeddings.weight` |
| nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-{Base-BF16, BF16} | `backbone.embeddings.weight` |
| nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16 | `backbone.embeddings.weight` |
| nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16 | `backbone.embeddings.weight` |

As a result the rule never matches during loading (the pattern requires exactly one character between `embedding` and `weight`). During saving, however, `save_pretrained` applies the **reverse** mapping by default (`save_original_format=True`), which rewrites `backbone.embeddings.weight` -> `backbone.embedding.weight`. The saved checkpoint then deviates from the released-checkpoint convention: external NemotronH consumers (vLLM's `NemotronHForCausalLM` loader, NeMo Automodel's state-dict adapter, the original modeling code shipped with earlier checkpoints) cannot find the embedding weights and fall back to random initialization, producing incoherent generations.

This was hit in production by an RLVR pipeline that merged a LoRA SFT adapter with PEFT + `save_pretrained` and then served the merged checkpoint with vLLM — generation KL exploded to ~1e2 until the key was traced back to this rename. Transformers itself silently repairs its own output on reload (the load direction maps singular -> plural), which is why the corruption is easy to miss.

Fix: drop the rule. `WeightRenaming` is bidirectional by design, so a load-only alias is not expressible with the current API; since no released checkpoint uses the singular spelling, the rule is dead on load and only harmful on save.

One behavior change worth flagging: checkpoints **already produced** by the buggy save path (singular keys) were previously healed silently on load; after this change they surface an explicit missing-key warning for `model.embeddings.weight` instead. We believe failing loudly is preferable — the silent repair is what masked this bug — but if a load-side alias is preferred we're happy to adjust.

## Before submitting
- [x] Did you read the contributor guideline and PR checks?
- [ ] Discussed via issue/forum (found no existing issue or open PR for this; happy to open one if preferred)
- [ ] New tests (can add a save/load key round-trip test for `nemotron_h` if desired)

## Who can review?

@liding-nv (nemotron_3 support, #44390) @ArthurZucker (core loading / reviewed #44390)