### PR TITLE
Fix segment-model tokenizers not returning token_type_ids by default

### DIFF
--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -78,7 +78,7 @@ class AlbertTokenizer(TokenizersBackend):
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
-    model_input_names = ["input_ids", "attention_mask"]
+    model_input_names = ["input_ids", "token_type_ids", "attention_mask"]
     model = Unigram
 
     def __init__(

--- a/src/transformers/models/funnel/tokenization_funnel.py
+++ b/src/transformers/models/funnel/tokenization_funnel.py
@@ -85,6 +85,7 @@ class FunnelTokenizer(TokenizersBackend):
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
+    model_input_names = ["input_ids", "token_type_ids", "attention_mask"]
     model = WordPiece
     cls_token_type_id: int = 2
 

--- a/src/transformers/models/herbert/tokenization_herbert.py
+++ b/src/transformers/models/herbert/tokenization_herbert.py
@@ -59,7 +59,7 @@ class HerbertTokenizer(TokenizersBackend):
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
-    model_input_names = ["input_ids", "attention_mask"]
+    model_input_names = ["input_ids", "token_type_ids", "attention_mask"]
     model = BPE
 
     def __init__(

--- a/src/transformers/models/rembert/tokenization_rembert.py
+++ b/src/transformers/models/rembert/tokenization_rembert.py
@@ -70,7 +70,7 @@ class RemBertTokenizer(TokenizersBackend):
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
-    model_input_names = ["input_ids", "attention_mask"]
+    model_input_names = ["input_ids", "token_type_ids", "attention_mask"]
     model = Unigram
 
     def __init__(

--- a/src/transformers/models/roformer/tokenization_roformer.py
+++ b/src/transformers/models/roformer/tokenization_roformer.py
@@ -45,6 +45,7 @@ class RoFormerTokenizer(PreTrainedTokenizerFast):
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
+    model_input_names = ["input_ids", "token_type_ids", "attention_mask"]
 
     def __init__(
         self,

--- a/src/transformers/models/splinter/tokenization_splinter.py
+++ b/src/transformers/models/splinter/tokenization_splinter.py
@@ -75,7 +75,7 @@ class SplinterTokenizer(TokenizersBackend):
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
-    model_input_names = ["input_ids", "attention_mask"]
+    model_input_names = ["input_ids", "token_type_ids", "attention_mask"]
     model = WordPiece
 
     def __init__(

--- a/src/transformers/models/xlnet/tokenization_xlnet.py
+++ b/src/transformers/models/xlnet/tokenization_xlnet.py
@@ -94,6 +94,7 @@ class XLNetTokenizer(TokenizersBackend):
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
+    model_input_names = ["input_ids", "token_type_ids", "attention_mask"]
     padding_side = "left"
     model = Unigram
 

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -36,6 +36,7 @@ from transformers import (
 from transformers.models.gpt2.tokenization_gpt2 import GPT2Tokenizer
 from transformers.testing_utils import (
     CaptureStderr,
+    require_rjieba,
     require_sentencepiece,
     require_tokenizers,
     require_torch,
@@ -394,3 +395,46 @@ class TokenizerUtilsTest(unittest.TestCase):
                     raise ValueError("real error")
                 except import_protobuf_decode_error():
                     pass
+
+
+@require_tokenizers
+class TokenTypeIdsDefaultReturnTest(unittest.TestCase):
+    """Tokenizers of models that consume `token_type_ids` (segment embeddings) must return them by default,
+    without requiring an explicit `return_token_type_ids=True`, as they did in v4."""
+
+    def _check_pair_encoding_returns_token_type_ids(self, tokenizer):
+        encoding_default = tokenizer("hello", "world")
+        encoding_explicit = tokenizer("hello", "world", return_token_type_ids=True)
+
+        self.assertIn("token_type_ids", encoding_default)
+        self.assertEqual(encoding_default["token_type_ids"], encoding_explicit["token_type_ids"])
+        # The second sequence of a pair must be tagged as segment 1
+        self.assertIn(1, encoding_default["token_type_ids"])
+
+    def test_pair_encoding_returns_token_type_ids_by_default(self):
+        from transformers import (
+            AlbertTokenizer,
+            FunnelTokenizer,
+            HerbertTokenizer,
+            RemBertTokenizer,
+            SplinterTokenizer,
+            XLNetTokenizer,
+        )
+
+        for tokenizer_class in [
+            AlbertTokenizer,
+            FunnelTokenizer,
+            HerbertTokenizer,
+            RemBertTokenizer,
+            SplinterTokenizer,
+            XLNetTokenizer,
+        ]:
+            with self.subTest(f"{tokenizer_class.__name__}"):
+                self._check_pair_encoding_returns_token_type_ids(tokenizer_class())
+
+    @require_rjieba
+    def test_roformer_pair_encoding_returns_token_type_ids_by_default(self):
+        from transformers import RoFormerTokenizer
+
+        vocab = {"[PAD]": 0, "[UNK]": 1, "[CLS]": 2, "[SEP]": 3, "[MASK]": 4, "hello": 5, "world": 6}
+        self._check_pair_encoding_returns_token_type_ids(RoFormerTokenizer(vocab=vocab))


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48129)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48129)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48128

**Problem**: the v5 tokenizer rewrite changed the `PreTrainedTokenizerBase.model_input_names` default from `["input_ids", "token_type_ids", "attention_mask"]` to `["input_ids", "attention_mask"]`, and seven tokenizers whose models consume segment embeddings were left without a per-model override: ALBERT, Funnel, HerBERT, RemBERT, RoFormer, Splinter, XLNet. Output keys are gated by `"token_type_ids" in self.model_input_names` (`src/transformers/tokenization_utils_tokenizers.py::_batch_encode_plus`), so sentence-pair encodes silently omit `token_type_ids` and the models fall back to all-zero segment ids — silent accuracy degradation with no error. All seven returned them by default in v4.57.0; the change is absent from MIGRATION_GUIDE_V5.md. Funnel's v5 tokenizer even preserves its special `cls:2` segment id in its `TemplateProcessing`, unreachable by default without this fix.

**Solution**: restore `model_input_names = ["input_ids", "token_type_ids", "attention_mask"]` on the seven affected tokenizers — the exact pattern already used by bert, deberta, and tapas in v5. BigBird (already declared its pair list in v4.57) and DistilBERT (deliberate opt-out) are intentionally untouched, keeping this strictly "restore v4 behavior".

**Tests**: new `TokenTypeIdsDefaultReturnTest` in `tests/tokenization/test_tokenization_utils.py` using offline toy vocabs (RoFormer split out under `@require_rjieba`), asserting the key is present by default, equals the explicit-request output, and contains segment 1. Fails on main for all seven; passes with the fix. `tests/tokenization/` shows no regressions (identical pre-existing hub-dependent failures on clean main in an offline env). `ruff check`/`ruff format` clean; `check_copies.py` and `check_modular_conversion.py` pass.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

Disclosure: this bug was found and the patch prepared with assistance from an AI coding agent; I reviewed the change, which is intentionally limited to the seven affected `model_input_names` declarations plus a regression test, and take responsibility for it.

cc @ArthurZucker @itazap