### PR TITLE
Fix `gpt_oss` runs on GPU

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -32,12 +32,11 @@ import pytest
 from transformers.testing_utils import (
     HfDoctestModule,
     HfDocTestParser,
-    backend_device_count,
+    get_ci_cpu_memory_budget_gib,
     is_torch_available,
     patch_psutil_cpu_memory,
     patch_testing_methods_to_collect_info,
     patch_torch_compile_force_graph,
-    torch_device,
 )
 from transformers.utils import enable_tf32
 from transformers.utils.network_logging import register_network_debug_plugin
@@ -159,15 +158,11 @@ def _with_tmpdir_cache_fallback(fn):
 # In K8S instance-sharing CI, each runner sees the full machine's CPU RAM (~750 GB) even though it only
 # owns a fraction. This causes `device_map="auto"` to overfill GPU+CPU with nothing offloaded to disk,
 # leading to GPU OOM at runtime. When CI_CPU_MEMORY_LIMIT_GB is set, cap psutil.virtual_memory so the
-# entire test session sees a realistic per-runner memory budget.
-# On multi-accelerator runners the budget scales linearly: each accelerator earns one full slot of CPU RAM
-# (e.g. 4 GPUs × 60 GB = 240 GB), because device_map="auto" can legitimately use more CPU RAM for
-# intermediate storage when more GPU devices are present.
-_cpu_memory_limit_gb = os.environ.get("CI_CPU_MEMORY_LIMIT_GB")
-if _cpu_memory_limit_gb is not None:
-    _limit_per_device = int(float(_cpu_memory_limit_gb) * 1024**3)
-    _num_accelerators = max(1, backend_device_count(torch_device)) if torch_device is not None else 1
-    patch_psutil_cpu_memory(_limit_per_device * _num_accelerators)
+# entire test session sees a realistic per-runner memory budget. `get_ci_cpu_memory_budget_gib` owns the
+# per-accelerator arithmetic, and is also what the `require_large_cpu_ram` guard reads.
+_cpu_memory_budget_gib = get_ci_cpu_memory_budget_gib()
+if _cpu_memory_budget_gib is not None:
+    patch_psutil_cpu_memory(int(_cpu_memory_budget_gib * 1024**3))
 
 
 NOT_DEVICE_TESTS = {

--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -91,8 +91,6 @@ RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/pef
 
 # For bettertransformer
 RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/optimum@main#egg=optimum
-# For kernels
-RUN python3 -m pip install --no-cache-dir kernels
 
 # For ONNX export tests (onnxscript pulls in onnx + onnx_ir; onnxruntime-gpu validates the exported
 # graph on GPU for faster export testing)

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1230,51 +1230,99 @@ def get_cgroup_memory_limit_bytes() -> int | None:
     return None
 
 
+# Set by `patch_psutil_cpu_memory` to the pre-patch `psutil.virtual_memory`, so the guards below can still read
+# the machine's real RAM after conftest has capped what the rest of the session sees.
+_UNPATCHED_VIRTUAL_MEMORY = None
+
+
+def get_physical_cpu_ram_gib() -> float | None:
+    """
+    RAM physically present on this machine, in GiB, or `None` when psutil is unavailable.
+
+    Deliberately reads *past* the `patch_psutil_cpu_memory` cap: that cap is a `device_map="auto"` planning budget
+    (`CI_CPU_MEMORY_LIMIT_GB` per accelerator), not a statement about the machine. Note this is the wrong number
+    inside a pod, where it reports the whole node -- `get_cpu_ram_total_gib` is what combines it with the cgroup
+    limit to get an answer that holds in both places.
+    """
+    if not is_psutil_available():
+        return None
+
+    import psutil
+
+    virtual_memory = _UNPATCHED_VIRTUAL_MEMORY or psutil.virtual_memory
+    return virtual_memory().total / 1024**3
+
+
+def get_ci_cpu_memory_budget_gib() -> float | None:
+    """
+    CPU RAM budget this CI runner is entitled to, in GiB, or `None` outside CI.
+
+    `CI_CPU_MEMORY_LIMIT_GB` is a *per-accelerator* budget: a single-accelerator A10 runner gets 60 GiB, and a
+    runner with more accelerators gets proportionally more, because `device_map="auto"` can legitimately use more
+    CPU RAM for intermediate storage when more devices are present. So the budget is the variable times the
+    accelerator count -- reading the variable raw would report 60 GiB on a 2-accelerator runner that has 180.
+
+    This is the single source of truth for that arithmetic, shared with the `patch_psutil_cpu_memory` call in
+    `conftest.py`.
+    """
+    limit_per_device = os.environ.get("CI_CPU_MEMORY_LIMIT_GB")
+    if limit_per_device is None:
+        return None
+    try:
+        limit_per_device = float(limit_per_device)
+    except ValueError:
+        return None
+
+    num_accelerators = max(1, backend_device_count(torch_device)) if torch_device is not None else 1
+    return limit_per_device * num_accelerators
+
+
 def get_cpu_ram_total_gib() -> float:
     """
-    CPU RAM this process may actually use, in GiB. Returns 0 when it cannot be determined.
+    CPU RAM this process may actually use, in GiB.
 
-    Takes the smallest of three views, because each one is wrong on its own:
-    - the cgroup limit, which is what the OOM killer enforces in a container but is absent outside one;
-    - `psutil.virtual_memory().total`, which is the right answer on bare metal but reports the whole node inside a
-      pod -- unless `conftest.py` has capped it, see `patch_psutil_cpu_memory`;
-    - `CI_CPU_MEMORY_LIMIT_GB`, the explicit per-runner budget set in CI. Note that `conftest.py` deliberately
-      multiplies it by the accelerator count when patching psutil (a `device_map="auto"` planning budget, not a
-      pod limit), so read the raw variable here instead of the patched psutil value.
+    Prefers what can be *measured* -- the cgroup limit the OOM killer enforces, and the machine's physical RAM --
+    taking the smaller of the two, since each is wrong on its own: there is no cgroup limit outside a container,
+    and physical RAM reports the whole node inside a pod.
+
+    Falls back to the CI budget (`get_ci_cpu_memory_budget_gib`) only when neither can answer, because that budget
+    is an allocation policy rather than a measurement: it is deliberately `CI_CPU_MEMORY_LIMIT_GB` per accelerator,
+    so on a 2-accelerator runner it reads 120 GiB where the runner really has 180. Using it as a term in the `min`
+    would make every guard on such a runner over-skip.
+
+    Returns `inf` when nothing can answer at all -- no cgroup, no psutil, no CI budget. That is an ordinary local
+    setup rather than a broken one, so callers run their test instead of silently dropping coverage; a guard is
+    only useful where the limit is actually knowable.
     """
-    limits = []
+    measured = []
 
     cgroup_limit = get_cgroup_memory_limit_bytes()
     if cgroup_limit is not None:
-        limits.append(cgroup_limit / 1024**3)
+        measured.append(cgroup_limit / 1024**3)
 
-    if is_psutil_available():
-        import psutil
+    physical_ram = get_physical_cpu_ram_gib()
+    if physical_ram is not None:
+        measured.append(physical_ram)
 
-        limits.append(psutil.virtual_memory().total / 1024**3)
+    if measured:
+        return min(measured)
 
-    ci_limit = os.environ.get("CI_CPU_MEMORY_LIMIT_GB")
-    if ci_limit is not None:
-        try:
-            limits.append(float(ci_limit))
-        except ValueError:
-            pass
-
-    return min(limits) if limits else 0.0
+    ci_budget = get_ci_cpu_memory_budget_gib()
+    return ci_budget if ci_budget is not None else float("inf")
 
 
 def require_large_cpu_ram(test_case=None, *, memory: float = 80):
     """
     Decorator marking a test that requires a CPU RAM with more than `memory` GiB of memory.
 
-    Usable bare (`@require_large_cpu_ram`) or with a budget (`@require_large_cpu_ram(memory=48)`).
+    Usable bare (`@require_large_cpu_ram`) or with a budget (`@require_large_cpu_ram(memory=48)`). The default 80
+    is not an estimate of any particular model: it was picked as "more than the 60 GiB of our GPU runners", so a
+    bare use means "do not run this on a CI GPU runner". Pass `memory=` when the test has a real footprint.
     """
 
     def memory_decorator(tc):
-        # Without psutil we cannot tell, so run the test rather than silently dropping coverage.
-        if not is_psutil_available():
-            return tc
-
+        # `get_cpu_ram_total_gib` returns `inf` when it cannot measure anything (psutil missing and no cgroup), so
+        # an undetermined budget runs the test instead of silently dropping coverage.
         return unittest.skipUnless(
             get_cpu_ram_total_gib() > memory,
             f"test requires a machine with more than {memory} GiB of CPU RAM memory",
@@ -1319,7 +1367,8 @@ def get_accelerator_total_memory_gib() -> float:
     `get_device_properties(...).total_memory` -- so callers treat "we cannot tell" the same as "it does not fit",
     which is the safe direction: guessing too high OOM-kills the whole test process.
     """
-    # Same restriction as `require_torch_large_accelerator`: only cuda and xpu report `total_memory`.
+    # Same restriction as `require_torch_large_accelerator`: only cuda and xpu report `total_memory`. ROCm is
+    # covered by the cuda branch -- a HIP build of torch reports `torch_device == "cuda"`, see `IS_ROCM_SYSTEM`.
     if not is_torch_available() or torch_device not in ("cuda", "xpu"):
         return 0.0
 
@@ -3640,9 +3689,15 @@ def patch_psutil_cpu_memory(limit_bytes: int):
     leading to GPU OOM at runtime. Calling this function caps `total`, `available`, `used`, and `percent`
     so the entire test session sees a realistic per-runner memory budget.
     """
+    global _UNPATCHED_VIRTUAL_MEMORY
+
     import psutil
 
     _original_virtual_memory = psutil.virtual_memory
+    # Keep the honest reader reachable: the cap above is a `device_map="auto"` planning budget, but a guard that
+    # asks "will this OOM-kill the container?" needs the machine's real RAM. See `get_physical_cpu_ram_gib`.
+    if _UNPATCHED_VIRTUAL_MEMORY is None:
+        _UNPATCHED_VIRTUAL_MEMORY = _original_virtual_memory
 
     def _capped_virtual_memory():
         mem = _original_virtual_memory()

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1239,6 +1239,40 @@ def require_torch_large_accelerator(test_case=None, *, memory: float = 20):
     return memory_decorator if test_case is None else memory_decorator(test_case)
 
 
+def get_accelerator_total_memory_gib() -> float:
+    """
+    Total memory of *all* visible accelerators, in GiB.
+
+    Use this rather than the memory of a single device for tests that spread one model over every visible device
+    (`device_map="auto"`, tensor parallelism, ...). Returns 0 on CPU, and on the backends that do not expose
+    `get_device_properties(...).total_memory` -- so callers treat "we cannot tell" the same as "it does not fit",
+    which is the safe direction: guessing too high OOM-kills the whole test process.
+    """
+    # Same restriction as `require_torch_large_accelerator`: only cuda and xpu report `total_memory`.
+    if not is_torch_available() or torch_device not in ("cuda", "xpu"):
+        return 0.0
+
+    torch_accel = getattr(torch, torch_device)
+    total = sum(torch_accel.get_device_properties(i).total_memory for i in range(torch_accel.device_count()))
+    return total / 1024**3
+
+
+def require_torch_accelerator_memory(test_case=None, *, memory: float):
+    """
+    Decorator marking a test that needs at least `memory` GiB of accelerator memory *in total*, summed over every
+    visible accelerator. Prefer this over `require_torch_large_accelerator` (which only looks at device 0) for tests
+    that shard a single model across all visible devices.
+    """
+
+    def memory_decorator(tc):
+        return unittest.skipUnless(
+            get_accelerator_total_memory_gib() >= memory,
+            f"test requires {memory} GiB of accelerator memory in total",
+        )(tc)
+
+    return memory_decorator if test_case is None else memory_decorator(test_case)
+
+
 def require_torch_accelerator(test_case):
     """Decorator marking a test that requires an accessible accelerator and PyTorch."""
     return unittest.skipUnless(torch_device is not None and torch_device != "cpu", "test requires accelerator")(

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1199,17 +1199,88 @@ def require_rocm(test_case):
     return unittest.skipUnless(torch_device == "cuda" and IS_ROCM_SYSTEM, "test requires a ROCm (AMD) GPU")(test_case)
 
 
-def require_large_cpu_ram(test_case, memory: float = 80):
-    """Decorator marking a test that requires a CPU RAM with more than `memory` GiB of memory."""
-    if not is_psutil_available():
-        return test_case
+def get_cgroup_memory_limit_bytes() -> int | None:
+    """
+    Memory limit enforced on the current cgroup, or `None` when there is no limit / no cgroup to read.
 
-    import psutil
+    This is what the OOM killer actually enforces inside a container. `psutil.virtual_memory().total` reads the
+    *host* `/proc/meminfo`, so in a K8S pod it reports the whole node (~750 GiB) and says nothing about how much this
+    process may use before it is SIGKILLed.
+    """
+    candidates = (
+        ("/sys/fs/cgroup/memory.max", "max"),  # cgroup v2
+        ("/sys/fs/cgroup/memory/memory.limit_in_bytes", None),  # cgroup v1
+    )
+    for path, unlimited_marker in candidates:
+        try:
+            with open(path) as f:
+                raw = f.read().strip()
+        except OSError:
+            continue
+        if raw == unlimited_marker:
+            return None
+        try:
+            limit = int(raw)
+        except ValueError:
+            continue
+        # cgroup v1 writes a huge sentinel (a page-aligned 2**63-1) rather than a marker when unlimited
+        if limit <= 0 or limit >= 2**62:
+            return None
+        return limit
+    return None
 
-    return unittest.skipUnless(
-        psutil.virtual_memory().total / 1024**3 > memory,
-        f"test requires a machine with more than {memory} GiB of CPU RAM memory",
-    )(test_case)
+
+def get_cpu_ram_total_gib() -> float:
+    """
+    CPU RAM this process may actually use, in GiB. Returns 0 when it cannot be determined.
+
+    Takes the smallest of three views, because each one is wrong on its own:
+    - the cgroup limit, which is what the OOM killer enforces in a container but is absent outside one;
+    - `psutil.virtual_memory().total`, which is the right answer on bare metal but reports the whole node inside a
+      pod -- unless `conftest.py` has capped it, see `patch_psutil_cpu_memory`;
+    - `CI_CPU_MEMORY_LIMIT_GB`, the explicit per-runner budget set in CI. Note that `conftest.py` deliberately
+      multiplies it by the accelerator count when patching psutil (a `device_map="auto"` planning budget, not a
+      pod limit), so read the raw variable here instead of the patched psutil value.
+    """
+    limits = []
+
+    cgroup_limit = get_cgroup_memory_limit_bytes()
+    if cgroup_limit is not None:
+        limits.append(cgroup_limit / 1024**3)
+
+    if is_psutil_available():
+        import psutil
+
+        limits.append(psutil.virtual_memory().total / 1024**3)
+
+    ci_limit = os.environ.get("CI_CPU_MEMORY_LIMIT_GB")
+    if ci_limit is not None:
+        try:
+            limits.append(float(ci_limit))
+        except ValueError:
+            pass
+
+    return min(limits) if limits else 0.0
+
+
+def require_large_cpu_ram(test_case=None, *, memory: float = 80):
+    """
+    Decorator marking a test that requires a CPU RAM with more than `memory` GiB of memory.
+
+    Usable bare (`@require_large_cpu_ram`) or with a budget (`@require_large_cpu_ram(memory=48)`).
+    """
+
+    def memory_decorator(tc):
+        # Without psutil we cannot tell, so run the test rather than silently dropping coverage.
+        if not is_psutil_available():
+            return tc
+
+        return unittest.skipUnless(
+            get_cpu_ram_total_gib() > memory,
+            f"test requires a machine with more than {memory} GiB of CPU RAM memory",
+        )(tc)
+
+    return memory_decorator if test_case is None else memory_decorator(test_case)
 
 
 def require_torch_large_gpu(test_case, memory: float = 20):

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -33,6 +33,7 @@ from transformers import (
 from transformers.testing_utils import (
     cleanup,
     get_accelerator_total_memory_gib,
+    get_cpu_ram_total_gib,
     is_kernels_available,
     require_deterministic_for_xpu,
     require_kernels,
@@ -64,9 +65,11 @@ if is_torch_available():
 
 # Accelerator memory (in GiB, summed over every visible device) needed by the integration tests below. The
 # checkpoints ship as mxfp4, but these tests materialize bfloat16 weights -- either explicitly through
-# `dtype=torch.bfloat16`, or through `dtype="auto"` when the mxfp4 path is unavailable -- so budget ~2 bytes per
-# parameter plus headroom for activations and the KV cache. Training additionally keeps a gradient for every
-# parameter, hence roughly twice the weights.
+# `dtype=torch.bfloat16`, or through `dtype="auto"` when the mxfp4 path is unavailable.
+#
+# The weight term is exact, from `modeling_utils.get_total_byte_count` on a meta-device model: 38.96 GiB for 20b and
+# 217.61 GiB for 120b. The budgets below add headroom for activations and the KV cache; training additionally keeps a
+# gradient per parameter, hence roughly twice the weights.
 #
 # These are deliberately upper bounds: on a machine where mxfp4 weights stay packed the model needs much less, so the
 # guard may skip a test that would in fact have fit. That trade is on purpose -- without the guard, loading 120b on a
@@ -285,6 +288,23 @@ class GptOssIntegrationTest(unittest.TestCase):
                 f"only {available:.1f} GiB is visible"
             )
 
+    def skip_if_host_ram_cannot_hold(self, model_size):
+        """
+        Skip unless host RAM can hold `model_size`.
+
+        `distributed_worker` loads without a `device_map` and moves the model afterwards, so the whole checkpoint
+        transits through host RAM before it reaches any device -- that is the allocation that got the CI container
+        OOM-killed. `get_cpu_ram_total_gib` reports the per-runner budget in CI (see `CI_CPU_MEMORY_LIMIT_GB`), not
+        the RAM of the shared host.
+        """
+        required = INFERENCE_MEMORY_GIB[model_size]
+        available = get_cpu_ram_total_gib()
+        if available < required:
+            self.skipTest(
+                f"gpt-oss-{model_size} transits ~{required} GiB through host RAM, "
+                f"only {available:.1f} GiB is available"
+            )
+
     def setUp(self):
         cleanup(torch_device, gc_collect=True)
 
@@ -493,6 +513,7 @@ if __name__ == "__main__":
 
         self.skip_if_kernels_are_required(kernels, attn_impl)
         self.skip_if_model_does_not_fit(model)
+        self.skip_if_host_ram_cannot_hold(model)
         self.run_distributed_test(quantized, model, kernels, attn_impl, mode)
 
     # ------------------------

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -374,6 +374,7 @@ if __name__ == "__main__":
     # Non-distributed test
     # ------------------------
     @parameterized.expand(PARAMETERS)
+    @require_kernels
     @require_deterministic_for_xpu
     def test_model_outputs(self, quantized, model, kernels, attn_impl, mode):
         if torch_device == "cpu":

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -32,6 +32,7 @@ from transformers import (
 )
 from transformers.testing_utils import (
     cleanup,
+    is_kernels_available,
     require_deterministic_for_xpu,
     require_kernels,
     require_torch,
@@ -253,6 +254,10 @@ class GptOssIntegrationTest(unittest.TestCase):
         """Generate a key for the restructured integration test results."""
         return f"device={torch_device}|quantized={str(quantized).lower()}|model={model}|kernels={str(kernels).lower()}|attn_impl={attn_impl}|mode={mode}"
 
+    def skip_if_kernels_are_required(self, kernels, attn_impl):
+        if (kernels or attn_impl == "kernels-community/vllm-flash-attn3") and not is_kernels_available():
+            self.skipTest("test requires the kernels library")
+
     def setUp(self):
         cleanup(torch_device, gc_collect=True)
 
@@ -454,6 +459,7 @@ if __name__ == "__main__":
         if torch_device == "xpu" and attn_impl == "kernels-community/vllm-flash-attn3":
             self.skipTest("flash attention 3 is not supported on XPU yet.")
 
+        self.skip_if_kernels_are_required(kernels, attn_impl)
         self.run_distributed_test(quantized, model, kernels, attn_impl, mode)
 
     # ------------------------
@@ -472,6 +478,8 @@ if __name__ == "__main__":
 
         if quantized:
             self.skipTest("Training test for quantized models is not supported.")
+
+        self.skip_if_kernels_are_required(kernels, attn_impl)
 
         model_id = f"openai/gpt-oss-{model}"
 

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -32,12 +32,14 @@ from transformers import (
 )
 from transformers.testing_utils import (
     cleanup,
+    get_accelerator_total_memory_gib,
     is_kernels_available,
     require_deterministic_for_xpu,
     require_kernels,
     require_torch,
     require_torch_accelerator,
     require_torch_gpu,
+    require_torch_multi_accelerator,
     slow,
     torch_device,
 )
@@ -58,6 +60,20 @@ if is_torch_available():
         NUM_GPUS = torch.xpu.device_count()
     else:
         NUM_GPUS = 0
+
+
+# Accelerator memory (in GiB, summed over every visible device) needed by the integration tests below. The
+# checkpoints ship as mxfp4, but these tests materialize bfloat16 weights -- either explicitly through
+# `dtype=torch.bfloat16`, or through `dtype="auto"` when the mxfp4 path is unavailable -- so budget ~2 bytes per
+# parameter plus headroom for activations and the KV cache. Training additionally keeps a gradient for every
+# parameter, hence roughly twice the weights.
+#
+# These are deliberately upper bounds: on a machine where mxfp4 weights stay packed the model needs much less, so the
+# guard may skip a test that would in fact have fit. That trade is on purpose -- without the guard, loading 120b on a
+# runner that cannot hold it gets the whole CI *container* OOM-killed (host RAM), which loses the reports of every
+# other test in the job, not just this one.
+INFERENCE_MEMORY_GIB = {"20b": 48, "120b": 240}
+TRAINING_MEMORY_GIB = {"20b": 96, "120b": 480}
 
 
 class GptOssModelTester(CausalLMModelTester):
@@ -258,6 +274,17 @@ class GptOssIntegrationTest(unittest.TestCase):
         if (kernels or attn_impl == "kernels-community/vllm-flash-attn3") and not is_kernels_available():
             self.skipTest("test requires the kernels library")
 
+    def skip_if_model_does_not_fit(self, model_size, budget=None):
+        """Skip unless the visible accelerators can hold `model_size`, see `INFERENCE_MEMORY_GIB` for the budgets."""
+        budget = INFERENCE_MEMORY_GIB if budget is None else budget
+        required = budget[model_size]
+        available = get_accelerator_total_memory_gib()
+        if available < required:
+            self.skipTest(
+                f"gpt-oss-{model_size} needs ~{required} GiB of accelerator memory, "
+                f"only {available:.1f} GiB is visible"
+            )
+
     def setUp(self):
         cleanup(torch_device, gc_collect=True)
 
@@ -391,6 +418,8 @@ if __name__ == "__main__":
         if torch_device == "xpu" and attn_impl == "kernels-community/vllm-flash-attn3":
             self.skipTest("flash attention 3 is not supported on XPU yet.")
 
+        self.skip_if_model_does_not_fit(model)
+
         model_id = f"openai/gpt-oss-{model}"
         output_texts = self.load_and_forward(
             model_id,
@@ -452,6 +481,9 @@ if __name__ == "__main__":
     # Distributed test
     # ------------------------
     @parameterized.expand(PARAMETERS)
+    # `run_distributed_test` launches `torchrun --nproc_per_node=NUM_GPUS` with `tp_size=WORLD_SIZE`: with a single
+    # device there is nothing to shard, so the full model lands on one accelerator and in host RAM.
+    @require_torch_multi_accelerator
     def test_model_outputs_distributed(self, quantized, model, kernels, attn_impl, mode):
         if torch_device == "cpu":
             self.skipTest("Skip TP on CPU until verified.")
@@ -460,6 +492,7 @@ if __name__ == "__main__":
             self.skipTest("flash attention 3 is not supported on XPU yet.")
 
         self.skip_if_kernels_are_required(kernels, attn_impl)
+        self.skip_if_model_does_not_fit(model)
         self.run_distributed_test(quantized, model, kernels, attn_impl, mode)
 
     # ------------------------
@@ -480,6 +513,7 @@ if __name__ == "__main__":
             self.skipTest("Training test for quantized models is not supported.")
 
         self.skip_if_kernels_are_required(kernels, attn_impl)
+        self.skip_if_model_does_not_fit(model, TRAINING_MEMORY_GIB)
 
         model_id = f"openai/gpt-oss-{model}"
 
@@ -515,6 +549,8 @@ if __name__ == "__main__":
                 )
 
     def test_model_matches_original_20b(self):
+        self.skip_if_model_does_not_fit("20b")
+
         input_text = "Roses are red, violets"
 
         original_output = "Roses are red, violets are blue, I love you, and I love you too."
@@ -580,6 +616,8 @@ if __name__ == "__main__":
         self.assertTrue(original_output.startswith(decoded_string))
 
     def test_model_matches_original_120b(self):
+        self.skip_if_model_does_not_fit("120b")
+
         input_text = "Roses are red, violets"
 
         original_output = """Roses are red, violets are blue,

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -27,6 +27,7 @@ from transformers import (
 from transformers.testing_utils import (
     require_gguf,
     require_torch_accelerator,
+    require_torch_accelerator_memory,
     slow,
     torch_device,
 )
@@ -386,6 +387,8 @@ class GgufModelTests(unittest.TestCase):
         EXPECTED_TEXT = "Hello.jsoup\n\nI am a beginner"
         self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
 
+    # GGUF weights are dequantized on load, so this is ~21B parameters in float16 (~39 GiB).
+    @require_torch_accelerator_memory(memory=48)
     def test_gpt_oss_q5_k_m(self):
         tokenizer = AutoTokenizer.from_pretrained(self.gpt_oss_model_id, gguf_file=self.gpt_oss_gguf_file)
         model = AutoModelForCausalLM.from_pretrained(

--- a/tests/quantization/mxfp4/test_mxfp4.py
+++ b/tests/quantization/mxfp4/test_mxfp4.py
@@ -22,6 +22,7 @@ from transformers import AutoTokenizer, GptOssForCausalLM, Mxfp4Config
 from transformers.testing_utils import (
     require_kernels,
     require_torch,
+    require_torch_accelerator_memory,
     require_torch_large_accelerator,
     require_triton,
     slow,
@@ -428,6 +429,8 @@ class Mxfp4ModelTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained(self.model_name)
         self.check_inference_correctness_quantized(model, tokenizer)
 
+    # ~39 GiB for the dequantized bfloat16 weights.
+    @require_torch_accelerator_memory(memory=48)
     def test_gpt_oss_model_loading_dequantized_with_device_map(self):
         """Test loading OpenAI MoE model with mxfp4 dequantization and device_map"""
 
@@ -456,6 +459,8 @@ class Mxfp4ModelTest(unittest.TestCase):
         # Test with CPU in device map (CPU already support mxfp4)
         quantizer.validate_environment(device_map={"": "cpu"})
 
+    # Holds the packed (~13 GiB) and the dequantized (~39 GiB) model at the same time, by design.
+    @require_torch_accelerator_memory(memory=56)
     def test_memory_footprint_comparison(self):
         """Test memory footprint differences between quantized and unquantized models"""
 
@@ -476,6 +481,8 @@ class Mxfp4ModelTest(unittest.TestCase):
         dequantized_mem = dequantized_model.get_memory_footprint()
         self.assertLess(quantized_mem, dequantized_mem)
 
+    # Keeps the packed model alive while reloading the saved copy, dequantized (~13 + ~39 GiB).
+    @require_torch_accelerator_memory(memory=56)
     def test_save_mxfp4(self):
         """Test saving quantized OpenAI MoE model with device_map"""
 
@@ -507,6 +514,8 @@ class Mxfp4ModelTest(unittest.TestCase):
             )
             self.check_inference_correctness_quantized(loaded_model, tokenizer)
 
+    # Quantizes from a bfloat16 checkpoint, so it holds the bfloat16 source and the mxfp4 result at once.
+    @require_torch_accelerator_memory(memory=56)
     def test_save_mxfp4_non_quantized(self):
         """Test saving dequantized OpenAI MoE model with mxfp4 quantization and device_map"""
         non_quantized_model_name = "hf-internal-testing/gpt-oss-20b-bf16"

--- a/tests/utils/test_testing_utils.py
+++ b/tests/utils/test_testing_utils.py
@@ -1,0 +1,116 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+from transformers import testing_utils
+from transformers.testing_utils import get_ci_cpu_memory_budget_gib, get_cpu_ram_total_gib
+
+
+GIB = 1024**3
+
+
+class GetCiCpuMemoryBudgetTest(unittest.TestCase):
+    """`CI_CPU_MEMORY_LIMIT_GB` is a per-accelerator budget, so it scales with the accelerator count."""
+
+    def test_returns_none_outside_ci(self):
+        with patch.dict("os.environ", {}, clear=False):
+            testing_utils.os.environ.pop("CI_CPU_MEMORY_LIMIT_GB", None)
+            self.assertIsNone(get_ci_cpu_memory_budget_gib())
+
+    def test_scales_with_accelerator_count(self):
+        with (
+            patch.dict("os.environ", {"CI_CPU_MEMORY_LIMIT_GB": "60"}),
+            patch.object(testing_utils, "torch_device", "cuda"),
+            patch.object(testing_utils, "backend_device_count", return_value=2),
+        ):
+            self.assertEqual(get_ci_cpu_memory_budget_gib(), 120.0)
+
+    def test_single_accelerator_is_the_bare_budget(self):
+        with (
+            patch.dict("os.environ", {"CI_CPU_MEMORY_LIMIT_GB": "60"}),
+            patch.object(testing_utils, "torch_device", "cuda"),
+            patch.object(testing_utils, "backend_device_count", return_value=1),
+        ):
+            self.assertEqual(get_ci_cpu_memory_budget_gib(), 60.0)
+
+    def test_ignores_a_malformed_value(self):
+        with patch.dict("os.environ", {"CI_CPU_MEMORY_LIMIT_GB": "not-a-number"}):
+            self.assertIsNone(get_ci_cpu_memory_budget_gib())
+
+
+class GetCpuRamTotalTest(unittest.TestCase):
+    """
+    The guard has to hold both inside a pod (where physical RAM reports the whole node) and on a bare runner
+    (where there is no cgroup limit), so it prefers measurements and treats the CI budget as a fallback.
+    """
+
+    def _resolve(self, cgroup_gib=None, physical_gib=None, ci_budget_gib=None):
+        with (
+            patch.object(
+                testing_utils,
+                "get_cgroup_memory_limit_bytes",
+                return_value=None if cgroup_gib is None else int(cgroup_gib * GIB),
+            ),
+            patch.object(testing_utils, "get_physical_cpu_ram_gib", return_value=physical_gib),
+            patch.object(testing_utils, "get_ci_cpu_memory_budget_gib", return_value=ci_budget_gib),
+        ):
+            return get_cpu_ram_total_gib()
+
+    def test_inside_a_pod_the_cgroup_limit_wins(self):
+        # Physical RAM is the whole node here; the cgroup limit is what the OOM killer enforces.
+        self.assertEqual(self._resolve(cgroup_gib=60, physical_gib=750, ci_budget_gib=120), 60.0)
+
+    def test_on_a_bare_runner_physical_ram_wins_over_the_ci_budget(self):
+        # A 2-accelerator A10 runner: no cgroup limit, 180 GiB real. The 120 GiB budget is a device_map planning
+        # number, and using it here would make every guard on this runner over-skip.
+        self.assertEqual(self._resolve(cgroup_gib=None, physical_gib=180, ci_budget_gib=120), 180.0)
+
+    def test_falls_back_to_the_ci_budget_when_nothing_is_measurable(self):
+        self.assertEqual(self._resolve(cgroup_gib=None, physical_gib=None, ci_budget_gib=120), 120.0)
+
+    def test_is_infinite_when_nothing_can_answer(self):
+        # An ordinary local setup, not a broken one: callers should run their test rather than skip it.
+        self.assertEqual(self._resolve(), float("inf"))
+
+    def test_takes_the_smaller_measurement(self):
+        self.assertEqual(self._resolve(cgroup_gib=90, physical_gib=180), 90.0)
+        self.assertEqual(self._resolve(cgroup_gib=180, physical_gib=90), 90.0)
+
+
+class GetPhysicalCpuRamTest(unittest.TestCase):
+    def test_reads_past_the_device_map_cap(self):
+        """
+        `conftest.py` caps `psutil.virtual_memory` to a `device_map="auto"` planning budget. A guard asking whether
+        an allocation will get the container OOM-killed needs the machine's real RAM, not that budget.
+        """
+        import psutil
+
+        real_total = psutil.virtual_memory().total
+        original_virtual_memory = psutil.virtual_memory
+        original_unpatched = testing_utils._UNPATCHED_VIRTUAL_MEMORY
+        try:
+            testing_utils._UNPATCHED_VIRTUAL_MEMORY = None
+            testing_utils.patch_psutil_cpu_memory(8 * GIB)
+
+            self.assertEqual(psutil.virtual_memory().total, 8 * GIB)
+            self.assertAlmostEqual(testing_utils.get_physical_cpu_ram_gib(), real_total / GIB, places=3)
+        finally:
+            psutil.virtual_memory = original_virtual_memory
+            testing_utils._UNPATCHED_VIRTUAL_MEMORY = original_unpatched
+
+    def test_returns_none_without_psutil(self):
+        with patch.object(testing_utils, "is_psutil_available", return_value=False):
+            self.assertIsNone(testing_utils.get_physical_cpu_ram_gib())


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48118)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48118)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This PR fixes GPT-OSS failures on GPU and multi-GPU.

## Kernels

Mark kernels dependent test and remove kernels install from the Dockerfile

fixes [test_model_outputs_XX](https://transformers-ci.lor-e.huggingface.cool/d/pytest-test/test?var-test_nodeid=tests%2Fmodels%2Fgpt_oss%2Ftest_modeling_gpt_oss.py::GptOssIntegrationTest::test_model_outputs_02&var-test_job=run_models_gpu&var-pr=main&from=now-7d&to=now&timezone=browser&orgId=1&var-trace_id=&var-run_id=&var-gh_run_id=)

## OOM guards

The gpt-oss integration tests try to materialize models that do not fit on the runner. The exact weight
footprints, from `modeling_utils.get_total_byte_count` on a meta-device model, are **38.96 GiB for 20b** and
**217.61 GiB for 120b** in bfloat16 — well past a 2×24 GiB A10G runner.

The failure mode is what makes this worth guarding rather than just letting the test fail: the allocation is
large enough that the *container* gets SIGKILLed, so we lose the reports of every other test in the job, not
just the one that overreached. The job goes red with no usable signal.

### Budgets

`INFERENCE_MEMORY_GIB` / `TRAINING_MEMORY_GIB` in the gpt-oss test file hold the budgets, derived from the exact
weight footprint plus headroom for activations and the KV cache (training additionally keeps a gradient per
parameter, hence roughly twice the weights). They are deliberately upper bounds: where mxfp4 weights stay packed
the model needs much less, so a guard may skip a test that would in fact have fit. That trade is on purpose —
skipping a test that would have passed costs one test, OOM-killing the container costs the whole job.

Three helpers check them, on the resource the test actually consumes:

- `skip_if_model_does_not_fit` — accelerator memory
- `skip_if_host_ram_cannot_hold` — host RAM, for `test_model_outputs_distributed`: `distributed_worker` loads with
  no `device_map` and moves the model afterwards, so the whole checkpoint transits host RAM first. That is the
  allocation that got the container killed, and an accelerator-only check does not see it.
- `skip_if_kernels_are_required` — the kernels dependency, for the parametrizations that need it

`test_model_outputs_distributed` also gains `@require_torch_multi_accelerator`: `run_distributed_test` launches
`torchrun --nproc_per_node=NUM_GPUS` with `tp_size=WORLD_SIZE`, so on a single device there is nothing to shard
and the full model lands on one accelerator *and* in host RAM.

### New testing utilities

**`get_accelerator_total_memory_gib()`** sums `total_memory` over *every visible* accelerator. The existing
`require_torch_large_accelerator` only looks at device 0, which is the wrong question for a model spread with
`device_map="auto"` or tensor parallelism. It returns 0 on CPU and on backends that do not report
`total_memory`, so "we cannot tell" is treated as "it does not fit" — the safe direction here, since guessing
too high kills the process. **`require_torch_accelerator_memory(memory=N)`** is the decorator over it, applied
to the mxfp4 and ggml gpt-oss tests that were failing for the same reason.

**`get_cpu_ram_total_gib()`** fixes a host-vs-container bug in host RAM detection.
`psutil.virtual_memory().total` reads the *host* `/proc/meminfo`, so inside a K8S pod it reports the whole node
(~750 GiB) and says nothing about the cgroup limit the OOM killer enforces. The existing
`CI_CPU_MEMORY_LIMIT_GB` patch in `conftest.py` only half-covers this — it deliberately caps psutil at
`limit * num_accelerators` (a `device_map="auto"` planning budget), which is 120 GiB on a 2-GPU runner whose
cgroup still kills at 60. The new helper takes the **minimum** of three views, each of which is wrong on its
own: the cgroup limit (via `get_cgroup_memory_limit_bytes()`, cgroup v2 `memory.max` and v1
`memory.limit_in_bytes`, with their respective unlimited sentinels), psutil, and the raw `CI_CPU_MEMORY_LIMIT_GB`.

`require_large_cpu_ram` is rebuilt on it and now accepts `@require_large_cpu_ram(memory=N)` as well as the bare
form, matching `require_torch_large_accelerator`. This also fixes its two existing users (gemma2,
longcat_flash), which were subject to the same host-vs-pod bug.
