### PR TITLE
Don't fail model loading when the accelerator can't report free memory

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5047,7 +5047,16 @@ def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: dict, 
         if device.type in ["cuda", "xpu"]:
             accelerator_module = getattr(torch, device.type)
             index = device.index if device.index is not None else accelerator_module.current_device()
-            free_device_memory, total_device_memory = accelerator_module.mem_get_info(index)
+            try:
+                free_device_memory, total_device_memory = accelerator_module.mem_get_info(index)
+            except (RuntimeError, NotImplementedError, AttributeError) as e:
+                # Some backends cannot report free memory (e.g. Intel XPU under WSL2, where the Level Zero Sysman
+                # interface is not exposed). Warmup is a best-effort optimization, so skip it for this device
+                # instead of failing the whole model load.
+                logger.warning_once(
+                    f"Skipping caching allocator warmup for {device}: could not query device memory ({e})"
+                )
+                continue
             unused_memory = accelerator_module.memory_reserved(index) - accelerator_module.memory_allocated(index)
             # If we have reserved but unused memory, we can lower the allocation we want to make, but only if it's still
             # higher than the unused memory. This is because otherwise torch will use that unused memory when performing

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -3798,6 +3798,51 @@ class DisableMmapLoadingTest(unittest.TestCase):
 
 
 @require_torch
+class CachingAllocatorWarmupTest(unittest.TestCase):
+    """Tests that `caching_allocator_warmup` degrades gracefully when the device cannot report its free memory."""
+
+    def test_warmup_skipped_when_mem_get_info_unavailable(self):
+        """
+        Some backends cannot answer free-memory queries (e.g. Intel XPU under WSL2, where the Level Zero Sysman
+        interface is not exposed, so `torch.xpu.mem_get_info` raises). Warmup is a best-effort optimization and must
+        not turn such a failure into a model loading failure.
+        """
+        from transformers.modeling_utils import caching_allocator_warmup
+
+        model = BertModel(BertConfig(hidden_size=32, num_hidden_layers=2, num_attention_heads=4, intermediate_size=37))
+        # Pretend everything is loaded on an accelerator; the warmup must bail out before touching the device
+        expanded_device_map = {name: "cuda:0" for name, _ in model.named_parameters()}
+        error = RuntimeError("The device doesn't support querying the available free memory.")
+
+        logger = logging.get_logger("transformers.modeling_utils")
+        # The warning is emitted through `warning_once`, which is cached globally
+        logging.warning_once.cache_clear()
+        with patch("torch.cuda.mem_get_info", side_effect=error):
+            with LoggingLevel(logging.WARNING):
+                with CaptureLogger(logger) as cl:
+                    caching_allocator_warmup(model, expanded_device_map, None)
+
+        self.assertIn("Skipping caching allocator warmup", cl.out)
+
+    @require_accelerate
+    @require_torch_accelerator
+    def test_from_pretrained_when_mem_get_info_unavailable(self):
+        """Loading with a `device_map` must succeed even if the accelerator cannot report its free memory."""
+        device_type = torch.device(torch_device).type
+        if device_type not in ["cuda", "xpu"]:
+            self.skipTest(f"`mem_get_info` is only used for cuda and xpu devices, got {device_type}")
+
+        with patch(
+            f"torch.{device_type}.mem_get_info",
+            side_effect=RuntimeError("The device doesn't support querying the available free memory."),
+        ):
+            model = AutoModelForCausalLM.from_pretrained(TINY_MISTRAL, device_map={"": torch_device})
+
+        for param in model.parameters():
+            self.assertEqual(param.device.type, device_type)
+
+
+@require_torch
 class RemoteAndCustomCodeModelTests(unittest.TestCase):
     def test_remote_code_registration(self):
         """


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48136&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48136) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48136&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48136)
<!-- ci-dashboard-badge:end -->

`caching_allocator_warmup` calls `mem_get_info` unguarded, so on backends that cannot answer free-memory queries the exception propagates out of `from_pretrained`, turning a best-effort optimization failure into a hard model loading failure.

This happens for every Intel GPU under WSL2, where the Level Zero Sysman interface is not exposed and `torch.xpu.mem_get_info` therefore raises, making `device_map` onto XPU unusable on that platform.

Skip the warmup for such devices instead, matching how the same function already handles `mps` and `neuron`.


# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #48127

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.

Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
for reviewers and other users and will almost certainly get you blocked.

For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it. (It runs checked test on my real machine)


## Before submitting
- [] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link 
      to it if that's the case. https://github.com/huggingface/transformers/issues/48127
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
- Intel XPU: @IlyasMoutawwakil
- model loading (from pretrained, etc): @CyrilVallez