### PR TITLE
[AudioProcessor] add numpy and torch backends

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ _deps = [
     "scikit-learn",
     "scipy",
     "sentencepiece>=0.1.91,!=0.1.92",
+    "soxr",
     "starlette",
     "sudachipy>=0.6.6",
     "sudachidict_core>=20220729",
@@ -177,7 +178,7 @@ extras = {}
 
 extras["torch"] = deps_list("torch", "accelerate")
 extras["vision"] = deps_list("torchvision", "Pillow")
-extras["audio"] = deps_list("torchaudio", "librosa", "pyctcdecode", "phonemizer")
+extras["audio"] = deps_list("torchaudio", "soxr", "librosa", "pyctcdecode", "phonemizer")
 if PYTHON_MINOR_VERSION < 13:
     extras["audio"] += deps_list("kenlm")
 extras["video"] = deps_list("av")

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -364,6 +364,7 @@ except OptionalDependencyNotAvailable:
 
     _import_structure["utils.dummy_pt_objects"] = [name for name in dir(dummy_pt_objects) if not name.startswith("_")]
 else:
+    _import_structure["audio_processing_backends"] = ["NumpyAudioBackend", "NumpyBackend", "TorchAudioBackend", "TorchBackend"]
     _import_structure["activations"] = []
     _import_structure["backbone_utils"] = ["BackboneConfigMixin", "BackboneMixin"]
     _import_structure["cache_utils"] = [
@@ -492,6 +493,10 @@ else:
 if TYPE_CHECKING:
     # All modeling imports
     # Models
+    from .audio_processing_backends import NumpyAudioBackend as NumpyAudioBackend
+    from .audio_processing_backends import NumpyBackend as NumpyBackend
+    from .audio_processing_backends import TorchAudioBackend as TorchAudioBackend
+    from .audio_processing_backends import TorchBackend as TorchBackend
     from .backbone_utils import BackboneConfigMixin, BackboneMixin
     from .cache_utils import Cache as Cache
     from .cache_utils import DynamicCache as DynamicCache

--- a/src/transformers/audio_processing_backends.py
+++ b/src/transformers/audio_processing_backends.py
@@ -1,0 +1,616 @@
+# Copyright 2025 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from typing import Unpack
+
+import numpy as np
+
+from .audio_processing_utils import BaseAudioProcessor
+from .audio_utils import (
+    _create_triangular_filter_bank,
+    hertz_to_mel,
+    mel_to_hertz,
+)
+from .processing_utils import AudioKwargs
+from .utils import is_speech_available, is_torch_available, logging, requires_backends
+
+
+logger = logging.get_logger(__name__)
+
+
+if is_torch_available():
+    import torch
+
+
+class NumpyAudioBackend(BaseAudioProcessor):
+    """NumPy backend for portable CPU-only audio processing."""
+
+    def __init__(self, *args, **kwargs: Unpack[AudioKwargs]):
+        super().__init__(*args, **kwargs)
+        self._set_attributes(**kwargs)
+
+    @property
+    def backend(self) -> str:
+        return "numpy"
+
+    # ── Backend array-API primitives ─────────────────────────────────────
+
+    def _astype(self, x, dtype_name):
+        return x.astype(np.dtype(dtype_name))
+
+    def _amax_over_features(self, x):
+        if x.ndim > 2:
+            return x.max(axis=tuple(range(1, x.ndim)), keepdims=True)
+        return x.max()
+
+    def _zeros_int32(self, shape):
+        return np.zeros(shape, dtype=np.int32)
+
+    def _as_backend_array(self, x):
+        return x if isinstance(x, np.ndarray) else np.asarray(x)
+
+    def _mean_axis0(self, x):
+        return x.mean(axis=0)
+
+    def _squeeze_axis0(self, x):
+        return np.squeeze(x, axis=0)
+
+    def _resample(self, audio, orig_sampling_rate: int, target_sampling_rate: int):
+        requires_backends(self._resample, ["soxr"])
+        import soxr
+
+        return soxr.resample(audio, orig_sampling_rate, target_sampling_rate, quality="HQ")
+
+    def _pad_axis(self, x, left, right, axis, value=0.0):
+        pad_width = [(0, 0)] * x.ndim
+        pad_width[axis] = (left, right)
+        return np.pad(x, pad_width, mode="constant", constant_values=value)
+
+    def _stack(self, seq):
+        return np.stack(seq)
+
+    def _insert_channel_dim(self, batch):
+        return batch[:, np.newaxis, :]
+
+    def _mean_last(self, x):
+        return x.mean(axis=-1, keepdims=True)
+
+    def _concat_last(self, parts):
+        return np.concatenate(parts, axis=-1)
+
+    # ── STFT pipeline ─────────────────────────────────────────────────────
+
+    def _create_stft_window(self, win_length, stft_cfg, audio):
+        if stft_cfg.window_fn == "hann_window_f32":
+            # fixed USM float32 periodic Hann (bit-exact with the legacy Gemma extractors);
+            # ignores `periodic`/`window_dtype`/`wkwargs`
+            arange = np.arange(win_length, dtype=np.float32)
+            return (0.5 * (1 - np.cos(2 * np.pi * arange / win_length))).astype(np.float32)
+        N = win_length + 1 if stft_cfg.periodic else win_length
+        fac = np.linspace(-np.pi, np.pi, N)
+        name = stft_cfg.window_fn
+        if name in ("hann", "hann_window"):
+            w = 0.5 + 0.5 * np.cos(fac)
+        elif name in ("hamming", "hamming_window"):
+            w = 0.54 + 0.46 * np.cos(fac)
+        elif name == "boxcar":
+            w = np.ones(N)
+        elif name == "povey":
+            w = (0.5 + 0.5 * np.cos(fac)) ** 0.85
+        else:
+            raise ValueError(f"Unknown window function '{name}'")
+        return w[:win_length] if stft_cfg.periodic else w
+
+    @staticmethod
+    def _np_frame(x, frame_length, hop_length):
+        """Create overlapping frames using stride tricks (replaces librosa.util.frame)."""
+        n_frames = 1 + (x.shape[-1] - frame_length) // hop_length
+        strides = x.strides[:-1] + (x.strides[-1] * hop_length, x.strides[-1])
+        shape = x.shape[:-1] + (n_frames, frame_length)
+        return np.lib.stride_tricks.as_strided(x, shape=shape, strides=strides)
+
+    def _frame_audio(self, audio, window, frame_length, hop_length, n_fft, stft_cfg):
+        if stft_cfg.center == "left":
+            # semicausal (USM/Gemma): zeros prepended only
+            audio = self._pad_axis(audio, (stft_cfg.win_length or n_fft) // 2, 0, axis=-1)
+        elif stft_cfg.center:
+            pad_width = [(0, 0)] * (audio.ndim - 1) + [(frame_length // 2, frame_length // 2)]
+            audio = np.pad(audio, pad_width, mode=stft_cfg.pad_mode)
+        frames = self._np_frame(np.ascontiguousarray(audio), frame_length, hop_length)
+        compute_dtype = np.result_type(audio.dtype, window.dtype)
+        return frames.astype(compute_dtype, copy=False)
+
+    def _preemphasize_waveform(self, audio, preemphasis, audio_ranges=None):
+        out = audio.copy()
+        out[..., 1:] = audio[..., 1:] - preemphasis * audio[..., :-1]  # first sample unchanged
+        if audio_ranges is not None:
+            lengths = np.asarray([end - start for start, end in audio_ranges])
+            mask = np.arange(out.shape[-1])[None, :] < lengths[:, None]
+            out = np.where(mask, out, 0.0).astype(audio.dtype, copy=False)
+        return out
+
+    def _apply_dither(self, audio, audio_ranges=None):
+        return audio + (self.dither * np.random.randn(*audio.shape)).astype(audio.dtype)
+
+    def _window_and_fft(self, frames, window, frame_length, n_fft, stft_cfg, audio_dtype=None):
+        frames = frames * window
+        spec = np.fft.rfft(frames, n=n_fft, axis=-1)
+        if stft_cfg.fft_dtype is None:
+            # librosa contract: FFT output rounded through complex64
+            spec = spec.astype(np.complex64)
+        if stft_cfg.normalized:
+            spec = spec / np.sqrt(np.sum(window**2)).astype(spec.real.dtype)
+        return np.moveaxis(spec, -1, -2)
+
+    def _native_stft(self, audio, window, frame_length, hop_length, n_fft, stft_cfg):
+        # No numpy-native STFT exists; compose the manual framing + FFT leaves. This path
+        # receives the center-padded window and frame_length == n_fft from
+        # `_prepare_window_and_framing`, unlike the manual path (left-aligned window).
+        # `fft_dtype` can't leak in here: `_stft` rejects it on native-STFT configurations.
+        frames = self._frame_audio(audio, window, frame_length, hop_length, n_fft, stft_cfg)
+        return self._window_and_fft(frames, window, frame_length, n_fft, stft_cfg)
+
+    def _compute_magnitudes(self, stft_out, power, spectrogram_config=None):
+        # computation_dtype signals that upstream FE used float64 magnitudes
+        if spectrogram_config and spectrogram_config.computation_dtype:
+            return np.abs(stft_out, dtype=np.float64) ** power
+        return np.abs(stft_out) ** power
+
+    # ── Mel scale & normalization ─────────────────────────────────────────
+    #
+    # The base `_mel_filter_bank` dispatcher (audio_processing_utils) resolves geometry
+    # and dtype; the three leaves below own the numerical construction. Each backend's
+    # leaves deliberately implement their own ecosystem's rounding pattern: these numpy
+    # leaves are bit-exact against librosa and the legacy numpy feature extractors, the
+    # torch leaves against torchaudio / torchaudio.compliance.kaldi. The two backends are
+    # numerically equivalent but NOT bit-identical.
+
+    @staticmethod
+    def _np_triangular_banks(fft_freqs, filter_freqs, computation_dtype):
+        """Triangular bank with the numpy ecosystem's dtype policy.
+
+        With no computation dtype, replicate librosa's per-band float32 rounding:
+        slopes computed in float64 with each band's column cast to float32 on
+        assignment (librosa assigns rows into a float32-initialized array, which
+        rounds differently than casting a float64 matrix at the end). With a dtype,
+        plain full-precision construction cast to that dtype.
+        """
+        if computation_dtype is None:
+            num_frequency_bins = fft_freqs.shape[0]
+            num_mel_filters = filter_freqs.shape[0] - 2
+            filter_diff = np.diff(filter_freqs)
+            ramps = np.subtract.outer(filter_freqs, fft_freqs)  # (num_mel_filters+2, num_frequency_bins)
+            mel_filters = np.zeros((num_frequency_bins, num_mel_filters), dtype=np.float32)
+            for i in range(num_mel_filters):
+                lower = -ramps[i] / filter_diff[i]
+                upper = ramps[i + 2] / filter_diff[i + 1]
+                mel_filters[:, i] = np.maximum(0, np.minimum(lower, upper)).astype(np.float32)
+            return mel_filters
+        return _create_triangular_filter_bank(fft_freqs, filter_freqs).astype(np.dtype(computation_dtype), copy=False)
+
+    def _kaldi_exact_mel_banks(
+        self,
+        num_mel_filters,
+        num_frequency_bins,
+        min_frequency,
+        max_frequency,
+        sampling_rate,
+        n_fft,
+        mel_cfg,
+        computation_dtype,
+    ):
+        """Mel-space triangularization, numpy-ecosystem semantics.
+
+        Bit-exact against the legacy numpy feature extractors (e.g. SeamlessM4T):
+        ``hertz_to_mel(mel_scale=...)`` on float64 bin frequencies and filter edges from
+        ``np.linspace`` in mel space. Deliberately NOT torchaudio's hardcoded
+        ``1127 * log`` float32 ``get_mel_banks`` arithmetic — the torch leaf owns that
+        rounding pattern; the two leaves are numerically equivalent, not bit-identical.
+        """
+        mel_min = hertz_to_mel(min_frequency, mel_scale=mel_cfg.mel_scale)
+        mel_max = hertz_to_mel(max_frequency, mel_scale=mel_cfg.mel_scale)
+        filter_freqs = np.linspace(mel_min, mel_max, num_mel_filters + 2)
+        fft_bin_width = sampling_rate / n_fft
+        fft_freqs = hertz_to_mel(fft_bin_width * np.arange(num_frequency_bins), mel_scale=mel_cfg.mel_scale)
+        return self._np_triangular_banks(fft_freqs, filter_freqs, computation_dtype)
+
+    def _kaldi_mel_banks_with_zero_bands(
+        self,
+        num_mel_filters,
+        num_frequency_bins,
+        min_frequency,
+        max_frequency,
+        sampling_rate,
+        n_fft,
+        mel_cfg,
+        computation_dtype,
+    ):
+        """Mel-space triangularization (numpy-ecosystem semantics, see
+        `_kaldi_exact_mel_banks`) with the lowest ``bands_to_zero`` bins zeroed."""
+        mel_min = hertz_to_mel(min_frequency, mel_scale=mel_cfg.mel_scale)
+        mel_max = hertz_to_mel(max_frequency, mel_scale=mel_cfg.mel_scale)
+        filter_freqs = np.linspace(mel_min, mel_max, num_mel_filters + 2)
+        fft_bin_width = sampling_rate / n_fft
+        fft_freqs = hertz_to_mel(
+            fft_bin_width * np.arange(mel_cfg.bands_to_zero, num_frequency_bins), mel_scale=mel_cfg.mel_scale
+        )
+        mel_filters = self._np_triangular_banks(fft_freqs, filter_freqs, computation_dtype)
+        if mel_cfg.bands_to_zero > 0:
+            mel_filters = np.pad(mel_filters, ((mel_cfg.bands_to_zero, 0), (0, 0)))
+        return mel_filters
+
+    def _standard_mel_banks(
+        self,
+        num_mel_filters,
+        num_frequency_bins,
+        min_frequency,
+        max_frequency,
+        sampling_rate,
+        n_fft,
+        mel_cfg,
+        computation_dtype,
+    ):
+        """Standard triangular mel filter bank, numpy-ecosystem semantics.
+
+        Bit-exact against librosa's filters (and the legacy numpy feature extractors
+        built on them): FFT bin frequencies always use the float64
+        ``linspace(0, sr // 2, bins)`` form regardless of ``frequency_bin_mode``, and
+        the slaney area-norm is applied after the dtype policy (i.e. after the per-band
+        float32 cast when no computation dtype is set — librosa's rounding order).
+        The torch leaf implements torchaudio's rounding instead; the two leaves are
+        numerically equivalent, not bit-identical.
+        """
+        mel_min = hertz_to_mel(min_frequency, mel_scale=mel_cfg.mel_scale)
+        mel_max = hertz_to_mel(max_frequency, mel_scale=mel_cfg.mel_scale)
+        mel_freqs = np.linspace(mel_min, mel_max, num_mel_filters + 2)
+        filter_freqs = mel_to_hertz(mel_freqs, mel_scale=mel_cfg.mel_scale)
+        fft_freqs = np.linspace(0, sampling_rate // 2, num_frequency_bins)
+        mel_filters = self._np_triangular_banks(fft_freqs, filter_freqs, computation_dtype)
+        if mel_cfg.norm == "slaney":
+            # Slaney-style mel is scaled to be approx constant energy per channel
+            enorm = 2.0 / (filter_freqs[2 : num_mel_filters + 2] - filter_freqs[:num_mel_filters])
+            mel_filters *= np.expand_dims(enorm, 0)
+        if mel_cfg.bands_to_zero > 0:
+            mel_filters = np.pad(mel_filters, ((mel_cfg.bands_to_zero, 0), (0, 0)))
+        return mel_filters
+
+    def _cast_mel_filters_to_default_float(self, mel_filters):
+        return mel_filters.astype(np.float32, copy=False)
+
+    def _apply_mel_scale(self, features, *, spectrogram_config, **kwargs):
+        mel_filters = self.mel_filters.astype(features.dtype, copy=False)
+        if spectrogram_config.mel_scale_config.matmul_order == "features_first":
+            mel_spec = np.matmul(features.swapaxes(-2, -1), mel_filters)
+        else:
+            mel_spec = np.matmul(mel_filters.T, features)
+        return np.maximum(spectrogram_config.mel_floor, mel_spec)
+
+    # ── Kaldi fbank helper ────────────────────────────────────────────────
+
+    def _kaldi_fbank(self, waveform, num_mel_bins, sample_frequency=None, **kwargs):
+        """Extract kaldi-compatible fbank features using torchaudio (or fallback to base pipeline).
+
+        Returns numpy array of shape (time, num_mel_bins).
+        """
+        if sample_frequency is None:
+            sample_frequency = self.sampling_rate
+
+        if is_speech_available():
+            import torchaudio.compliance.kaldi as ta_kaldi
+
+            waveform_tensor = torch.from_numpy(np.asarray(waveform)).unsqueeze(0)
+            fbank = ta_kaldi.fbank(
+                waveform_tensor, num_mel_bins=num_mel_bins, sample_frequency=sample_frequency, **kwargs
+            )
+            return fbank.numpy()
+
+        waveform = np.squeeze(waveform)
+        features = self.extract_spectrogram([waveform], spectrogram_config=self.spectrogram_config)
+        return features[0].T
+
+
+class TorchAudioBackend(BaseAudioProcessor):
+    """Torch backend for audio processing."""
+
+    def __init__(self, *args, **kwargs: Unpack[AudioKwargs]):
+        super().__init__(*args, **kwargs)
+        self._set_attributes(**kwargs)
+
+    @property
+    def backend(self) -> str:
+        return "torch"
+
+    # ── Backend array-API primitives ─────────────────────────────────────
+
+    def _astype(self, x, dtype_name):
+        return x.to(getattr(torch, dtype_name))
+
+    def _amax_over_features(self, x):
+        return x.amax(dim=(-2, -1), keepdim=True)
+
+    def _zeros_int32(self, shape):
+        return torch.zeros(shape, dtype=torch.int32)
+
+    def _as_backend_array(self, x):
+        if isinstance(x, np.ndarray):
+            return torch.from_numpy(x)
+        if isinstance(x, torch.Tensor):
+            return x
+        # Sequences (e.g. `list[list[float]]`) are a documented input type; convert through numpy
+        # so the torch backend accepts everything the numpy one does.
+        return torch.from_numpy(np.asarray(x))
+
+    def _mean_axis0(self, x):
+        return x.mean(dim=0)
+
+    def _squeeze_axis0(self, x):
+        return x.squeeze(0)
+
+    def _resample(self, audio, orig_sampling_rate: int, target_sampling_rate: int):
+        requires_backends(self._resample, ["torchaudio"])
+        import torchaudio
+
+        return torchaudio.functional.resample(audio, orig_freq=orig_sampling_rate, new_freq=target_sampling_rate)
+
+    def _pad_axis(self, x, left, right, axis, value=0.0):
+        axis = axis % x.ndim
+        pad = [0, 0] * (x.ndim - 1 - axis) + [left, right]
+        return torch.nn.functional.pad(x, pad, "constant", value)
+
+    def _stack(self, seq):
+        return torch.stack(seq)
+
+    def _insert_channel_dim(self, batch):
+        return batch.unsqueeze(1)
+
+    def _mean_last(self, x):
+        return x.mean(dim=-1, keepdim=True)
+
+    def _concat_last(self, parts):
+        return torch.cat(parts, dim=-1)
+
+    # ── STFT pipeline ─────────────────────────────────────────────────────
+
+    def _create_stft_window(self, win_length, stft_cfg, audio):
+        dtype = getattr(torch, stft_cfg.window_dtype) if stft_cfg.window_dtype else audio.dtype
+        wkwargs = {**(stft_cfg.wkwargs or {}), "dtype": dtype}
+        name = stft_cfg.window_fn
+        if name == "hann_window_f32":
+            # numpy build + convert, so both backends' windows are bit-identical;
+            # ignores `periodic`/`window_dtype`/`wkwargs`
+            arange = np.arange(win_length, dtype=np.float32)
+            window = torch.from_numpy((0.5 * (1 - np.cos(2 * np.pi * arange / win_length))).astype(np.float32))
+            return window.to(device=audio.device)
+        if name in ("hann", "hann_window"):
+            window = torch.hann_window(win_length, periodic=stft_cfg.periodic, **wkwargs)
+        elif name in ("hamming", "hamming_window"):
+            window = torch.hamming_window(win_length, periodic=stft_cfg.periodic, **wkwargs)
+        elif name == "boxcar":
+            window = torch.ones(win_length, dtype=dtype)
+        elif name == "povey":
+            window = torch.hann_window(win_length, periodic=stft_cfg.periodic, **wkwargs).pow(0.85)
+        else:
+            raise ValueError(f"Unknown window function '{name}'")
+        return window.to(device=audio.device)
+
+    def _frame_audio(self, audio, window, frame_length, hop_length, n_fft, stft_cfg):
+        if stft_cfg.center == "left":
+            pad_left = (stft_cfg.win_length or n_fft) // 2
+            audio = torch.nn.functional.pad(audio, (pad_left, 0), mode="constant", value=0.0)
+        elif stft_cfg.center:
+            audio = torch.nn.functional.pad(audio, (frame_length // 2, frame_length // 2), mode=stft_cfg.pad_mode)
+        return audio.unfold(-1, frame_length, hop_length)
+
+    def _preemphasize_waveform(self, audio, preemphasis, audio_ranges=None):
+        audio = torch.cat([audio[..., :1], audio[..., 1:] - preemphasis * audio[..., :-1]], dim=-1)
+        if audio_ranges is not None:
+            lengths = torch.tensor([end - start for start, end in audio_ranges], device=audio.device)
+            mask = torch.arange(audio.shape[-1], device=audio.device).unsqueeze(0) < lengths.unsqueeze(1)
+            audio = audio.masked_fill(~mask, 0.0)
+        return audio
+
+    def _apply_dither(self, audio, audio_ranges=None):
+        noise = torch.randn(audio.shape, dtype=audio.dtype, device=audio.device)
+        return audio + self.dither * noise
+
+    def _window_and_fft(self, frames, window, frame_length, n_fft, stft_cfg, audio_dtype=None):
+        frames = frames * window
+        if stft_cfg.fft_dtype == "float64":
+            frames = frames.to(torch.float64)  # mirrors numpy's rfft float64 promotion
+        if frame_length < n_fft:
+            frames = torch.nn.functional.pad(frames, (0, n_fft - frame_length))
+        spec = torch.fft.rfft(frames, n=n_fft)
+        if stft_cfg.normalized:
+            spec = spec / window.pow(2.0).sum().sqrt()
+        return spec.transpose(-2, -1)
+
+    def _native_stft(self, audio, window, frame_length, hop_length, n_fft, stft_cfg):
+        stft_out = torch.stft(
+            audio,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=frame_length,
+            window=window,
+            center=stft_cfg.center,
+            pad_mode=stft_cfg.pad_mode,
+            normalized=False,
+            return_complex=True,
+        )
+        if stft_cfg.normalized:
+            stft_out = stft_out / window.pow(2.0).sum().sqrt()
+        return stft_out
+
+    def _cast_stft_output(self, magnitudes, spectrogram_config):
+        if spectrogram_config.computation_dtype:
+            return magnitudes
+        return magnitudes.float()
+
+    def _compute_magnitudes(self, stft_out, power, spectrogram_config=None):
+        # `torch.stft` returns a non-contiguous tensor and `abs() ** power` keeps that layout.
+        # On some CPU backends the downstream `mel_filters.T @ magnitudes` matmul then falls onto
+        # a slow strided-GEMM path (~8x slower on a ROCm build, see #47351). Forcing contiguity
+        # here is cheap, changes no values, and keeps the matmul on the fast path.
+        if spectrogram_config and spectrogram_config.stft_config.magnitude_mode == "sqrt_sum_squares":
+            # NeMo-derived form; differs from `abs()` in the last ulp
+            magnitudes = torch.view_as_real(stft_out).pow(2).sum(-1).sqrt()
+            magnitudes = magnitudes.pow(power) if power != 1.0 else magnitudes
+            return magnitudes.contiguous()
+        return (stft_out.abs() ** power).contiguous()
+
+    # ── Mel scale & normalization ─────────────────────────────────────────
+    #
+    # The base `_mel_filter_bank` dispatcher (audio_processing_utils) resolves geometry
+    # and dtype; the three leaves below own the numerical construction. Each backend's
+    # leaves deliberately implement their own ecosystem's rounding pattern: these torch
+    # leaves are bit-exact against torchaudio / torchaudio.compliance.kaldi, the numpy
+    # leaves against librosa and the legacy numpy feature extractors. The two backends
+    # are numerically equivalent but NOT bit-identical.
+
+    @staticmethod
+    def _kaldi_exact_mel_banks(
+        num_mel_filters,
+        num_frequency_bins,
+        min_frequency,
+        max_frequency,
+        sampling_rate,
+        n_fft,
+        mel_cfg,
+        computation_dtype,
+    ):
+        """Matches torchaudio.compliance.kaldi.get_mel_banks exactly.
+
+        Hardcoded ``1127 * log`` kaldi mel scale and ``get_mel_banks``'s edge arithmetic,
+        in torch's default float32 when no computation dtype is set. The numpy leaf owns
+        the legacy numpy-FE construction instead (``hertz_to_mel`` + linspace in float64);
+        the two leaves are numerically equivalent, not bit-identical.
+        """
+        dtype = getattr(torch, computation_dtype) if computation_dtype else None
+        num_fft_bins = n_fft // 2
+        fft_bin_width = sampling_rate / n_fft
+        mel_low = 1127.0 * math.log(1.0 + min_frequency / 700.0)
+        mel_high = 1127.0 * math.log(1.0 + max_frequency / 700.0)
+        mel_delta = (mel_high - mel_low) / (num_mel_filters + 1)
+
+        bin_idx = torch.arange(num_mel_filters, dtype=dtype).unsqueeze(1)
+        left_mel = mel_low + bin_idx * mel_delta
+        center_mel = mel_low + (bin_idx + 1.0) * mel_delta
+        right_mel = mel_low + (bin_idx + 2.0) * mel_delta
+
+        mel = 1127.0 * (1.0 + fft_bin_width * torch.arange(num_fft_bins, dtype=dtype) / 700.0).log()
+        mel = mel.unsqueeze(0)
+
+        up_slope = (mel - left_mel) / (center_mel - left_mel)
+        down_slope = (right_mel - mel) / (right_mel - center_mel)
+        banks = torch.max(torch.zeros(1, dtype=dtype), torch.min(up_slope, down_slope))
+        banks = torch.nn.functional.pad(banks, (0, 1), mode="constant", value=0)
+        return banks.T
+
+    @staticmethod
+    def _kaldi_mel_banks_with_zero_bands(
+        num_mel_filters,
+        num_frequency_bins,
+        min_frequency,
+        max_frequency,
+        sampling_rate,
+        n_fft,
+        mel_cfg,
+        computation_dtype,
+    ):
+        """Kaldi-style (triangularize in mel space) with optional zeroed low bands."""
+        dtype = getattr(torch, computation_dtype) if computation_dtype else None
+        mel_min = hertz_to_mel(min_frequency, mel_scale=mel_cfg.mel_scale)
+        mel_max = hertz_to_mel(max_frequency, mel_scale=mel_cfg.mel_scale)
+        filter_freqs = torch.linspace(mel_min, mel_max, num_mel_filters + 2, dtype=dtype)
+
+        fft_bin_width = sampling_rate / n_fft
+        hz_freqs = fft_bin_width * torch.arange(mel_cfg.bands_to_zero, num_frequency_bins, dtype=dtype)
+        fft_freqs = hertz_to_mel(hz_freqs, mel_scale=mel_cfg.mel_scale)
+
+        mel_filters = _create_triangular_filter_bank(fft_freqs, filter_freqs)
+        if mel_cfg.bands_to_zero > 0:
+            mel_filters = torch.nn.functional.pad(mel_filters, (0, 0, mel_cfg.bands_to_zero, 0))
+        return mel_filters
+
+    @staticmethod
+    def _standard_mel_banks(
+        num_mel_filters,
+        num_frequency_bins,
+        min_frequency,
+        max_frequency,
+        sampling_rate,
+        n_fft,
+        mel_cfg,
+        computation_dtype,
+    ):
+        """Standard (non-kaldi) triangular mel filter bank, torchaudio-ecosystem semantics.
+
+        Bit-exact against ``torchaudio.functional.melscale_fbanks`` in the default-dtype
+        case; the numpy leaf owns librosa's rounding pattern instead, so the two leaves are
+        numerically equivalent but not bit-identical.
+
+        ``bank_rounding="librosa"`` opts this leaf into librosa's pattern too, for models
+        whose legacy extractor built its filters with ``librosa.filters.mel`` (Parakeet,
+        Cohere-ASR): float64 ``linspace`` bins regardless of ``frequency_bin_mode``, cast to
+        float32 *before* the slaney norm, then a second float32 rounding after it — the only
+        order that reproduces those filters bit-exactly.
+        """
+        librosa_rounding = mel_cfg.bank_rounding == "librosa"
+        if librosa_rounding:
+            dtype = torch.float64
+        else:
+            dtype = getattr(torch, computation_dtype) if computation_dtype else None
+        mel_min = hertz_to_mel(min_frequency, mel_scale=mel_cfg.mel_scale)
+        mel_max = hertz_to_mel(max_frequency, mel_scale=mel_cfg.mel_scale)
+        mel_freqs = torch.linspace(mel_min, mel_max, num_mel_filters + 2, dtype=dtype)
+        filter_freqs = mel_to_hertz(mel_freqs, mel_scale=mel_cfg.mel_scale)
+
+        if mel_cfg.frequency_bin_mode == "rfft" and not librosa_rounding:
+            fft_freqs = torch.fft.rfftfreq(n=n_fft, d=1.0 / sampling_rate)
+        else:
+            fft_freqs = torch.linspace(0, sampling_rate // 2, num_frequency_bins)
+        if dtype is not None:
+            fft_freqs = fft_freqs.to(dtype)
+
+        mel_filters = _create_triangular_filter_bank(fft_freqs, filter_freqs)
+        if librosa_rounding:
+            mel_filters = mel_filters.to(torch.float32)
+
+        if mel_cfg.norm == "slaney":
+            enorm = 2.0 / (filter_freqs[2 : num_mel_filters + 2] - filter_freqs[:num_mel_filters])
+            mel_filters = mel_filters * enorm[None, :]
+            if librosa_rounding:
+                mel_filters = mel_filters.to(torch.float32)
+
+        if mel_cfg.bands_to_zero > 0:
+            mel_filters = torch.nn.functional.pad(mel_filters, (0, 0, mel_cfg.bands_to_zero, 0))
+        return mel_filters
+
+    def _cast_mel_filters_to_default_float(self, mel_filters):
+        return mel_filters.to(torch.get_default_dtype())
+
+    def _apply_mel_scale(self, features, *, spectrogram_config, **kwargs):
+        # Match the filters to the feature dtype: unlike numpy, `torch.matmul` refuses mixed
+        # dtypes, so float64 filters against float32 features would raise instead of promoting.
+        mel_filters = self.mel_filters.to(device=features.device, dtype=features.dtype)
+        matmul_order = spectrogram_config.mel_scale_config.matmul_order
+        if matmul_order == "features_first":
+            mel_spec = torch.matmul(features.transpose(-2, -1), mel_filters)
+        elif matmul_order == "filters_first_matmul":
+            # legacy `mel_filters @ magnitudes`; differs from F.linear in the last ulp
+            mel_spec = torch.matmul(mel_filters.T, features)
+        else:
+            # F.linear matches torchaudio's MelScale implementation exactly
+            mel_spec = torch.nn.functional.linear(features.transpose(-2, -1), mel_filters.T).transpose(-2, -1)
+        return torch.clamp(mel_spec, min=spectrogram_config.mel_floor)

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -66,6 +66,7 @@ deps = {
     "scikit-learn": "scikit-learn",
     "scipy": "scipy",
     "sentencepiece": "sentencepiece>=0.1.91,!=0.1.92",
+    "soxr": "soxr",
     "starlette": "starlette",
     "sudachipy": "sudachipy>=0.6.6",
     "sudachidict_core": "sudachidict_core>=20220729",

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -214,6 +214,7 @@ from .import_utils import (
     is_sinq_available,
     is_sklearn_available,
     is_soundfile_available,
+    is_soxr_available,
     is_spacy_available,
     is_speech_available,
     is_spqr_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1551,6 +1551,12 @@ def is_torchao_available(min_version: str = TORCHAO_MIN_VERSION) -> bool:
 
 @lru_cache
 @_make_compile_constant
+def is_soxr_available() -> bool:
+    return _is_package_available("soxr")[0]
+
+
+@lru_cache
+@_make_compile_constant
 def is_speech_available() -> bool:
     # For now this depends on torchaudio but the exact dependency might evolve in the future.
     return is_torchaudio_available()
@@ -2092,8 +2098,16 @@ Please note that you may need to restart your runtime after installation.
 
 # docstyle-ignore
 TORCHAUDIO_IMPORT_ERROR = """
-{0} requires the torchaudio library but it was not found in your environment. Please install it and restart your
-runtime.
+{0} requires the torchaudio library but it was not found in your environment. You can install it with pip:
+`pip install transformers[audio]`
+Please note that you may need to restart your runtime after installation.
+"""
+
+# docstyle-ignore
+SOXR_IMPORT_ERROR = """
+{0} requires the soxr library but it was not found in your environment. You can install it with pip:
+`pip install transformers[audio]`
+Please note that you may need to restart your runtime after installation.
 """
 
 # docstyle-ignore
@@ -2301,6 +2315,7 @@ BACKENDS_MAPPING = OrderedDict(
         ("pytorch_quantization", (is_pytorch_quantization_available, PYTORCH_QUANTIZATION_IMPORT_ERROR)),
         ("sentencepiece", (is_sentencepiece_available, SENTENCEPIECE_IMPORT_ERROR)),
         ("sklearn", (is_sklearn_available, SKLEARN_IMPORT_ERROR)),
+        ("soxr", (is_soxr_available, SOXR_IMPORT_ERROR)),
         ("speech", (is_speech_available, SPEECH_IMPORT_ERROR)),
         ("timm", (is_timm_available, TIMM_IMPORT_ERROR)),
         ("torchaudio", (is_torchaudio_available, TORCHAUDIO_IMPORT_ERROR)),


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48112&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48112) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48112&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48112)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Adds `NumpyAudioBackend` and `TorchAudioBackend`, the two concrete implementations of `BaseAudioProcessor`'s array primitives — bit-exact with librosa/kaldi and with torchaudio respectively. Every model processor picks a backend and supplies a `SpectrogramConfig` rather than reimplementing STFT/mel/log framing.