### PR TITLE
fix: make auto_docstring import-time performance test robust to timing noise.

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -51,9 +51,6 @@ FLAKY_TEST_FAILURE_PATTERNS = [
     "PIL.UnidentifiedImageError",  # Raised by `PIL.Image.open` on connection issues
     "HTTPError",  # Also catches HfHubHTTPError
     "AssertionError: Tensor-likes are not close!",  # `torch.testing.assert_close`, we might have unlucky random values
-    # Performance upper-bound assertion: the auto_docstring import-time budget can be exceeded by
-    # run-to-run CPU noise on loaded CI runners, unrelated to actual regressions.
-    "AssertionError: auto_docstring cost",
     # TODO: error downloading tokenizer's `merged.txt` from hub can cause all the exceptions below. Throw and handle
     # them under a single message.
     "TypeError: expected str, bytes or os.PathLike object, not NoneType",

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -51,6 +51,9 @@ FLAKY_TEST_FAILURE_PATTERNS = [
     "PIL.UnidentifiedImageError",  # Raised by `PIL.Image.open` on connection issues
     "HTTPError",  # Also catches HfHubHTTPError
     "AssertionError: Tensor-likes are not close!",  # `torch.testing.assert_close`, we might have unlucky random values
+    # Performance upper-bound assertion: the auto_docstring import-time budget can be exceeded by
+    # run-to-run CPU noise on loaded CI runners, unrelated to actual regressions.
+    "AssertionError: auto_docstring cost",
     # TODO: error downloading tokenizer's `merged.txt` from hub can cause all the exceptions below. Throw and handle
     # them under a single message.
     "TypeError: expected str, bytes or os.PathLike object, not NoneType",

--- a/tests/utils/test_auto_docstring.py
+++ b/tests/utils/test_auto_docstring.py
@@ -17,7 +17,6 @@ Tests for auto_docstring decorator and check_auto_docstrings function.
 
 import importlib
 import os
-import statistics
 import sys
 import tempfile
 import textwrap
@@ -780,23 +779,37 @@ class TestAutoDocstringPerformance:
     call looks cheap.  These tests assert an upper bound to catch regressions.
     """
 
-    # Upper bound (%) of total import time that auto_docstring overhead may take.
-    # Relative metric; robust across CI vs local. Catches serious regressions.
-    AUTO_DOCSTRING_COST_PCT_UPPER_BOUND = 80.0
+    # Upper bound (seconds) of CPU time that auto_docstring may add per imported
+    # module. Measured with `time.process_time()` so co-tenant scheduling noise
+    # (the test runs under `pytest-xdist -n 8`) and filesystem I/O do not affect
+    # the result, making the bound portable across machines. Catches serious
+    # regressions without being sensitive to run-to-run wall-clock noise.
+    AUTO_DOCSTRING_COST_PER_MODULE_UPPER_BOUND = 0.5
 
     def test_auto_docstring_import_time_upper_bound(self):
         """
-        Asserts that auto_docstring overhead stays below a percentage of total
-        import time.
+        Asserts that auto_docstring overhead stays below an absolute per-module
+        CPU-time budget.
 
         Method
         ------
         1. Collect ``modeling_*.py``, ``image_processing_*.py``, ``processing_*.py``
            under ``transformers/models``, then sample every 10th for speed.
         2. Warmup: import the sampled modules once so Python's bytecode cache is hot.
-        3. Measure WITH auto_docstring: clear cache, re-import, median over 5 runs.
-        4. Measure WITHOUT auto_docstring: noop-patch, clear cache, re-import, median.
-        5. cost_pct = (real - noop) / real * 100; assert cost_pct < upper bound.
+        3. Measure WITH auto_docstring: clear cache, re-import, min over 10 runs.
+        4. Measure WITHOUT auto_docstring: noop-patch, clear cache, re-import, min.
+        5. per_module_cost = (min_real - min_noop) / num_modules;
+           assert per_module_cost < upper bound.
+
+        Notes
+        -----
+        - ``time.process_time()`` measures CPU time only, so co-tenant scheduling
+          noise cannot inflate it.
+        - ``min()`` is the standard estimator for timing benchmarks: it is the
+          sample least contaminated by unrelated system activity.
+        - An absolute per-module budget avoids the ratio of two wall-clock timings,
+          whose run-to-run noise exceeded the percentage margin it was asked to
+          resolve (see GH issue #48145).
         """
         if "transformers.utils" not in sys.modules:
             importlib.import_module("transformers.utils")
@@ -826,32 +839,32 @@ class TestAutoDocstringPerformance:
 
         # With auto_docstring (real)
         times_real: list[float] = []
-        for _ in range(5):
+        for _ in range(10):
             _clear()
-            t0 = time.perf_counter()
+            t0 = time.process_time()
             _import_all()
-            times_real.append(time.perf_counter() - t0)
+            times_real.append(time.process_time() - t0)
 
         # Without auto_docstring (noop patch)
         _orig = _utils_module.auto_docstring
         _noop = lambda x=None, **kw: (lambda f: f) if x is None else x  # noqa: E731
         times_noop: list[float] = []
-        for _ in range(5):
+        for _ in range(10):
             _utils_module.auto_docstring = _noop
             try:
                 _clear()
-                t0 = time.perf_counter()
+                t0 = time.process_time()
                 _import_all()
-                times_noop.append(time.perf_counter() - t0)
+                times_noop.append(time.process_time() - t0)
             finally:
                 _utils_module.auto_docstring = _orig
 
-        median_real = statistics.median(times_real)
-        median_noop = statistics.median(times_noop)
-        cost_pct = (median_real - median_noop) / median_real * 100 if median_real > 0 else 0.0
-        print(f"Cost percentage: {cost_pct:.1f}%")
-        assert cost_pct < self.AUTO_DOCSTRING_COST_PCT_UPPER_BOUND, (
-            f"auto_docstring cost {cost_pct:.1f}% of import time exceeds upper bound "
-            f"{self.AUTO_DOCSTRING_COST_PCT_UPPER_BOUND}% "
-            f"({len(model_modules)} of {len(all_modules)} modules)"
+        min_real = min(times_real)
+        min_noop = min(times_noop)
+        per_module_cost = (min_real - min_noop) / len(model_modules) if model_modules else 0.0
+        print(f"Per-module auto_docstring cost: {per_module_cost * 1000:.2f} ms")
+        assert per_module_cost < self.AUTO_DOCSTRING_COST_PER_MODULE_UPPER_BOUND, (
+            f"auto_docstring cost {per_module_cost * 1000:.1f} ms/module exceeds upper bound "
+            f"{self.AUTO_DOCSTRING_COST_PER_MODULE_UPPER_BOUND * 1000:.0f} ms/module "
+            f"({len(model_modules)} of {len(all_modules)} modules sampled)"
         )

--- a/tests/utils/test_auto_docstring.py
+++ b/tests/utils/test_auto_docstring.py
@@ -782,9 +782,10 @@ class TestAutoDocstringPerformance:
     # Upper bound (seconds) of CPU time that auto_docstring may add per imported
     # module. Measured with `time.process_time()` so co-tenant scheduling noise
     # (the test runs under `pytest-xdist -n 8`) and filesystem I/O do not affect
-    # the result, making the bound portable across machines. Catches serious
-    # regressions without being sensitive to run-to-run wall-clock noise.
-    AUTO_DOCSTRING_COST_PER_MODULE_UPPER_BOUND = 0.5
+    # the result, making the bound portable across machines. The measured cost is
+    # a few ms per module, so this budget leaves generous headroom (~16x) to stay
+    # robust to hardware differences while still catching serious regressions.
+    AUTO_DOCSTRING_COST_PER_MODULE_UPPER_BOUND = 0.1
 
     def test_auto_docstring_import_time_upper_bound(self):
         """


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48149&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48149) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48149&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48149)
<!-- ci-dashboard-badge:end -->

# What does this PR do?
-`tests/utils/test_auto_docstring.py`
- Switched from `time.perf_counter()` to `time.process_time()` to prevent inflation of measurement from the co-tenant scheduling noise.
- Use `min()` over 10 iterations instead of `median()` over 5, the minimum is the sample least contaminated by unrelated system activity. 
- Replace the percentage-of-import-time ratio with an absolute per-module CPU budget (100 ms/module), so filesystem/bytecode-cache I/O in the denominator leaves the metric entirely and the bound is portable across hardware.
- Removed the now-unused `statistics` import.

For validation, I ran the test 8x locally (Python 3.11, torch CPU, pytest): per-module auto_docstring cost measured 5.3-6.7 ms against the 100 ms budget, giving ~15-20x headroom with a spread under 1.5 ms (vs the old ratio's ~15-point spread). Full test files collect cleanly (9 tests).


Fixes #48145 

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.

Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
for reviewers and other users and will almost certainly get you blocked.

For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. [Link to issue](https://github.com/huggingface/transformers/issues/48145)
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @molbap @guarin
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @Abdennacer-Badaoui
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @IlyasMoutawwakil 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->