### PR TITLE
Validate even rotary head dimensions

### DIFF
--- a/src/transformers/models/arcee/configuration_arcee.py
+++ b/src/transformers/models/arcee/configuration_arcee.py
@@ -95,6 +95,8 @@ class ArceeConfig(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
 
 __all__ = ["ArceeConfig"]

--- a/src/transformers/models/aria/configuration_aria.py
+++ b/src/transformers/models/aria/configuration_aria.py
@@ -97,6 +97,8 @@ class AriaTextConfig(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
 
 @auto_docstring(checkpoint="rhymes-ai/Aria")

--- a/src/transformers/models/cosmos3_edge/configuration_cosmos3_edge.py
+++ b/src/transformers/models/cosmos3_edge/configuration_cosmos3_edge.py
@@ -102,6 +102,8 @@ class Cosmos3EdgeTextConfig(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
         rope_type = self.rope_parameters["rope_type"]
         if rope_type != "default":
             raise ValueError(f"Cosmos3 Edge requires `rope_type='default'`, got {rope_type!r}.")

--- a/src/transformers/models/cwm/configuration_cwm.py
+++ b/src/transformers/models/cwm/configuration_cwm.py
@@ -120,6 +120,8 @@ class CwmConfig(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
 
 __all__ = ["CwmConfig"]

--- a/src/transformers/models/deepseek_ocr2/configuration_deepseek_ocr2.py
+++ b/src/transformers/models/deepseek_ocr2/configuration_deepseek_ocr2.py
@@ -271,6 +271,8 @@ class DeepseekOcr2TextConfig(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
 
 @auto_docstring(checkpoint="deepseek-community/DeepSeek-OCR-2")

--- a/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
@@ -137,6 +137,8 @@ class DeepseekV2Config(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
 
 __all__ = ["DeepseekV2Config"]

--- a/src/transformers/models/eurobert/configuration_eurobert.py
+++ b/src/transformers/models/eurobert/configuration_eurobert.py
@@ -106,6 +106,8 @@ class EuroBertConfig(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
 
 __all__ = ["EuroBertConfig"]

--- a/src/transformers/models/higgs_audio_v2/configuration_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/configuration_higgs_audio_v2.py
@@ -126,6 +126,8 @@ class HiggsAudioV2Config(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
 
 __all__ = ["HiggsAudioV2Config"]

--- a/src/transformers/models/hrm_text/configuration_hrm_text.py
+++ b/src/transformers/models/hrm_text/configuration_hrm_text.py
@@ -124,6 +124,8 @@ class HrmTextConfig(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
     @property
     def _attn_implementation(self):

--- a/src/transformers/models/jais2/configuration_jais2.py
+++ b/src/transformers/models/jais2/configuration_jais2.py
@@ -96,6 +96,8 @@ class Jais2Config(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
 
 __all__ = ["Jais2Config"]

--- a/src/transformers/models/llama/configuration_llama.py
+++ b/src/transformers/models/llama/configuration_llama.py
@@ -98,7 +98,8 @@ class LlamaConfig(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
-        if self.head_dim % 2 != 0:
+        # Remote custom-code configurations may reuse LlamaConfig for a non-RoPE architecture.
+        if self.head_dim % 2 != 0 and self.auto_map is None:
             raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
 

--- a/src/transformers/models/llama/configuration_llama.py
+++ b/src/transformers/models/llama/configuration_llama.py
@@ -98,6 +98,10 @@ class LlamaConfig(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(
+                f"The head dimension ({self.head_dim}) must be even for rotary position embeddings."
+            )
 
 
 __all__ = ["LlamaConfig"]

--- a/src/transformers/models/llama/configuration_llama.py
+++ b/src/transformers/models/llama/configuration_llama.py
@@ -99,9 +99,7 @@ class LlamaConfig(PreTrainedConfig):
                 f"heads ({self.num_attention_heads})."
             )
         if self.head_dim % 2 != 0:
-            raise ValueError(
-                f"The head dimension ({self.head_dim}) must be even for rotary position embeddings."
-            )
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
 
 __all__ = ["LlamaConfig"]

--- a/src/transformers/models/minicpm3/configuration_minicpm3.py
+++ b/src/transformers/models/minicpm3/configuration_minicpm3.py
@@ -142,6 +142,8 @@ class MiniCPM3Config(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
     @property
     def logits_scaling(self) -> float:

--- a/src/transformers/models/xcodec2/configuration_xcodec2.py
+++ b/src/transformers/models/xcodec2/configuration_xcodec2.py
@@ -105,6 +105,8 @@ class Xcodec2Config(PreTrainedConfig):
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."
             )
+        if self.head_dim % 2 != 0:
+            raise ValueError(f"The head dimension ({self.head_dim}) must be even for rotary position embeddings.")
 
     @property
     def hop_length(self) -> int:

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1703,7 +1703,9 @@ class ModelUtilsTest(TestCasePlus):
     def test_tied_weights_are_always_tied_from_config(self):
         """Test that if a model is initialized from config it's always tied, and that the context `no_tie_weights` works
         as expected"""
-        config = LlamaConfig(num_hidden_layers=2, hidden_size=32, intermediate_size=16, tie_word_embeddings=True)
+        config = LlamaConfig(
+            num_hidden_layers=2, hidden_size=32, intermediate_size=16, head_dim=2, tie_word_embeddings=True
+        )
 
         # Make sure they are tied if called with `_from_config` and directly
         model = LlamaForCausalLM._from_config(copy.deepcopy(config))
@@ -1711,17 +1713,25 @@ class ModelUtilsTest(TestCasePlus):
         model = LlamaForCausalLM(copy.deepcopy(config))
         self.assertTrue(model.lm_head.weight is model.model.embed_tokens.weight)
 
-        # Also when using a meta device explicitly (as it skips e.g. weight init automatically)
         with torch.device("meta"):
             model = LlamaForCausalLM._from_config(copy.deepcopy(config))
             self.assertTrue(model.lm_head.weight is model.model.embed_tokens.weight)
             model = LlamaForCausalLM(copy.deepcopy(config))
             self.assertTrue(model.lm_head.weight is model.model.embed_tokens.weight)
 
-        # Make sure the context works as expected
         with init.no_tie_weights():
             model = LlamaForCausalLM._from_config(copy.deepcopy(config))
             self.assertTrue(model.lm_head.weight is not model.model.embed_tokens.weight)
+
+    def test_llama_config_rejects_odd_rotary_head_dim(self):
+        with self.assertRaisesRegex(ValueError, r"head dimension \(3\) must be even"):
+            LlamaConfig(hidden_size=12, num_attention_heads=4, head_dim=3)
+
+        # Custom remote-code configs can reuse LlamaConfig without using rotary embeddings.
+        config = LlamaConfig(
+            hidden_size=12, num_attention_heads=4, head_dim=3, auto_map={"AutoModel": "modeling.Custom"}
+        )
+        self.assertEqual(config.head_dim, 3)
 
     def test_unexpected_keys_warnings(self):
         model = ModelWithHead(PreTrainedConfig(tie_word_embeddings=True))

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1757,7 +1757,7 @@ class ModelUtilsTest(TestCasePlus):
                 with CaptureLogger(logger) as cl:
                     _, loading_info = ModelWithHead.from_pretrained(tmp_dir, output_loading_info=True)
             # Will be colored if terminal is interactive
-            expected_output = "added_key | [38;5;208mUNEXPECTED" if sys.stdout.isatty() else "added_key | UNEXPECTED"
+            expected_output = "added_key | \x1b[38;5;208mUNEXPECTED" if sys.stdout.isatty() else "added_key | UNEXPECTED"
             self.assertIn(expected_output, cl.out)
             self.assertEqual(loading_info["unexpected_keys"], {"added_key"})
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48125)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48125)
<!-- ci-dashboard-badge:end -->

Fixes #48101. Reject odd Llama head_dim during configuration validation before RoPE forward shape errors.