### PR TITLE
Fix assisted text-to-audio pipeline initialization

### DIFF
--- a/src/transformers/pipelines/text_to_audio.py
+++ b/src/transformers/pipelines/text_to_audio.py
@@ -273,6 +273,9 @@ class TextToAudioPipeline(Pipeline):
         forward_params=None,
         generate_kwargs=None,
     ):
+        forward_params = {} if forward_params is None else forward_params.copy()
+        generate_kwargs = {} if generate_kwargs is None else generate_kwargs.copy()
+
         if getattr(self, "assistant_model", None) is not None:
             generate_kwargs["assistant_model"] = self.assistant_model
         if getattr(self, "assistant_tokenizer", None) is not None:
@@ -280,8 +283,8 @@ class TextToAudioPipeline(Pipeline):
             generate_kwargs["assistant_tokenizer"] = self.assistant_tokenizer
 
         params = {
-            "forward_params": forward_params if forward_params else {},
-            "generate_kwargs": generate_kwargs if generate_kwargs else {},
+            "forward_params": forward_params,
+            "generate_kwargs": generate_kwargs,
         }
 
         if preprocess_params is None:

--- a/tests/pipelines/test_pipelines_text_to_audio.py
+++ b/tests/pipelines/test_pipelines_text_to_audio.py
@@ -41,6 +41,23 @@ class TextToAudioPipelineTests(unittest.TestCase):
     model_mapping = MODEL_FOR_TEXT_TO_WAVEFORM_MAPPING
     # for now only test text_to_waveform and not text_to_spectrogram
 
+    def test_assistant_kwargs_are_added_without_mutating_inputs(self):
+        pipe = object.__new__(TextToAudioPipeline)
+        pipe.assistant_model = object()
+        pipe.assistant_tokenizer = object()
+        pipe.tokenizer = object()
+
+        _, params, _ = pipe._sanitize_parameters()
+        self.assertIs(params["generate_kwargs"]["assistant_model"], pipe.assistant_model)
+        self.assertIs(params["generate_kwargs"]["assistant_tokenizer"], pipe.assistant_tokenizer)
+        self.assertIs(params["generate_kwargs"]["tokenizer"], pipe.tokenizer)
+
+        forward_params = {"speaker_id": 5}
+        generate_kwargs = {"do_sample": True}
+        pipe._sanitize_parameters(forward_params=forward_params, generate_kwargs=generate_kwargs)
+        self.assertEqual(forward_params, {"speaker_id": 5})
+        self.assertEqual(generate_kwargs, {"do_sample": True})
+
     @require_torch
     def test_small_speecht5_pt(self):
         audio_generator = pipeline(task="text-to-audio", model="microsoft/speecht5_tts")


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48086)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48086)
<!-- ci-dashboard-badge:end -->

## Summary
- initialize `generate_kwargs` before injecting assisted-generation parameters, preventing `TextToAudioPipeline` construction from crashing when `assistant_model` is provided without explicit generation kwargs
- copy caller-provided forward and generation dictionaries before adding internal parameters
- add a focused regression test for both behaviors

## Test plan
- `uv run --with pytest --with '.[torch]' pytest tests/pipelines/test_pipelines_text_to_audio.py -k assistant_kwargs -q`
- `uv run --with '.[quality]' make style`

## Acknowledgement
Prepared with assistance from an AI coding agent. The change is limited to the reproduced pipeline crash and caller-state mutation.

**Note:** Early contribution from `@hungnnvidia`. HF discourages first-time agent-submitted PRs; please advise if maintainers prefer a different process.