### PR TITLE
QA: Fall back to the import name when a distribution is missing

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -56,18 +56,24 @@ def _is_package_available(pkg_name: str, return_version: bool = False) -> tuple[
         try:
             # importlib.metadata works with the distribution package, which may be different from the import
             # name (e.g. `PIL` is the import name, but `pillow` is the distribution name)
-            distributions = PACKAGE_DISTRIBUTION_MAPPING[pkg_name]
-            # Per PEP 503, underscores and hyphens are equivalent in package names.
-            # Prefer the distribution that matches the (normalized) package name.
-            normalized_pkg_name = pkg_name.replace("_", "-")
-            if normalized_pkg_name in distributions:
-                distribution_name = normalized_pkg_name
-            elif pkg_name in distributions:
+            try:
+                distributions = PACKAGE_DISTRIBUTION_MAPPING[pkg_name]
+                # Per PEP 503, underscores and hyphens are equivalent in package names.
+                # Prefer the distribution that matches the (normalized) package name.
+                normalized_pkg_name = pkg_name.replace("_", "-")
+                if normalized_pkg_name in distributions:
+                    distribution_name = normalized_pkg_name
+                elif pkg_name in distributions:
+                    distribution_name = pkg_name
+                else:
+                    distribution_name = distributions[0]
+            except KeyError:
+                # `importlib.metadata.packages_distributions()` can miss an installed distribution whose dist-info
+                # carries no usable top-level record. The import name is then still the best guess at the
+                # distribution name, and is correct for the vast majority of packages.
                 distribution_name = pkg_name
-            else:
-                distribution_name = distributions[0]
             package_version = importlib.metadata.version(distribution_name)
-        except (importlib.metadata.PackageNotFoundError, KeyError):
+        except importlib.metadata.PackageNotFoundError:
             # If we cannot find the metadata (because of editable install for example), try to import directly.
             # Note that this branch will almost never be run, so we do not import packages for nothing here
             package = importlib.import_module(pkg_name)

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -12,6 +12,7 @@ from transformers.utils.import_utils import (
     clear_import_cache,
     is_flash_attn_2_available,
     is_flash_attn_3_available,
+    is_gguf_available,
 )
 
 
@@ -57,6 +58,36 @@ def test_is_package_available_edge_cases():
             patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
         ):
             assert _is_package_available(pkg_name, return_version=True) == expected
+
+
+def test_is_package_available_missing_from_distribution_mapping():
+    """
+    `importlib.metadata.packages_distributions()` can miss an installed distribution whose dist-info carries no
+    usable top-level record. Observed with `gguf==0.19.0` in the quantization CI image: the `KeyError` sent
+    `_is_package_available` down the import fallback, `gguf` exposes no `__version__`, and the returned `"N/A"`
+    reached `packaging.version.parse` in `is_gguf_available`, raising `InvalidVersion` while merely *collecting*
+    `tests/quantization/ggml/test_ggml.py`. The import name is the right fallback for the distribution name.
+    """
+    pkg_name = "pkg_missing_from_mapping"
+    with (
+        patch("transformers.utils.import_utils.importlib.util.find_spec", return_value=object()),
+        patch("transformers.utils.import_utils.PACKAGE_DISTRIBUTION_MAPPING", {}),
+        patch("transformers.utils.import_utils.importlib.metadata.version", return_value="0.19.0") as version_mock,
+    ):
+        assert _is_package_available(pkg_name, return_version=True) == (True, "0.19.0")
+    version_mock.assert_called_once_with(pkg_name)
+
+    # The symptom, end to end: callers parse the version, so an unparseable sentinel is a hard error.
+    is_gguf_available.cache_clear()
+    try:
+        with (
+            patch("transformers.utils.import_utils.importlib.util.find_spec", return_value=object()),
+            patch("transformers.utils.import_utils.PACKAGE_DISTRIBUTION_MAPPING", {}),
+            patch("transformers.utils.import_utils.importlib.metadata.version", return_value="0.19.0"),
+        ):
+            assert is_gguf_available() is True
+    finally:
+        is_gguf_available.cache_clear()
 
 
 @contextmanager


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48144)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48144)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`_is_package_available` looks the import name up in `PACKAGE_DISTRIBUTION_MAPPING`, which is built from `importlib.metadata.packages_distributions()`. That call can miss an installed distribution whose dist-info carries no usable top-level record. The resulting `KeyError` was lumped in with `PackageNotFoundError` and sent execution down the import fallback, which returns `getattr(module, "__version__", "N/A")` -- so a perfectly installed package could be reported as version `"N/A"`.

Callers then feed that sentinel straight to `packaging.version.parse`:

    return is_available and version.parse(gguf_version) >= version.parse(min_version)

which raises `InvalidVersion`. In the quantization CI image this made `tests/quantization/ggml/test_ggml.py` unable to even be *collected*, despite `pip freeze` reporting `gguf==0.19.0`:

    tests/quantization/ggml/test_ggml.py:40: in <module>
        if is_gguf_available():
    packaging.version.InvalidVersion: Invalid version: 'N/A'

Handle the `KeyError` on its own and fall back to the import name, which is the correct distribution name for the large majority of packages, before giving up on metadata entirely. Around twenty `is_*_available` helpers parse a version this way, so the fix belongs at this choke point rather than in each of them.

Note that the `"N/A"` sentinel can still reach those helpers when a package has neither metadata nor `__version__` (an editable install, say). Narrowing that is left out of this change.

See https://github.com/huggingface/transformers/actions/runs/32347015888