### PR TITLE
Retry transient network errors (RemoteDisconnected) in github_utils

### DIFF
--- a/tests/repo_utils/test_github_utils.py
+++ b/tests/repo_utils/test_github_utils.py
@@ -245,16 +245,19 @@ class GithubRequestTest(unittest.TestCase):
             github_request("https://api.github.com/x", token="t")
         self.assertEqual(mock.call_count, 1)
 
-    def test_network_error_retries_then_fails(self):
-        # All attempts raise URLError → exhausts max_retries then raises RuntimeError.
+    def test_connection_error_retries_then_fails(self):
+        # _request normalizes ConnectionError subclasses (e.g. RemoteDisconnected) into URLError
+        # before they reach github_request, so the mock raises URLError here — that is the type
+        # github_request sees. All attempts fail → exhausts max_retries → raises RuntimeError.
         mock = self._patch_request(gh.urllib.error.URLError("connection reset"))
         with self.assertRaises(RuntimeError) as ctx:
             github_request("https://api.github.com/x", token="t", max_retries=3)
         self.assertIn("connection reset", str(ctx.exception))
         self.assertEqual(mock.call_count, 3)
 
-    def test_network_error_retries_then_succeeds(self):
-        # Transient error on first attempt, then succeeds — should not raise.
+    def test_connection_error_retries_then_succeeds(self):
+        # Same normalization: mock raises URLError (what _request surfaces after catching
+        # ConnectionError). Transient error on attempt 1, success on attempt 2.
         mock = self._patch_request(
             [
                 gh.urllib.error.URLError("connection reset"),

--- a/tests/repo_utils/test_github_utils.py
+++ b/tests/repo_utils/test_github_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import http.client
 import logging
 import os
 import sys
@@ -227,6 +228,20 @@ class GithubRequestTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             github_request("https://api.github.com/x", token="t")
         self.assertEqual(mock.call_count, 1)
+
+    def test_connection_error_is_wrapped_as_url_error(self):
+        # ConnectionError (and subclasses) are OSError, not urllib.error.URLError — _request must
+        # normalize them so callers see a single consistent exception type.
+        with patch("urllib.request.urlopen", side_effect=ConnectionResetError("reset")):
+            with self.assertRaises(gh.urllib.error.URLError):
+                gh._request("https://api.github.com/x", {})
+
+    def test_remote_disconnected_is_wrapped_as_url_error(self):
+        # The concrete error seen in CI: RemoteDisconnected is a ConnectionResetError subclass.
+        exc = http.client.RemoteDisconnected("Remote end closed connection without response")
+        with patch("urllib.request.urlopen", side_effect=exc):
+            with self.assertRaises(gh.urllib.error.URLError):
+                gh._request("https://api.github.com/x", {})
 
     def test_network_error_retries_then_fails(self):
         # All attempts raise URLError → exhausts max_retries → raises RuntimeError.

--- a/tests/repo_utils/test_github_utils.py
+++ b/tests/repo_utils/test_github_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import http.client
 import logging
 import os
 import sys
@@ -162,22 +161,6 @@ class LogTokenStatusTest(unittest.TestCase):
         # A connectivity failure is logged but must not abort the caller.
         self._patch_request(gh.urllib.error.URLError("timeout"))
         gh._log_token_status(token="t")  # must not raise
-
-
-class RequestTest(unittest.TestCase):
-    def test_connection_error_is_wrapped_as_url_error(self):
-        # ConnectionError (and subclasses) are OSError, not urllib.error.URLError — _request must
-        # normalize them so callers see a single consistent exception type.
-        with patch("urllib.request.urlopen", side_effect=ConnectionResetError("reset")):
-            with self.assertRaises(gh.urllib.error.URLError):
-                gh._request("https://api.github.com/x", {})
-
-    def test_remote_disconnected_is_wrapped_as_url_error(self):
-        # The concrete error seen in CI: RemoteDisconnected is a ConnectionResetError subclass.
-        exc = http.client.RemoteDisconnected("Remote end closed connection without response")
-        with patch("urllib.request.urlopen", side_effect=exc):
-            with self.assertRaises(gh.urllib.error.URLError):
-                gh._request("https://api.github.com/x", {})
 
 
 class GithubRequestTest(unittest.TestCase):

--- a/tests/repo_utils/test_github_utils.py
+++ b/tests/repo_utils/test_github_utils.py
@@ -245,10 +245,8 @@ class GithubRequestTest(unittest.TestCase):
             github_request("https://api.github.com/x", token="t")
         self.assertEqual(mock.call_count, 1)
 
-    def test_connection_error_retries_then_fails(self):
-        # _request normalizes ConnectionError subclasses (e.g. RemoteDisconnected) into URLError
-        # before they reach github_request, so the mock raises URLError here — that is the type
-        # github_request sees. All attempts fail → exhausts max_retries → raises RuntimeError.
+    def test_network_error_retries_then_fails(self):
+        # All attempts raise URLError → exhausts max_retries → raises RuntimeError.
         mock = self._patch_request(gh.urllib.error.URLError("connection reset"))
         with self.assertRaises(RuntimeError) as ctx:
             github_request("https://api.github.com/x", token="t", max_retries=3)
@@ -256,8 +254,9 @@ class GithubRequestTest(unittest.TestCase):
         self.assertEqual(mock.call_count, 3)
 
     def test_connection_error_retries_then_succeeds(self):
-        # Same normalization: mock raises URLError (what _request surfaces after catching
-        # ConnectionError). Transient error on attempt 1, success on attempt 2.
+        # _request normalizes ConnectionError subclasses (e.g. RemoteDisconnected) into URLError
+        # before they reach github_request. The mock raises URLError to simulate that — transient
+        # error on attempt 1, success on attempt 2.
         mock = self._patch_request(
             [
                 gh.urllib.error.URLError("connection reset"),

--- a/tests/repo_utils/test_github_utils.py
+++ b/tests/repo_utils/test_github_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import http.client
 import logging
 import os
 import sys
@@ -163,6 +164,22 @@ class LogTokenStatusTest(unittest.TestCase):
         gh._log_token_status(token="t")  # must not raise
 
 
+class RequestTest(unittest.TestCase):
+    def test_connection_error_is_wrapped_as_url_error(self):
+        # ConnectionError (and subclasses) are OSError, not urllib.error.URLError — _request must
+        # normalize them so callers see a single consistent exception type.
+        with patch("urllib.request.urlopen", side_effect=ConnectionResetError("reset")):
+            with self.assertRaises(gh.urllib.error.URLError):
+                gh._request("https://api.github.com/x", {})
+
+    def test_remote_disconnected_is_wrapped_as_url_error(self):
+        # The concrete error seen in CI: RemoteDisconnected is a ConnectionResetError subclass.
+        exc = http.client.RemoteDisconnected("Remote end closed connection without response")
+        with patch("urllib.request.urlopen", side_effect=exc):
+            with self.assertRaises(gh.urllib.error.URLError):
+                gh._request("https://api.github.com/x", {})
+
+
 class GithubRequestTest(unittest.TestCase):
     def setUp(self):
         # Never actually sleep while exercising the retry loop.
@@ -228,11 +245,24 @@ class GithubRequestTest(unittest.TestCase):
             github_request("https://api.github.com/x", token="t")
         self.assertEqual(mock.call_count, 1)
 
-    def test_network_error_fails_hard(self):
-        self._patch_request(gh.urllib.error.URLError("connection reset"))
+    def test_network_error_retries_then_fails(self):
+        # All attempts raise URLError → exhausts max_retries then raises RuntimeError.
+        mock = self._patch_request(gh.urllib.error.URLError("connection reset"))
         with self.assertRaises(RuntimeError) as ctx:
-            github_request("https://api.github.com/x", token="t")
+            github_request("https://api.github.com/x", token="t", max_retries=3)
         self.assertIn("connection reset", str(ctx.exception))
+        self.assertEqual(mock.call_count, 3)
+
+    def test_network_error_retries_then_succeeds(self):
+        # Transient error on first attempt, then succeeds — should not raise.
+        mock = self._patch_request(
+            [
+                gh.urllib.error.URLError("connection reset"),
+                _response(200, body='{"ok": true}'),
+            ]
+        )
+        self.assertEqual(github_request("https://api.github.com/x", token="t"), {"ok": True})
+        self.assertEqual(mock.call_count, 2)
 
     def test_rate_limit_is_retried_then_succeeds(self):
         mock = self._patch_request(

--- a/utils/github_utils.py
+++ b/utils/github_utils.py
@@ -277,12 +277,12 @@ def github_request(url, token=None, method="GET", payload=None, max_retries=8):
             # almost always transient (the runner saw RemoteDisconnected mid-TLS handshake).
             if attempt < max_retries - 1:
                 wait = min(2**attempt, 60)
-                logger.warning(
-                    "[%s] Network error on %s %s (%s) — retrying in %ss", label, method, url, error, wait
-                )
+                logger.warning("[%s] Network error on %s %s (%s) — retrying in %ss", label, method, url, error, wait)
                 time.sleep(wait)
                 continue
-            raise RuntimeError(f"GitHub API request to {method} {url} failed after {max_retries} attempts: {error}") from error
+            raise RuntimeError(
+                f"GitHub API request to {method} {url} failed after {max_retries} attempts: {error}"
+            ) from error
 
         logger.info("[%s] %s %s → HTTP %s", label, method, url, status)
         # Rate-limit headers are absent on 401 (auth rejected before rate-limit machinery runs).

--- a/utils/github_utils.py
+++ b/utils/github_utils.py
@@ -222,6 +222,11 @@ def _request(url, headers, method="GET", data=None):
             return response.status, response.headers, response.read().decode("utf-8", errors="replace")
     except urllib.error.HTTPError as error:
         return error.code, error.headers, error.read().decode("utf-8", errors="replace")
+    except ConnectionError as error:
+        # http.client.RemoteDisconnected (and siblings like ConnectionResetError) are OSError
+        # subclasses that urllib does not always wrap in URLError — re-raise so callers see a
+        # consistent urllib.error.URLError and can decide whether to retry.
+        raise urllib.error.URLError(reason=error) from error
 
 
 def github_request(url, token=None, method="GET", payload=None, max_retries=8):
@@ -231,17 +236,23 @@ def github_request(url, token=None, method="GET", payload=None, max_retries=8):
     the response with e.g. ``result["jobs"]`` and raised a bare ``KeyError`` when GitHub returned an
     error payload instead of data).
 
-    **Rate limiting is the only thing that is ever retried.** Both the primary limit
-    (``X-RateLimit-Remaining: 0`` + ``X-RateLimit-Reset``) and the secondary limit are waited out
-    (``Retry-After`` / reset epoch when present, otherwise ~1 min, growing per attempt) up to
-    ``max_retries`` times, and the token is always kept -- retrying without it would only lower the
-    limit. Everything else fails hard immediately with ``RuntimeError`` (no retry):
+    Two categories of failures are retried up to ``max_retries`` times:
+
+      * **Rate limiting** — both the primary limit (``X-RateLimit-Remaining: 0`` +
+        ``X-RateLimit-Reset``) and the secondary limit are waited out (``Retry-After`` / reset epoch
+        when present, otherwise ~1 min, growing per attempt). The token is always kept — retrying
+        without it would only lower the limit.
+      * **Transient network errors** (``urllib.error.URLError``, including
+        ``http.client.RemoteDisconnected`` and other ``ConnectionError`` subclasses) — retried with
+        exponential backoff (1 s, 2 s, 4 s … capped at 60 s).
+
+    Everything else fails hard immediately with ``RuntimeError`` (no retry):
 
       * a 401 with a token: the token is bad/revoked/expired. It is *never* retried and *never* falls
         back to an unauthenticated request, because the anonymous 60-request/hour limit is exhausted
         almost at once while crawling a large run and every subsequent call comes back 403 -- an
         expired credential masquerading as a rate limit.
-      * 5xx server errors, network failures, 404s, permission 403s, and any other non-2xx status:
+      * 5xx server errors, 404s, permission 403s, and any other non-2xx HTTP status:
         raised at once so callers fail loudly instead of indexing into an error payload or masking a
         real outage behind silent retries.
     """
@@ -261,8 +272,17 @@ def github_request(url, token=None, method="GET", payload=None, max_retries=8):
         try:
             status, response_headers, body = _request(url, headers, method=method, data=data)
         except urllib.error.URLError as error:
-            # Network-level failure (DNS, connection reset, timeout): not a rate limit, so fail hard.
-            raise RuntimeError(f"GitHub API request to {method} {url} failed: {error}") from error
+            # Transient network-level failure (DNS, connection reset, RemoteDisconnected, timeout).
+            # Retry with exponential backoff rather than failing immediately, because these are
+            # almost always transient (the runner saw RemoteDisconnected mid-TLS handshake).
+            if attempt < max_retries - 1:
+                wait = min(2**attempt, 60)
+                logger.warning(
+                    "[%s] Network error on %s %s (%s) — retrying in %ss", label, method, url, error, wait
+                )
+                time.sleep(wait)
+                continue
+            raise RuntimeError(f"GitHub API request to {method} {url} failed after {max_retries} attempts: {error}") from error
 
         logger.info("[%s] %s %s → HTTP %s", label, method, url, status)
         # Rate-limit headers are absent on 401 (auth rejected before rate-limit machinery runs).


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48124)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48124)
<!-- ci-dashboard-badge:end -->

## Summary

Fixes the unhandled `http.client.RemoteDisconnected` traceback seen in CI run [31988833378](https://github.com/huggingface/transformers/actions/runs/31988833378/job/95325351646).

- `http.client.RemoteDisconnected` inherits from `ConnectionResetError → ConnectionError → OSError` — it is **not** a `urllib.error.URLError` subclass, so it escaped both `except` clauses in `_request` / `github_request` and produced an unhandled exception.
- `_request`: catch `ConnectionError` and re-raise wrapped in `urllib.error.URLError` so all network-level failures surface as one consistent type to callers.
- `github_request`: instead of failing hard on `URLError`, retry with exponential backoff (1 s, 2 s, 4 s … capped at 60 s) up to `max_retries` times, since `RemoteDisconnected` / connection resets are almost always transient (as confirmed by the run succeeding on manual retrigger).

## Test plan

- [ ] Verify the daily CI job that previously failed with `RemoteDisconnected` now auto-retries instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)