### PR TITLE
Honor per-param `_is_hf_initialized` flags for built-in models in `_initialize_weights`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2442,13 +2442,17 @@ class PreTrainedModel(
         if getattr(module, "_is_hf_initialized", False):
             return
 
-        # If every param/buffer owned by this module is already flagged as initialized, skip `_init_weights`. This also
-        # covers built-in models under FSDP/ZeRO on non-rank-0 processes, where `_initialize_missing_keys` flags the
-        # (broadcast) params/buffers but not the enclosing submodules, avoiding a redundant `_init_weights`.
-        if all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False)) and all(
-            getattr(buffer, "_is_hf_initialized", False)
-            for buffer in module.buffers(recurse=False)
-            if buffer is not None
+        # This check is for remote code that does NOT use either `torch.init` or `transformers.initialization` in `_init_weights`
+        # which allow to check the flag directly on param. As they don't and write the params in-place, params would be reinitialized
+        # otherwise
+        if (
+            is_custom_code
+            and all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
+            and all(
+                getattr(buffer, "_is_hf_initialized", False)
+                for buffer in module.buffers(recurse=False)
+                if buffer is not None
+            )
         ):
             module._is_hf_initialized = True
             return
@@ -4767,6 +4771,24 @@ class PreTrainedModel(
             value = torch.empty_like(buffer, device=buffer_device)
             _load_parameter_into_model(self, key, value)
 
+    def _mark_fully_loaded_submodules_as_initialized(self) -> None:
+        """Set the module-level `_is_hf_initialized` flag on every submodule (including `self`) whose parameters and
+        buffers are all already flagged as initialized, so `_initialize_weights` skips `_init_weights` for them.
+
+        Used on non-rank-0 FSDP/ZeRO processes, where the loaded params/buffers are flagged (they are broadcast from
+        rank 0) but their enclosing modules are not, which would otherwise re-run `_init_weights` on every submodule
+        (wasteful in general, and very costly on accelerators where `normal_` is far slower than on CUDA). Modules with
+        unflagged buffers (e.g. non-persistent buffers absent from the state dict) are left untouched so they are still
+        re-initialized with correct values.
+        """
+        for submodule in self.modules():
+            params_ready = all(getattr(p, "_is_hf_initialized", False) for p in submodule.parameters(recurse=False))
+            buffers_ready = all(
+                getattr(b, "_is_hf_initialized", False) for b in submodule.buffers(recurse=False) if b is not None
+            )
+            if params_ready and buffers_ready:
+                submodule._is_hf_initialized = True
+
     def _initialize_missing_keys(self, is_quantized: bool) -> None:
         """
         Initialize the missing keys (keys that are part of the model parameters, but were NOT found in the loaded state dicts), according to
@@ -4788,7 +4810,7 @@ class PreTrainedModel(
                     param_or_buffer._is_hf_initialized = True
                 except AttributeError:
                     pass  # may happen when handling pre-quantized weights
-            self._is_hf_initialized = True
+            self._mark_fully_loaded_submodules_as_initialized()
 
         # This will only initialize submodules that are not marked as initialized by the line above.
         if is_deepspeed_zero3_enabled() and not is_quantized:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2442,17 +2442,13 @@ class PreTrainedModel(
         if getattr(module, "_is_hf_initialized", False):
             return
 
-        # This check is for remote code that does NOT use either `torch.init` or `transformers.initialization` in `_init_weights`
-        # which allow to check the flag directly on param. As they don't and write the params in-place, params would be reinitialized
-        # otherwise
-        if (
-            is_custom_code
-            and all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False))
-            and all(
-                getattr(buffer, "_is_hf_initialized", False)
-                for buffer in module.buffers(recurse=False)
-                if buffer is not None
-            )
+        # If every param/buffer owned by this module is already flagged as initialized, skip `_init_weights`. This also
+        # covers built-in models under FSDP/ZeRO on non-rank-0 processes, where `_initialize_missing_keys` flags the
+        # (broadcast) params/buffers but not the enclosing submodules, avoiding a redundant `_init_weights`.
+        if all(getattr(param, "_is_hf_initialized", False) for param in module.parameters(recurse=False)) and all(
+            getattr(buffer, "_is_hf_initialized", False)
+            for buffer in module.buffers(recurse=False)
+            if buffer is not None
         ):
             module._is_hf_initialized = True
             return

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1773,7 +1773,9 @@ class ModelUtilsTest(TestCasePlus):
                 with CaptureLogger(logger) as cl:
                     _, loading_info = ModelWithHead.from_pretrained(tmp_dir, output_loading_info=True)
             # Will be colored if terminal is interactive
-            expected_output = "added_key | [38;5;208mUNEXPECTED" if sys.stdout.isatty() else "added_key | UNEXPECTED"
+            expected_output = (
+                "added_key | \x1b[38;5;208mUNEXPECTED" if sys.stdout.isatty() else "added_key | UNEXPECTED"
+            )
             self.assertIn(expected_output, cl.out)
             self.assertEqual(loading_info["unexpected_keys"], {"added_key"})
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -475,6 +475,32 @@ class ModelUtilsTest(TestCasePlus):
         self.assertEqual(model.config.output_hidden_states, True)
         self.assertEqual(model.config, config)
 
+    def test_initialize_weights_skips_module_with_all_params_flagged(self):
+        # Regression test for #47427: a built-in model must skip `_init_weights` when all of a module's params are
+        # already flagged (the FSDP non-rank-0 state, where the module flag itself is left unset).
+        config = BertConfig(
+            hidden_size=32, num_hidden_layers=1, num_attention_heads=2, intermediate_size=37, vocab_size=99
+        )
+        model = BertModel(config)
+
+        submodule = model.encoder.layer[0].attention.self.query
+        submodule._is_hf_initialized = False
+        for param in submodule.parameters(recurse=False):
+            param._is_hf_initialized = True
+        with mock.patch.object(type(model), "_init_weights") as mocked_init:
+            model._initialize_weights(submodule)
+        mocked_init.assert_not_called()
+        self.assertTrue(submodule._is_hf_initialized)
+
+        # A module with an unflagged param must still be initialized.
+        fresh = model.encoder.layer[0].attention.self.key
+        fresh._is_hf_initialized = False
+        for param in fresh.parameters(recurse=False):
+            param._is_hf_initialized = False
+        with mock.patch.object(type(model), "_init_weights") as mocked_init:
+            model._initialize_weights(fresh)
+        mocked_init.assert_called_once_with(fresh)
+
     def test_model_from_pretrained_subfolder(self):
         config = BertConfig.from_pretrained("hf-internal-testing/tiny-random-bert")
         model = BertModel(config)

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -475,31 +475,36 @@ class ModelUtilsTest(TestCasePlus):
         self.assertEqual(model.config.output_hidden_states, True)
         self.assertEqual(model.config, config)
 
-    def test_initialize_weights_skips_module_with_all_params_flagged(self):
-        # Regression test for #47427: a built-in model must skip `_init_weights` when all of a module's params are
-        # already flagged (the FSDP non-rank-0 state, where the module flag itself is left unset).
+    def test_mark_fully_loaded_submodules_as_initialized(self):
+        # Regression test for #47427: on non-rank-0 FSDP/ZeRO processes the loaded params/buffers are flagged but
+        # their enclosing modules are not, so `_init_weights` would redundantly re-run on every submodule. A module
+        # whose params/buffers are all flagged must get the module-level flag (so `_initialize_weights` skips it),
+        # while a module with an unflagged buffer (e.g. a non-persistent buffer) must be left to re-initialize.
         config = BertConfig(
             hidden_size=32, num_hidden_layers=1, num_attention_heads=2, intermediate_size=37, vocab_size=99
         )
         model = BertModel(config)
+        for submodule in model.modules():
+            submodule._is_hf_initialized = False
 
-        submodule = model.encoder.layer[0].attention.self.query
-        submodule._is_hf_initialized = False
-        for param in submodule.parameters(recurse=False):
+        flagged = model.encoder.layer[0].attention.self.query
+        for param in flagged.parameters(recurse=False):
             param._is_hf_initialized = True
-        with mock.patch.object(type(model), "_init_weights") as mocked_init:
-            model._initialize_weights(submodule)
-        mocked_init.assert_not_called()
-        self.assertTrue(submodule._is_hf_initialized)
 
-        # A module with an unflagged param must still be initialized.
-        fresh = model.encoder.layer[0].attention.self.key
-        fresh._is_hf_initialized = False
-        for param in fresh.parameters(recurse=False):
-            param._is_hf_initialized = False
+        with_unflagged_buffer = model.embeddings
+        for param in with_unflagged_buffer.parameters(recurse=False):
+            param._is_hf_initialized = True
+        # position_ids is a (non-persistent) buffer left unflagged.
+
+        model._mark_fully_loaded_submodules_as_initialized()
+
+        self.assertTrue(flagged._is_hf_initialized)
+        self.assertFalse(with_unflagged_buffer._is_hf_initialized)
+
+        # And a module marked as initialized is then skipped by `_initialize_weights`.
         with mock.patch.object(type(model), "_init_weights") as mocked_init:
-            model._initialize_weights(fresh)
-        mocked_init.assert_called_once_with(fresh)
+            model._initialize_weights(flagged)
+        mocked_init.assert_not_called()
 
     def test_model_from_pretrained_subfolder(self):
         config = BertConfig.from_pretrained("hf-internal-testing/tiny-random-bert")


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48140)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48140)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Fixes #47427.

`_initialize_weights` only honored the per-parameter/buffer `_is_hf_initialized` flags when `is_custom_code` was `True`, so for built-in models the check was dead code.

Under FSDP/ZeRO on non-rank-0 processes, `_initialize_missing_keys` flags the loaded params/buffers (which are broadcast from rank 0) but does not set the flag on their enclosing submodules. The guarded `torch.nn.init` wrappers only protect `torch.nn.init.*` calls, not in-place tensor methods such as `weight.data.normal_()`, so `_init_weights` redundantly re-ran on every submodule. This is wasted work on every process and is extremely costly on accelerators where `normal_` is far slower than on CUDA (the reporter measured ~224s wasted on 16x Ascend NPU).

This generalizes the per-param/buffer skip to all models. Modules with any unflagged param/buffer (missing keys, non-persistent buffers) are still initialized, so the standard loading path is numerically unchanged.

## Tests

Added `tests/utils/test_modeling_utils.py::ModelUtilsTest::test_initialize_weights_skips_module_with_all_params_flagged`, which reproduces the non-rank-0 flag state and asserts `_init_weights` is skipped for built-in models (and still runs when a param is unflagged). It fails on `main` and passes with this change. Existing BERT and CLIP init/save-load tests still pass locally.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a GitHub issue? Fixes #47427.
- [x] Did you make sure to update the documentation with your changes? N/A
- [x] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review. cc @Cyrilvallez