### PR TITLE
fix missing functools.wraps for wrapped in force_accelerate_hooks

### DIFF
--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -17,6 +17,7 @@ and simplicity/ease of use.
 """
 
 import copy
+import functools
 import inspect
 import os
 import re
@@ -932,6 +933,7 @@ def force_accelerate_hooks(child_module_names: str | list[str]) -> Callable:
         child_module_names = [child_module_names]
 
     def decorator(forward_func: Callable) -> Callable:
+        @functools.wraps(forward_func)
         def wrapped(self, *args, **kwargs):
             hooked_modules = []
             for child_module_name in child_module_names:

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import copy
 import glob
+import inspect
 import json
 import os
 import os.path
@@ -3795,6 +3796,39 @@ class DisableMmapLoadingTest(unittest.TestCase):
         self.assertEqual(set(loaded_mmap.keys()), set(loaded_no_mmap.keys()))
         for k in loaded_mmap:
             torch.testing.assert_close(loaded_mmap[k], loaded_no_mmap[k])
+
+
+@require_torch
+class ForceAccelerateHooksTest(unittest.TestCase):
+    """Tests for the `force_accelerate_hooks` decorator in `integrations.accelerate`."""
+
+    def test_decorator_preserves_signature(self):
+        # Downstream tools introspect the decorated method with `inspect.signature(...).bind(*args, **kwargs)`
+        # to replay captured inputs, so the decorator must not hide the real signature behind `(*args, **kwargs)`.
+        from transformers.integrations.accelerate import force_accelerate_hooks
+
+        class Mixer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1d = torch.nn.Conv1d(1, 1, 1)
+
+            @force_accelerate_hooks("conv1d")
+            def forward(self, hidden_states, cache_params=None, attention_mask=None, **kwargs):
+                """Mixer forward."""
+                return hidden_states
+
+        module = Mixer()
+        signature = inspect.signature(module.forward)
+        self.assertEqual(list(signature.parameters), ["hidden_states", "cache_params", "attention_mask", "kwargs"])
+
+        bound = signature.bind(torch.zeros(1, 1, 1), attention_mask=None)
+        self.assertEqual(list(bound.arguments), ["hidden_states", "attention_mask"])
+
+        self.assertEqual(Mixer.forward.__name__, "forward")
+        self.assertEqual(Mixer.forward.__doc__, "Mixer forward.")
+
+        # and the wrapper still runs the underlying forward
+        torch.testing.assert_close(module(torch.ones(1, 1, 1)), torch.ones(1, 1, 1))
 
 
 @require_torch


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

`force_accelerate_hooks` returns a wrapper that is not decorated with `functools.wraps`, so the metadata of the wrapped method is lost. This is a regression from #46978

I got this issue when trying to do AWQ quantization for Qwen3.8-27B. The code itself was largely assisted by an LLM, but I have reviewed the code. The patch itself is straightforward and trivial.

## Code Agent Policy

- [x] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

@Cyrilvallez, @vasqu, @SunMarc

(I'm not very familiar with the repo, so I'm sorry if you are not relevant.) 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @molbap @guarin
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @Abdennacer-Badaoui
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @IlyasMoutawwakil 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
