### PR TITLE
Mark MellumModelTest.test_load_balancing_loss as flaky

### DIFF
--- a/tests/models/mellum/test_modeling_mellum.py
+++ b/tests/models/mellum/test_modeling_mellum.py
@@ -19,6 +19,7 @@ from transformers import is_torch_available
 from transformers.testing_utils import (
     Expectations,
     cleanup,
+    is_flaky,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -54,6 +55,7 @@ class MellumModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = MellumModelTester
     model_split_percents = [0.5, 0.8, 0.9]
 
+    @is_flaky(max_attempts=2)
     def test_load_balancing_loss(self):
         # Copied from Qwen3-Moe
         config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
Fixes #48138

## What

Adds `@is_flaky(max_attempts=2)` to `MellumModelTest.test_load_balancing_loss`, matching the seven other copies of the same test.

## Why

On `main`, mellum is the only one of the eight copies of this test without the decorator:

| test file | `@is_flaky(max_attempts=2)` |
| --- | --- |
| `tests/models/ernie4_5_moe/test_modeling_ernie4_5_moe.py` | yes |
| `tests/models/jamba/test_modeling_jamba.py` | yes |
| `tests/models/minimax/test_modeling_minimax.py` | yes |
| `tests/models/minimax_m2/test_modeling_minimax_m2.py` | yes |
| `tests/models/mixtral/test_modeling_mixtral.py` | yes |
| `tests/models/qwen2_moe/test_modeling_qwen2_moe.py` | yes |
| `tests/models/qwen3_moe/test_modeling_qwen3_moe.py` | yes |
| `tests/models/mellum/test_modeling_mellum.py` | **no** |

The mellum body is marked `# Copied from Qwen3-Moe`, and the Qwen3-MoE copy carries the decorator — so the omission reads as an oversight when the model was added rather than a deliberate choice.

## The assertion is genuinely init-RNG sensitive

The first assertion compares `aux_loss` against `2.0` with `rtol=atol=1e-2`, i.e. a ±0.03 band. That value moves with the model init RNG state. Sweeping 300 init seeds through the same construction path the test uses (`prepare_config_and_inputs_for_common()` → `MellumForCausalLM(config)` → forward):

```
seeds: 300
min: 1.998362 (seed 214)  max: 2.022192 (seed 221)
tolerance band: |aux_loss - 2.0| <= 0.03
failing seeds: []
```

So on this machine the value stays inside the band, but the top of the observed range uses 0.022 of the 0.03 budget. The merge-queue failure reported in the issue landed at `2.037735939025879` — just past the same edge. That is the failure mode the other seven copies already guard against with `@is_flaky`.

I did not touch the tolerance: widening it would be a separate call about how much drift is acceptable, and the point here is only to bring mellum in line with the copy it was taken from.

## How is this tested

```
$ pytest tests/models/mellum/test_modeling_mellum.py -k test_load_balancing_loss -q
1 passed, 290 deselected, 31 warnings in 4.98s
```

`ruff format --check` and `ruff check` are clean on the touched file.

---

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it.
