### PR TITLE
[AudioProcessor] add AutoAudioProcessor

### DIFF
--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -11,19 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""AutoFeatureExtractor class."""
+"""AutoAudioProcessor and (deprecated) AutoFeatureExtractor classes."""
 
 import importlib
 import os
+import warnings
 from collections import OrderedDict
 
-# Build the list of all feature extractors
+from ...audio_processing_base import AudioProcessingMixin
 from ...configuration_utils import PreTrainedConfig
 from ...dynamic_module_utils import get_class_from_dynamic_module, resolve_trust_remote_code
-from ...feature_extraction_utils import FeatureExtractionMixin
 from ...utils import CONFIG_NAME, FEATURE_EXTRACTOR_NAME, PROCESSOR_NAME, cached_file, logging, safe_load_json_file
 from .auto_factory import _LazyAutoMapping
-from .auto_mappings import FEATURE_EXTRACTOR_MAPPING_NAMES
 from .configuration_auto import (
     CONFIG_MAPPING_NAMES,
     AutoConfig,
@@ -34,64 +33,139 @@ from .configuration_auto import (
 
 logger = logging.get_logger(__name__)
 
-MISSING_FEATURE_EXTRACTOR_MAPPING_NAMES = OrderedDict(
+# Each entry maps a `model_type` to a dict of backend → audio-processor class name. The torch
+# entry is the default returned by `AutoAudioProcessor.from_pretrained`; the numpy entry, when
+# present, is the bit-exact CPU-only sibling (see docs/adr/0001-bit-exact-backend-parity.md).
+# Non-audio feature extractors (e.g. MarkupLM) keep a single-key dict for back-compat.
+FEATURE_EXTRACTOR_MAPPING_NAMES = OrderedDict(
     [
-        ("audioflamingo3", "WhisperFeatureExtractor"),
-        ("csm", "EncodecFeatureExtractor"),
-        ("data2vec-audio", "Wav2Vec2FeatureExtractor"),
-        ("glmasr", "WhisperFeatureExtractor"),
-        ("granite_speech_plus", "GraniteSpeechFeatureExtractor"),
-        ("higgs_audio_v2_tokenizer", "DacFeatureExtractor"),
-        ("hubert", "Wav2Vec2FeatureExtractor"),
-        ("inkling_mm_model", "InklingFeatureExtractor"),
-        ("lasr_ctc", "LasrFeatureExtractor"),
-        ("lasr_encoder", "LasrFeatureExtractor"),
-        ("mimi", "EncodecFeatureExtractor"),
-        ("moonshine", "Wav2Vec2FeatureExtractor"),
-        ("moshi", "EncodecFeatureExtractor"),
-        ("musicgen", "EncodecFeatureExtractor"),
-        ("nemotron3_5_asr", "NemotronAsrStreamingFeatureExtractor"),
-        ("nemotron_asr_streaming_encoder", "NemotronAsrStreamingFeatureExtractor"),
-        ("parakeet_ctc", "ParakeetFeatureExtractor"),
-        ("parakeet_encoder", "ParakeetFeatureExtractor"),
-        ("parakeet_rnnt", "ParakeetFeatureExtractor"),
-        ("parakeet_tdt", "ParakeetFeatureExtractor"),
-        ("pe_audio_video", "PeAudioFeatureExtractor"),
-        ("qwen2_5_omni", "WhisperFeatureExtractor"),
-        ("qwen2_audio", "WhisperFeatureExtractor"),
-        ("qwen3_omni_moe", "WhisperFeatureExtractor"),
-        ("seamless_m4t_v2", "SeamlessM4TFeatureExtractor"),
-        ("sew", "Wav2Vec2FeatureExtractor"),
-        ("sew-d", "Wav2Vec2FeatureExtractor"),
-        ("unispeech", "Wav2Vec2FeatureExtractor"),
-        ("unispeech-sat", "Wav2Vec2FeatureExtractor"),
-        ("vibevoice_asr", "VibeVoiceAcousticTokenizerFeatureExtractor"),
-        ("voxtral", "WhisperFeatureExtractor"),
-        ("wav2vec2-bert", "Wav2Vec2FeatureExtractor"),
-        ("wav2vec2-conformer", "Wav2Vec2FeatureExtractor"),
-        ("wavlm", "Wav2Vec2FeatureExtractor"),
-        ("xcodec", "DacFeatureExtractor"),
+        ("audio-spectrogram-transformer", {"torch": "ASTFeatureExtractor"}),
+        ("clap", {"torch": "ClapFeatureExtractor"}),
+        ("clvp", {"torch": "ClvpFeatureExtractor"}),
+        ("cohere_asr", {"torch": "CohereAsrFeatureExtractor"}),
+        ("dac", {"torch": "DacFeatureExtractor"}),
+        ("dia", {"torch": "DiaFeatureExtractor"}),
+        ("encodec", {"torch": "EncodecFeatureExtractor"}),
+        ("gemma3n", {"torch": "Gemma3nAudioFeatureExtractor"}),
+        ("gemma4", {"torch": "Gemma4AudioFeatureExtractor"}),
+        ("gemma4_unified", {"torch": "Gemma4UnifiedAudioFeatureExtractor"}),
+        ("granite_speech", {"torch": "GraniteSpeechFeatureExtractor"}),
+        ("kyutai_speech_to_text", {"torch": "KyutaiSpeechToTextFeatureExtractor"}),
+        ("musicgen_melody", {"torch": "MusicgenMelodyFeatureExtractor"}),
+        ("nemotron_asr_streaming", {"torch": "NemotronAsrStreamingFeatureExtractor"}),
+        ("pe_audio", {"torch": "PeAudioFeatureExtractor"}),
+        ("phi4_multimodal", {"torch": "Phi4MultimodalFeatureExtractor"}),
+        ("pop2piano", {"torch": "Pop2PianoFeatureExtractor"}),
+        ("qwen3_asr", {"torch": "Qwen3ASRFeatureExtractor"}),
+        ("seamless_m4t", {"torch": "SeamlessM4TFeatureExtractor"}),
+        ("speech_to_text", {"torch": "Speech2TextFeatureExtractor"}),
+        ("speecht5", {"torch": "SpeechT5FeatureExtractor"}),
+        ("univnet", {"torch": "UnivNetFeatureExtractor"}),
+        ("vibevoice_acoustic_tokenizer", {"torch": "VibeVoiceAcousticTokenizerFeatureExtractor"}),
+        ("voxtral_realtime", {"torch": "VoxtralRealtimeFeatureExtractor"}),
+        ("wav2vec2", {"torch": "Wav2Vec2FeatureExtractor"}),
+        ("whisper", {"torch": "WhisperFeatureExtractor"}),
+        ("xcodec2", {"torch": "Xcodec2FeatureExtractor"}),
+        ("audioflamingo3", {"torch": "WhisperFeatureExtractor"}),
+        ("csm", {"torch": "EncodecFeatureExtractor"}),
+        ("data2vec-audio", {"torch": "Wav2Vec2FeatureExtractor"}),
+        ("glmasr", {"torch": "WhisperFeatureExtractor"}),
+        ("granite_speech_plus", {"torch": "GraniteSpeechFeatureExtractor"}),
+        ("higgs_audio_v2_tokenizer", {"torch": "DacFeatureExtractor"}),
+        ("hubert", {"torch": "Wav2Vec2FeatureExtractor"}),
+        ("inkling_mm_model", {"torch": "InklingFeatureExtractor"}),
+        ("lasr_ctc", {"torch": "LasrFeatureExtractor"}),
+        ("lasr_encoder", {"torch": "LasrFeatureExtractor"}),
+        ("mimi", {"torch": "EncodecFeatureExtractor"}),
+        ("moonshine", {"torch": "Wav2Vec2FeatureExtractor"}),
+        ("moshi", {"torch": "EncodecFeatureExtractor"}),
+        ("musicgen", {"torch": "EncodecFeatureExtractor"}),
+        ("nemotron3_5_asr", {"torch": "NemotronAsrStreamingFeatureExtractor"}),
+        ("nemotron_asr_streaming_encoder", {"torch": "NemotronAsrStreamingFeatureExtractor"}),
+        ("parakeet_ctc", {"torch": "ParakeetFeatureExtractor"}),
+        ("parakeet_encoder", {"torch": "ParakeetFeatureExtractor"}),
+        ("parakeet_rnnt", {"torch": "ParakeetFeatureExtractor"}),
+        ("parakeet_tdt", {"torch": "ParakeetFeatureExtractor"}),
+        ("pe_audio_video", {"torch": "PeAudioFeatureExtractor"}),
+        ("qwen2_5_omni", {"torch": "WhisperFeatureExtractor"}),
+        ("qwen2_audio", {"torch": "WhisperFeatureExtractor"}),
+        ("qwen3_omni_moe", {"torch": "WhisperFeatureExtractor"}),
+        ("seamless_m4t_v2", {"torch": "SeamlessM4TFeatureExtractor"}),
+        ("sew", {"torch": "Wav2Vec2FeatureExtractor"}),
+        ("sew-d", {"torch": "Wav2Vec2FeatureExtractor"}),
+        ("unispeech", {"torch": "Wav2Vec2FeatureExtractor"}),
+        ("unispeech-sat", {"torch": "Wav2Vec2FeatureExtractor"}),
+        ("vibevoice_asr", {"torch": "VibeVoiceAcousticTokenizerFeatureExtractor"}),
+        ("voxtral", {"torch": "WhisperFeatureExtractor"}),
+        ("wav2vec2-bert", {"torch": "Wav2Vec2FeatureExtractor"}),
+        ("wav2vec2-conformer", {"torch": "Wav2Vec2FeatureExtractor"}),
+        ("wavlm", {"torch": "Wav2Vec2FeatureExtractor"}),
+        ("xcodec", {"torch": "DacFeatureExtractor"}),
     ]
 )
 
-FEATURE_EXTRACTOR_MAPPING_NAMES.update(MISSING_FEATURE_EXTRACTOR_MAPPING_NAMES)
+# Irregular legacy `XxxFeatureExtractor` names that do not derive from the new
+# `XxxAudioProcessor` by simple suffix substitution. Used by
+# `feature_extractor_class_from_name` to resolve hub JSON `feature_extractor_type` strings.
+LEGACY_FEATURE_EXTRACTOR_NAME_MAP = {
+    "ASTFeatureExtractor": "AudioSpectrogramTransformerAudioProcessor",
+    "Gemma3nAudioFeatureExtractor": "Gemma3nAudioProcessor",
+    "Gemma4AudioFeatureExtractor": "Gemma4AudioProcessor",
+    "Gemma4UnifiedAudioFeatureExtractor": "Gemma4UnifiedAudioProcessor",
+    "Speech2TextFeatureExtractor": "SpeechToTextAudioProcessor",
+    "SeamlessM4TFeatureExtractor": "SeamlessM4tAudioProcessor",
+    "VibeVoiceAcousticTokenizerFeatureExtractor": "VibevoiceAcousticTokenizerAudioProcessor",
+    "PeAudioFeatureExtractor": "PeAudioAudioProcessor",
+}
+
+
 FEATURE_EXTRACTOR_MAPPING = _LazyAutoMapping(CONFIG_MAPPING_NAMES, FEATURE_EXTRACTOR_MAPPING_NAMES)
 
 
+def _legacy_name_candidates(class_name: str) -> list[str]:
+    """Translate a legacy `XxxFeatureExtractor` name into modern candidates.
+
+    Hub `preprocessor_config.json` files have `feature_extractor_type: "WhisperFeatureExtractor"`
+    (legacy) or `audio_processor_type: "WhisperAudioProcessor"` (new). When loading legacy
+    configs we need to find the new class by name. Tries, in order:
+      1. The name as-is (modern names already match)
+      2. An explicit override in `LEGACY_FEATURE_EXTRACTOR_NAME_MAP`
+      3. The simple `FeatureExtractor → AudioProcessor` suffix substitution
+    """
+    candidates = [class_name]
+    if class_name in LEGACY_FEATURE_EXTRACTOR_NAME_MAP:
+        # Explicit override wins over the generic suffix substitution
+        candidates.append(LEGACY_FEATURE_EXTRACTOR_NAME_MAP[class_name])
+    elif class_name.endswith("FeatureExtractor"):
+        candidates.append(class_name.replace("FeatureExtractor", "AudioProcessor"))
+    # De-duplicate while preserving order
+    seen = set()
+    return [c for c in candidates if not (c in seen or seen.add(c))]
+
+
 def feature_extractor_class_from_name(class_name: str):
-    for module_name, extractors in FEATURE_EXTRACTOR_MAPPING_NAMES.items():
-        if class_name in extractors:
-            module_name = model_type_to_module_name(module_name)
+    """Resolve an audio-processor or legacy feature-extractor name to its class object.
 
-            module = importlib.import_module(f".{module_name}", "transformers.models")
-            try:
-                return getattr(module, class_name)
-            except AttributeError:
-                continue
+    Handles both modern names (`WhisperAudioProcessor`, `WhisperAudioProcessorNumpy`) and the
+    legacy `XxxFeatureExtractor` names still found in hub `preprocessor_config.json` files.
+    """
+    for candidate in _legacy_name_candidates(class_name):
+        for model_type, extractors_dict in FEATURE_EXTRACTOR_MAPPING_NAMES.items():
+            if candidate in extractors_dict.values():
+                module_name = model_type_to_module_name(model_type)
+                module = importlib.import_module(f".{module_name}", "transformers.models")
+                try:
+                    return getattr(module, candidate)
+                except AttributeError:
+                    continue
 
-    for extractor in FEATURE_EXTRACTOR_MAPPING._extra_content.values():
-        if getattr(extractor, "__name__", None) == class_name:
-            return extractor
+    for mapping in FEATURE_EXTRACTOR_MAPPING._extra_content.values():
+        if isinstance(mapping, dict):
+            for cls in mapping.values():
+                if getattr(cls, "__name__", None) == class_name:
+                    return cls
+        elif getattr(mapping, "__name__", None) == class_name:
+            return mapping
 
     # We did not find the class, but maybe it's because a dep is missing. In that case, the class will be in the main
     # init and we return the proper dummy to get an appropriate error message.
@@ -100,6 +174,92 @@ def feature_extractor_class_from_name(class_name: str):
         return getattr(main_module, class_name)
 
     return None
+
+
+def _resolve_audio_backend(backend: str | None) -> str:
+    """Resolve raw backend input to a concrete backend name (`'torch'` or `'numpy'`).
+
+    Default is `'torch'`; `'numpy'` is the bit-exact CPU-only sibling. If a model has no
+    sibling for the requested backend, `_load_class_with_fallback` warns and falls back to
+    the available one.
+    """
+    if backend is None:
+        return "torch"
+    if backend not in {"torch", "numpy"}:
+        raise ValueError(f"Unknown audio-processor backend: {backend!r}. Expected 'torch' or 'numpy'.")
+    return backend
+
+
+def _load_class_with_fallback(mapping, backend):
+    """Load an audio-processor class from a backend→class mapping, with fallback.
+
+    Tries the requested backend first; if the model has no sibling for it, falls back to any
+    other available backend and warns. Returns `None` if the mapping is empty.
+    """
+    backends_to_try = [backend] + [b for b in mapping if b != backend]
+
+    for b in backends_to_try:
+        value = mapping.get(b)
+        if value is None:
+            continue
+
+        if isinstance(value, type):
+            processor_class = value
+        else:
+            processor_class = feature_extractor_class_from_name(value)
+
+        if processor_class is None or getattr(processor_class, "is_dummy", False):
+            continue
+
+        if b != backend:
+            logger.warning_once(
+                f"Requested audio-processor backend {backend!r} is not available for this model. "
+                f"Falling back to {b!r} backend."
+            )
+        return processor_class
+
+    return None
+
+
+def _find_mapping_for_audio_processor(base_class_name: str) -> dict | None:
+    """Find the backend→class mapping that contains `base_class_name` in its values."""
+
+    def _value_matches(val, name: str) -> bool:
+        if val is None:
+            return False
+        if isinstance(val, str):
+            return val == name
+        if isinstance(val, type):
+            return getattr(val, "__name__", None) == name
+        return False
+
+    for mapping_dict in FEATURE_EXTRACTOR_MAPPING_NAMES.values():
+        if any(_value_matches(v, base_class_name) for v in mapping_dict.values()):
+            return mapping_dict
+
+    for content in FEATURE_EXTRACTOR_MAPPING._extra_content.values():
+        if isinstance(content, dict) and any(_value_matches(v, base_class_name) for v in content.values()):
+            return content
+
+    return None
+
+
+def _load_backend_class(base_class_name: str, backend: str):
+    """Load an audio-processor class for the requested backend, with fallback."""
+    mapping = _find_mapping_for_audio_processor(base_class_name)
+    if mapping is None:
+        # Unknown class name (e.g. remote code, custom registration): default to the literal name
+        mapping = {"torch": base_class_name}
+    return _load_class_with_fallback(mapping, backend)
+
+
+def _resolve_auto_map_class_ref(auto_map, backend: str) -> str:
+    """Extract the class reference string from an `auto_map` entry based on backend preference."""
+    if isinstance(auto_map, dict):
+        return auto_map.get(backend) or next(iter(auto_map.values()))
+    if isinstance(auto_map, (list, tuple)):
+        return auto_map[0]
+    return auto_map
 
 
 def get_feature_extractor_config(
@@ -113,7 +273,7 @@ def get_feature_extractor_config(
     **kwargs,
 ):
     """
-    Loads the feature extractor configuration from a pretrained model feature extractor configuration.
+    Loads the audio-processor / feature-extractor configuration from a pretrained model.
 
     Args:
         pretrained_model_name_or_path (`str` or `os.PathLike`):
@@ -122,7 +282,7 @@ def get_feature_extractor_config(
             - a string, the *model id* of a pretrained model configuration hosted inside a model repo on
               huggingface.co.
             - a path to a *directory* containing a configuration file saved using the
-              [`~FeatureExtractionMixin.save_pretrained`] method, e.g., `./my_model_directory/`.
+              [`~AudioProcessingMixin.save_pretrained`] method, e.g., `./my_model_directory/`.
 
         cache_dir (`str` or `os.PathLike`, *optional*):
             Path to a directory in which a downloaded pretrained model configuration should be cached if the standard
@@ -141,32 +301,11 @@ def get_feature_extractor_config(
             git-based system for storing models and other artifacts on huggingface.co, so `revision` can be any
             identifier allowed by git.
         local_files_only (`bool`, *optional*, defaults to `False`):
-            If `True`, will only try to load the feature extractor configuration from local files.
-
-    <Tip>
-
-    Passing `token=True` is required when you want to use a private model.
-
-    </Tip>
+            If `True`, will only try to load the audio-processor configuration from local files.
 
     Returns:
-        `Dict`: The configuration of the feature extractor.
-
-    Examples:
-
-    ```python
-    # Download configuration from huggingface.co and cache.
-    feature_extractor_config = get_feature_extractor_config("facebook/wav2vec2-base-960h")
-    # This model does not have a feature extractor config so the result will be an empty dict.
-    feature_extractor_config = get_feature_extractor_config("FacebookAI/xlm-roberta-base")
-
-    # Save a pretrained feature extractor locally and you can reload its config
-    from transformers import AutoFeatureExtractor
-
-    feature_extractor = AutoFeatureExtractor.from_pretrained("facebook/wav2vec2-base-960h")
-    feature_extractor.save_pretrained("feature-extractor-test")
-    feature_extractor_config = get_feature_extractor_config("feature-extractor-test")
-    ```"""
+        `Dict`: The configuration of the audio processor.
+    """
     # Load with a priority given to the nested processor config, if available in repo
     resolved_processor_file = cached_file(
         pretrained_model_name_or_path,
@@ -193,31 +332,159 @@ def get_feature_extractor_config(
         _raise_exceptions_for_missing_entries=False,
     )
 
-    # An empty list if none of the possible files is found in the repo
     if not resolved_feature_extractor_file and not resolved_processor_file:
-        logger.info("Could not locate the feature extractor configuration file.")
+        logger.info("Could not locate the audio-processor configuration file.")
         return {}
 
-    # Load feature_extractor dict. Priority goes as (nested config if found -> feature extractor config)
-    # We are downloading both configs because almost all models have a `processor_config.json` but
-    # not all of these are nested. We need to check if it was saved recently as nested or if it is legacy style
-    feature_extractor_dict = None
+    feature_extractor_dict = {}
     if resolved_processor_file is not None:
         processor_dict = safe_load_json_file(resolved_processor_file)
-        if "feature_extractor" in processor_dict:
+        # New nested key takes priority; legacy `feature_extractor` key is the fallback.
+        if "audio_processor" in processor_dict:
+            feature_extractor_dict = processor_dict["audio_processor"]
+        elif "feature_extractor" in processor_dict:
             feature_extractor_dict = processor_dict["feature_extractor"]
 
-    if resolved_feature_extractor_file is not None and feature_extractor_dict is None:
+    if resolved_feature_extractor_file is not None and not feature_extractor_dict:
         feature_extractor_dict = safe_load_json_file(resolved_feature_extractor_file)
-    return feature_extractor_dict or {}
+    return feature_extractor_dict
+
+
+def _resolve_audio_processor_from_pretrained(pretrained_model_name_or_path, *, backend: str, **kwargs):
+    """Shared resolution logic used by `AutoAudioProcessor` and the deprecated `AutoFeatureExtractor`.
+
+    Reads the hub config, identifies the class via the new `audio_processor_type` key, falling
+    back to the legacy `feature_extractor_type` key, then picks the right backend sibling.
+    """
+    config = kwargs.pop("config", None)
+    trust_remote_code = kwargs.pop("trust_remote_code", None)
+    kwargs["_from_auto"] = True
+
+    config_dict, _ = AudioProcessingMixin.get_audio_processor_dict(pretrained_model_name_or_path, **kwargs)
+
+    class_name_in_config = config_dict.get("audio_processor_type") or config_dict.get("feature_extractor_type")
+    auto_map = config_dict.get("auto_map") or {}
+    audio_processor_auto_map = auto_map.get("AutoAudioProcessor") or auto_map.get("AutoFeatureExtractor")
+
+    if class_name_in_config is None and audio_processor_auto_map is None:
+        if not isinstance(config, PreTrainedConfig):
+            config = AutoConfig.from_pretrained(
+                pretrained_model_name_or_path, trust_remote_code=trust_remote_code, **kwargs
+            )
+        class_name_in_config = getattr(config, "audio_processor_type", None) or getattr(
+            config, "feature_extractor_type", None
+        )
+        if hasattr(config, "auto_map"):
+            audio_processor_auto_map = config.auto_map.get("AutoAudioProcessor") or config.auto_map.get(
+                "AutoFeatureExtractor"
+            )
+
+    audio_processor_class = None
+    if class_name_in_config is not None:
+        # Try the modern (translated) name first so the backend mapping applies, then the
+        # literal name (covers registered custom classes that keep a legacy-style name).
+        for candidate in reversed(_legacy_name_candidates(class_name_in_config)):
+            audio_processor_class = _load_backend_class(candidate, backend)
+            if audio_processor_class is not None:
+                break
+
+    has_remote_code = audio_processor_auto_map is not None
+    has_local_code = audio_processor_class is not None or type(config) in FEATURE_EXTRACTOR_MAPPING
+    if has_local_code and audio_processor_class is None:
+        audio_processor_class = _load_class_with_fallback(FEATURE_EXTRACTOR_MAPPING[type(config)], backend)
+    explicit_local_code = (
+        has_local_code
+        and audio_processor_class is not None
+        and not audio_processor_class.__module__.startswith("transformers.")
+    )
+
+    if has_remote_code:
+        class_ref = _resolve_auto_map_class_ref(audio_processor_auto_map, backend)
+        upstream_repo = class_ref.split("--")[0] if "--" in class_ref else None
+        trust_remote_code = resolve_trust_remote_code(
+            trust_remote_code, pretrained_model_name_or_path, has_local_code, has_remote_code, upstream_repo
+        )
+
+    if has_remote_code and trust_remote_code and not explicit_local_code:
+        audio_processor_class = get_class_from_dynamic_module(class_ref, pretrained_model_name_or_path, **kwargs)
+        _ = kwargs.pop("code_revision", None)
+        audio_processor_class.register_for_auto_class()
+        return audio_processor_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
+
+    if audio_processor_class is not None:
+        return audio_processor_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
+
+    raise ValueError(
+        f"Unrecognized audio processor in {pretrained_model_name_or_path}. Should have an "
+        f"`audio_processor_type` or `feature_extractor_type` key in its {FEATURE_EXTRACTOR_NAME} or {CONFIG_NAME}, "
+        f"or one of the following `model_type` keys in its {CONFIG_NAME}: "
+        f"{', '.join(c for c in FEATURE_EXTRACTOR_MAPPING_NAMES)}"
+    )
+
+
+class AutoAudioProcessor:
+    r"""
+    This is a generic audio processor class that will be instantiated as one of the
+    backend-specific [`~audio_processing_base.AudioProcessingMixin`] subclasses when created with the
+    [`AutoAudioProcessor.from_pretrained`] class method.
+
+    This class cannot be instantiated directly using `__init__()` (throws an error).
+    """
+
+    def __init__(self):
+        raise OSError(
+            "AutoAudioProcessor is designed to be instantiated "
+            "using the `AutoAudioProcessor.from_pretrained(pretrained_model_name_or_path)` method."
+        )
+
+    @classmethod
+    @replace_list_option_in_docstrings(FEATURE_EXTRACTOR_MAPPING_NAMES)
+    def from_pretrained(cls, pretrained_model_name_or_path, *inputs, **kwargs):
+        r"""
+        Instantiate one of the audio processor classes of the library from a pretrained model.
+
+        The class to instantiate is selected by reading the `audio_processor_type`
+        (or legacy `feature_extractor_type`) entry in the hub `preprocessor_config.json`, then
+        picking the right backend sibling (`backend="torch"` by default; `"numpy"` for the
+        bit-exact CPU-only variant — see [`~docs/adr/0001-bit-exact-backend-parity`]).
+
+        Params:
+            pretrained_model_name_or_path (`str` or `os.PathLike`):
+                A model identifier on huggingface.co, a path to a saved model directory, or a path to
+                a saved audio-processor JSON file.
+            backend (`str`, *optional*, defaults to `"torch"`):
+                Which backend sibling to load. `"torch"` returns the `XxxAudioProcessor` class;
+                `"numpy"` returns `XxxAudioProcessorNumpy` when it exists. If the requested
+                backend has no sibling for the resolved model, falls back to the available one
+                with a warning.
+
+        List options
+        """
+        backend = _resolve_audio_backend(kwargs.pop("backend", None))
+        return _resolve_audio_processor_from_pretrained(pretrained_model_name_or_path, backend=backend, **kwargs)
+
+    @staticmethod
+    def register(config_class, audio_processor_class, exist_ok=False):
+        """
+        Register a new audio processor for this class.
+
+        Args:
+            config_class ([`PreTrainedConfig`]):
+                The configuration corresponding to the model to register.
+            audio_processor_class ([`AudioProcessingMixin`] or `dict[str, type]`):
+                Either a single class (treated as the torch backend) or a backend→class dict.
+        """
+        if not isinstance(audio_processor_class, dict):
+            audio_processor_class = {"torch": audio_processor_class}
+        FEATURE_EXTRACTOR_MAPPING.register(config_class, audio_processor_class, exist_ok=exist_ok)
 
 
 class AutoFeatureExtractor:
     r"""
-    This is a generic feature extractor class that will be instantiated as one of the feature extractor classes of the
-    library when created with the [`AutoFeatureExtractor.from_pretrained`] class method.
+    Deprecated alias for [`AutoAudioProcessor`].
 
-    This class cannot be instantiated directly using `__init__()` (throws an error).
+    Returns the same class as `AutoAudioProcessor.from_pretrained` (torch backend by default).
+    Removal target: transformers v5.15. See [ADR 0002](docs/adr/0002-legacy-field-mapping.md).
     """
 
     def __init__(self):
@@ -227,144 +494,27 @@ class AutoFeatureExtractor:
         )
 
     @classmethod
-    @replace_list_option_in_docstrings(FEATURE_EXTRACTOR_MAPPING_NAMES)
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
-        r"""
-        Instantiate one of the feature extractor classes of the library from a pretrained model vocabulary.
-
-        The feature extractor class to instantiate is selected based on the `model_type` property of the config object
-        (either passed as an argument or loaded from `pretrained_model_name_or_path` if possible), or when it's
-        missing, by falling back to using pattern matching on `pretrained_model_name_or_path`:
-
-        List options
-
-        Params:
-            pretrained_model_name_or_path (`str` or `os.PathLike`):
-                This can be either:
-
-                - a string, the *model id* of a pretrained feature_extractor hosted inside a model repo on
-                  huggingface.co.
-                - a path to a *directory* containing a feature extractor file saved using the
-                  [`~feature_extraction_utils.FeatureExtractionMixin.save_pretrained`] method, e.g.,
-                  `./my_model_directory/`.
-                - a path to a saved feature extractor JSON *file*, e.g.,
-                  `./my_model_directory/preprocessor_config.json`.
-            cache_dir (`str` or `os.PathLike`, *optional*):
-                Path to a directory in which a downloaded pretrained model feature extractor should be cached if the
-                standard cache should not be used.
-            force_download (`bool`, *optional*, defaults to `False`):
-                Whether or not to force to (re-)download the feature extractor files and override the cached versions
-                if they exist.
-            proxies (`dict[str, str]`, *optional*):
-                A dictionary of proxy servers to use by protocol or endpoint, e.g., `{'http': 'foo.bar:3128',
-                'http://hostname': 'foo.bar:4012'}.` The proxies are used on each request.
-            token (`str` or *bool*, *optional*):
-                The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
-                when running `hf auth login` (stored in `~/.huggingface`).
-            revision (`str`, *optional*, defaults to `"main"`):
-                The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
-                git-based system for storing models and other artifacts on huggingface.co, so `revision` can be any
-                identifier allowed by git.
-            return_unused_kwargs (`bool`, *optional*, defaults to `False`):
-                If `False`, then this function returns just the final feature extractor object. If `True`, then this
-                functions returns a `Tuple(feature_extractor, unused_kwargs)` where *unused_kwargs* is a dictionary
-                consisting of the key/value pairs whose keys are not feature extractor attributes: i.e., the part of
-                `kwargs` which has not been used to update `feature_extractor` and is otherwise ignored.
-            trust_remote_code (`bool`, *optional*, defaults to `False`):
-                Whether or not to allow for custom models defined on the Hub in their own modeling files. This option
-                should only be set to `True` for repositories you trust and in which you have read the code, as it will
-                execute code present on the Hub on your local machine.
-            kwargs (`dict[str, Any]`, *optional*):
-                The values in kwargs of any keys which are feature extractor attributes will be used to override the
-                loaded values. Behavior concerning key/value pairs whose keys are *not* feature extractor attributes is
-                controlled by the `return_unused_kwargs` keyword parameter.
-
-        <Tip>
-
-        Passing `token=True` is required when you want to use a private model.
-
-        </Tip>
-
-        Examples:
-
-        ```python
-        >>> from transformers import AutoFeatureExtractor
-
-        >>> # Download feature extractor from huggingface.co and cache.
-        >>> feature_extractor = AutoFeatureExtractor.from_pretrained("facebook/wav2vec2-base-960h")
-
-        >>> # If feature extractor files are in a directory (e.g. feature extractor was saved using *save_pretrained('./test/saved_model/')*)
-        >>> # feature_extractor = AutoFeatureExtractor.from_pretrained("./test/saved_model/")
-        ```"""
-        config = kwargs.pop("config", None)
-        trust_remote_code = kwargs.pop("trust_remote_code", None)
-        kwargs["_from_auto"] = True
-
-        config_dict, _ = FeatureExtractionMixin.get_feature_extractor_dict(pretrained_model_name_or_path, **kwargs)
-        feature_extractor_class = config_dict.get("feature_extractor_type", None)
-        feature_extractor_auto_map = None
-        if "AutoFeatureExtractor" in config_dict.get("auto_map", {}):
-            feature_extractor_auto_map = config_dict["auto_map"]["AutoFeatureExtractor"]
-
-        # If we don't find the feature extractor class in the feature extractor config, let's try the model config.
-        if feature_extractor_class is None and feature_extractor_auto_map is None:
-            if not isinstance(config, PreTrainedConfig):
-                config = AutoConfig.from_pretrained(
-                    pretrained_model_name_or_path, trust_remote_code=trust_remote_code, **kwargs
-                )
-            # It could be in `config.feature_extractor_type``
-            feature_extractor_class = getattr(config, "feature_extractor_type", None)
-            if hasattr(config, "auto_map") and "AutoFeatureExtractor" in config.auto_map:
-                feature_extractor_auto_map = config.auto_map["AutoFeatureExtractor"]
-
-        if feature_extractor_class is not None:
-            feature_extractor_class = feature_extractor_class_from_name(feature_extractor_class)
-
-        has_remote_code = feature_extractor_auto_map is not None
-        has_local_code = feature_extractor_class is not None or type(config) in FEATURE_EXTRACTOR_MAPPING
-        explicit_local_code = has_local_code and not (
-            feature_extractor_class or FEATURE_EXTRACTOR_MAPPING[type(config)]
-        ).__module__.startswith("transformers.")
-        if has_remote_code:
-            if "--" in feature_extractor_auto_map:
-                upstream_repo = feature_extractor_auto_map.split("--")[0]
-            else:
-                upstream_repo = None
-            trust_remote_code = resolve_trust_remote_code(
-                trust_remote_code, pretrained_model_name_or_path, has_local_code, has_remote_code, upstream_repo
-            )
-
-        if has_remote_code and trust_remote_code and not explicit_local_code:
-            feature_extractor_class = get_class_from_dynamic_module(
-                feature_extractor_auto_map, pretrained_model_name_or_path, **kwargs
-            )
-            _ = kwargs.pop("code_revision", None)
-            feature_extractor_class.register_for_auto_class()
-            return feature_extractor_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
-        elif feature_extractor_class is not None:
-            return feature_extractor_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
-        # Last try: we use the FEATURE_EXTRACTOR_MAPPING.
-        elif type(config) in FEATURE_EXTRACTOR_MAPPING:
-            feature_extractor_class = FEATURE_EXTRACTOR_MAPPING[type(config)]
-            return feature_extractor_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
-
-        raise ValueError(
-            f"Unrecognized feature extractor in {pretrained_model_name_or_path}. Should have a "
-            f"`feature_extractor_type` key in its {FEATURE_EXTRACTOR_NAME} of {CONFIG_NAME}, or one of the following "
-            f"`model_type` keys in its {CONFIG_NAME}: {', '.join(c for c in FEATURE_EXTRACTOR_MAPPING_NAMES)}"
+        r"""Deprecated alias for [`AutoAudioProcessor.from_pretrained`]."""
+        warnings.warn(
+            "`AutoFeatureExtractor` is deprecated and will be removed in transformers v5.15. "
+            "Use `AutoAudioProcessor` instead.",
+            FutureWarning,
+            stacklevel=2,
         )
+        backend = _resolve_audio_backend(kwargs.pop("backend", None))
+        return _resolve_audio_processor_from_pretrained(pretrained_model_name_or_path, backend=backend, **kwargs)
 
     @staticmethod
     def register(config_class, feature_extractor_class, exist_ok=False):
-        """
-        Register a new feature extractor for this class.
+        """Deprecated alias for [`AutoAudioProcessor.register`]."""
+        warnings.warn(
+            "`AutoFeatureExtractor.register` is deprecated and will be removed in transformers v5.15. "
+            "Use `AutoAudioProcessor.register` instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        AutoAudioProcessor.register(config_class, feature_extractor_class, exist_ok=exist_ok)
 
-        Args:
-            config_class ([`PreTrainedConfig`]):
-                The configuration corresponding to the model to register.
-            feature_extractor_class ([`FeatureExtractorMixin`]): The feature extractor to register.
-        """
-        FEATURE_EXTRACTOR_MAPPING.register(config_class, feature_extractor_class, exist_ok=exist_ok)
 
-
-__all__ = ["FEATURE_EXTRACTOR_MAPPING", "AutoFeatureExtractor"]
+__all__ = ["FEATURE_EXTRACTOR_MAPPING", "AutoAudioProcessor", "AutoFeatureExtractor"]

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -130,9 +130,9 @@ MODALITY_TO_BASE_CLASS_MAPPING = {
         "HiggsAudioV2TokenizerModel",
         "DacModel",
     ),  # TODO: @eustlb, to be replaced with PreTrainedAudioTokenizerBase
-    "audio_processor": "FeatureExtractionMixin",
+    "audio_processor": ("FeatureExtractionMixin", "TorchAudioBackend", "NumpyAudioBackend"),
     "tokenizer": ("PreTrainedTokenizerBase", "MistralCommonBackend"),
-    "feature_extractor": "FeatureExtractionMixin",
+    "feature_extractor": ("FeatureExtractionMixin", "TorchAudioBackend", "NumpyAudioBackend"),
     "image_processor": "ImageProcessingMixin",
     "video_processor": "BaseVideoProcessor",
 }

--- a/src/transformers/utils/auto_docstring.py
+++ b/src/transformers/utils/auto_docstring.py
@@ -2961,9 +2961,14 @@ def format_args_docstring(docstring: str, model_name: str) -> str:
     placeholders_dict = get_placeholders_dict(placeholders, model_name)
     # replace the placeholders in the docstring with the values from the placeholders_dict
     for placeholder, value in placeholders_dict.items():
-        if isinstance(value, dict) and placeholder == "image_processor_class":
-            value = value.get("torchvision", value.get("pil", None))
-        if placeholder is not None:
+        # Backend-keyed mapping values: image processors use {"torchvision": ..., "pil": ...};
+        # audio processors use {"torch": ..., "numpy": ...}. Resolve to the default backend's class.
+        if isinstance(value, dict):
+            if placeholder == "image_processor_class":
+                value = value.get("torchvision", value.get("pil"))
+            else:
+                value = value.get("torch", next(iter(value.values()), None))
+        if isinstance(value, str):
             docstring = docstring.replace(f"{{{placeholder}}}", value)
     return docstring
 

--- a/tests/models/auto/test_feature_extraction_auto.py
+++ b/tests/models/auto/test_feature_extraction_auto.py
@@ -95,7 +95,7 @@ class AutoFeatureExtractorTest(unittest.TestCase):
     def test_feature_extractor_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError,
-            "Can't load feature extractor for 'hf-internal-testing/config-no-model'.",
+            "Can't load audio processor for 'hf-internal-testing/config-no-model'.",
         ):
             _ = AutoFeatureExtractor.from_pretrained("hf-internal-testing/config-no-model")
 

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -334,12 +334,15 @@ class ProcessorTesterMixin:
             else:
                 component_class = component_class[0] if component_class[0] is not None else component_class[1]
         elif isinstance(component_class, dict):
-            if not use_fast:
-                component_class = component_class["pil"]
+            # Image processors are keyed by {"pil": ..., "torchvision": ...}; audio processors
+            # by {"torch": ..., "numpy": ...}. Pick the preferred key present in the mapping.
+            if "pil" in component_class or "torchvision" in component_class:
+                if not use_fast:
+                    component_class = component_class["pil"]
+                else:
+                    component_class = component_class.get("torchvision") or component_class["pil"]
             else:
-                component_class = (
-                    component_class["torchvision"] if "torchvision" in component_class else component_class["pil"]
-                )
+                component_class = component_class.get("torch") or next(iter(component_class.values()))
         return component_class
 
     @staticmethod


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48092)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48092)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Adds `AutoAudioProcessor`, successor to `AutoFeatureExtractor` which is now deprecated and delegates to it. Since a model can ship a torch and a numpy processor, the auto mapping becomes backend-keyed (`{"torch": ..., "numpy": ...}`), resolved by `from_pretrained(..., backend=...)` and falling back with a warning when only one sibling exists.

Entries still name the current `XxxFeatureExtractor` classes; each model migration flips its own as it lands, so both Auto classes resolve correctly at every point in the stack.