### PR TITLE
Add configurable Laguna router scoring

### DIFF
--- a/src/transformers/models/laguna/configuration_laguna.py
+++ b/src/transformers/models/laguna/configuration_laguna.py
@@ -46,6 +46,8 @@ class LagunaConfig(PreTrainedConfig):
         in transformers yet; ``True`` will raise a ``NotImplementedError`` for now.
     moe_router_logit_softcapping (`float`, *optional*, defaults to 0.0):
         Scaling factor when applying tanh softcapping on the logits of the MoE router logits.
+    moe_router_score_func (`str`, *optional*, defaults to `"sigmoid"`):
+        Router scoring function. Supported values are `"sigmoid"` and `"sqrtsoftplus"`.
 
     Example:
 
@@ -126,6 +128,7 @@ class LagunaConfig(PreTrainedConfig):
     moe_routed_scaling_factor: float = 1.0
     moe_apply_router_weight_on_input: bool = False
     moe_router_logit_softcapping: float = 0.0
+    moe_router_score_func: str = "sigmoid"
 
     def __post_init__(self, **kwargs):
         if self.layer_types is None:
@@ -155,6 +158,11 @@ class LagunaConfig(PreTrainedConfig):
             raise NotImplementedError(
                 "moe_apply_router_weight_on_input=True is not yet supported in the "
                 "transformers implementation of Laguna."
+            )
+        if self.moe_router_score_func not in {"sigmoid", "sqrtsoftplus"}:
+            raise ValueError(
+                f"moe_router_score_func must be one of 'sigmoid' or 'sqrtsoftplus', got "
+                f"{self.moe_router_score_func!r}."
             )
         if (
             self.num_attention_heads_per_layer is not None

--- a/src/transformers/models/laguna/modeling_laguna.py
+++ b/src/transformers/models/laguna/modeling_laguna.py
@@ -163,6 +163,7 @@ class LagunaTopKRouter(nn.Module):
         self.weight = nn.Parameter(torch.zeros(self.num_experts, self.hidden_dim))
         self.e_score_correction_bias = nn.Parameter(torch.zeros(config.num_experts), requires_grad=False)
         self.router_logit_softcapping = config.moe_router_logit_softcapping
+        self.score_fn = ACT2FN[config.moe_router_score_func]
 
     def forward(
         self,
@@ -173,8 +174,7 @@ class LagunaTopKRouter(nn.Module):
         # Optional logits softcapping
         if self.router_logit_softcapping > 0.0:
             router_logits = torch.tanh(router_logits / self.router_logit_softcapping) * self.router_logit_softcapping
-        # Sigmoid instead of softmax normalization
-        routing_scores = torch.sigmoid(router_logits)
+        routing_scores = self.score_fn(router_logits)
 
         scores_for_selection = routing_scores + self.e_score_correction_bias.to(routing_scores.dtype)
         _, selected_experts = torch.topk(scores_for_selection, self.top_k, dim=-1)

--- a/src/transformers/models/laguna/modular_laguna.py
+++ b/src/transformers/models/laguna/modular_laguna.py
@@ -22,6 +22,7 @@ from huggingface_hub.dataclasses import strict
 from torch import nn
 
 from ... import initialization as init
+from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...configuration_utils import PreTrainedConfig
 from ...masking_utils import create_causal_mask, create_sliding_window_causal_mask
@@ -65,6 +66,8 @@ class LagunaConfig(Qwen2MoeConfig):
         in transformers yet; ``True`` will raise a ``NotImplementedError`` for now.
     moe_router_logit_softcapping (`float`, *optional*, defaults to 0.0):
         Scaling factor when applying tanh softcapping on the logits of the MoE router logits.
+    moe_router_score_func (`str`, *optional*, defaults to `"sigmoid"`):
+        Router scoring function. Supported values are `"sigmoid"` and `"sqrtsoftplus"`.
 
     Example:
 
@@ -119,6 +122,7 @@ class LagunaConfig(Qwen2MoeConfig):
     moe_routed_scaling_factor: float = 1.0
     moe_apply_router_weight_on_input: bool = False
     moe_router_logit_softcapping: float = 0.0
+    moe_router_score_func: str = "sigmoid"
 
     # Fields declared by Qwen2MoeConfig but not used by Laguna. ``= AttributeError()``
     # tells modular to drop these from the materialized child.
@@ -159,6 +163,11 @@ class LagunaConfig(Qwen2MoeConfig):
             raise NotImplementedError(
                 "moe_apply_router_weight_on_input=True is not yet supported in the "
                 "transformers implementation of Laguna."
+            )
+        if self.moe_router_score_func not in {"sigmoid", "sqrtsoftplus"}:
+            raise ValueError(
+                f"moe_router_score_func must be one of 'sigmoid' or 'sqrtsoftplus', got "
+                f"{self.moe_router_score_func!r}."
             )
         if (
             self.num_attention_heads_per_layer is not None
@@ -225,6 +234,7 @@ class LagunaTopKRouter(Qwen3_5MoeTopKRouter):
         super().__init__()
         self.e_score_correction_bias = nn.Parameter(torch.zeros(config.num_experts), requires_grad=False)
         self.router_logit_softcapping = config.moe_router_logit_softcapping
+        self.score_fn = ACT2FN[config.moe_router_score_func]
 
     def forward(
         self,
@@ -235,8 +245,7 @@ class LagunaTopKRouter(Qwen3_5MoeTopKRouter):
         # Optional logits softcapping
         if self.router_logit_softcapping > 0.0:
             router_logits = torch.tanh(router_logits / self.router_logit_softcapping) * self.router_logit_softcapping
-        # Sigmoid instead of softmax normalization
-        routing_scores = torch.sigmoid(router_logits)
+        routing_scores = self.score_fn(router_logits)
 
         scores_for_selection = routing_scores + self.e_score_correction_bias.to(routing_scores.dtype)
         _, selected_experts = torch.topk(scores_for_selection, self.top_k, dim=-1)

--- a/tests/models/laguna/test_modeling_laguna.py
+++ b/tests/models/laguna/test_modeling_laguna.py
@@ -15,6 +15,7 @@
 
 import unittest
 
+from huggingface_hub.errors import StrictDataclassClassValidationError
 from parameterized import parameterized
 
 from transformers import is_torch_available
@@ -29,6 +30,7 @@ if is_torch_available():
         LagunaForCausalLM,
         LagunaModel,
     )
+    from transformers.models.laguna.modeling_laguna import LagunaTopKRouter
 
 
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
@@ -64,6 +66,47 @@ class LagunaModelTest(CausalLMModelTest, unittest.TestCase):
         cfg_kwargs["moe_apply_router_weight_on_input"] = True
         with self.assertRaises(NotImplementedError):
             LagunaConfig(**cfg_kwargs)
+
+    def test_router_score_func_validation(self):
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        self.assertEqual(config.moe_router_score_func, "sigmoid")
+        cfg_kwargs = config.to_dict()
+        cfg_kwargs["moe_router_score_func"] = "softmax"
+        with self.assertRaisesRegex(StrictDataclassClassValidationError, "moe_router_score_func"):
+            LagunaConfig(**cfg_kwargs)
+
+    @parameterized.expand([("sigmoid",), ("sqrtsoftplus",)])
+    def test_router_score_func(self, score_func):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        config.moe_router_score_func = score_func
+        router = LagunaTopKRouter(config)
+        hidden_states = torch.linspace(-1.0, 1.0, 2 * config.hidden_size).view(1, 2, config.hidden_size)
+
+        with torch.no_grad():
+            router.weight.copy_(
+                torch.linspace(-0.5, 0.5, config.num_experts * config.hidden_size).view_as(router.weight)
+            )
+            router.e_score_correction_bias.copy_(torch.linspace(0.4, -0.4, config.num_experts))
+
+        router_logits, routing_weights, selected_experts = router(hidden_states)
+        expected_scores = (
+            torch.sigmoid(router_logits)
+            if score_func == "sigmoid"
+            else torch.nn.functional.softplus(router_logits).sqrt()
+        )
+        expected_experts = torch.topk(
+            expected_scores + router.e_score_correction_bias, config.num_experts_per_tok, dim=-1
+        ).indices
+        expected_weights = expected_scores.gather(-1, expected_experts)
+        expected_weights /= expected_weights.sum(dim=-1, keepdim=True)
+
+        torch.testing.assert_close(selected_experts, expected_experts)
+        torch.testing.assert_close(routing_weights, expected_weights)
+
+        model = self.model_tester.base_model_class(config).to(torch_device).eval()
+        with torch.no_grad():
+            outputs = model(input_ids=inputs_dict["input_ids"].to(torch_device))
+        self.assertTrue(torch.isfinite(outputs.last_hidden_state).all())
 
     @parameterized.expand([(True,), ("per-head",), ("per-element",)])
     def test_gating_variations(self, gating):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48119)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48119)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

We are adding extra support for `sqrtsoftplus` for the router scoring function. This is needed to support future planned Laguna variants. The default stays `sigmoid` for backward compatibility.

This PR is implemented with agent assistance (codex-5.6-sol-medium) and checked/edited by me.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)? Not relevant here I guess 
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)? 


## Who can review?