### PR TITLE
Fix PyAV video sampling when stream.frames is 0

### DIFF
--- a/src/transformers/video_utils.py
+++ b/src/transformers/video_utils.py
@@ -481,16 +481,17 @@ def read_video_pyav(
     import av
 
     container = av.open(video_path)
-    total_num_frames = container.streams.video[0].frames
-    video_fps = container.streams.video[0].average_rate  # should we better use `av_guess_frame_rate`?
+    stream = container.streams.video[0]
+    video_fps = stream.average_rate  # should we better use `av_guess_frame_rate`?
+    total_num_frames = _get_pyav_total_num_frames(container, stream, video_fps)
     duration = total_num_frames / video_fps if video_fps else 0
     metadata = VideoMetadata(
         total_num_frames=int(total_num_frames),
-        fps=float(video_fps),
+        fps=float(video_fps) if video_fps is not None else None,
         duration=float(duration),
         video_backend="pyav",
-        height=container.streams.video[0].height,
-        width=container.streams.video[0].width,
+        height=stream.height,
+        width=stream.width,
     )
 
     indices = sample_indices_fn(metadata=metadata, **kwargs)
@@ -506,6 +507,35 @@ def read_video_pyav(
     video = np.stack([x.to_ndarray(format="rgb24") for x in frames])
     metadata.frames_indices = indices
     return video, metadata
+
+
+def _get_pyav_total_num_frames(container, stream, video_fps) -> int:
+    """
+    Resolve the number of frames for a PyAV video stream.
+
+    `stream.frames` is often `0` for containers that omit `nb_frames` (common for
+    webm/mkv and some mp4 encodes). Fall back to duration-based estimates, then to
+    an explicit decode count as a last resort.
+    """
+    import av
+
+    total_num_frames = int(stream.frames or 0)
+    if total_num_frames > 0:
+        return total_num_frames
+
+    if stream.duration is not None and stream.time_base is not None and video_fps is not None:
+        total_num_frames = int(stream.duration * stream.time_base * video_fps)
+        if total_num_frames > 0:
+            return total_num_frames
+
+    if container.duration is not None and video_fps is not None:
+        total_num_frames = int(container.duration / av.time_base * float(video_fps))
+        if total_num_frames > 0:
+            return total_num_frames
+
+    total_num_frames = sum(1 for _ in container.decode(video=0))
+    container.seek(0)
+    return total_num_frames
 
 
 # `torchvision.io.read_video` removed in `torchvision==0.26` (https://github.com/pytorch/vision/releases#release-v0.26.0),

--- a/tests/utils/test_video_utils.py
+++ b/tests/utils/test_video_utils.py
@@ -387,3 +387,43 @@ class LoadVideoTester(unittest.TestCase):
                 fps=1,
                 num_frames=10,
             )
+
+
+@require_av
+class PyAVFrameCountTester(unittest.TestCase):
+    def test_get_pyav_total_num_frames_falls_back_when_stream_frames_is_zero(self):
+        from fractions import Fraction
+
+        from transformers.video_utils import _get_pyav_total_num_frames
+
+        class FakeStream:
+            frames = 0
+            duration = 300300
+            time_base = Fraction(1, 30000)
+
+        class FakeContainer:
+            duration = None
+
+            def decode(self, video=0):
+                raise AssertionError("decode count fallback should not be needed")
+
+            def seek(self, *args, **kwargs):
+                raise AssertionError("seek should not be needed")
+
+        stream = FakeStream()
+        fps = 29.97002997002997
+        total = _get_pyav_total_num_frames(FakeContainer(), stream, fps)
+        self.assertEqual(total, int(stream.duration * stream.time_base * fps))
+
+    def test_get_pyav_total_num_frames_uses_stream_frames_when_present(self):
+        from transformers.video_utils import _get_pyav_total_num_frames
+
+        class FakeStream:
+            frames = 243
+            duration = None
+            time_base = None
+
+        class FakeContainer:
+            duration = None
+
+        self.assertEqual(_get_pyav_total_num_frames(FakeContainer(), FakeStream(), 25.0), 243)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48077)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48077)
<!-- ci-dashboard-badge:end -->

## Impact
**Realistic breakage:** many WebM/MKV (and some MP4) containers omit `nb_frames`, so PyAV reports `stream.frames == 0`. `read_video_pyav` then sets `total_num_frames=0`, which breaks frame sampling indices/metadata for `load_video` / video processors — wrong frames or failed sampling on common uploaded video files.

## Summary
- Fall back to duration-based estimates (`stream.duration`, then `container.duration`) when `stream.frames` is 0.
- Decode-count only as a last resort.

## Code Agent Policy
Assisted by a coding agent at the request of @hungnnvidia (early contributor). Please review carefully.

## Test plan
- [x] `pytest tests/utils/test_video_utils.py::PyAVFrameCountTester`
- [ ] CI video utils / load_video tests