### PR TITLE
Accept artifact dir as argument in post_mlinter_review.py

### DIFF
--- a/utils/post_mlinter_review.py
+++ b/utils/post_mlinter_review.py
@@ -169,8 +169,9 @@ def main():
     token = os.environ.get("GITHUB_TOKEN")
     repo = os.environ.get("GITHUB_REPOSITORY")
 
-    pr_number_path = Path("mlinter-pr-number.txt")
-    findings_path = Path("mlinter-findings.json")
+    artifact_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    pr_number_path = artifact_dir / "mlinter-pr-number.txt"
+    findings_path = artifact_dir / "mlinter-findings.json"
 
     if not pr_number_path.exists() or not findings_path.exists():
         print("Artifact files missing; skipping.")


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48106)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48106)
<!-- ci-dashboard-badge:end -->

## Summary

Follow-up to #48088 which changed the workflow to pass `$MLINTER_FINDINGS_DIR` to `post_mlinter_review.py`, but the script was still hardcoding `Path("mlinter-findings.json")` in the CWD and ignoring the argument — causing `Artifact files missing; skipping.`

Accept `sys.argv[1]` as the artifact directory, falling back to `.` when not provided.