### PR TITLE
Skip caching allocator warmup when the device cannot report free memory

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5047,7 +5047,13 @@ def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: dict, 
         if device.type in ["cuda", "xpu"]:
             accelerator_module = getattr(torch, device.type)
             index = device.index if device.index is not None else accelerator_module.current_device()
-            free_device_memory, total_device_memory = accelerator_module.mem_get_info(index)
+            try:
+                free_device_memory, total_device_memory = accelerator_module.mem_get_info(index)
+            except RuntimeError:
+                # Some devices cannot report their free memory, e.g. Intel integrated GPUs under WSL2, where the
+                # driver raises `RuntimeError: The device ... doesn't support querying the available free memory`.
+                # Since the warmup is only a speed optimization, skip it instead of failing the whole model loading.
+                continue
             unused_memory = accelerator_module.memory_reserved(index) - accelerator_module.memory_allocated(index)
             # If we have reserved but unused memory, we can lower the allocation we want to make, but only if it's still
             # higher than the unused memory. This is because otherwise torch will use that unused memory when performing

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -132,6 +132,7 @@ if is_torch_available():
         FLASH_ATTN_KERNEL_FALLBACK,
         _find_disjoint,
         _find_identical,
+        caching_allocator_warmup,
         get_total_byte_count,
     )
 
@@ -436,6 +437,28 @@ class ModelUtilsTest(TestCasePlus):
         mock_world_size.assert_not_called()
         self.assertIn(torch.device("cpu"), total_byte_count)
         self.assertGreater(total_byte_count[torch.device("cpu")], 0)
+
+    @require_torch
+    def test_caching_allocator_warmup_skips_device_that_cannot_report_free_memory(self):
+        # Some accelerators cannot answer `mem_get_info`, e.g. Intel integrated GPUs under WSL2. The warmup is only
+        # a speed optimization, so such a device must be skipped instead of bringing down the whole model loading.
+        model = BaseModel(PreTrainedConfig())
+        expanded_device_map = {name: "xpu:0" for name, _ in model.named_parameters()}
+        unsupported = RuntimeError(
+            "The device (Intel(R) Graphics [0xb080]) doesn't support querying the available free memory."
+        )
+
+        with (
+            patch.object(torch.xpu, "current_device", return_value=0),
+            patch.object(torch.xpu, "mem_get_info", side_effect=unsupported),
+            patch.object(torch.xpu, "memory_reserved", return_value=0),
+            patch.object(torch.xpu, "memory_allocated", return_value=0),
+            patch("transformers.modeling_utils.torch.empty") as mock_empty,
+        ):
+            caching_allocator_warmup(model, expanded_device_map, None)
+
+        # The device was skipped, so no pre-allocation was attempted on it
+        mock_empty.assert_not_called()
 
     def test_hub_retry(self):
         @hub_retry(max_attempts=2)


### PR DESCRIPTION
Fixes #48127

## Root cause

`caching_allocator_warmup()` queries free device memory unguarded:

https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L5050

```python
free_device_memory, total_device_memory = accelerator_module.mem_get_info(index)
```

Not every accelerator can answer that query. On Intel integrated GPUs under WSL2 (Level Zero Sysman unavailable), `torch.xpu.mem_get_info()` raises:

```
RuntimeError: The device (Intel(R) Graphics [0xb080]) doesn't support querying the available free memory.
```

Because the call is on the model-loading path, that turns a *best-effort speed optimization* into a hard failure: every `from_pretrained(..., device_map=...)` onto such a device aborts in `_load_pretrained_model`.

## Fix

Skip the warmup for a device whose free memory cannot be queried, rather than propagating the error. This follows what the same function already does for devices it cannot serve — MPS (`Invalid buffer size`) and Neuron both `continue` — and the docstring is explicit that this function only exists to save one `Malloc` round-trip. Loading proceeds and simply pays the ordinary allocation cost.

The `except` is scoped to the `mem_get_info` call alone, so a genuine allocation error later in the loop still surfaces.

## Test evidence

Added `ModelUtilsTest::test_caching_allocator_warmup_skips_device_that_cannot_report_free_memory`, which mocks `mem_get_info` into the WSL2 `RuntimeError` and asserts the device is skipped (no pre-allocation attempted). It needs no XPU hardware.

Fails without the fix:

```
E   RuntimeError: The device (Intel(R) Graphics [0xb080]) doesn't support querying the available free memory.
1 failed, 151 deselected
```

Passes with it, and the whole surrounding file is green:

```
$ python -m pytest tests/utils/test_modeling_utils.py -q
109 passed, 42 skipped, 1 xfailed, 15 warnings, 10 subtests passed in 327.44s (0:05:27)
```

`ruff format` / `ruff check` clean. Verified end-to-end that `from_pretrained("hf-internal-testing/tiny-random-MistralForCausalLM", device_map={"": "xpu:0"})` no longer raises at the warmup step under a mocked unsupported-`mem_get_info` device.

---

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it.
