### PR TITLE
Skip embeddings without `.weight` in `_init_weights`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2400,10 +2400,13 @@ class PreTrainedModel(
                 elif "bias" in name:
                     init.constant_(param, 0.0)
         elif isinstance(module, nn.Embedding):
-            init.normal_(module.weight, mean=0.0, std=std)
-            # Here we need the check explicitly, as we slice the weight in the `zeros_` call, so it looses the flag
-            if module.padding_idx is not None and not getattr(module.weight, "_is_hf_initialized", False):
-                init.zeros_(module.weight[module.padding_idx])
+            # Quantized (e.g. pack-quantized) embedding modules may not expose a dense
+            # `.weight`; their weights live in packed parameters instead. Skip those.
+            if getattr(module, "weight", None) is not None:
+                init.normal_(module.weight, mean=0.0, std=std)
+                # Here we need the check explicitly, as we slice the weight in the `zeros_` call, so it looses the flag
+                if module.padding_idx is not None and not getattr(module.weight, "_is_hf_initialized", False):
+                    init.zeros_(module.weight[module.padding_idx])
         elif isinstance(module, nn.MultiheadAttention):
             # This uses torch's original init
             module._reset_parameters()

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -412,6 +412,43 @@ def check_models_equal(model1, model2):
 
 @require_torch
 class ModelUtilsTest(TestCasePlus):
+    def test_init_weights_skips_embedding_without_weight(self):
+        # Pack-quantized embedding modules (e.g. compressed-tensors NVFP4) do not expose a
+        # dense `.weight`; their data lives in packed parameters. `_init_weights` must skip
+        # them instead of crashing, and must still initialize regular embeddings.
+        #
+        # NB: the packed parameters are load-bearing for this test. An embedding with *no*
+        # parameters at all is skipped earlier, by the `is_custom_code` guard in
+        # `_initialize_weights` (`all()` over an empty parameter list is vacuously True), so
+        # it would never reach the `nn.Embedding` branch and the test would pass unpatched.
+        class PackQuantizedEmbedding(nn.Embedding):
+            def __init__(self, num_embeddings, embedding_dim):
+                super().__init__(num_embeddings, embedding_dim)
+                del self.weight
+                self.weight_packed = nn.Parameter(torch.zeros(num_embeddings, embedding_dim // 2))
+                self.weight_scale = nn.Parameter(torch.ones(num_embeddings, 1))
+
+        class ModelWithPackQuantizedEmbedding(PreTrainedModel):
+            config_class = PreTrainedConfig
+
+            def __init__(self, config):
+                super().__init__(config)
+                self.packed = PackQuantizedEmbedding(8, 4)
+                self.regular = nn.Embedding(8, 4, padding_idx=0)
+                self.post_init()  # runs _init_weights; must not raise on the packed embedding
+
+        config = PreTrainedConfig(tie_word_embeddings=False)
+        model = ModelWithPackQuantizedEmbedding(config)
+
+        # the packed embedding is left exactly as-is
+        self.assertFalse(hasattr(model.packed, "weight"))
+        self.assertTrue((model.packed.weight_packed == 0).all())
+        self.assertTrue((model.packed.weight_scale == 1).all())
+
+        # the regular embedding is still initialized as before
+        self.assertTrue(torch.isfinite(model.regular.weight).all())
+        self.assertTrue((model.regular.weight[0] == 0).all())  # padding_idx zeroed
+
     def setUp(self):
         self.old_dtype = torch.get_default_dtype()
         super().setUp()


### PR DESCRIPTION
# Skip embeddings without `.weight` in `_init_weights`

## Summary

Quantized (e.g. pack-quantized) embedding modules may not expose a dense `.weight`, their weights live in packed parameters instead. `_init_weights` unconditionally calls `init.normal_(module.weight)` on every `nn.Embedding`, so initializing a model containing such a module crashes with `AttributeError` (or an init on a bogus attribute) before any weights are loaded.

Concrete instance: loading `unsloth/gemma-4-E2B-it-NVFP4` (compressed-tensors NVFP4 checkpoint) on transformers 5.15.0 dies in `_init_weights` because `embed_tokens_per_layer` (`Gemma4TextScaledWordEmbedding`) is pack-quantized and has no `.weight`.

## Fix

Guard the `nn.Embedding` branch with `getattr(module, "weight", None) is not None`, the same pattern the `nn.Linear` branch directly above already uses. Regular embeddings are initialized exactly as before, including the `padding_idx` zeroing.

## Test

- New `test_init_weights_skips_embedding_without_weight`: a model containing a pack-quantized-style embedding (no `.weight`) plus a regular embedding. `post_init()` must not raise, the weightless embedding is left untouched, and the regular embedding is still initialized (finite values, `padding_idx` row zeroed).
- Verified end-to-end on hardware (GB10): `AutoModelForImageTextToText.from_pretrained("unsloth/gemma-4-E2B-it-NVFP4", ...)` now gets past `_init_weights` and completes the load. (The load additionally requires the compressed-tensors fix in vllm-project/compressed-tensors#844; the remaining missing/unexpected keys in its load report are a separate compressed-tensors group-priority issue, not related to this change.)
