### PR TITLE
Persist the Whisper spelling normalizer across save_pretrained

### DIFF
--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -562,9 +562,6 @@ class WhisperTokenizer(TokenizersBackend):
         merge_file = os.path.join(
             save_directory, (filename_prefix + "-" if filename_prefix else "") + VOCAB_FILES_NAMES["merges_file"]
         )
-        normalizer_file = os.path.join(
-            save_directory, (filename_prefix + "-" if filename_prefix else "") + VOCAB_FILES_NAMES["normalizer_file"]
-        )
 
         with open(vocab_file, "w", encoding="utf-8") as f:
             f.write(json.dumps(self._vocab, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
@@ -573,13 +570,35 @@ class WhisperTokenizer(TokenizersBackend):
             writer.write("#version: 0.2\n")
             writer.writelines(" ".join(merge_pair) + "\n" for merge_pair in self._merges)
 
-        if self.english_spelling_normalizer is not None:
-            with open(normalizer_file, "w", encoding="utf-8") as f:
-                f.write(
-                    json.dumps(self.english_spelling_normalizer, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
-                )
+        return (vocab_file, merge_file) + self._save_english_spelling_normalizer(save_directory, filename_prefix)
 
-        return (vocab_file, merge_file, normalizer_file)
+    def _save_english_spelling_normalizer(
+        self, save_directory: str, filename_prefix: str | None = None
+    ) -> tuple[str, ...]:
+        """
+        Write `normalizer.json`. Unlike the vocabulary, the spelling map is not carried by `tokenizer.json`, so
+        `normalize` cannot work after a reload unless it is saved alongside it.
+        """
+        if self.english_spelling_normalizer is None:
+            return ()
+
+        normalizer_file = os.path.join(
+            save_directory, (filename_prefix + "-" if filename_prefix else "") + VOCAB_FILES_NAMES["normalizer_file"]
+        )
+        with open(normalizer_file, "w", encoding="utf-8") as f:
+            f.write(json.dumps(self.english_spelling_normalizer, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
+
+        return (normalizer_file,)
+
+    def _save_pretrained(
+        self,
+        save_directory: str | os.PathLike,
+        file_names: tuple[str, ...],
+        legacy_format: bool | None = None,
+        filename_prefix: str | None = None,
+    ) -> tuple[str, ...]:
+        file_names = super()._save_pretrained(save_directory, file_names, legacy_format, filename_prefix)
+        return file_names + self._save_english_spelling_normalizer(str(save_directory), filename_prefix)
 
     def set_prefix_tokens(
         self, language: str | None = None, task: str | None = None, predict_timestamps: bool | None = None

--- a/tests/models/whisper/test_tokenization_whisper.py
+++ b/tests/models/whisper/test_tokenization_whisper.py
@@ -317,6 +317,13 @@ class WhisperTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         )
         self.assertEqual(decoded_output_diacritics, expected_output_diacritics)
 
+    def test_english_spelling_normalizer_survives_save_pretrained(self):
+        # `setUpClass` saved the hub tokenizer to `tmpdirname`, which `get_tokenizer` reloads.
+        tokenizer = self.get_tokenizer()
+
+        self.assertEqual(tokenizer.english_spelling_normalizer, self.tokenizers[0].english_spelling_normalizer)
+        self.assertEqual(tokenizer.normalize("colour"), "color")
+
     def test_decode_asr_with_word_level_timestamps(self):
         # fmt: off
         model_outputs = [


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48143)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48143)
<!-- ci-dashboard-badge:end -->

Fixes #48142.

`WhisperTokenizer.normalize` raises `AttributeError` on a tokenizer reloaded from
`save_pretrained`, because `normalizer.json` — the English spelling map — is never written:

```python
tok = WhisperTokenizer.from_pretrained("openai/whisper-tiny")
tok.save_pretrained(d)                                  # ['tokenizer.json', 'tokenizer_config.json']
WhisperTokenizer.from_pretrained(d).normalize("colour")  # AttributeError: 'NoneType' object has no attribute 'get'
```

WER evaluation and `decode(..., normalize=True)` both go through that map, so they fail on any
locally saved Whisper checkpoint.

### Root cause

[`TokenizersBackend._save_pretrained`](https://github.com/huggingface/transformers/blob/94f09cfec149050b5355bab7f207ac69e21f1a02/src/transformers/tokenization_utils_tokenizers.py#L1129-L1144)
writes `tokenizer.json` and returns without calling `save_vocabulary`, which is Whisper's only
writer of `normalizer.json`. Before #40936 the call lived in the `save_slow` branch of
[`tokenization_utils_fast.py`](https://github.com/huggingface/transformers/blob/v4.57.1/src/transformers/tokenization_utils_fast.py#L714-L740),
which ran whenever `legacy_format` was not `False` — i.e. by default. Removing slow tokenizers
removed the branch, and with it the only caller. The load side is untouched:
`normalizer_file` is still in `vocab_files_names` and `__init__` still reads it.

### The fix

`WhisperTokenizer` now writes the map from its own `_save_pretrained`, through a small
`_save_english_spelling_normalizer` helper that `save_vocabulary` also uses. The helper returns
`()` when there is no map, which also stops `save_vocabulary` from returning a `normalizer.json`
path it never wrote.

This is deliberately narrow. Restoring the `save_vocabulary` call in `TokenizersBackend` would
also fix the dead extension point, but it regresses mLUKE: `entity_vocab` is already inlined into
`tokenizer_config.json` (353,698,182 B for `studio-ousia/mluke-base`), so adding the sidecar back
produces a 336,948,106 B duplicate. The issue has the measured table for all four affected
tokenizers and the maintainer's call on scope.

### Blast radius

Only `WhisperTokenizer` changes. Measured on `openai/whisper-tiny`:

| | `main@94f09cfe` | this PR |
|---|---|---|
| files written | `tokenizer.json`, `tokenizer_config.json` | + `normalizer.json` (52,666 B) |
| `english_spelling_normalizer` after reload | `None` (was 1740 entries) | 1740 entries, equal to the original |
| `normalize("colour")` after reload | `AttributeError` | `"color"` |
| `save_vocabulary` return, no map present | includes an unwritten `normalizer.json` path | omits it |

mLUKE, MarkupLM and UDOP are untouched — the diff does not reach any file they import.

### Tests

`test_english_spelling_normalizer_survives_save_pretrained` in the existing
`WhisperTokenizerTest`. It reuses the suite's fixtures (`setUpClass` already saves the hub
tokenizer to `tmpdirname`, and `get_tokenizer()` reloads from it), so the round trip is the
fixture, and it asserts behavior after the reload rather than the presence of a file.

```bash
pytest tests/models/whisper/test_tokenization_whisper.py -k english_spelling_normalizer -q
```

At `94f09cfe` without the fix:

```
E       AssertionError: None != {'accessorise': 'accessorize', 'accessori[49137 chars]rts'}
1 failed, 82 deselected
```

With the fix: `1 passed, 82 deselected`.

Whole file — `70 passed, 9 skipped, 32 subtests passed, 4 failed`, against `69 passed, 9 skipped,
32 subtests passed, 4 failed` on clean `94f09cfe`: exactly the one new test, and the same four
pre-existing failures either way (`test_decode_asr_with_word_level_timestamps` and the three
`SpeechToTextTokenizerMultilinguialTest` cases).

The other three tokenizers in the blast-radius table, for completeness:
`tests/models/markuplm/test_tokenization_markuplm.py` `57 passed, 18 skipped`;
`tests/models/udop/test_tokenization_udop.py` `56 passed, 26 skipped`;
`tests/models/mluke/test_tokenization_mluke.py` is skipped in full at `main`
(`@unittest.skip("Skip for now as this fails after #40936")`).

### Verification

```bash
make style       # All 4 checks passed
make check-repo  # All 24 checks passed
```

### AI assistance

AI tooling was used for the root-cause analysis and the measurements in this description. I reviewed
every changed line and ran every command listed here myself.

- Coordination: #48142
- Differentiation from existing PRs: `gh pr list --state open` for `whisper normalizer`,
  `save_vocabulary`, `tokenizer save_pretrained` and `normalizer.json` surfaces nothing that
  touches the save path — #47017 changes only `tokenization_auto.py`, #29969 adds a SigLIP
  tokenizer. No open issue covers it either.
- Test commands and results: see **Tests** and **Verification** above.