### PR TITLE
fix(nanochat): add TRUST_REMOTE_CODE guard before pickle.load (gh-48068)

### DIFF
--- a/src/transformers/models/nanochat/convert_nanochat_checkpoints.py
+++ b/src/transformers/models/nanochat/convert_nanochat_checkpoints.py
@@ -231,11 +231,10 @@ def write_tokenizer(input_dir, output_dir):
         try:
             import pickle
 
-from ...utils import strtobool
-
             from transformers.integrations.tiktoken import convert_tiktoken_to_fast
 
-            with open(tokenizer_pkl, "rb") as f:
+            from ...utils import strtobool
+
             if not strtobool(os.environ.get("TRUST_REMOTE_CODE", "False")):
                 raise ValueError(
                     "This part uses `pickle.load` which is insecure and will execute arbitrary code that is potentially "
@@ -243,6 +242,7 @@ from ...utils import strtobool
                     "that could have been tampered with. If you already verified the pickle data and decided to use it, "
                     "you can set the environment variable `TRUST_REMOTE_CODE` to `True` to allow it."
                 )
+            with open(tokenizer_pkl, "rb") as f:
                 tok_pkl = pickle.load(f)
             convert_tiktoken_to_fast(tok_pkl, output_dir)
             print("Converted tokenizer.pkl to HuggingFace format")

--- a/src/transformers/models/nanochat/convert_nanochat_checkpoints.py
+++ b/src/transformers/models/nanochat/convert_nanochat_checkpoints.py
@@ -231,9 +231,18 @@ def write_tokenizer(input_dir, output_dir):
         try:
             import pickle
 
+from ...utils import strtobool
+
             from transformers.integrations.tiktoken import convert_tiktoken_to_fast
 
             with open(tokenizer_pkl, "rb") as f:
+            if not strtobool(os.environ.get("TRUST_REMOTE_CODE", "False")):
+                raise ValueError(
+                    "This part uses `pickle.load` which is insecure and will execute arbitrary code that is potentially "
+                    "malicious. It's recommended to never unpickle data that could have come from an untrusted source, or "
+                    "that could have been tampered with. If you already verified the pickle data and decided to use it, "
+                    "you can set the environment variable `TRUST_REMOTE_CODE` to `True` to allow it."
+                )
                 tok_pkl = pickle.load(f)
             convert_tiktoken_to_fast(tok_pkl, output_dir)
             print("Converted tokenizer.pkl to HuggingFace format")


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48122)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48122)
<!-- ci-dashboard-badge:end -->

Hi @ydshieh, @Rocketknight1 — friendly heads-up that this PR is ready for review.

**Issue:** #48068 — `src/transformers/models/nanochat/convert_nanochat_checkpoints.py` calls `pickle.load(f)` without the `TRUST_REMOTE_CODE` guard that every other conversion script in transformers uses (reformer, olmo3, maskformer, etc.). This was an oversight, not a deliberate choice.

**Fix:**
1. Added `from ...utils import strtobool` import (line 234)
2. Added the standard TRUST_REMOTE_CODE guard before `pickle.load` at line 237
3. If TRUST_REMOTE_CODE is not set to True, raises the same ValueError message used by `convert_reformer_trax_checkpoint_to_pytorch.py`

**Why this matters:** `pickle.load` can execute arbitrary code. The guard ensures users must explicitly opt in before unpickling untrusted checkpoint data.

**Files changed:** `src/transformers/models/nanochat/convert_nanochat_checkpoints.py` (+8 lines)
No logic changes to the conversion itself.

Ready for review/merge. Thanks!