### PR TITLE
Fix frame_sampling_rate ignored on video_processor path

### DIFF
--- a/src/transformers/pipelines/video_classification.py
+++ b/src/transformers/pipelines/video_classification.py
@@ -23,6 +23,7 @@ from ..utils import (
     logging,
     requires_backends,
 )
+from ..video_utils import load_video
 from .base import Pipeline, build_pipeline_init_args
 
 
@@ -161,6 +162,25 @@ class VideoClassificationPipeline(Pipeline):
             video = read_video_pyav(container, indices)
             video = list(video)
             model_inputs = self.image_processor(video, return_tensors="pt").to(self.dtype)
+        elif frame_sampling_rate != 1:
+            # Video processors sample uniformly across the whole video by default and have no
+            # `frame_sampling_rate` argument. When a non-default rate is requested, sample with the
+            # same windowed linspace logic as the legacy image-processor path, then process frames
+            # without re-sampling.
+            def sample_indices_fn(metadata, **kwargs):
+                total = metadata.total_num_frames
+                if total is None or total <= 0:
+                    raise ValueError(
+                        f"Cannot apply `frame_sampling_rate={frame_sampling_rate}` because video "
+                        f"metadata reports `total_num_frames={total}`."
+                    )
+                end_idx = min(num_frames * frame_sampling_rate - 1, total - 1)
+                return np.linspace(0, end_idx, num=num_frames, dtype=np.int64)
+
+            sampled_video, _ = load_video(video, sample_indices_fn=sample_indices_fn)
+            model_inputs = self.video_processor(sampled_video, do_sample_frames=False, return_tensors="pt").to(
+                self.dtype
+            )
         else:
             processing_kwargs = {"num_frames": num_frames, "do_sample_frames": True}
             model_inputs = self.video_processor(video, **processing_kwargs, return_tensors="pt").to(self.dtype)

--- a/tests/pipelines/test_pipelines_video_classification.py
+++ b/tests/pipelines/test_pipelines_video_classification.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import MagicMock, patch
 
+import numpy as np
 from huggingface_hub import VideoClassificationOutputElement, hf_hub_download
 
 from transformers import MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING, VideoMAEImageProcessor
@@ -26,6 +28,7 @@ from transformers.testing_utils import (
     require_torch,
     require_vision,
 )
+from transformers.video_utils import VideoMetadata
 
 from .test_pipelines_common import ANY
 
@@ -122,3 +125,31 @@ class VideoClassificationPipelineTests(unittest.TestCase):
         for output in outputs:
             for element in output:
                 compare_pipeline_output_to_hub_spec(element, VideoClassificationOutputElement)
+
+    @require_torch
+    def test_frame_sampling_rate_honored_with_video_processor(self):
+        """`frame_sampling_rate` must not be silently ignored when a video_processor is used."""
+        pipe = MagicMock()
+        pipe.image_processor = None
+        pipe.dtype = "float32"
+        pipe.model.config.num_frames = 8
+
+        processed = MagicMock()
+        processed.to.return_value = {"pixel_values_videos": "ok"}
+        pipe.video_processor = MagicMock(return_value=processed)
+
+        captured = {}
+
+        def fake_load_video(video, sample_indices_fn=None, **kwargs):
+            metadata = VideoMetadata(total_num_frames=100, fps=25.0, duration=4.0, video_backend="pyav")
+            indices = sample_indices_fn(metadata=metadata)
+            captured["indices"] = indices
+            return np.zeros((len(indices), 8, 8, 3), dtype=np.uint8), metadata
+
+        with patch("transformers.pipelines.video_classification.load_video", side_effect=fake_load_video):
+            VideoClassificationPipeline.preprocess(pipe, "dummy.mp4", num_frames=8, frame_sampling_rate=4)
+
+        expected = np.linspace(0, 8 * 4 - 1, num=8, dtype=np.int64)
+        np.testing.assert_array_equal(captured["indices"], expected)
+        pipe.video_processor.assert_called_once()
+        self.assertFalse(pipe.video_processor.call_args.kwargs.get("do_sample_frames", True))


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48076)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48076)
<!-- ci-dashboard-badge:end -->

## Impact
**Silent wrong results:** `VideoClassificationPipeline(frame_sampling_rate=N)` is documented and works on the legacy `image_processor` path, but is **ignored** whenever a modern `video_processor` is present (the common case for current video models). Users requesting denser temporal windows still get whole-video uniform sampling with no warning.

Default `frame_sampling_rate=1` is unchanged.

## Summary
- When `frame_sampling_rate != 1`, sample with the same windowed linspace logic as the image-processor path, then run the video processor with `do_sample_frames=False`.

## Code Agent Policy
Assisted by a coding agent at the request of @hungnnvidia (early contributor). Please review carefully.

## Test plan
- [x] `pytest tests/pipelines/test_pipelines_video_classification.py::VideoClassificationPipelineTests::test_frame_sampling_rate_honored_with_video_processor`
- [ ] CI video-classification pipeline tests