### PR TITLE
Fix mlinter artifact path

### DIFF
--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mlinter-findings
-          path: ${{ runner.temp }}/mlinter-findings
+          path: .
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -57,4 +57,4 @@ jobs:
         if: steps.download.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 utils/post_mlinter_review.py ${{ runner.temp }}/mlinter-findings
+        run: python3 utils/post_mlinter_review.py

--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -57,4 +57,5 @@ jobs:
         if: steps.download.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 utils/post_mlinter_review.py ${{ runner.temp }}/mlinter-findings
+          MLINTER_FINDINGS_DIR: ${{ runner.temp }}/mlinter-findings
+        run: python3 utils/post_mlinter_review.py "$MLINTER_FINDINGS_DIR"

--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mlinter-findings
-          path: .
+          path: ${{ runner.temp }}/mlinter-findings
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -57,4 +57,4 @@ jobs:
         if: steps.download.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 utils/post_mlinter_review.py
+        run: python3 utils/post_mlinter_review.py ${{ runner.temp }}/mlinter-findings

--- a/.github/workflows/pr-ci-post-dashboard-link.yml
+++ b/.github/workflows/pr-ci-post-dashboard-link.yml
@@ -57,4 +57,4 @@ jobs:
         if: steps.download.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 utils/post_mlinter_review.py
+        run: python3 utils/post_mlinter_review.py ${{ runner.temp }}/mlinter-findings

--- a/utils/post_mlinter_review.py
+++ b/utils/post_mlinter_review.py
@@ -52,30 +52,13 @@ def _findings_hash(findings):
 
 
 def _read_pr_state(pr_body):
-    """Extract the mlinter hash and review ID from the PR description state block.
-
-    Returns (hash_str, review_id_str) or (None, None).
-    """
+    """Extract the mlinter hash from the PR description state block. Returns hash string or None."""
     m = re.search(
-        r"<!-- mlinter-state-start -->.*?hash: `([0-9a-f]{8})`.*?"
-        r"review: [^\n]*#pullrequestreview-(\d+).*?<!-- mlinter-state-end -->",
+        r"<!-- mlinter-state-start -->.*?hash: `([0-9a-f]{8})`.*?<!-- mlinter-state-end -->",
         pr_body or "",
         re.DOTALL,
     )
-    if not m:
-        return None, None
-    return m.group(1), m.group(2)
-
-
-def _delete_old_review_comments(review_id, pulls_url, token):
-    """Delete all inline comments from a previous mlinter review to prevent accumulation."""
-    comments = get_github_json(f"{pulls_url}/reviews/{review_id}/comments", token=token) or []
-    repo_api_url = pulls_url.split("/pulls/")[0]
-    for comment in comments:
-        try:
-            github_request(f"{repo_api_url}/pulls/comments/{comment['id']}", token=token, method="DELETE")
-        except RuntimeError as exc:
-            print(f"Failed to delete comment {comment['id']}: {exc}", file=sys.stderr)
+    return m.group(1) if m else None
 
 
 def _update_pr_description(pr_body, findings_hash, commit_sha, review_url):
@@ -186,9 +169,8 @@ def main():
     token = os.environ.get("GITHUB_TOKEN")
     repo = os.environ.get("GITHUB_REPOSITORY")
 
-    artifact_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
-    pr_number_path = artifact_dir / "mlinter-pr-number.txt"
-    findings_path = artifact_dir / "mlinter-findings.json"
+    pr_number_path = Path("mlinter-pr-number.txt")
+    findings_path = Path("mlinter-findings.json")
 
     if not pr_number_path.exists() or not findings_path.exists():
         print("Artifact files missing; skipping.")
@@ -215,13 +197,12 @@ def main():
     pr_body = pr_data.get("body") or ""
     commit_sha = pr_data["head"]["sha"][:8]
 
-    existing_hash, existing_review_id = _read_pr_state(pr_body)
+    existing_hash = _read_pr_state(pr_body)
     if existing_hash == current_hash:
         print(f"Findings unchanged (hash {current_hash}); skipping.")
         return 0
-    if existing_hash and existing_review_id:
-        print(f"Findings changed (was {existing_hash}, now {current_hash}); deleting old inline comments.")
-        _delete_old_review_comments(existing_review_id, pulls_url, token)
+    if existing_hash:
+        print(f"Findings changed (was {existing_hash}, now {current_hash}); posting new review.")
 
     # Map each changed file to its commentable lines.
     anchors = {f["filename"]: _commentable_lines(f.get("patch")) for f in _paginate(f"{pulls_url}/files", token)}

--- a/utils/post_mlinter_review.py
+++ b/utils/post_mlinter_review.py
@@ -52,13 +52,30 @@ def _findings_hash(findings):
 
 
 def _read_pr_state(pr_body):
-    """Extract the mlinter hash from the PR description state block. Returns hash string or None."""
+    """Extract the mlinter hash and review ID from the PR description state block.
+
+    Returns (hash_str, review_id_str) or (None, None).
+    """
     m = re.search(
-        r"<!-- mlinter-state-start -->.*?hash: `([0-9a-f]{8})`.*?<!-- mlinter-state-end -->",
+        r"<!-- mlinter-state-start -->.*?hash: `([0-9a-f]{8})`.*?"
+        r"review: [^\n]*#pullrequestreview-(\d+).*?<!-- mlinter-state-end -->",
         pr_body or "",
         re.DOTALL,
     )
-    return m.group(1) if m else None
+    if not m:
+        return None, None
+    return m.group(1), m.group(2)
+
+
+def _delete_old_review_comments(review_id, pulls_url, token):
+    """Delete all inline comments from a previous mlinter review to prevent accumulation."""
+    comments = get_github_json(f"{pulls_url}/reviews/{review_id}/comments", token=token) or []
+    repo_api_url = pulls_url.split("/pulls/")[0]
+    for comment in comments:
+        try:
+            github_request(f"{repo_api_url}/pulls/comments/{comment['id']}", token=token, method="DELETE")
+        except RuntimeError as exc:
+            print(f"Failed to delete comment {comment['id']}: {exc}", file=sys.stderr)
 
 
 def _update_pr_description(pr_body, findings_hash, commit_sha, review_url):
@@ -169,8 +186,9 @@ def main():
     token = os.environ.get("GITHUB_TOKEN")
     repo = os.environ.get("GITHUB_REPOSITORY")
 
-    pr_number_path = Path("mlinter-pr-number.txt")
-    findings_path = Path("mlinter-findings.json")
+    artifact_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    pr_number_path = artifact_dir / "mlinter-pr-number.txt"
+    findings_path = artifact_dir / "mlinter-findings.json"
 
     if not pr_number_path.exists() or not findings_path.exists():
         print("Artifact files missing; skipping.")
@@ -197,12 +215,13 @@ def main():
     pr_body = pr_data.get("body") or ""
     commit_sha = pr_data["head"]["sha"][:8]
 
-    existing_hash = _read_pr_state(pr_body)
+    existing_hash, existing_review_id = _read_pr_state(pr_body)
     if existing_hash == current_hash:
         print(f"Findings unchanged (hash {current_hash}); skipping.")
         return 0
-    if existing_hash:
-        print(f"Findings changed (was {existing_hash}, now {current_hash}); posting new review.")
+    if existing_hash and existing_review_id:
+        print(f"Findings changed (was {existing_hash}, now {current_hash}); deleting old inline comments.")
+        _delete_old_review_comments(existing_review_id, pulls_url, token)
 
     # Map each changed file to its commentable lines.
     anchors = {f["filename"]: _commentable_lines(f.get("patch")) for f in _paginate(f"{pulls_url}/files", token)}

--- a/utils/post_mlinter_review.py
+++ b/utils/post_mlinter_review.py
@@ -169,8 +169,9 @@ def main():
     token = os.environ.get("GITHUB_TOKEN")
     repo = os.environ.get("GITHUB_REPOSITORY")
 
-    pr_number_path = Path("mlinter-pr-number.txt")
-    findings_path = Path("mlinter-findings.json")
+    artifact_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    pr_number_path = artifact_dir / "mlinter-pr-number.txt"
+    findings_path = artifact_dir / "mlinter-findings.json"
 
     if not pr_number_path.exists() or not findings_path.exists():
         print("Artifact files missing; skipping.")

--- a/utils/post_mlinter_review.py
+++ b/utils/post_mlinter_review.py
@@ -169,9 +169,8 @@ def main():
     token = os.environ.get("GITHUB_TOKEN")
     repo = os.environ.get("GITHUB_REPOSITORY")
 
-    artifact_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
-    pr_number_path = artifact_dir / "mlinter-pr-number.txt"
-    findings_path = artifact_dir / "mlinter-findings.json"
+    pr_number_path = Path("mlinter-pr-number.txt")
+    findings_path = Path("mlinter-findings.json")
 
     if not pr_number_path.exists() or not findings_path.exists():
         print("Artifact files missing; skipping.")


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48088)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48088)
<!-- ci-dashboard-badge:end -->

## Summary

Necessary follow-up after #47949 (Potential fix for code scanning alert no. 267: Artifact poisoning).

That PR downloads the mlinter findings artifact into `${{ runner.temp }}/mlinter-findings` (outside the workspace, for security), but `post_mlinter_review.py` was still looking for the files in the CWD — causing `Artifact files missing; skipping.` on every run.

- Pass the artifact directory via an env var to `post_mlinter_review.py` in the workflow
- TODO: Accept it via `sys.argv[1]` in the script (falls back to `.` when not provided)