### PR TITLE
Enable mlinter findings artifact for inline PR reviews

### DIFF
--- a/utils/check_modeling_structure.py
+++ b/utils/check_modeling_structure.py
@@ -26,7 +26,7 @@ CHECKER_CONFIG = {
         "src/transformers/models/**/modular_*.py",
         "src/transformers/models/**/configuration_*.py",
     ],
-    "check_args": ["--rules-toml", "utils/rules.toml"],
+    "check_args": ["--rules-toml", "utils/rules.toml", "--output-json", "mlinter-findings.json"],
     "fix_args": None,
 }
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48117)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48117)
<!-- ci-dashboard-badge:end -->

## Summary

Last piece of the mlinter inline review pipeline, verified in #48109.

Adds `--output-json mlinter-findings.json` to the mlinter invocation so the `check_code_quality` job uploads a `mlinter-findings` artifact. The `post-mlinter-review` job (already on main) then downloads it and posts inline review comments on the PR.

The full pipeline:
1. `check_code_quality` → runs mlinter → writes `mlinter-findings.json` → uploads artifact ← **this PR**
2. `pr-ci-post-dashboard-link.yml` → downloads artifact → runs `post_mlinter_review.py` → posts inline review