### PR TITLE
Raise on non-zero ffmpeg exit in _ffmpeg_stream

### DIFF
--- a/src/transformers/pipelines/audio_utils.py
+++ b/src/transformers/pipelines/audio_utils.py
@@ -266,11 +266,21 @@ def _ffmpeg_stream(ffmpeg_command, buflen: int):
     bufsize = 2**24  # 16Mo
     try:
         with subprocess.Popen(ffmpeg_command, stdout=subprocess.PIPE, bufsize=bufsize) as ffmpeg_process:
-            while True:
-                raw = ffmpeg_process.stdout.read(buflen)
-                if raw == b"":
-                    break
-                yield raw
+            try:
+                while True:
+                    raw = ffmpeg_process.stdout.read(buflen)
+                    if raw == b"":
+                        break
+                    yield raw
+            finally:
+                if ffmpeg_process.stdout is not None:
+                    ffmpeg_process.stdout.close()
+                returncode = ffmpeg_process.wait()
+            if returncode:
+                raise ValueError(
+                    f"ffmpeg returned non-zero exit status {returncode} while streaming audio. "
+                    "Ensure the input is a valid audio source and that ffmpeg can decode it."
+                )
     except FileNotFoundError as error:
         raise ValueError("ffmpeg was not found but is required to stream audio files from filename") from error
 

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -32,7 +33,7 @@ from transformers import (
     WhisperForConditionalGeneration,
 )
 from transformers.pipelines import AutomaticSpeechRecognitionPipeline, pipeline
-from transformers.pipelines.audio_utils import chunk_bytes_iter, ffmpeg_microphone_live
+from transformers.pipelines.audio_utils import _ffmpeg_stream, chunk_bytes_iter, ffmpeg_microphone_live
 from transformers.pipelines.automatic_speech_recognition import chunk_iter
 from transformers.testing_utils import (
     Expectations,
@@ -1884,3 +1885,26 @@ class AudioUtilsTest(unittest.TestCase):
     def test_ffmpeg_additional_args(self):
         mic = ffmpeg_microphone_live(16000, 2.0, ffmpeg_additional_args=["-nostdin"])
         mic.close()
+
+
+class FFmpegStreamExitStatusTest(unittest.TestCase):
+    def test_ffmpeg_stream_raises_on_nonzero_exit(self):
+        mock_proc = MagicMock()
+        mock_proc.stdout.read.side_effect = [b"abc", b""]
+        mock_proc.wait.return_value = 1
+        mock_proc.__enter__.return_value = mock_proc
+        mock_proc.__exit__.return_value = None
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            with self.assertRaisesRegex(ValueError, "non-zero exit status 1"):
+                list(_ffmpeg_stream(["ffmpeg", "-i", "bad"], 3))
+
+    def test_ffmpeg_stream_ok_on_zero_exit(self):
+        mock_proc = MagicMock()
+        mock_proc.stdout.read.side_effect = [b"abc", b""]
+        mock_proc.wait.return_value = 0
+        mock_proc.__enter__.return_value = mock_proc
+        mock_proc.__exit__.return_value = None
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            self.assertEqual(list(_ffmpeg_stream(["ffmpeg", "-i", "ok"], 3)), [b"abc"])


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48078)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48078)
<!-- ci-dashboard-badge:end -->

## Impact
**Silent empty/short audio on stream decode failure:** `_ffmpeg_stream` (live/mic and streaming ASR paths) stopped when stdout drained empty **without** checking ffmpeg’s exit status. A failed decode could look like a short or empty stream instead of a clear error.

Complements #48043 (`ffmpeg_read` / file path). This PR only covers the streaming helper.

## Summary
- After draining stdout, `wait()` and raise `ValueError` on non-zero exit.

## Code Agent Policy
Assisted by a coding agent at the request of @hungnnvidia (early contributor). Please review carefully.

## Test plan
- [x] `pytest tests/pipelines/test_pipelines_automatic_speech_recognition.py::FFmpegStreamExitStatusTest`
- [ ] CI ASR / audio utils tests