### PR TITLE
[Whisper] Fix speculative decoding: preserve cleared suppress tokens through super().generate()

### DIFF
--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -1033,6 +1033,13 @@ class WhisperGenerationMixin(GenerationMixin):
                 synced_gpus=synced_gpus,
                 decoder_input_ids=decoder_input_ids,
                 attention_mask=attention_mask,
+                # Preserve suppress_tokens/begin_suppress_tokens that were cleared by
+                # _retrieve_logit_processors(). Without this, _prepare_generation_config
+                # inside super().generate() restores them from the model generation config
+                # (defaults_only=True treats None as not set), causing duplicate/extra
+                # logits processors in the assistant model during speculative decoding.
+                suppress_tokens=generation_config.suppress_tokens,
+                begin_suppress_tokens=generation_config.begin_suppress_tokens,
                 **generate_kwargs,
             )
 

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -1033,6 +1033,8 @@ class WhisperGenerationMixin(GenerationMixin):
                 synced_gpus=synced_gpus,
                 decoder_input_ids=decoder_input_ids,
                 attention_mask=attention_mask,
+                # See PR #48108 for more details. This is a hacky workaround to deal with the problem from legacy model
+                # generation config.
                 # Preserve suppress_tokens/begin_suppress_tokens that were cleared by
                 # _retrieve_logit_processors(). Without this, _prepare_generation_config
                 # inside super().generate() restores them from the model generation config


### PR DESCRIPTION
## Root Cause

PR #42702 (`a81e04a923`) changed `_prepare_generation_config` to unconditionally merge `self.generation_config` values with `defaults_only=True`. This broke Whisper speculative decoding through a double-call problem.

**Before #42702 (good commit: `bdaddb6f58`) — test passes**

When Whisper's `generate()` override calls `super().generate()` internally, `_prepare_generation_config` is invoked a second time. In the pre-#42702 code, this second call was guarded by a version check:

```python
# utils.py _prepare_generation_config (pre-#42702)
model_base_version = version.parse(version.parse(self.generation_config.transformers_version).base_version)
if use_model_defaults is True or (
    use_model_defaults is None and model_base_version >= version.parse("4.50.0")
):
    # merge model defaults into provided generation_config
    ...
else:
    # legacy: only copy eos/bos/pad/decoder_start token ids
    ...
```

`whisper-large-v2`'s `generation_config.json` has `transformers_version: "4.31.0.dev0"`, so `model_base_version = 4.31.0 < 4.50.0` — the merge block is **skipped**. `suppress_tokens` and `begin_suppress_tokens` (which Whisper had already cleared to `None`) stay `None`.

Note: without this version gate — even before #42702 — the double-call would have reset `suppress_tokens` and `begin_suppress_tokens` from the model's config, and the test would have failed the same way. The gate was accidentally acting as the safeguard.

**After #42702 (bad commit: `a81e04a923`) — test fails**

The version-gated logic was replaced with an unconditional merge:

```python
# utils.py _prepare_generation_config (post-#42702)
generation_config.update(**self.generation_config.to_dict(), defaults_only=True)
```

`defaults_only=True` means: update a field only if its current value is `None`. Whisper had cleared both fields to `None`, so the second `_prepare_generation_config` call now restores them from the model's config (`suppress_tokens=[1, 2, 7, ...]`, `begin_suppress_tokens=[220, 50257]`), undoing the intentional clearing.

The full failure chain:

1. Whisper's `generate()` override calls `_prepare_generation_config` (first call) → `suppress_tokens` and `begin_suppress_tokens` set from `generation_config.json`.
2. For speculative decoding, `begin_suppress_tokens` is explicitly cleared to `None` (line ~731) so the assistant model can emit EOS.
3. `_retrieve_logit_processors()` creates the logits processors and clears `suppress_tokens = None` as well.
4. Whisper calls `super().generate(generation_config=generation_config, ...)`.
5. Inside `super().generate()`, `_prepare_generation_config` is called **again** — both fields are `None` (== global default), so `defaults_only=True` restores `suppress_tokens=[1, 2, 7, ...]` and `begin_suppress_tokens=[220, 50257]`.
6. `_get_logits_processor` creates a `SuppressTokensAtBeginLogitsProcessor` suppressing token 50257 (`<|endoftext|>`) at position 0 in the assistant model — it can no longer stop, and hallucinates `"Thank you."`.

## Fix

Pass `suppress_tokens` and `begin_suppress_tokens` explicitly to `super().generate()`. Since both are `None` at that point (cleared by `_retrieve_logit_processors()`), the final `generation_config.update(**kwargs)` step in `_prepare_generation_config` (which has **no** `defaults_only` restriction) pins them at `None`, overriding the model-defaults merge.

## Testing

- `test_speculative_decoding_non_distil` now **PASSES** (verified on GPU runner at commit `a81e04a923`)
- Full `WhisperModelIntegrationTests` suite passes on the PR branch

## Remark

The root cause is PR #42702. That PR is also responsible for the `test_speculative_decoding_distil` failure, which was separately fixed in PR #48000 (Fix 4 there). However, that fix addressed a different symptom (confidence threshold sync); it did not fix `test_speculative_decoding_non_distil`. This PR fixes the remaining failure.