### PR TITLE
Fix flaky `MellumModelTest.test_load_balancing_loss`

### DIFF
--- a/tests/models/mellum/test_modeling_mellum.py
+++ b/tests/models/mellum/test_modeling_mellum.py
@@ -19,6 +19,7 @@ from transformers import is_torch_available
 from transformers.testing_utils import (
     Expectations,
     cleanup,
+    is_flaky,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -54,6 +55,7 @@ class MellumModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = MellumModelTester
     model_split_percents = [0.5, 0.8, 0.9]
 
+    @is_flaky(max_attempts=2)
     def test_load_balancing_loss(self):
         # Copied from Qwen3-Moe
         config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
# What does this PR do?

`MellumModelTest.test_load_balancing_loss` is the only copy of this test in the repo that is not
decorated with `@is_flaky`. It compares `aux_loss` against `2.0` with `rtol=atol=1e-2` on a randomly
initialized model, so it fails whenever the random routing happens to be a little less balanced than
usual:

```
tests/models/mellum/test_modeling_mellum.py:71: AssertionError: Scalars are not close!
E       Expected 2.0 but got 2.037735939025879.
E       Absolute difference: 0.037735939025878906 (up to 0.01 allowed)
E       Relative difference: 0.018867969512939453 (up to 0.01 allowed)
```

That was the only failing test of the merge-queue run of #48072
([run](https://github.com/huggingface/transformers/actions/runs/32273200040), 1 failing job out of
102), which got the PR evicted from the queue. The next merge-queue run on the same base commit
(`decba1d2`) ran the same test and it passed
([run](https://github.com/huggingface/transformers/actions/runs/32274654712)).

## Why it is flaky

Neither input to the assertion is seeded:

* the model weights come from the default torch generator, and
* `input_ids` come from `ids_tensor`, which draws from `global_rng` in
  `tests/test_modeling_common.py` — a private `random.Random()` instance that `set_seed()` does not
  touch (it seeds `random`, `numpy` and `torch`).

So the result depends on the state those two generators happen to be in when the test runs, which
differs between runs (the CI runs with `--random-order`). Repeating the test body 3000 times without
seeding, on `main` (`94f09cf`, torch 2.13, CPU):

| | |
| --- | --- |
| mean | 2.0031 |
| stdev | 0.0038 |
| max | 2.0316 |
| outside the `assert_close` band (`2.0 ± 0.03`) | **2 / 3000 (0.07%)** |

Same order of magnitude as the `0.01 %` that #40617 recorded for the Jamba copy of this test, and
the CI failure above (2.0377) sits just past the tail I could reach locally.

## Why `@is_flaky(max_attempts=2)`

Eight model tests carry a copy of this test, and seven of them are already decorated:

| test | `@is_flaky` | `set_seed` in the test |
| --- | --- | --- |
| `mixtral` | ✅ | ✅ |
| `qwen3_moe` | ✅ | – |
| `qwen2_moe` | ✅ | – |
| `minimax` | ✅ | – |
| `minimax_m2` | ✅ | ✅ |
| `jamba` | ✅ | – |
| `ernie4_5_moe` | ✅ | ✅ |
| `mellum` | ❌ | – |

The decorator was introduced for exactly this assertion in #40617. Mellum's copy is annotated
`# Copied from Qwen3-Moe`, and the Qwen3-MoE test on main has the decorator, so this looks like it
was simply missed when the model was added in #46112.

Adding `set_seed()` instead would not be enough on its own, because of the `global_rng` above — which
is presumably why the three copies that do call `set_seed()` keep the decorator as well. Happy to add
a `set_seed()` here too if you prefer that.

## Unrelated observation, not fixed here

`FLAKY_TEST_FAILURE_PATTERNS` in `.circleci/create_circleci_config.py` (mirrored in the pr-ci
workflow) contains `AssertionError: Tensor-likes are not close!` with the comment "`we might have
unlucky random values`", but `torch.testing.assert_close` reports 0-d comparisons as
`Scalars are not close!`, so scalar `assert_close` flakes like this one never match the auto-rerun
filter. Let me know if you want a follow-up PR adding that pattern.

## Who can review?

@ydshieh (CIs)
