### PR TITLE
Fix DataCollatorForTokenClassification numpy label handling

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -305,13 +305,19 @@ class DataCollatorForTokenClassification(DataCollatorMixin):
             return list(tensor_or_iterable)
 
         if padding_side == "right":
-            batch[label_name] = [
-                to_list(label) + [self.label_pad_token_id] * (sequence_length - len(label)) for label in labels
-            ]
+            batch[label_name] = []
+            for label in labels:
+                truncated_label = to_list(label)[:sequence_length]
+                batch[label_name].append(
+                    truncated_label + [self.label_pad_token_id] * (sequence_length - len(truncated_label))
+                )
         else:
-            batch[label_name] = [
-                [self.label_pad_token_id] * (sequence_length - len(label)) + to_list(label) for label in labels
-            ]
+            batch[label_name] = []
+            for label in labels:
+                truncated_label = to_list(label)[:sequence_length]
+                batch[label_name].append(
+                    [self.label_pad_token_id] * (sequence_length - len(truncated_label)) + truncated_label
+                )
 
         batch[label_name] = torch.tensor(batch[label_name], dtype=torch.int64)
         return batch
@@ -319,14 +325,16 @@ class DataCollatorForTokenClassification(DataCollatorMixin):
     def numpy_call(self, features):
         label_name = "label" if "label" in features[0] else "labels"
         labels = [feature[label_name] for feature in features] if label_name in features[0] else None
+
+        no_labels_features = [{k: v for k, v in feature.items() if k != label_name} for feature in features]
+
         batch = pad_without_fast_tokenizer_warning(
             self.tokenizer,
-            features,
+            no_labels_features,
             padding=self.padding,
             max_length=self.max_length,
             pad_to_multiple_of=self.pad_to_multiple_of,
-            # Conversion to tensors will fail if we have labels as they are not of the same length yet.
-            return_tensors="np" if labels is None else None,
+            return_tensors="np",
         )
 
         if labels is None:
@@ -335,13 +343,19 @@ class DataCollatorForTokenClassification(DataCollatorMixin):
         sequence_length = np.array(batch["input_ids"]).shape[1]
         padding_side = self.tokenizer.padding_side
         if padding_side == "right":
-            batch["labels"] = [
-                list(label) + [self.label_pad_token_id] * (sequence_length - len(label)) for label in labels
-            ]
+            batch[label_name] = []
+            for label in labels:
+                truncated_label = list(label)[:sequence_length]
+                batch[label_name].append(
+                    truncated_label + [self.label_pad_token_id] * (sequence_length - len(truncated_label))
+                )
         else:
-            batch["labels"] = [
-                [self.label_pad_token_id] * (sequence_length - len(label)) + list(label) for label in labels
-            ]
+            batch[label_name] = []
+            for label in labels:
+                truncated_label = list(label)[:sequence_length]
+                batch[label_name].append(
+                    [self.label_pad_token_id] * (sequence_length - len(truncated_label)) + truncated_label
+                )
 
         batch = {k: np.array(v, dtype=np.int64) for k, v in batch.items()}
         return batch

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -526,6 +526,36 @@ class TestDataCollatorForTokenClassification(DataCollatorTestMixin, unittest.Tes
         self.assertEqual(batch["input_ids"].shape, (2, 6))
         self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2, -100, -100, -100])
 
+    def test_numpy_singular_label_key(self):
+        """NumPy path should honor the `label` key like the torch path."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [
+            {"input_ids": [0, 1, 2], "label": [0, 1, 2]},
+            {"input_ids": [0, 1, 2, 3, 4, 5], "label": [0, 1, 2, 3, 4, 5]},
+        ]
+        collator = DataCollatorForTokenClassification(tokenizer, return_tensors="np")
+        batch = collator(features)
+
+        self.assertIn("label", batch)
+        self.assertNotIn("labels", batch)
+        self.assertEqual(batch["label"][0].tolist(), [0, 1, 2, -100, -100, -100])
+
+    def test_truncates_labels_longer_than_inputs(self):
+        """Labels longer than padded/truncated inputs must be truncated to match."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [
+            {"input_ids": [0, 1, 2, 3], "labels": [0, 1, 2, 3, 4, 5, 6, 7]},
+            {"input_ids": [0, 1], "labels": [0, 1, 2]},
+        ]
+
+        for return_tensors in ["pt", "np"]:
+            collator = DataCollatorForTokenClassification(tokenizer, return_tensors=return_tensors)
+            batch = collator(features)
+            self.assertEqual(batch["input_ids"].shape[-1], 4)
+            self.assertEqual(batch["labels"].shape[-1], 4)
+            self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2, 3])
+            self.assertEqual(batch["labels"][1].tolist(), [0, 1, 2, -100])
+
     def test_immutability(self):
         """Test that collation does not mutate input data."""
         tokenizer = BertTokenizer(self.vocab_file)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48079)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48079)
<!-- ci-dashboard-badge:end -->

## Impact
**User-facing crash:** `DataCollatorForTokenClassification` with `return_tensors="np"` raises `ValueError: setting an array element with a sequence` / inhomogeneous shape when features use the singular `"label"` key (common in some datasets / HF examples). The torch path already handled `"label"` correctly.

Also: if labels are longer than padded inputs, both backends could fail when building the label tensor — truncate to match input length.

## Summary
- Strip labels before padding on the NumPy path (match `torch_call`).
- Preserve `"label"` vs `"labels"` key name in the NumPy batch.
- Truncate over-long label rows before pad on both backends.

## Test plan
- [x] `pytest tests/trainer/test_data_collator.py::TestDataCollatorForTokenClassification`
- [ ] CI trainer / data collator tests