### PR TITLE
[AudioProcessor] add BaseAudioProcessor and SpectrogramConfig

### DIFF
--- a/src/transformers/audio_processing_base.py
+++ b/src/transformers/audio_processing_base.py
@@ -1,0 +1,359 @@
+# Copyright 2025 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import warnings
+from dataclasses import fields, replace
+from typing import Any, ClassVar, TypeVar
+
+from .audio_utils import MelScaleConfig, is_valid_audio, load_audio
+from .preprocessing_base import BatchFeature as BaseBatchFeature
+from .preprocessing_base import PreprocessingMixin
+from .utils import (
+    FEATURE_EXTRACTOR_NAME,
+    copy_func,
+    logging,
+)
+
+
+_LEGACY_KEY_MAP = {
+    "input_features": "audio_features",
+    "input_values": "audio_values",
+    "audio_input_features": "audio_features",
+}
+
+
+AudioProcessorType = TypeVar("AudioProcessorType", bound="AudioProcessingMixin")
+
+
+logger = logging.get_logger(__name__)
+
+
+class BatchFeature(BaseBatchFeature):
+    r"""
+    Holds the output of the audio processor specific `__call__` methods.
+
+    This class is derived from a python dictionary and can be used as a dictionary.
+
+    Args:
+        data (`dict`):
+            Dictionary of lists/arrays/tensors returned by the __call__ method ('input_values', 'input_features', etc.).
+        tensor_type (`Union[None, str, TensorType]`, *optional*):
+            You can give a tensor_type here to convert the lists of integers in PyTorch/Numpy Tensors at
+            initialization.
+    """
+
+    _warned_keys: ClassVar[set] = set()
+
+    def __getitem__(self, item):
+        if isinstance(item, str) and item not in self.data:
+            new_key = self._resolve_legacy_key(item)
+            if new_key is not None and new_key in self.data:
+                if item not in BatchFeature._warned_keys:
+                    warnings.warn(
+                        f"Accessing '{item}' is deprecated, use '{new_key}' instead.",
+                        FutureWarning,
+                        stacklevel=2,
+                    )
+                    BatchFeature._warned_keys.add(item)
+                return self.data[new_key]
+        return super().__getitem__(item)
+
+    def __contains__(self, item):
+        if item in self.data:
+            return True
+        new_key = self._resolve_legacy_key(item)
+        return new_key is not None and new_key in self.data
+
+    def __getattr__(self, item):
+        # `outputs.input_features` is as common in the wild as `outputs["input_features"]`.
+        if isinstance(item, str) and item not in ("data", "skip_tensor_conversion"):
+            new_key = self._resolve_legacy_key(item)
+            if new_key is not None and new_key in self.data:
+                return self[item]
+        return super().__getattr__(item)
+
+    def __delitem__(self, item):
+        # Makes `pop`/`del` on a legacy key work, since both route through here.
+        if isinstance(item, str) and item not in self.data:
+            new_key = self._resolve_legacy_key(item)
+            if new_key is not None and new_key in self.data:
+                item = new_key
+        del self.data[item]
+
+    def _resolve_legacy_key(self, old_key):
+        if old_key in ("attention_mask", "padding_mask"):
+            if "audio_features_mask" in self.data:
+                return "audio_features_mask"
+            if "audio_values_mask" in self.data:
+                return "audio_values_mask"
+            return None
+        return _LEGACY_KEY_MAP.get(old_key)
+
+
+class AudioProcessingMixin(PreprocessingMixin):
+    """
+    This is an audio processor mixin used to provide saving/loading functionality for audio processors.
+    """
+
+    _config_name = FEATURE_EXTRACTOR_NAME
+    _type_key = "audio_processor_type"
+    _nested_config_keys = ["audio_processor", "feature_extractor"]
+    _auto_class_default = "AutoAudioProcessor"
+    _file_type_label = "audio processor"
+    # `_cached_stft_window` holds a `(window, frame_length)` array/tensor pair populated on the first call;
+    # without excluding it, `save_pretrained` after any call hands a tensor to the JSON writer.
+    _excluded_dict_keys = {"mel_filters", "window", "_cached_stft_window"}
+    _extra_init_pops = ["feature_extractor_type"]
+    _config_filename_kwarg = "audio_processor_filename"
+    _subfolder_default = ""
+
+    # Legacy hub-config translation. Hub `preprocessor_config.json` files written by the
+    # old `XxxFeatureExtractor` classes use a flat key schema that doesn't match the new
+    # nested `SpectrogramConfig` API. `from_dict` applies `_legacy_field_mapping_base`
+    # first, then any per-model `legacy_field_mapping` last (highest priority). Values:
+    #
+    #   - str:       dot-path to the nested target (e.g. ``"spectrogram_config.stft_config.hop_length"``)
+    #                — `from_dict` walks/creates intermediate dicts and writes the value.
+    #   - callable:  invoked as ``f(value, config_dict)`` and expected to mutate
+    #                ``config_dict`` in place. For non-1:1 mappings, where one legacy key has to be
+    #                spread across several modern ones. Note the callable *consumes* the legacy key:
+    #                if the modern API keeps a field of the same name, leave it out of the mapping
+    #                entirely so it passes through untranslated (see `sampling_rate` below).
+    #   - None:      drop the legacy key with no translation.
+    #
+    # The base mapping covers both universal keys (`return_attention_mask`, `feature_extractor_type`,
+    # …) and spectrogram-domain keys (`n_fft`, `hop_length`, …). For non-spectrogram models
+    # the spectrogram keys are simply absent from the hub config — translation is a no-op.
+    # See docs/adr/0002-legacy-field-mapping.md.
+    _legacy_field_mapping_base: dict = {
+        # Universal keys (apply to every audio processor).
+        # NOTE: `sampling_rate` is intentionally not listed — the hub key matches the modern
+        # instance attribute `sampling_rate` verbatim, so it passes through `from_dict` untranslated.
+        "feature_extractor_type": None,
+        "audio_processor_type": None,
+        "processor_class": None,
+        "return_attention_mask": "return_padding_mask",
+        # Length keys, in samples.
+        "n_samples": "max_length",
+        "nb_max_samples": "max_length",
+        # Spectrogram-domain keys, skipped for models that declare no `spectrogram_config`
+        # (see `_legacy_target_exists`). Several appear under more than one legacy spelling.
+        "hop_length": "spectrogram_config.stft_config.hop_length",
+        "n_fft": "spectrogram_config.stft_config.n_fft",
+        "fft_length": "spectrogram_config.stft_config.n_fft",
+        "fft_window_size": "spectrogram_config.stft_config.n_fft",
+        "win_length": "spectrogram_config.stft_config.win_length",
+        "frame_length": "spectrogram_config.stft_config.win_length",
+        "window_fn": "spectrogram_config.stft_config.window_fn",
+        "power": "spectrogram_config.stft_config.power",
+        "center": "spectrogram_config.stft_config.center",
+        "pad_mode": "spectrogram_config.stft_config.pad_mode",
+        # `feature_size` is the mel count for the 17 spectrogram FEs that persisted it. The
+        # guard skips the raw-audio models whose configs also carry it (always as `1`); the
+        # three that produce mels *and* saved `feature_size=1` keep the count in
+        # `num_mel_bins` and opt out with `"feature_size": None`.
+        "feature_size": "spectrogram_config.mel_scale_config.n_mels",
+        "num_mel_bins": "spectrogram_config.mel_scale_config.n_mels",
+        "f_min": "spectrogram_config.mel_scale_config.f_min",
+        "f_max": "spectrogram_config.mel_scale_config.f_max",
+        "min_frequency": "spectrogram_config.mel_scale_config.f_min",
+        "max_frequency": "spectrogram_config.mel_scale_config.f_max",
+        "frequency_min": "spectrogram_config.mel_scale_config.f_min",
+        "frequency_max": "spectrogram_config.mel_scale_config.f_max",
+        "preemphasis": "spectrogram_config.preemphasis",
+        "mel_floor": "spectrogram_config.mel_floor",
+        # Derived from the keys above; the modern pipeline recomputes them. `max_length_s` is
+        # deliberately absent: UnivNet still reads it off the instance.
+        "nb_max_frames": None,
+        "nb_frequency_bins": None,
+    }
+    legacy_field_mapping: dict | None = None
+
+    @classmethod
+    def _legacy_target_exists(cls, target: str) -> bool:
+        """Whether the config a dot-path ``target`` writes into is declared on the class.
+
+        Guards the spectrogram-domain mappings: a raw-audio model whose hub config happens to
+        carry `hop_length` or `num_mel_bins` has no `spectrogram_config` to receive them, and
+        conjuring one out of those keys alone would silently turn it into a spectrogram
+        extractor (`_standardize_kwargs` derives `do_extract_spectrogram` from its presence).
+        """
+        config = cls
+        for part in target.split(".")[:-1]:
+            config = getattr(config, part, None)
+            if config is None:
+                return False
+        return True
+
+    @classmethod
+    def _apply_legacy_field_mapping(cls, config_dict: dict) -> dict:
+        """Translate legacy hub-config keys to the new nested schema. Mutates and returns ``config_dict``."""
+        merged = {**cls._legacy_field_mapping_base, **(cls.legacy_field_mapping or {})}
+        for legacy_key, target in merged.items():
+            if legacy_key not in config_dict:
+                continue
+            if isinstance(target, str) and not cls._legacy_target_exists(target):
+                # Leave the key flat rather than dropping it: models that compute their own
+                # features read it straight off the instance (e.g. Musicgen-Melody's `n_fft`).
+                continue
+            value = config_dict.pop(legacy_key)
+            if target is None:
+                continue
+            if callable(target):
+                target(value, config_dict)
+                continue
+            # Dot-path target: walk/create intermediate dicts. Don't overwrite an
+            # existing modern value if both legacy and modern keys are present.
+            parts = target.split(".")
+            d = config_dict
+            for part in parts[:-1]:
+                next_d = d.get(part)
+                if next_d is None:
+                    next_d = {}
+                    d[part] = next_d
+                elif not isinstance(next_d, dict):
+                    raise TypeError(
+                        f"Cannot apply legacy mapping {legacy_key!r}→{target!r}: "
+                        f"intermediate key {part!r} is not a dict ({type(next_d).__name__})."
+                    )
+                d = next_d
+            if parts[-1] not in d:
+                d[parts[-1]] = value
+        return config_dict
+
+    @classmethod
+    def from_dict(cls, config_dict: dict[str, Any], **kwargs):
+        config_dict = dict(config_dict)
+        cls._apply_legacy_field_mapping(config_dict)
+        cls._merge_spectrogram_config(config_dict)
+        return super().from_dict(config_dict, **kwargs)
+
+    @classmethod
+    def _merge_spectrogram_config(cls, config_dict: dict[str, Any]) -> None:
+        """Merge an incoming (usually partial) ``spectrogram_config`` onto the class-level one.
+
+        Legacy hub configs only carry a handful of flat keys, which `_apply_legacy_field_mapping`
+        turns into a *partial* nested dict such as ``{"stft_config": {"hop_length": 160}}``.
+        Instantiating from that alone would fall back to bare `SpectrogramConfig` defaults and
+        silently drop everything the model class defines (mel scale, log mode, dtypes, ...), so
+        the incoming values are layered on top of the class config instead.
+        """
+        incoming = config_dict.get("spectrogram_config")
+        default = getattr(cls, "spectrogram_config", None)
+        if not isinstance(incoming, dict) or default is None:
+            return
+
+        incoming = dict(incoming)
+        merged = default
+        for key, nested_cls in (("stft_config", None), ("mel_scale_config", MelScaleConfig)):
+            nested = incoming.pop(key, None)
+            if not isinstance(nested, dict):
+                continue
+            current = getattr(merged, key)
+            if current is None:
+                # No class-level nested config (e.g. a raw-audio model gaining a mel scale).
+                if nested_cls is None:
+                    continue
+                current = nested_cls()
+            valid = {f.name for f in fields(current)}
+            merged = replace(merged, **{key: replace(current, **{k: v for k, v in nested.items() if k in valid})})
+
+        valid = {f.name for f in fields(merged)}
+        config_dict["spectrogram_config"] = replace(merged, **{k: v for k, v in incoming.items() if k in valid})
+
+    @classmethod
+    def get_audio_processor_dict(
+        cls, pretrained_model_name_or_path: str | os.PathLike, **kwargs
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """
+        From a `pretrained_model_name_or_path`, resolve to a dictionary of parameters, to be used for instantiating an
+        audio processor of type [`~audio_processing_base.AudioProcessingMixin`] using `from_dict`.
+
+        Parameters:
+            pretrained_model_name_or_path (`str` or `os.PathLike`):
+                The identifier of the pre-trained checkpoint from which we want the dictionary of parameters.
+            subfolder (`str`, *optional*, defaults to `""`):
+                In case the relevant files are located inside a subfolder of the model repo on huggingface.co, you can
+                specify the folder name here.
+            audio_processor_filename (`str`, *optional*, defaults to `"preprocessor_config.json"`):
+                The name of the file in the model directory to use for the audio processor config.
+
+        Returns:
+            `tuple[Dict, Dict]`: The dictionary(ies) that will be used to instantiate the audio processor object.
+        """
+        return cls._get_config_dict(pretrained_model_name_or_path, **kwargs)
+
+    def fetch_audio(self, audio_url_or_urls: str | list[str] | list[list[str]], sampling_rate: int | None = None):
+        """
+        Convert a single or a list of urls into the corresponding `np.ndarray` objects.
+
+        If a single url is passed, the return value will be a single object. If a list is passed a list of objects is
+        returned.
+        """
+        if sampling_rate is None:
+            sampling_rate = getattr(self, "sampling_rate", 16000)
+        if isinstance(audio_url_or_urls, list):
+            return [self.fetch_audio(x, sampling_rate=sampling_rate) for x in audio_url_or_urls]
+        elif isinstance(audio_url_or_urls, str):
+            return load_audio(audio_url_or_urls, sampling_rate=sampling_rate)
+        elif is_valid_audio(audio_url_or_urls):
+            return audio_url_or_urls
+        else:
+            raise TypeError(f"only a single or a list of entries is supported but got type={type(audio_url_or_urls)}")
+
+
+def make_legacy_audio_processor_alias(new_class: type, legacy_name: str) -> type:
+    """Create a deprecated subclass alias for the legacy ``XxxFeatureExtractor`` name.
+
+    Instantiating the alias emits a ``FutureWarning`` directing users to the new class. The
+    alias overrides ``to_dict`` so that saved configs identify themselves under the new
+    class name (``audio_processor_type: "WhisperAudioProcessor"``, not the legacy name) —
+    a `from_pretrained` followed by `save_pretrained` is enough to migrate a checkpoint.
+
+    Removal target: transformers v5.15. See [ADR 0002](docs/adr/0002-legacy-field-mapping.md).
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            f"`{legacy_name}` is deprecated and will be removed in transformers v5.15. "
+            f"Use `{new_class.__name__}` instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        new_class.__init__(self, *args, **kwargs)
+
+    def to_dict(self):
+        output = new_class.to_dict(self)
+        # Migrate only direct alias instances; user subclasses keep their own class name.
+        if type(self).__name__ == legacy_name:
+            output[self._type_key] = new_class.__name__
+        return output
+
+    return type(
+        legacy_name,
+        (new_class,),
+        {
+            "__init__": __init__,
+            "to_dict": to_dict,
+            "__doc__": f"Deprecated alias for [`{new_class.__name__}`]. Removal: transformers v5.15.",
+        },
+    )
+
+
+AudioProcessingMixin.push_to_hub = copy_func(AudioProcessingMixin.push_to_hub)
+if AudioProcessingMixin.push_to_hub.__doc__ is not None:
+    AudioProcessingMixin.push_to_hub.__doc__ = AudioProcessingMixin.push_to_hub.__doc__.format(
+        object="audio processor", object_class="AutoFeatureExtractor", object_files="audio processor file"
+    )

--- a/src/transformers/audio_processing_utils.py
+++ b/src/transformers/audio_processing_utils.py
@@ -1,0 +1,844 @@
+# Copyright 2025 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from dataclasses import fields, replace
+from typing import Any, Unpack
+
+import numpy as np
+from huggingface_hub.dataclasses import validate_typed_dict
+
+from .audio_processing_base import AudioProcessingMixin, BatchFeature
+from .audio_utils import (
+    AudioInput,
+    SpectrogramConfig,
+    _array_namespace,
+    _clamp_min,
+    amplitude_to_db,
+    make_list_of_audio,
+    power_to_db,
+)
+from .processing_utils import AudioKwargs
+from .tokenization_utils_base import TruncationStrategy
+from .utils import PaddingStrategy, TensorType, logging
+
+
+logger = logging.get_logger(__name__)
+
+
+class BaseAudioProcessor(AudioProcessingMixin):
+    valid_kwargs = AudioKwargs
+    # `valid_kwargs` is the config surface; this is the subset `__call__` accepts. Everything a model adds
+    # on top of `AudioKwargs` is config-only by default, because model hooks read `self.x` rather than the
+    # merged kwarg — a model wanting a genuine per-call knob allowlists it *and* adds a read site (see
+    # `Qwen3ASRAudioProcessor._postprocess_output`). See docs/adr/0007-per-call-kwargs-allowlist.md.
+    per_call_kwargs = set(AudioKwargs.__annotations__) - {"add_channel_dim"}
+
+    add_channel_dim: bool = False
+    padding = True
+    padding_side = "right"
+    padding_value = 0.0
+    return_padding_mask = True
+    do_batch_spectrogram = True
+    # Keys `_postprocess_output` adds on top of the derived ones, for `model_input_names`.
+    extra_model_input_names: list[str] = []
+    dither: float = 0.0
+    # Output keys left untouched by `convert_to_tensors`, for non-array metadata a model
+    # returns alongside its features (e.g. Cohere-ASR's `audio_chunk_index`).
+    skip_tensor_conversion: list[str] = []
+
+    def __init__(
+        self,
+        sampling_rate: int | None = None,
+        **kwargs: Unpack[AudioKwargs],
+    ):
+        if sampling_rate is not None:
+            self.sampling_rate = sampling_rate
+        if self.sampling_rate is None:
+            raise ValueError(
+                f"`sampling_rate` must be set either as a class attribute on {self.__class__.__name__} "
+                "or passed to __init__."
+            )
+
+        super().__init__(**kwargs)
+        # _set_attributes runs in the backend subclasses' __init__, not here, for remote-code BC.
+
+    def _set_attributes(self, **kwargs):
+        """Called from the backend subclasses' ``__init__`` (not the base, for remote-code BC)."""
+        super()._set_attributes(**kwargs)
+        # Validate the *resolved* attribute set, not just what the caller passed: a bad value reaching us
+        # from a class default or a hub config should fail here, not crash somewhere inside `_preprocess`.
+        validate_typed_dict(self.valid_kwargs, {key: getattr(self, key) for key in self._valid_kwargs_names})
+        if self.spectrogram_config is not None:
+            if self.spectrogram_config.mel_scale_config is not None and not hasattr(self, "mel_filters"):
+                self.mel_filters = self._mel_filter_bank(self.spectrogram_config)
+        self._cached_stft_window = None
+
+    @property
+    def model_input_names(self) -> list[str]:
+        """The keys `__call__` emits, i.e. the kwargs the model's `forward` accepts.
+
+        Mirrors how `_standardize_kwargs` resolves `do_extract_spectrogram`. Declare
+        `extra_model_input_names` for keys `_postprocess_output` adds; shadow this with a plain
+        list only when it *renames* the derived keys. A composite processor subtracts the ones
+        it consumes itself via its `unused_input_names`.
+        """
+        extracts_spectrogram = getattr(self, "do_extract_spectrogram", self.spectrogram_config is not None)
+        key = "audio_features" if extracts_spectrogram else "audio_values"
+        names = [key, f"{key}_mask"] if self.return_padding_mask else [key]
+        return names + self.extra_model_input_names
+
+    def _standardize_kwargs(
+        self,
+        **kwargs,
+    ) -> dict:
+        if isinstance(kwargs.get("spectrogram_config"), dict):
+            kwargs["spectrogram_config"] = SpectrogramConfig.from_dict(kwargs["spectrogram_config"])
+        if kwargs.get("spectrogram_config") is not None and kwargs.get("do_extract_spectrogram") is None:
+            kwargs["do_extract_spectrogram"] = True
+        return kwargs
+
+    def _validate_preprocess_kwargs(
+        self,
+        sampling_rate: int | None = None,
+        max_length: int | None = None,
+        truncation: bool | None = None,
+        pad_to_multiple_of: int | None = None,
+        return_tensors: str | TensorType | None = None,
+        **kwargs,
+    ):
+        if truncation and max_length is None:
+            raise ValueError("When setting `truncation=True`, make sure that `max_length` is defined.")
+
+    def _serialize_value(self, key, value):
+        if key == "spectrogram_config" and hasattr(value, "to_dict"):
+            return value.to_dict()
+        return value
+
+    def __call__(self, audio: AudioInput, *args, **kwargs: Unpack[AudioKwargs]) -> BatchFeature:
+        # `return_attention_mask` was the legacy spelling of `return_padding_mask`. Alias it rather than
+        # letting it fall through to `**kwargs` unread — a silently ignored mask request is the exact
+        # failure this contract removes. Removal target: v5.15, alongside the other legacy aliases.
+        if "return_attention_mask" in kwargs:
+            warnings.warn(
+                "`return_attention_mask` is deprecated and will be removed in transformers v5.15. "
+                "Use `return_padding_mask` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            kwargs.setdefault("return_padding_mask", kwargs.pop("return_attention_mask"))
+        return super().preprocess(audio, *args, **kwargs)
+
+    def _preprocess_like_inputs(self, audio: AudioInput, *args, **kwargs) -> BatchFeature:
+        return self._preprocess_audio_like_inputs(audio, *args, **kwargs)
+
+    def _preprocess_audio_like_inputs(
+        self,
+        audio: AudioInput,
+        *args,
+        sampling_rate: int | None = None,
+        **kwargs: Unpack[AudioKwargs],
+    ) -> BatchFeature:
+        audio = self._prepare_audio_like_inputs(audio=audio, sampling_rate=sampling_rate)
+        return self._preprocess(audio, *args, **kwargs)
+
+    def _prepare_audio_like_inputs(self, audio: AudioInput, *args, sampling_rate: int | None = None, **kwargs) -> list:
+        audio, sampling_rate = self._prepare_audio_structure(audio, sampling_rate=sampling_rate)
+        audio = [self.process_audio(audio_el) for audio_el in audio]
+        # Resample after `process_audio`, so `_resample` always sees a mono waveform in the backend's
+        # own array type.
+        if sampling_rate != self.sampling_rate:
+            logger.warning_once(
+                f"Resampling audio from {sampling_rate} Hz to {self.__class__.__name__}'s native sampling rate "
+                f"of {self.sampling_rate} Hz. Pass audio already sampled at {self.sampling_rate} Hz to skip this."
+            )
+            audio = [self._resample(audio_el, sampling_rate, self.sampling_rate) for audio_el in audio]
+        return audio
+
+    def _prepare_audio_structure(self, audio: AudioInput, sampling_rate: int | None = None) -> tuple[list, int]:
+        """Resolve `audio` to a list of waveforms, plus the rate those waveforms are actually at.
+
+        `sampling_rate` describes *passed arrays* only: it is the caller's assertion about data we cannot
+        inspect. Audio referenced by URL or path is decoded at the native rate by construction, so a rate
+        given alongside such input has nothing to describe and is ignored.
+        """
+        is_url_input = isinstance(audio, str) or (
+            isinstance(audio, (list, tuple)) and all(isinstance(el, str) for el in audio)
+        )
+
+        if is_url_input:
+            # `preprocess` setdefaults `sampling_rate` from `self.sampling_rate`, so only a caller who
+            # passed a *different* rate is telling us something we cannot honour.
+            if sampling_rate is not None and sampling_rate != self.sampling_rate:
+                logger.warning_once(
+                    f"Ignoring `sampling_rate={sampling_rate}`: audio given as a URL or path is decoded at "
+                    f"{self.__class__.__name__}'s native sampling rate of {self.sampling_rate}. "
+                    "`sampling_rate` describes audio passed as an array."
+                )
+            return make_list_of_audio(self.fetch_audio(audio)), self.sampling_rate
+
+        return make_list_of_audio(audio), sampling_rate if sampling_rate is not None else self.sampling_rate
+
+    def _resample(self, audio, orig_sampling_rate: int, target_sampling_rate: int):
+        """Resample one mono waveform to ``target_sampling_rate``. Implemented per backend."""
+        raise NotImplementedError
+
+    def process_audio(self, *args, **kwargs):
+        return self._process_audio(*args, **kwargs)
+
+    def _preprocess(
+        self,
+        audio: list[np.ndarray] | list["torch.Tensor"],
+        padding: bool | str | PaddingStrategy | None,
+        max_length: int | None,
+        truncation: bool | str | TruncationStrategy | None,
+        pad_to_multiple_of: int | None,
+        return_tensors: str | TensorType | None,
+        spectrogram_config: SpectrogramConfig | None = None,
+        do_extract_spectrogram: bool | None = True,
+        do_batch_spectrogram: bool | None = True,
+        **kwargs: Any,
+    ) -> BatchFeature:
+        # Path 1: per-waveform spectrogram extraction, padded at the feature level.
+        if do_extract_spectrogram and not do_batch_spectrogram:
+            features = self.extract_spectrogram(audio, spectrogram_config=spectrogram_config, **kwargs)
+            feature_lengths = [f.shape[0] for f in features]
+            features = self._postprocess_features(features, feature_lengths)
+            features, feature_ranges = self._pad_features(
+                features,
+                padding,
+                max_length,
+                truncation,
+                pad_to_multiple_of,
+            )
+            output = {"audio_features": self._stack_features(features)}
+            if self.return_padding_mask:
+                output["audio_features_mask"] = self._get_mask(feature_ranges, features[0].shape[0])
+            output = self._postprocess_output(output, feature_ranges=feature_ranges, **kwargs)
+            return BatchFeature(
+                data=output, tensor_type=return_tensors, skip_tensor_conversion=self.skip_tensor_conversion
+            )
+
+        # Path 2: pad audio first, then optionally extract a spectrogram on the padded batch.
+        audio, audio_ranges = self.pad(audio, padding, max_length, truncation, pad_to_multiple_of)
+        padded_length = audio[0].shape[-1]
+        batched = self._to_batch(audio)
+
+        if do_extract_spectrogram:
+            output = {
+                "audio_features": self.extract_spectrogram(
+                    batched,
+                    spectrogram_config=spectrogram_config,
+                    audio_ranges=audio_ranges,
+                    **kwargs,
+                )
+            }
+        else:
+            output = {"audio_values": batched}
+
+        if self.return_padding_mask:
+            # Features live on the frame axis: map audio ranges → feature ranges via hop_length.
+            if do_extract_spectrogram:
+                spec_cfg = spectrogram_config or self.spectrogram_config
+                audio_lengths = np.array([end - start for start, end in audio_ranges])
+                feature_lengths = self._get_valid_feature_lengths(audio_lengths, spec_cfg)
+                mask_ranges = [(0, int(length)) for length in feature_lengths]
+                mask_length = self._get_mask_width(padded_length, spec_cfg)
+            else:
+                mask_ranges = audio_ranges
+                mask_length = padded_length
+            mask_key = "audio_features_mask" if do_extract_spectrogram else "audio_values_mask"
+            output[mask_key] = self._get_mask(mask_ranges, mask_length)
+
+        output = self._postprocess_output(output, audio_ranges=audio_ranges, **kwargs)
+        return BatchFeature(
+            data=output, tensor_type=return_tensors, skip_tensor_conversion=self.skip_tensor_conversion
+        )
+
+    def _postprocess_features(self, features, feature_lengths):
+        """Hook: per-utterance feature processing after extraction, before feature-level padding.
+        Override for normalization that must happen on unpadded features
+        """
+        return features
+
+    def _postprocess_output(self, output, audio_ranges=None, feature_ranges=None, **kwargs):
+        """Hook: augment or modify the output dict after main processing.
+        Override to add custom fields (e.g., audio_embed_sizes) or post-hoc normalization on the stacked/batched output.
+        """
+        return output
+
+    def _get_padding_strategies(self, padding=False, max_length=None):
+        if padding is not False:
+            if padding is True:
+                padding_strategy = PaddingStrategy.LONGEST
+            elif not isinstance(padding, PaddingStrategy):
+                padding_strategy = PaddingStrategy(padding)
+            elif isinstance(padding, PaddingStrategy):
+                padding_strategy = padding
+        else:
+            padding_strategy = PaddingStrategy.DO_NOT_PAD
+
+        if max_length is None:
+            if padding_strategy == PaddingStrategy.MAX_LENGTH:
+                raise ValueError(
+                    f"When setting ``padding={PaddingStrategy.MAX_LENGTH}``, make sure that max_length is defined"
+                )
+
+        if padding_strategy != PaddingStrategy.DO_NOT_PAD and (self.padding_value is None):
+            raise ValueError(
+                "Asking to pad but the feature_extractor does not have a padding value. Please select a value to use"
+                " as `padding_value`. For example: `feature_extractor.padding_value = 0.0`."
+            )
+
+        return padding_strategy
+
+    def pad(
+        self,
+        audio: list[np.ndarray] | list["torch.Tensor"],
+        padding: bool | str | PaddingStrategy = True,
+        max_length: int | None = None,
+        truncation: bool = False,
+        pad_to_multiple_of: int | None = None,
+    ) -> tuple[list, list[tuple[int, int]]]:
+        padding_strategy = self._get_padding_strategies(padding=padding, max_length=max_length)
+
+        if truncation:
+            # `_validate_preprocess_kwargs` enforces this on the `preprocess` path, but `pad` is public
+            # and callable directly, where that hook never runs.
+            if max_length is None:
+                raise ValueError("When setting `truncation=True`, make sure that `max_length` is defined.")
+            trunc_length = max_length
+            if pad_to_multiple_of is not None and (trunc_length % pad_to_multiple_of != 0):
+                trunc_length = ((trunc_length // pad_to_multiple_of) + 1) * pad_to_multiple_of
+            audio = [self._truncate_single(audio_el, max_length=trunc_length) for audio_el in audio]
+
+        if padding_strategy == PaddingStrategy.LONGEST:
+            max_length = max(audio_el.shape[-1] for audio_el in audio)
+            padding_strategy = PaddingStrategy.MAX_LENGTH
+
+        if max_length is not None and pad_to_multiple_of is not None and (max_length % pad_to_multiple_of != 0):
+            max_length = ((max_length // pad_to_multiple_of) + 1) * pad_to_multiple_of
+
+        actual_lengths = [audio_el.shape[-1] for audio_el in audio]
+
+        if padding_strategy != PaddingStrategy.DO_NOT_PAD:
+            audio = [self._pad_single(audio_el, max_length=max_length) for audio_el in audio]
+
+        audio_ranges = []
+        for i, length in enumerate(actual_lengths):
+            padded_length = audio[i].shape[-1]
+            if self.padding_side == "left":
+                audio_ranges.append((padded_length - length, padded_length))
+            else:
+                audio_ranges.append((0, length))
+
+        return audio, audio_ranges
+
+    def _truncate_single(self, audio_el, max_length: int):
+        return audio_el[..., :max_length] if audio_el.shape[-1] > max_length else audio_el
+
+    def _pad_features(self, features, padding, max_length, truncation, pad_to_multiple_of):
+        padding_strategy = self._get_padding_strategies(padding=padding, max_length=max_length)
+        if truncation and max_length is not None:
+            features = [f[:max_length] for f in features]
+        actual_lengths = [f.shape[0] for f in features]
+        if padding_strategy == PaddingStrategy.LONGEST:
+            max_length = max(actual_lengths)
+            padding_strategy = PaddingStrategy.MAX_LENGTH
+        if max_length is not None and pad_to_multiple_of is not None and max_length % pad_to_multiple_of != 0:
+            max_length = ((max_length // pad_to_multiple_of) + 1) * pad_to_multiple_of
+        if padding_strategy == PaddingStrategy.MAX_LENGTH and max_length is not None:
+            features = [f if f.shape[0] >= max_length else self._pad_feature_single(f, max_length) for f in features]
+        return features, [(0, length) for length in actual_lengths]
+
+    def _pad_feature_single(self, feature, max_length):
+        """Right-pad one feature array/tensor along its first (time) axis with `padding_value`."""
+        return self._pad_axis(feature, 0, max_length - feature.shape[0], axis=0, value=self.padding_value)
+
+    def _process_audio(self, audio_el):
+        audio_el = self._as_backend_array(audio_el)
+        if audio_el.ndim > 1:
+            # Multi-channel input is always averaged down to mono.
+            audio_el = self._squeeze_axis0(audio_el) if audio_el.shape[0] == 1 else self._mean_axis0(audio_el)
+        return audio_el
+
+    def _to_batch(self, audio):
+        batch = self._stack(audio)
+        if self.add_channel_dim:
+            batch = self._insert_channel_dim(batch)
+        return batch
+
+    def _pad_single(self, audio, max_length: int) -> AudioInput:
+        current_length = audio.shape[-1]
+        if current_length >= max_length:
+            return audio
+        pad = max_length - current_length
+        if self.padding_side == "right":
+            left, right = 0, pad
+        elif self.padding_side == "left":
+            left, right = pad, 0
+        else:
+            raise ValueError(f"Invalid padding side: {self.padding_side}")
+        return self._pad_axis(audio, left, right, axis=-1, value=self.padding_value)
+
+    def _stack_features(self, features):
+        return self._stack(features)
+
+    def _get_mask(self, ranges, padded_length):
+        mask = self._zeros_int32((len(ranges), padded_length))
+        for i, (start, end) in enumerate(ranges):
+            mask[i, start:end] = 1
+        return mask
+
+    # ── Spectrogram core ─────────────────────────────────────────────────
+
+    def extract_spectrogram(self, audio, *, spectrogram_config: SpectrogramConfig | None = None, **kwargs):
+        if spectrogram_config is None:
+            spectrogram_config = self.spectrogram_config
+
+        config_field_names = {f.name for f in fields(SpectrogramConfig)}
+        overrides = {k: kwargs.pop(k) for k in list(kwargs) if k in config_field_names}
+        if overrides:
+            spectrogram_config = replace(spectrogram_config, **overrides)
+
+        norm_kwargs = {k: v for k, v in kwargs.items() if k not in ("audio_ranges", "feature_ranges")}
+
+        if isinstance(audio, list):
+            features = [self._extract_spectrogram(a, spectrogram_config=spectrogram_config, **kwargs) for a in audio]
+            if spectrogram_config.mel_scale_config is not None:
+                features = [
+                    self._apply_mel_scale(f, spectrogram_config=spectrogram_config, **kwargs) for f in features
+                ]
+            features = [
+                self._normalize_magnitude(f, spectrogram_config=spectrogram_config, **norm_kwargs) for f in features
+            ]
+        else:
+            features = self._extract_spectrogram(audio, spectrogram_config=spectrogram_config, **kwargs)
+            if spectrogram_config.mel_scale_config is not None:
+                features = self._apply_mel_scale(features, spectrogram_config=spectrogram_config, **kwargs)
+            features = self._normalize_magnitude(features, spectrogram_config=spectrogram_config, **norm_kwargs)
+
+        return features
+
+    def _extract_spectrogram(self, audio, *, spectrogram_config, **kwargs):
+        return self._stft(audio, spectrogram_config=spectrogram_config, **kwargs)
+
+    def _stft(self, audio, *, spectrogram_config, **kwargs):
+        stft_cfg = spectrogram_config.stft_config
+        needs_manual_framing = self._needs_manual_framing(spectrogram_config)
+        if stft_cfg.frame_extension:
+            if stft_cfg.frame_extension != 1:
+                raise ValueError(f"Only frame_extension=1 is supported, got {stft_cfg.frame_extension}.")
+            if stft_cfg.center is True:
+                raise ValueError("frame_extension requires center=False or center='left', not symmetric centering.")
+            if spectrogram_config.remove_dc_offset:
+                raise ValueError("remove_dc_offset is not supported with frame_extension.")
+        elif spectrogram_config.preemphasis_mode == "htk_per_frame":
+            raise ValueError("preemphasis_mode='htk_per_frame' requires frame_extension=1.")
+        if stft_cfg.fft_dtype is not None:
+            if stft_cfg.fft_dtype not in ("float64", "native"):
+                raise ValueError(f"fft_dtype must be None, 'float64' or 'native', got {stft_cfg.fft_dtype!r}.")
+            if not needs_manual_framing:
+                raise ValueError(
+                    "fft_dtype applies to the manual-framing path only; this configuration uses the native STFT."
+                )
+        n_fft = stft_cfg.n_fft
+        win_length = stft_cfg.win_length or n_fft
+        hop_length = stft_cfg.hop_length or win_length // 2
+
+        if spectrogram_config.computation_dtype and stft_cfg.fft_dtype is None:
+            # with `fft_dtype`, the cast happens at the FFT boundary instead
+            dtype_str = spectrogram_config.computation_dtype
+            if isinstance(audio, np.ndarray):
+                audio = audio.astype(dtype_str)
+            else:
+                import torch
+
+                audio = audio.to(getattr(torch, dtype_str))
+        if self.dither > 0:
+            audio = self._apply_dither(audio, kwargs.get("audio_ranges"))
+        if spectrogram_config.waveform_scale is not None:
+            audio = audio * spectrogram_config.waveform_scale
+        if spectrogram_config.preemphasis is not None and spectrogram_config.preemphasis_mode == "waveform":
+            audio = self._preemphasize_waveform(audio, spectrogram_config.preemphasis, kwargs.get("audio_ranges"))
+
+        # Cache window on first call; reuse on subsequent calls with same config
+        if self._cached_stft_window is not None and spectrogram_config is self.spectrogram_config:
+            window, frame_length = self._cached_stft_window
+        else:
+            window = self._create_stft_window(win_length, stft_cfg, audio)
+            window, frame_length = self._prepare_window_and_framing(window, win_length, n_fft, needs_manual_framing)
+            if spectrogram_config is self.spectrogram_config:
+                self._cached_stft_window = (window, frame_length)
+
+        if needs_manual_framing:
+            audio_dtype = audio.dtype
+            frames = self._frame_audio(
+                audio, window, frame_length + stft_cfg.frame_extension, hop_length, n_fft, stft_cfg
+            )
+            frames = self._apply_frame_processing(frames, spectrogram_config=spectrogram_config, **kwargs)
+            stft_out = self._window_and_fft(frames, window, frame_length, n_fft, stft_cfg, audio_dtype=audio_dtype)
+        else:
+            stft_out = self._native_stft(audio, window, frame_length, hop_length, n_fft, stft_cfg)
+
+        magnitudes = self._compute_magnitudes(stft_out, stft_cfg.power, spectrogram_config=spectrogram_config)
+        return self._cast_stft_output(magnitudes, spectrogram_config)
+
+    # ── Spectrogram hooks ────────────────────────────────────────────────
+
+    def _needs_manual_framing(self, spectrogram_config):
+        """Whether the STFT requires manual framing (unfold-based) instead of a native STFT."""
+        return (
+            (
+                spectrogram_config.preemphasis is not None
+                and spectrogram_config.preemphasis_mode in ("per_frame", "htk_per_frame")
+            )
+            or spectrogram_config.remove_dc_offset
+            or bool(spectrogram_config.stft_config.frame_extension)
+            or spectrogram_config.stft_config.center == "left"  # truthy string would center-pad natively
+            # A native STFT frames on `n_fft`; left-aligning the window inside the FFT buffer
+            # means the framing must use `win_length`, which only the manual path can do.
+            or spectrogram_config.stft_config.left_align_fft
+        )
+
+    def _cast_stft_output(self, magnitudes, spectrogram_config):
+        """Cast STFT output to the desired output dtype. Default: no-op."""
+        return magnitudes
+
+    def _frame_count(self, lengths, stft_cfg):
+        """Frames the framing yields for `lengths` samples, excluding the extra centered frame."""
+        win_length = stft_cfg.win_length or stft_cfg.n_fft
+        hop_length = stft_cfg.hop_length or win_length // 2
+        if stft_cfg.center == "left":
+            count = (lengths + win_length // 2 - (win_length + stft_cfg.frame_extension)) // hop_length + 1
+            return max(0, count) if isinstance(count, int) else count.clip(min=0)
+        if not stft_cfg.center:
+            return (lengths - (win_length + stft_cfg.frame_extension)) // hop_length + 1
+        return lengths // hop_length
+
+    def _get_mask_width(self, padded_length, spectrogram_config) -> int:
+        """Width of the extracted features' frame axis, and therefore of the padding mask.
+
+        Override when the framing produces a frame count the geometry above can't express
+        (e.g. a model that right-pads to a whole number of hops).
+        """
+        stft_cfg = spectrogram_config.stft_config
+        width = self._frame_count(padded_length, stft_cfg)
+        if stft_cfg.center and stft_cfg.center != "left":
+            width += 1  # a centered STFT emits the extra frame centered at t=0
+        if spectrogram_config.skip_last_frame:
+            width -= 1  # the log stage drops the trailing frame
+        return int(width)
+
+    def _get_valid_feature_lengths(self, audio_lengths, spectrogram_config):
+        """Per-utterance number of frames covered by real (non-padding) audio.
+
+        Honours `count_partial_frames`; override only for framing a config can't describe.
+        """
+        stft_cfg = spectrogram_config.stft_config
+        if spectrogram_config.count_partial_frames:
+            win_length = stft_cfg.win_length or stft_cfg.n_fft
+            hop_length = stft_cfg.hop_length or win_length // 2
+            return (audio_lengths + hop_length - 1) // hop_length
+        return self._frame_count(audio_lengths, stft_cfg)
+
+    # ── Spectrogram backend ──────────────────────────────────────────────
+
+    def _create_stft_window(self, win_length, stft_cfg, audio):
+        raise NotImplementedError
+
+    def _prepare_window_and_framing(self, window, win_length, n_fft, needs_manual_framing):
+        if needs_manual_framing and win_length < n_fft:
+            return window, win_length
+        if win_length < n_fft:
+            left_pad = (n_fft - win_length) // 2
+            right_pad = n_fft - win_length - left_pad
+            window = self._pad_axis(window, left_pad, right_pad, axis=-1, value=0.0)
+        return window, n_fft
+
+    def _frame_audio(self, audio, window, frame_length, hop_length, n_fft, stft_cfg):
+        """Extract overlapping frames from the audio signal.
+
+        Handles center padding and dtype promotion. Returns frames of shape
+        (..., num_frames, frame_length). Implemented by backend subclasses.
+        """
+        raise NotImplementedError
+
+    def _apply_frame_processing(self, frames, *, spectrogram_config, **kwargs):
+        """Hook: per-frame signal conditioning after frame extraction.
+
+        Called after framing, before windowing and FFT. Applies DC-offset removal, per-frame
+        (kaldi-style) preemphasis, and USM/HTK-style extended-frame preemphasis when
+        ``stft_config.frame_extension`` is set. Override for non-standard frame processing
+        that doesn't fit these knobs, e.g. boundary-frame masking (Phi4-multimodal).
+        """
+        if spectrogram_config.stft_config.frame_extension:
+            # USM-style extended frames: preemphasis consumes the extra trailing sample,
+            # reducing the frame back to `win_length`.
+            preemphasis = spectrogram_config.preemphasis
+            if preemphasis is None or preemphasis <= 0.0:
+                return frames[..., :-1]
+            if spectrogram_config.preemphasis_mode == "htk_per_frame":
+                # HTK flavor: first sample scaled by (1 - p) instead of replicate-padded
+                first = frames[..., :1] * (1.0 - preemphasis)
+                rest = frames[..., 1:-1] - preemphasis * frames[..., :-2]
+                return self._concat_last([first, rest])
+            if spectrogram_config.preemphasis_mode == "per_frame":
+                return frames[..., 1:] - preemphasis * frames[..., :-1]
+            return frames[..., :-1]  # "waveform" mode: already applied upstream
+        if spectrogram_config.remove_dc_offset:
+            frames = frames - self._mean_last(frames)
+        preemphasis = spectrogram_config.preemphasis
+        if preemphasis is not None and spectrogram_config.preemphasis_mode == "per_frame":
+            # Replicate-pad first sample (x0 - p*x0, not x0*(1-p)): bit-exact with kaldi.
+            first = frames[..., :1] - preemphasis * frames[..., :1]
+            rest = frames[..., 1:] - preemphasis * frames[..., :-1]
+            frames = self._concat_last([first, rest])
+        return frames
+
+    def _preemphasize_waveform(self, audio, preemphasis, audio_ranges=None):
+        """Waveform-level preemphasis (first sample unchanged), zeroing padded samples via
+        ``audio_ranges``. Used when ``spectrogram_config.preemphasis_mode == "waveform"``
+        (ASR models: Parakeet/Cohere/Nemotron). Implemented by backend subclasses."""
+        raise NotImplementedError
+
+    def _window_and_fft(self, frames, window, frame_length, n_fft, stft_cfg, audio_dtype=None):
+        """Apply window, zero-pad, FFT, and normalize. Returns complex STFT of shape (..., freq, time).
+        Implemented by backend subclasses."""
+        raise NotImplementedError
+
+    def _apply_dither(self, audio, audio_ranges=None):
+        """Additive dither, applied when ``self.dither`` is nonzero. Backend defaults add
+        unseeded Gaussian noise; deterministic implementations (Cohere-ASR) override.
+        ``audio_ranges`` is ``None`` on unbatched calls. Implemented by backend subclasses."""
+        raise NotImplementedError
+
+    def _native_stft(self, audio, window, frame_length, hop_length, n_fft, stft_cfg):
+        """Native STFT (e.g. torch.stft). Returns complex output. Implemented by backend subclasses."""
+        raise NotImplementedError
+
+    def _compute_magnitudes(self, stft_out, power, spectrogram_config=None):
+        """Convert complex STFT output to a real-valued magnitude spectrogram.
+        Implemented by backend subclasses. Overridable for custom magnitude computation (e.g. Parakeet)."""
+        raise NotImplementedError
+
+    def _apply_mel_scale(self, *args, **kwargs):
+        """Apply mel filterbank to spectrogram features."""
+        raise NotImplementedError
+
+    def _normalize_magnitude(
+        self, features, *, spectrogram_config, reference=1.0, min_value=1e-10, db_range=None, **kwargs
+    ):
+        log_mel = spectrogram_config.log_mode
+        if log_mel is None:
+            return self._maybe_transpose_features(self._astype(features, "float32"), spectrogram_config)
+
+        if spectrogram_config.pre_log_offset is not None:
+            result = features + spectrogram_config.pre_log_offset
+        else:
+            result = _clamp_min(features, spectrogram_config.mel_floor)
+
+        if log_mel == "log":
+            result = self._astype(_array_namespace(result).log(result), "float32")
+        elif log_mel == "log10":
+            result = self._astype(_array_namespace(result).log10(result), "float32")
+        elif log_mel == "dB":
+            power = spectrogram_config.stft_config.power
+            if power == 2.0:
+                result = power_to_db(result, reference, min_value, db_range)
+            elif power == 1.0:
+                result = amplitude_to_db(result, reference, min_value, db_range)
+            else:
+                raise ValueError(f"Cannot use log_mel option 'dB' with power {power}")
+            result = self._astype(result, "float32")
+        else:
+            raise ValueError(f"Unknown log_mel option: {log_mel}")
+
+        if spectrogram_config.skip_last_frame:
+            result = result[..., :-1]
+        result = self._apply_post_log_normalization(result, spectrogram_config)
+        return self._maybe_transpose_features(result, spectrogram_config)
+
+    def _maybe_transpose_features(self, result, spectrogram_config):
+        """Swap the mel and frame axes when ``transpose_features`` is set. Backend-agnostic:
+        ``swapaxes`` is spelled the same on numpy arrays and torch tensors."""
+        if spectrogram_config.transpose_features:
+            result = result.swapaxes(-2, -1)
+        return result
+
+    def _apply_post_log_normalization(self, result, spectrogram_config):
+        if spectrogram_config.clip_max_offset is not None:
+            max_vals = self._amax_over_features(result)
+            result = _array_namespace(result).maximum(result, max_vals - spectrogram_config.clip_max_offset)
+        if spectrogram_config.post_log_shift is not None:
+            result = result + spectrogram_config.post_log_shift
+        if spectrogram_config.post_log_scale is not None:
+            result = result * spectrogram_config.post_log_scale
+        return result
+
+    # ── Backend array-API primitives ─────────────────────────────────────
+
+    def _astype(self, x, dtype_name):
+        raise NotImplementedError
+
+    def _amax_over_features(self, x):
+        raise NotImplementedError
+
+    def _zeros_int32(self, shape):
+        raise NotImplementedError
+
+    def _as_backend_array(self, x):
+        raise NotImplementedError
+
+    def _mean_axis0(self, x):
+        raise NotImplementedError
+
+    def _squeeze_axis0(self, x):
+        raise NotImplementedError
+
+    def _pad_axis(self, x, left, right, axis, value=0.0):
+        raise NotImplementedError
+
+    def _stack(self, seq):
+        raise NotImplementedError
+
+    def _insert_channel_dim(self, batch):
+        raise NotImplementedError
+
+    def _mean_last(self, x):
+        raise NotImplementedError
+
+    def _concat_last(self, parts):
+        raise NotImplementedError
+
+    def _mel_filter_bank(self, spectrogram_config: SpectrogramConfig):
+        """Build the mel filter bank described by ``spectrogram_config.mel_scale_config``.
+
+        Backend-agnostic dispatcher: derives the geometry (number of frequency bins, FFT
+        size, frequency range) and the computation dtype, then delegates the numerical
+        construction to one of three backend leaves:
+
+        - ``_kaldi_exact_mel_banks``: ``triangularize_in_mel_space`` with no zeroed bands
+        - ``_kaldi_mel_banks_with_zero_bands``: ``triangularize_in_mel_space`` with ``bands_to_zero``
+        - ``_standard_mel_banks``: standard triangular (librosa/torchaudio-style) filters
+
+        Dtype policy: the dtype name is resolved as ``mel_scale_config.computation_dtype``
+        falling back to the top-level ``spectrogram_config.computation_dtype`` (pipelines
+        that run in float64 for legacy-FE parity need float64 filters as well), and passed
+        to the leaves as a string (or None); each backend resolves it natively. When only
+        the mel-level dtype is set, the filters are built in that dtype and cast back to
+        the backend's default float afterwards, since the rest of the pipeline runs in
+        default precision.
+        """
+        stft_cfg = spectrogram_config.stft_config
+        mel_cfg = spectrogram_config.mel_scale_config
+        n_fft = stft_cfg.n_fft
+        num_frequency_bins = 1 + n_fft // 2
+        min_frequency = mel_cfg.f_min
+        max_frequency = mel_cfg.f_max if mel_cfg.f_max is not None else self.sampling_rate / 2
+        computation_dtype = mel_cfg.computation_dtype or spectrogram_config.computation_dtype
+
+        if mel_cfg.triangularize_in_mel_space and mel_cfg.bands_to_zero == 0:
+            mel_filters = self._kaldi_exact_mel_banks(
+                mel_cfg.n_mels,
+                num_frequency_bins,
+                min_frequency,
+                max_frequency,
+                self.sampling_rate,
+                n_fft,
+                mel_cfg,
+                computation_dtype,
+            )
+        elif mel_cfg.triangularize_in_mel_space:
+            mel_filters = self._kaldi_mel_banks_with_zero_bands(
+                mel_cfg.n_mels,
+                num_frequency_bins,
+                min_frequency,
+                max_frequency,
+                self.sampling_rate,
+                n_fft,
+                mel_cfg,
+                computation_dtype,
+            )
+        else:
+            mel_filters = self._standard_mel_banks(
+                mel_cfg.n_mels,
+                num_frequency_bins,
+                min_frequency,
+                max_frequency,
+                self.sampling_rate,
+                n_fft,
+                mel_cfg,
+                computation_dtype,
+            )
+
+        # Cast back when only the mel-level dtype requested higher precision.
+        if mel_cfg.computation_dtype is not None and not spectrogram_config.computation_dtype:
+            mel_filters = self._cast_mel_filters_to_default_float(mel_filters)
+        return mel_filters
+
+    def _kaldi_exact_mel_banks(
+        self,
+        num_mel_filters,
+        num_frequency_bins,
+        min_frequency,
+        max_frequency,
+        sampling_rate,
+        n_fft,
+        mel_cfg,
+        computation_dtype,
+    ):
+        """Mel filter bank triangularized in mel space, without zeroed bands.
+
+        Each backend leaf owns its ecosystem's rounding pattern: the torch leaf matches
+        ``torchaudio.compliance.kaldi.get_mel_banks`` arithmetic, the numpy leaf matches
+        the legacy numpy feature extractors. Numerically equivalent, not bit-identical.
+        Implemented by backend subclasses."""
+        raise NotImplementedError
+
+    def _kaldi_mel_banks_with_zero_bands(
+        self,
+        num_mel_filters,
+        num_frequency_bins,
+        min_frequency,
+        max_frequency,
+        sampling_rate,
+        n_fft,
+        mel_cfg,
+        computation_dtype,
+    ):
+        """Mel filter bank triangularized in mel space with the lowest ``bands_to_zero``
+        frequency bins zeroed out. Implemented by backend subclasses."""
+        raise NotImplementedError
+
+    def _standard_mel_banks(
+        self,
+        num_mel_filters,
+        num_frequency_bins,
+        min_frequency,
+        max_frequency,
+        sampling_rate,
+        n_fft,
+        mel_cfg,
+        computation_dtype,
+    ):
+        """Standard (non-kaldi) triangular mel filter bank. Each backend leaf owns its
+        ecosystem's rounding pattern (numpy: librosa/legacy numpy FEs; torch: torchaudio).
+        Implemented by backend subclasses."""
+        raise NotImplementedError
+
+    def _cast_mel_filters_to_default_float(self, mel_filters):
+        """Cast a built filter bank to the backend's default float dtype (torch:
+        ``torch.get_default_dtype()``, numpy: float32). Implemented by backend subclasses."""
+        raise NotImplementedError

--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -19,9 +19,10 @@ and remove unnecessary dependencies.
 import base64
 import importlib
 import io
+import math
 import os
 import warnings
-from collections.abc import Sequence
+from dataclasses import dataclass, field, fields
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, Union
 from urllib.parse import urlparse
@@ -34,6 +35,7 @@ from .utils import (
     is_librosa_available,
     is_numpy_array,
     is_soundfile_available,
+    is_torch_available,
     is_torch_tensor,
     is_torchaudio_available,
     is_torchcodec_available,
@@ -60,7 +62,113 @@ if is_torchaudio_available():
 if is_torchcodec_available():
     TORCHCODEC_VERSION = version.parse(importlib.metadata.version("torchcodec"))
 
-AudioInput = Union[np.ndarray, "torch.Tensor", Sequence[np.ndarray], Sequence["torch.Tensor"]]
+AudioInput = Union[np.ndarray, "torch.Tensor", list[np.ndarray], list["torch.Tensor"]]
+
+
+@dataclass(frozen=True)
+class StftConfig:
+    n_fft: int = 400
+    win_length: int | None = None
+    hop_length: int | None = None
+    window_fn: str = "hann_window"
+    wkwargs: dict | None = None
+    power: float = 2.0
+    center: bool | str = True
+    pad_mode: str = "reflect"
+    normalized: bool = False
+    onesided: bool | None = None
+    periodic: bool = True
+    left_align_fft: bool = False
+    window_dtype: str | None = None
+    frame_extension: int = 0
+    fft_dtype: str | None = None
+    magnitude_mode: str | None = None
+
+    def to_dict(self) -> dict:
+        return {f.name: getattr(self, f.name) for f in fields(self) if getattr(self, f.name) is not None}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "StftConfig":
+        valid_keys = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in d.items() if k in valid_keys})
+
+
+@dataclass(frozen=True)
+class MelScaleConfig:
+    n_mels: int = 128
+    f_min: float = 0.0
+    f_max: float | None = None
+    mel_scale: str = "htk"
+    norm: str | None = None
+    triangularize_in_mel_space: bool = False
+    frequency_bin_mode: str = "rfft"
+    computation_dtype: str | None = None
+    bands_to_zero: int = 0
+    matmul_order: str = "filters_first"
+    bank_rounding: str | None = None
+
+    def to_dict(self) -> dict:
+        return {f.name: getattr(self, f.name) for f in fields(self) if getattr(self, f.name) is not None}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "MelScaleConfig":
+        valid_keys = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in d.items() if k in valid_keys})
+
+
+@dataclass(frozen=True)
+class SpectrogramConfig:
+    stft_config: StftConfig = field(default_factory=StftConfig)
+    mel_scale_config: MelScaleConfig | None = None
+    log_mode: str = "log10"
+    preemphasis: float | None = None
+    preemphasis_mode: str = "per_frame"
+    remove_dc_offset: bool = False
+    mel_floor: float = 1e-10
+    pre_log_offset: float | None = None
+    waveform_scale: float | None = None
+    computation_dtype: str | None = None
+    skip_last_frame: bool = False
+    count_partial_frames: bool = False
+    transpose_features: bool = False
+    clip_max_offset: float | None = None
+    post_log_shift: float | None = None
+    post_log_scale: float | None = None
+
+    def __getitem__(self, key):
+        if hasattr(self, key):
+            return getattr(self, key)
+        raise KeyError(f"Key {key} not found in SpectrogramConfig.")
+
+    def __iter__(self):
+        for f in fields(self):
+            val = getattr(self, f.name)
+            if val is not None:
+                if hasattr(val, "to_dict"):
+                    yield f.name, val.to_dict()
+                else:
+                    yield f.name, val
+
+    def __eq__(self, other):
+        if isinstance(other, dict):
+            return dict(self) == other
+        if isinstance(other, SpectrogramConfig):
+            return tuple(getattr(self, f.name) for f in fields(self)) == tuple(
+                getattr(other, f.name) for f in fields(self)
+            )
+        return NotImplemented
+
+    def to_dict(self) -> dict:
+        return dict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "SpectrogramConfig":
+        kwargs = {k: v for k, v in d.items() if k in {f.name for f in fields(cls)}}
+        if "stft_config" in kwargs and isinstance(kwargs["stft_config"], dict):
+            kwargs["stft_config"] = StftConfig.from_dict(kwargs["stft_config"])
+        if "mel_scale_config" in kwargs and isinstance(kwargs["mel_scale_config"], dict):
+            kwargs["mel_scale_config"] = MelScaleConfig.from_dict(kwargs["mel_scale_config"])
+        return cls(**kwargs)
 
 
 @retry(exceptions=(httpx.HTTPError,))
@@ -543,78 +651,6 @@ def prepare_language_inputs(
     raise TypeError("`language` must be a string, a list of strings, or `None`.")
 
 
-def hertz_to_mel(freq: float | np.ndarray, mel_scale: str = "htk") -> float | np.ndarray:
-    """
-    Convert frequency from hertz to mels.
-
-    Args:
-        freq (`float` or `np.ndarray`):
-            The frequency, or multiple frequencies, in hertz (Hz).
-        mel_scale (`str`, *optional*, defaults to `"htk"`):
-            The mel frequency scale to use, `"htk"`, `"kaldi"` or `"slaney"`.
-
-    Returns:
-        `float` or `np.ndarray`: The frequencies on the mel scale.
-    """
-
-    if mel_scale not in ["slaney", "htk", "kaldi"]:
-        raise ValueError('mel_scale should be one of "htk", "slaney" or "kaldi".')
-
-    if mel_scale == "htk":
-        return 2595.0 * np.log10(1.0 + (freq / 700.0))
-    elif mel_scale == "kaldi":
-        return 1127.0 * np.log(1.0 + (freq / 700.0))
-
-    min_log_hertz = 1000.0
-    min_log_mel = 15.0
-    logstep = 27.0 / np.log(6.4)
-    mels = 3.0 * freq / 200.0
-
-    if isinstance(freq, np.ndarray):
-        log_region = freq >= min_log_hertz
-        mels[log_region] = min_log_mel + np.log(freq[log_region] / min_log_hertz) * logstep
-    elif freq >= min_log_hertz:
-        mels = min_log_mel + np.log(freq / min_log_hertz) * logstep
-
-    return mels
-
-
-def mel_to_hertz(mels: float | np.ndarray, mel_scale: str = "htk") -> float | np.ndarray:
-    """
-    Convert frequency from mels to hertz.
-
-    Args:
-        mels (`float` or `np.ndarray`):
-            The frequency, or multiple frequencies, in mels.
-        mel_scale (`str`, *optional*, `"htk"`):
-            The mel frequency scale to use, `"htk"`, `"kaldi"` or `"slaney"`.
-
-    Returns:
-        `float` or `np.ndarray`: The frequencies in hertz.
-    """
-
-    if mel_scale not in ["slaney", "htk", "kaldi"]:
-        raise ValueError('mel_scale should be one of "htk", "slaney" or "kaldi".')
-
-    if mel_scale == "htk":
-        return 700.0 * (np.power(10, mels / 2595.0) - 1.0)
-    elif mel_scale == "kaldi":
-        return 700.0 * (np.exp(mels / 1127.0) - 1.0)
-
-    min_log_hertz = 1000.0
-    min_log_mel = 15.0
-    logstep = np.log(6.4) / 27.0
-    freq = 200.0 * mels / 3.0
-
-    if isinstance(mels, np.ndarray):
-        log_region = mels >= min_log_mel
-        freq[log_region] = min_log_hertz * np.exp(logstep * (mels[log_region] - min_log_mel))
-    elif mels >= min_log_mel:
-        freq = min_log_hertz * np.exp(logstep * (mels - min_log_mel))
-
-    return freq
-
-
 def hertz_to_octave(freq: float | np.ndarray, tuning: float = 0.0, bins_per_octave: int = 12):
     """
     Convert frequency from hertz to fractional octave numbers.
@@ -634,28 +670,6 @@ def hertz_to_octave(freq: float | np.ndarray, tuning: float = 0.0, bins_per_octa
     stuttgart_pitch = 440.0 * 2.0 ** (tuning / bins_per_octave)
     octave = np.log2(freq / (float(stuttgart_pitch) / 16))
     return octave
-
-
-def _create_triangular_filter_bank(fft_freqs: np.ndarray, filter_freqs: np.ndarray) -> np.ndarray:
-    """
-    Creates a triangular filter bank.
-
-    Adapted from *torchaudio* and *librosa*.
-
-    Args:
-        fft_freqs (`np.ndarray` of shape `(num_frequency_bins,)`):
-            Discrete frequencies of the FFT bins in Hz.
-        filter_freqs (`np.ndarray` of shape `(num_mel_filters,)`):
-            Center frequencies of the triangular filters to create, in Hz.
-
-    Returns:
-        `np.ndarray` of shape `(num_frequency_bins, num_mel_filters)`
-    """
-    filter_diff = np.diff(filter_freqs)
-    slopes = np.expand_dims(filter_freqs, 0) - np.expand_dims(fft_freqs, 1)
-    down_slopes = -slopes[:, :-2] / filter_diff[:-1]
-    up_slopes = slopes[:, 2:] / filter_diff[1:]
-    return np.maximum(np.zeros(1), np.minimum(down_slopes, up_slopes))
 
 
 def chroma_filter_bank(
@@ -731,6 +745,354 @@ def chroma_filter_bank(
 
     # remove aliasing columns, copy to ensure row-contiguity
     return np.ascontiguousarray(chroma_filters[:, : int(1 + num_frequency_bins / 2)])
+
+
+def optimal_fft_length(window_length: int) -> int:
+    """
+    Finds the best FFT input size for a given `window_length`. This function takes a given window length and, if not
+    already a power of two, rounds it up to the next power or two.
+
+    The FFT algorithm works fastest when the length of the input is a power of two, which may be larger than the size
+    of the window or analysis frame. For example, if the window is 400 samples, using an FFT input size of 512 samples
+    is more optimal than an FFT size of 400 samples. Using a larger FFT size does not affect the detected frequencies,
+    it simply gives a higher frequency resolution (i.e. the frequency bins are smaller).
+    """
+    return 2 ** int(np.ceil(np.log2(window_length)))
+
+
+def window_function(
+    window_length: int,
+    name: str = "hann",
+    periodic: bool = True,
+    frame_length: int | None = None,
+    center: bool = True,
+) -> np.ndarray:
+    """
+    Returns an array containing the specified window. This window is intended to be used with `stft`.
+
+    The following window types are supported:
+
+        - `"boxcar"`: a rectangular window
+        - `"hamming"`: the Hamming window
+        - `"hann"`: the Hann window
+        - `"povey"`: the Povey window
+
+    Args:
+        window_length (`int`):
+            The length of the window in samples.
+        name (`str`, *optional*, defaults to `"hann"`):
+            The name of the window function.
+        periodic (`bool`, *optional*, defaults to `True`):
+            Whether the window is periodic or symmetric.
+        frame_length (`int`, *optional*):
+            The length of the analysis frames in samples. Provide a value for `frame_length` if the window is smaller
+            than the frame length, so that it will be zero-padded.
+        center (`bool`, *optional*, defaults to `True`):
+            Whether to center the window inside the FFT buffer. Only used when `frame_length` is provided.
+
+    Returns:
+        `np.ndarray` of shape `(window_length,)` or `(frame_length,)` containing the window.
+    """
+    length = window_length + 1 if periodic else window_length
+
+    if name == "boxcar":
+        window = np.ones(length)
+    elif name in ["hamming", "hamming_window"]:
+        window = np.hamming(length)
+    elif name in ["hann", "hann_window"]:
+        window = np.hanning(length)
+    elif name == "povey":
+        window = np.power(np.hanning(length), 0.85)
+    else:
+        raise ValueError(f"Unknown window function '{name}'")
+
+    if periodic:
+        window = window[:-1]
+
+    if frame_length is None:
+        return window
+
+    if window_length > frame_length:
+        raise ValueError(
+            f"Length of the window ({window_length}) may not be larger than frame_length ({frame_length})"
+        )
+
+    padded_window = np.zeros(frame_length)
+    offset = (frame_length - window_length) // 2 if center else 0
+    padded_window[offset : offset + window_length] = window
+    return padded_window
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Audio math helpers (numpy/torch agnostic)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _array_namespace(x):
+    """Return the array module (``numpy`` or ``torch``) matching ``x``.
+
+    Raises ``TypeError`` for unknown types. Use :func:`_xp_or_math` instead when
+    Python scalars are also valid input.
+    """
+    if isinstance(x, np.ndarray):
+        return np
+    if is_torch_available():
+        import torch
+
+        if isinstance(x, torch.Tensor):
+            return torch
+    raise TypeError(f"Unsupported array type: {type(x)}")
+
+
+def _xp_or_math(x):
+    """Like :func:`_array_namespace` but returns ``math`` for Python scalars.
+
+    Lets scalar-or-array math be written once: ``math.log10`` has the right
+    signature for Python floats; numpy and torch use the same names on arrays.
+    """
+    if isinstance(x, (int, float)):
+        return math
+    return _array_namespace(x)
+
+
+def _clamp_min(x, min_value):
+    """Element-wise ``max(x, min_value)`` for numpy arrays or torch tensors.
+
+    Needed because ``np.maximum(arr, scalar)`` accepts a Python scalar but
+    ``torch.maximum(tensor, scalar)`` does not — and ``torch.clamp(x, min=)``
+    has a different kwarg name than ``np.clip(x, a_min=)``.
+    """
+    if isinstance(x, np.ndarray):
+        return np.maximum(x, min_value)
+    return x.clamp(min=min_value)
+
+
+def hertz_to_mel(freq: float | np.ndarray, mel_scale: str = "htk"):
+    """
+    Convert frequency from hertz to mels.
+
+    Args:
+        freq (`float`, `np.ndarray`, or `torch.Tensor`):
+            The frequency, or multiple frequencies, in hertz (Hz).
+        mel_scale (`str`, *optional*, defaults to `"htk"`):
+            The mel frequency scale to use, `"htk"`, `"kaldi"` or `"slaney"`.
+
+    Returns:
+        The frequencies on the mel scale, in the same form as the input.
+    """
+    if mel_scale not in ("htk", "kaldi", "slaney"):
+        raise ValueError('mel_scale should be one of "htk", "slaney" or "kaldi".')
+
+    xp = _xp_or_math(freq)
+
+    if mel_scale == "htk":
+        return 2595.0 * xp.log10(1.0 + freq / 700.0)
+    if mel_scale == "kaldi":
+        return 1127.0 * xp.log(1.0 + freq / 700.0)
+
+    # slaney: linear below 1000 Hz, logarithmic above. The constants are written
+    # differently per backend to preserve bit-exact parity with librosa (numpy) and
+    # torchaudio (torch) — they use different float32 rounding paths.
+    min_log_hertz = 1000.0
+    min_log_mel = 15.0
+
+    if xp is math:
+        if freq >= min_log_hertz:
+            return min_log_mel + math.log(freq / min_log_hertz) * 27.0 / math.log(6.4)
+        return 3.0 * freq / 200.0
+
+    if xp is np:
+        linear = 3.0 * freq / 200.0
+        logstep = 27.0 / np.log(6.4)
+    else:  # torch — float32-tensor logstep matches torchaudio
+        import torch
+
+        linear = freq / (200.0 / 3.0)
+        logstep = 27.0 / torch.log(torch.tensor(6.4))
+
+    # Guard log against discarded-branch values; xp.where evaluates both branches.
+    safe = _clamp_min(freq, min_log_hertz)
+    log_branch = min_log_mel + xp.log(safe / min_log_hertz) * logstep
+    return xp.where(freq >= min_log_hertz, log_branch, linear)
+
+
+def mel_to_hertz(mels: float | np.ndarray, mel_scale: str = "htk"):
+    """
+    Convert frequency from mels to hertz.
+
+    Args:
+        mels (`float`, `np.ndarray`, or `torch.Tensor`):
+            The frequency, or multiple frequencies, in mels.
+        mel_scale (`str`, *optional*, defaults to `"htk"`):
+            The mel frequency scale to use, `"htk"`, `"kaldi"` or `"slaney"`.
+
+    Returns:
+        The frequencies in hertz, in the same form as the input.
+    """
+    if mel_scale not in ("htk", "kaldi", "slaney"):
+        raise ValueError('mel_scale should be one of "htk", "slaney" or "kaldi".')
+
+    xp = _xp_or_math(mels)
+
+    if mel_scale == "htk":
+        return 700.0 * (10.0 ** (mels / 2595.0) - 1.0)
+    if mel_scale == "kaldi":
+        return 700.0 * (xp.exp(mels / 1127.0) - 1.0)
+
+    # slaney — see note in hertz_to_mel; constants are written per-backend for
+    # bit-exact parity with librosa (numpy) and torchaudio (torch).
+    min_log_hertz = 1000.0
+    min_log_mel = 15.0
+
+    if xp is math:
+        if mels >= min_log_mel:
+            return min_log_hertz * math.exp(math.log(6.4) / 27.0 * (mels - min_log_mel))
+        return 200.0 * mels / 3.0
+
+    if xp is np:
+        linear = 200.0 * mels / 3.0
+        logstep = np.log(6.4) / 27.0
+    else:  # torch — match old per-backend precision (Python-float logstep here,
+        # though the reciprocal in hertz_to_mel uses a float32 tensor — old code
+        # was inconsistent and we preserve that for bit-exact parity).
+        linear = (200.0 / 3.0) * mels
+        logstep = math.log(6.4) / 27.0
+
+    log_branch = min_log_hertz * xp.exp(logstep * (mels - min_log_mel))
+    return xp.where(mels >= min_log_mel, log_branch, linear)
+
+
+def _create_triangular_filter_bank(fft_freqs, filter_freqs):
+    """
+    Triangular filter bank from FFT bin frequencies and filter center frequencies.
+
+    Adapted from *torchaudio* and *librosa*. Works on numpy or torch inputs.
+
+    Args:
+        fft_freqs (array of shape `(num_frequency_bins,)`):
+            Discrete frequencies of the FFT bins (in Hz, or in mel space when
+            ``triangularize_in_mel_space=True``).
+        filter_freqs (array of shape `(num_mel_filters + 2,)`):
+            Edges and center frequencies of the triangular filters.
+
+    Returns:
+        Filter bank of shape `(num_frequency_bins, num_mel_filters)`.
+    """
+    xp = _array_namespace(fft_freqs)
+    filter_diff = filter_freqs[1:] - filter_freqs[:-1]
+    slopes = filter_freqs[None, :] - fft_freqs[:, None]
+    down_slopes = -slopes[:, :-2] / filter_diff[:-1]
+    up_slopes = slopes[:, 2:] / filter_diff[1:]
+    return _clamp_min(xp.minimum(down_slopes, up_slopes), 0)
+
+
+def power_to_db(
+    spectrogram,
+    reference: float = 1.0,
+    min_value: float = 1e-10,
+    db_range: float | None = None,
+):
+    """
+    Converts a power spectrogram to the decibel scale. This computes `10 * log10(spectrogram / reference)`, using basic
+    logarithm properties for numerical stability.
+
+    The motivation behind applying the log function on the (mel) spectrogram is that humans do not hear loudness on a
+    linear scale. Generally to double the perceived volume of a sound we need to put 8 times as much energy into it.
+    This means that large variations in energy may not sound all that different if the sound is loud to begin with.
+    This compression operation makes the (mel) spectrogram features match more closely what humans actually hear.
+
+    Based on the implementation of `librosa.power_to_db`. Works on numpy or torch inputs.
+
+    Args:
+        spectrogram (`np.ndarray` or `torch.Tensor`):
+            The input power (mel) spectrogram. Note that a power spectrogram has the amplitudes squared!
+        reference (`float`, *optional*, defaults to 1.0):
+            Sets the input spectrogram value that corresponds to 0 dB. For example, use `np.max(spectrogram)` to set
+            the loudest part to 0 dB. Must be greater than zero.
+        min_value (`float`, *optional*, defaults to `1e-10`):
+            The spectrogram will be clipped to this minimum value before conversion to decibels, to avoid taking
+            `log(0)`. The default of `1e-10` corresponds to a minimum of -100 dB. Must be greater than zero.
+        db_range (`float`, *optional*):
+            Sets the maximum dynamic range in decibels. For example, if `db_range = 80`, the difference between the
+            peak value and the smallest value will never be more than 80 dB. Must be greater than zero.
+
+    Returns:
+        The spectrogram in decibels, same array type as the input.
+    """
+    if reference <= 0.0:
+        raise ValueError("reference must be greater than zero")
+    if min_value <= 0.0:
+        raise ValueError("min_value must be greater than zero")
+
+    reference = max(min_value, reference)
+
+    spectrogram = _clamp_min(spectrogram, min_value)
+    spectrogram = 10.0 * (_array_namespace(spectrogram).log10(spectrogram) - math.log10(reference))
+
+    if db_range is not None:
+        if db_range <= 0.0:
+            raise ValueError("db_range must be greater than zero")
+        spectrogram = _clamp_min(spectrogram, spectrogram.max() - db_range)
+
+    return spectrogram
+
+
+def amplitude_to_db(
+    spectrogram,
+    reference: float = 1.0,
+    min_value: float = 1e-5,
+    db_range: float | None = None,
+):
+    """
+    Converts an amplitude spectrogram to the decibel scale. This computes `20 * log10(spectrogram / reference)`, using
+    basic logarithm properties for numerical stability.
+
+    The motivation behind applying the log function on the (mel) spectrogram is that humans do not hear loudness on a
+    linear scale. Generally to double the perceived volume of a sound we need to put 8 times as much energy into it.
+    This means that large variations in energy may not sound all that different if the sound is loud to begin with.
+    This compression operation makes the (mel) spectrogram features match more closely what humans actually hear.
+
+    Works on numpy or torch inputs.
+
+    Args:
+        spectrogram (`np.ndarray` or `torch.Tensor`):
+            The input amplitude (mel) spectrogram.
+        reference (`float`, *optional*, defaults to 1.0):
+            Sets the input spectrogram value that corresponds to 0 dB. For example, use `np.max(spectrogram)` to set
+            the loudest part to 0 dB. Must be greater than zero.
+        min_value (`float`, *optional*, defaults to `1e-5`):
+            The spectrogram will be clipped to this minimum value before conversion to decibels, to avoid taking
+            `log(0)`. The default of `1e-5` corresponds to a minimum of -100 dB. Must be greater than zero.
+        db_range (`float`, *optional*):
+            Sets the maximum dynamic range in decibels. For example, if `db_range = 80`, the difference between the
+            peak value and the smallest value will never be more than 80 dB. Must be greater than zero.
+
+    Returns:
+        The spectrogram in decibels, same array type as the input.
+    """
+    if reference <= 0.0:
+        raise ValueError("reference must be greater than zero")
+    if min_value <= 0.0:
+        raise ValueError("min_value must be greater than zero")
+
+    reference = max(min_value, reference)
+
+    spectrogram = _clamp_min(spectrogram, min_value)
+    spectrogram = 20.0 * (_array_namespace(spectrogram).log10(spectrogram) - math.log10(reference))
+
+    if db_range is not None:
+        if db_range <= 0.0:
+            raise ValueError("db_range must be greater than zero")
+        spectrogram = _clamp_min(spectrogram, spectrogram.max() - db_range)
+
+    return spectrogram
+
+
+# ── Legacy spectrogram helpers ────────────────────────────────────────────────
+#
+# Retained verbatim from before the AudioProcessor migration so the legacy
+# `feature_extraction_<model>.py` modules keep importing while this layer is reviewed
+# on its own. Removed in the layer that migrates the models.
 
 
 def mel_filter_bank(
@@ -827,83 +1189,6 @@ def mel_filter_bank(
     return mel_filters
 
 
-def optimal_fft_length(window_length: int) -> int:
-    """
-    Finds the best FFT input size for a given `window_length`. This function takes a given window length and, if not
-    already a power of two, rounds it up to the next power or two.
-
-    The FFT algorithm works fastest when the length of the input is a power of two, which may be larger than the size
-    of the window or analysis frame. For example, if the window is 400 samples, using an FFT input size of 512 samples
-    is more optimal than an FFT size of 400 samples. Using a larger FFT size does not affect the detected frequencies,
-    it simply gives a higher frequency resolution (i.e. the frequency bins are smaller).
-    """
-    return 2 ** int(np.ceil(np.log2(window_length)))
-
-
-def window_function(
-    window_length: int,
-    name: str = "hann",
-    periodic: bool = True,
-    frame_length: int | None = None,
-    center: bool = True,
-) -> np.ndarray:
-    """
-    Returns an array containing the specified window. This window is intended to be used with `stft`.
-
-    The following window types are supported:
-
-        - `"boxcar"`: a rectangular window
-        - `"hamming"`: the Hamming window
-        - `"hann"`: the Hann window
-        - `"povey"`: the Povey window
-
-    Args:
-        window_length (`int`):
-            The length of the window in samples.
-        name (`str`, *optional*, defaults to `"hann"`):
-            The name of the window function.
-        periodic (`bool`, *optional*, defaults to `True`):
-            Whether the window is periodic or symmetric.
-        frame_length (`int`, *optional*):
-            The length of the analysis frames in samples. Provide a value for `frame_length` if the window is smaller
-            than the frame length, so that it will be zero-padded.
-        center (`bool`, *optional*, defaults to `True`):
-            Whether to center the window inside the FFT buffer. Only used when `frame_length` is provided.
-
-    Returns:
-        `np.ndarray` of shape `(window_length,)` or `(frame_length,)` containing the window.
-    """
-    length = window_length + 1 if periodic else window_length
-
-    if name == "boxcar":
-        window = np.ones(length)
-    elif name in ["hamming", "hamming_window"]:
-        window = np.hamming(length)
-    elif name in ["hann", "hann_window"]:
-        window = np.hanning(length)
-    elif name == "povey":
-        window = np.power(np.hanning(length), 0.85)
-    else:
-        raise ValueError(f"Unknown window function '{name}'")
-
-    if periodic:
-        window = window[:-1]
-
-    if frame_length is None:
-        return window
-
-    if window_length > frame_length:
-        raise ValueError(
-            f"Length of the window ({window_length}) may not be larger than frame_length ({frame_length})"
-        )
-
-    padded_window = np.zeros(frame_length)
-    offset = (frame_length - window_length) // 2 if center else 0
-    padded_window[offset : offset + window_length] = window
-    return padded_window
-
-
-# Note: This method processes a single waveform. For batch processing, use spectrogram_batch().
 def spectrogram(
     waveform: np.ndarray,
     window: np.ndarray,
@@ -1326,38 +1611,30 @@ def spectrogram_batch(
     return spectrogram_list
 
 
-def power_to_db(
-    spectrogram: np.ndarray,
-    reference: float = 1.0,
-    min_value: float = 1e-10,
-    db_range: float | None = None,
+def amplitude_to_db_batch(
+    spectrogram: np.ndarray, reference: float = 1.0, min_value: float = 1e-5, db_range: float | None = None
 ) -> np.ndarray:
     """
-    Converts a power spectrogram to the decibel scale. This computes `10 * log10(spectrogram / reference)`, using basic
-    logarithm properties for numerical stability.
+    Converts a batch of amplitude spectrograms to the decibel scale. This computes `20 * log10(spectrogram / reference)`,
+    using basic logarithm properties for numerical stability.
 
-    The motivation behind applying the log function on the (mel) spectrogram is that humans do not hear loudness on a
-    linear scale. Generally to double the perceived volume of a sound we need to put 8 times as much energy into it.
-    This means that large variations in energy may not sound all that different if the sound is loud to begin with.
-    This compression operation makes the (mel) spectrogram features match more closely what humans actually hear.
-
-    Based on the implementation of `librosa.power_to_db`.
+    The function supports batch processing, where each item in the batch is an individual amplitude (mel) spectrogram.
 
     Args:
         spectrogram (`np.ndarray`):
-            The input power (mel) spectrogram. Note that a power spectrogram has the amplitudes squared!
+            The input batch of amplitude (mel) spectrograms. Expected shape is (batch_size, *spectrogram_shape).
         reference (`float`, *optional*, defaults to 1.0):
             Sets the input spectrogram value that corresponds to 0 dB. For example, use `np.max(spectrogram)` to set
             the loudest part to 0 dB. Must be greater than zero.
-        min_value (`float`, *optional*, defaults to `1e-10`):
+        min_value (`float`, *optional*, defaults to `1e-5`):
             The spectrogram will be clipped to this minimum value before conversion to decibels, to avoid taking
-            `log(0)`. The default of `1e-10` corresponds to a minimum of -100 dB. Must be greater than zero.
+            `log(0)`. The default of `1e-5` corresponds to a minimum of -100 dB. Must be greater than zero.
         db_range (`float`, *optional*):
             Sets the maximum dynamic range in decibels. For example, if `db_range = 80`, the difference between the
             peak value and the smallest value will never be more than 80 dB. Must be greater than zero.
 
     Returns:
-        `np.ndarray`: the spectrogram in decibels
+        `np.ndarray`: the batch of spectrograms in decibels
     """
     if reference <= 0.0:
         raise ValueError("reference must be greater than zero")
@@ -1367,15 +1644,16 @@ def power_to_db(
     reference = max(min_value, reference)
 
     spectrogram = np.clip(spectrogram, a_min=min_value, a_max=None)
-    spectrogram = 10.0 * (np.log10(spectrogram) - np.log10(reference))
+    spectrogram = 20.0 * (np.log10(spectrogram) - np.log10(reference))
 
     if db_range is not None:
         if db_range <= 0.0:
             raise ValueError("db_range must be greater than zero")
-        spectrogram = np.clip(spectrogram, a_min=spectrogram.max() - db_range, a_max=None)
+        # Apply db_range clipping per batch item
+        max_values = spectrogram.max(axis=(1, 2), keepdims=True)
+        spectrogram = np.clip(spectrogram, a_min=max_values - db_range, a_max=None)
 
     return spectrogram
-
 
 def power_to_db_batch(
     spectrogram: np.ndarray,
@@ -1425,96 +1703,3 @@ def power_to_db_batch(
 
     return spectrogram
 
-
-def amplitude_to_db(
-    spectrogram: np.ndarray,
-    reference: float = 1.0,
-    min_value: float = 1e-5,
-    db_range: float | None = None,
-) -> np.ndarray:
-    """
-    Converts an amplitude spectrogram to the decibel scale. This computes `20 * log10(spectrogram / reference)`, using
-    basic logarithm properties for numerical stability.
-
-    The motivation behind applying the log function on the (mel) spectrogram is that humans do not hear loudness on a
-    linear scale. Generally to double the perceived volume of a sound we need to put 8 times as much energy into it.
-    This means that large variations in energy may not sound all that different if the sound is loud to begin with.
-    This compression operation makes the (mel) spectrogram features match more closely what humans actually hear.
-
-    Args:
-        spectrogram (`np.ndarray`):
-            The input amplitude (mel) spectrogram.
-        reference (`float`, *optional*, defaults to 1.0):
-            Sets the input spectrogram value that corresponds to 0 dB. For example, use `np.max(spectrogram)` to set
-            the loudest part to 0 dB. Must be greater than zero.
-        min_value (`float`, *optional*, defaults to `1e-5`):
-            The spectrogram will be clipped to this minimum value before conversion to decibels, to avoid taking
-            `log(0)`. The default of `1e-5` corresponds to a minimum of -100 dB. Must be greater than zero.
-        db_range (`float`, *optional*):
-            Sets the maximum dynamic range in decibels. For example, if `db_range = 80`, the difference between the
-            peak value and the smallest value will never be more than 80 dB. Must be greater than zero.
-
-    Returns:
-        `np.ndarray`: the spectrogram in decibels
-    """
-    if reference <= 0.0:
-        raise ValueError("reference must be greater than zero")
-    if min_value <= 0.0:
-        raise ValueError("min_value must be greater than zero")
-
-    reference = max(min_value, reference)
-
-    spectrogram = np.clip(spectrogram, a_min=min_value, a_max=None)
-    spectrogram = 20.0 * (np.log10(spectrogram) - np.log10(reference))
-
-    if db_range is not None:
-        if db_range <= 0.0:
-            raise ValueError("db_range must be greater than zero")
-        spectrogram = np.clip(spectrogram, a_min=spectrogram.max() - db_range, a_max=None)
-
-    return spectrogram
-
-
-def amplitude_to_db_batch(
-    spectrogram: np.ndarray, reference: float = 1.0, min_value: float = 1e-5, db_range: float | None = None
-) -> np.ndarray:
-    """
-    Converts a batch of amplitude spectrograms to the decibel scale. This computes `20 * log10(spectrogram / reference)`,
-    using basic logarithm properties for numerical stability.
-
-    The function supports batch processing, where each item in the batch is an individual amplitude (mel) spectrogram.
-
-    Args:
-        spectrogram (`np.ndarray`):
-            The input batch of amplitude (mel) spectrograms. Expected shape is (batch_size, *spectrogram_shape).
-        reference (`float`, *optional*, defaults to 1.0):
-            Sets the input spectrogram value that corresponds to 0 dB. For example, use `np.max(spectrogram)` to set
-            the loudest part to 0 dB. Must be greater than zero.
-        min_value (`float`, *optional*, defaults to `1e-5`):
-            The spectrogram will be clipped to this minimum value before conversion to decibels, to avoid taking
-            `log(0)`. The default of `1e-5` corresponds to a minimum of -100 dB. Must be greater than zero.
-        db_range (`float`, *optional*):
-            Sets the maximum dynamic range in decibels. For example, if `db_range = 80`, the difference between the
-            peak value and the smallest value will never be more than 80 dB. Must be greater than zero.
-
-    Returns:
-        `np.ndarray`: the batch of spectrograms in decibels
-    """
-    if reference <= 0.0:
-        raise ValueError("reference must be greater than zero")
-    if min_value <= 0.0:
-        raise ValueError("min_value must be greater than zero")
-
-    reference = max(min_value, reference)
-
-    spectrogram = np.clip(spectrogram, a_min=min_value, a_max=None)
-    spectrogram = 20.0 * (np.log10(spectrogram) - np.log10(reference))
-
-    if db_range is not None:
-        if db_range <= 0.0:
-            raise ValueError("db_range must be greater than zero")
-        # Apply db_range clipping per batch item
-        max_values = spectrogram.max(axis=(1, 2), keepdims=True)
-        spectrogram = np.clip(spectrogram, a_min=max_values - db_range, a_max=None)
-
-    return spectrogram

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -35,7 +35,7 @@ from huggingface_hub import is_offline_mode
 from huggingface_hub.dataclasses import validate_typed_dict
 from huggingface_hub.errors import EntryNotFoundError
 
-from .audio_utils import AudioInput, load_audio, make_list_of_audio
+from .audio_utils import AudioInput, SpectrogramConfig, load_audio, make_list_of_audio
 from .dynamic_module_utils import custom_object_save
 from .feature_extraction_utils import BatchFeature
 from .image_utils import ChannelDimension, ImageInput, is_vision_available, make_flat_list_of_images
@@ -67,6 +67,7 @@ from .utils.chat_template_utils import _get_template_variables, render_jinja_tem
 from .utils.type_validators import (
     device_validator,
     image_size_validator,
+    padding_side_validator,
     padding_validator,
     positive_any_number,
     positive_int,
@@ -130,9 +131,9 @@ MODALITY_TO_BASE_CLASS_MAPPING = {
         "HiggsAudioV2TokenizerModel",
         "DacModel",
     ),  # TODO: @eustlb, to be replaced with PreTrainedAudioTokenizerBase
-    "audio_processor": "FeatureExtractionMixin",
+    "audio_processor": ("FeatureExtractionMixin", "TorchAudioBackend", "NumpyAudioBackend"),
     "tokenizer": ("PreTrainedTokenizerBase", "MistralCommonBackend"),
-    "feature_extractor": "FeatureExtractionMixin",
+    "feature_extractor": ("FeatureExtractionMixin", "TorchAudioBackend", "NumpyAudioBackend"),
     "image_processor": "ImageProcessingMixin",
     "video_processor": "BaseVideoProcessor",
 }
@@ -385,15 +386,32 @@ class VideosKwargs(TypedDict, total=False):
 
 class AudioKwargs(TypedDict, total=False):
     """
-    Keyword arguments for audio processing.
+    Keyword arguments for audio processing. For extended documentation, check the appropriate AudioProcessor
+    class methods and docstrings.
+
+    Note on `sampling_rate`: a model's native sampling rate is a processor *identity* attribute, set once at
+    init time as `sampling_rate` (e.g. `WhisperAudioProcessor.sampling_rate == 16000`). The per-call
+    `sampling_rate` keyword below reuses the same name as the *caller's assertion* of the rate at which the
+    provided arrays were actually sampled; it never modifies the processor's own `sampling_rate`. A mismatch
+    resamples the input to the native rate. It describes a passed array only: audio referenced by URL or path
+    is always decoded at the native rate, so a `sampling_rate` given alongside such input is ignored with a
+    warning.
 
     Attributes:
         sampling_rate (`int`, *optional*):
-            The sampling rate at which the `raw_speech` input was sampled.
-        raw_speech (`np.ndarray`, `list[float]`, `list[np.ndarray]`, `list[list[float]]`):
-            The sequence or batch of sequences to be padded. Each sequence can be a numpy array, a list of float
-            values, a list of numpy arrays or a list of list of float values. Must be mono channel audio, not
-            stereo, i.e. single float per timestep.
+            The sampling rate at which the provided audio arrays were sampled, asserted by the caller. If it
+            differs from the model's native `sampling_rate`, the audio is resampled to the native rate.
+        spectrogram_config (`dict` or [`~audio_utils.SpectrogramConfig`], *optional*):
+            Per-call override of the spectrogram extraction parameters (STFT, mel filterbank, log scaling).
+            A plain dict is coerced to [`~audio_utils.SpectrogramConfig`].
+        do_extract_spectrogram (`bool`, *optional*):
+            Whether to extract spectrogram features from the audio (otherwise padded raw waveforms are returned).
+        do_batch_spectrogram (`bool`, *optional*):
+            Whether to extract the spectrogram on the padded batch at once (`True`) or per waveform with
+            feature-level padding (`False`).
+        add_channel_dim (`bool`, *optional*):
+            Whether to insert a channel axis into the batched waveform, giving `(batch, channels, samples)`.
+            Config only — not accepted by `__call__`; see `per_call_kwargs`.
         padding (`bool`, `str` or [`~utils.PaddingStrategy`], *optional*):
             Select a strategy to pad the returned sequences (according to the model's padding side and padding
             index) among:
@@ -409,29 +427,45 @@ class AudioKwargs(TypedDict, total=False):
             Activates truncation to cut input sequences longer than *max_length* to *max_length*.
         pad_to_multiple_of (`int`, *optional*):
             If set, will pad the sequence to a multiple of the provided value.
-        return_attention_mask (`bool`, *optional*):
-            Whether or not [`~ASTFeatureExtractor.__call__`] should return `attention_mask`.
-        device (`str` or `torch.device`, *optional*):
-            The device to compute the audio features on (e.g. "cpu", "cuda"), only relevant for feature
-            extractors that compute them with torch.
+        padding_side (`str`, *optional*):
+            Side the padding is added on, `"left"` or `"right"`.
+        padding_value (`float`, *optional*):
+            Value used to fill the padded positions.
+        return_padding_mask (`bool`, *optional*):
+            Whether the processor should return a padding mask alongside its output. The mask accompanies
+            whichever output family the processor emits: `audio_features_mask`, `audio_values_mask` or
+            `audio_input_ids_mask`.
+        dither (`float`, *optional*):
+            Amount of dithering noise added to the waveform before feature extraction. `0.0` disables it.
         return_tensors (`str` or [`~utils.TensorType`], *optional*):
             If set, will return tensors of a particular framework. Acceptable values are:
             - `'pt'`: Return PyTorch `torch.Tensor` objects.
             - `'np'`: Return NumPy `np.ndarray` objects.
+        device (`str`, *optional*):
+            The device to use for processing (e.g. "cpu", "cuda"), only relevant for the torch backend.
         load_audio_backend (`str`, *optional*):
             Backend used by [`~audio_utils.load_audio`] to decode/resample audio referenced by URL/path
             in `apply_chat_template`. One of `"auto"`, `"torchcodec"`, `"librosa"`, `"torchaudio"`.
     """
 
     sampling_rate: Annotated[int | None, positive_int()]
-    raw_speech: Union["np.ndarray", list[float], list["np.ndarray"], list[list[float]]] | None
+    spectrogram_config: dict | SpectrogramConfig | None
+    do_extract_spectrogram: bool | None
+    do_batch_spectrogram: bool | None
+    # TODO: remove `add_channel_dim` — from here and from `BaseAudioProcessor.per_call_kwargs`'s exclusion —
+    # once the six codec models that set it (dia, dac, encodec, xcodec2, vibevoice_acoustic_tokenizer,
+    # kyutai_speech_to_text) align their modeling with the library's batch layout.
+    add_channel_dim: bool | None
     padding: Annotated[bool | str | PaddingStrategy | None, padding_validator()]
     max_length: Annotated[int | None, positive_int()]
     truncation: Annotated[bool | str | TruncationStrategy | None, truncation_validator()]
     pad_to_multiple_of: Annotated[int | None, positive_int()]
-    return_attention_mask: bool | None
-    device: Annotated[Union[str, "torch.device"] | None, device_validator()]
+    padding_side: Annotated[str | None, padding_side_validator()]
+    padding_value: float | int | None
+    return_padding_mask: bool | None
+    dither: Annotated[float | int | None, positive_any_number()]
     return_tensors: Annotated[str | TensorType | None, tensor_type_validator()]
+    device: Annotated[Union[str, "torch.device"] | None, device_validator()]
     load_audio_backend: str | None
 
 
@@ -735,8 +769,10 @@ class ProcessorMixin(PushToHubMixin):
             text = list(text).copy()
 
         if audio is not None and self._audio_processor is not None:
-            sampling_rate = kwargs.get("sampling_rate", self._audio_processor.sampling_rate)
-            audio = self._audio_processor.fetch_audio(audio, sampling_rate=sampling_rate)
+            # Always decode at the processor's own rate: `sampling_rate` describes arrays the caller passes,
+            # not a decode target. Honouring it here produced audio at the wrong rate, which the audio
+            # processor then reported as the caller's mistake.
+            audio = self._audio_processor.fetch_audio(audio)
             audio = make_list_of_audio(audio)
 
         if images is not None and hasattr(self, "image_processor"):

--- a/src/transformers/utils/deprecation.py
+++ b/src/transformers/utils/deprecation.py
@@ -33,6 +33,41 @@ class Action(ExplicitEnum):
     RAISE = "raise"
 
 
+def deprecated_feature_extractor(audio_processor_class, old_class_name, version="5.5"):
+    """Create a deprecated FeatureExtractor alias for an AudioProcessor.
+
+    Uses dynamic class creation to reduce boilerplate across ~20 models.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            f"`{old_class_name}` is deprecated and will be removed in v{version}. "
+            f"Use `{audio_processor_class.__name__}` instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        super(type(self), self).__init__(*args, **kwargs)
+
+    def __init_subclass__(cls, **kwargs):
+        warnings.warn(
+            f"`{old_class_name}` is deprecated and will be removed in v{version}. "
+            f"Use `{audio_processor_class.__name__}` instead.",
+            FutureWarning,
+        )
+        super(type(cls), cls).__init_subclass__(**kwargs)
+
+    return type(
+        old_class_name,
+        (audio_processor_class,),
+        {
+            "__init__": __init__,
+            "__init_subclass__": __init_subclass__,
+            "__module__": audio_processor_class.__module__,
+            "__doc__": f"Deprecated. Use {audio_processor_class.__name__} instead.",
+        },
+    )
+
+
 def deprecate_kwarg(
     old_name: str,
     version: str,

--- a/src/transformers/utils/type_validators.py
+++ b/src/transformers/utils/type_validators.py
@@ -60,6 +60,14 @@ def truncation_validator(value: bool | str | TruncationStrategy | None = None):
         raise ValueError(f"If truncation is a string, value must be one of {possible_names}")
 
 
+def padding_side_validator(value: str | None = None):
+    possible_names = ["left", "right"]
+    if value is None:
+        pass
+    elif not isinstance(value, str) or value not in possible_names:
+        raise ValueError(f"Value for padding_side must be one of {possible_names} but got padding_side={value}")
+
+
 def image_size_validator(value: int | Sequence[int] | dict[str, int] | None = None):
     possible_keys = [
         "height",


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48111&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48111) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48111&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48111)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Adds `SpectrogramConfig` (with `StftConfig` / `MelScaleConfig`) to describe an audio frontend declaratively instead of as a call into `spectrogram()` with a dozen positional arguments, and the modality layer on top of it: `AudioProcessingMixin` and `BaseAudioProcessor`, which own padding, truncation, masking and the `preprocess` pipeline.

No numerics here — the concrete backends come next, and `BaseAudioProcessor` has no dependency on them. `hertz_to_mel`, `mel_to_hertz` and `_create_triangular_filter_bank` become numpy/torch generic, verified bit-exact against the current implementations.