### PR TITLE
[PoC] End to end vision exports

### DIFF
--- a/src/transformers/exporters/base.py
+++ b/src/transformers/exporters/base.py
@@ -17,13 +17,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import MutableMapping
-from typing import TYPE_CHECKING
+from collections.abc import Callable, MutableMapping
+from typing import TYPE_CHECKING, Any
 
 from packaging import version
 
 from ..utils import logging
-from ..utils.import_utils import _is_package_available, is_torch_available
+from ..utils.import_utils import _is_package_available, is_torch_available, requires
 from .configs import ExportConfigMixin
 from .utils import decompose_for_generation
 
@@ -129,6 +129,67 @@ class HfExporter(ABC):
             "in your subclass with a backend-specific tracing pipeline that consumes `config` "
             "and returns the runtime artifact."
         )
+
+    @requires(backends=("torch",))
+    def export_end_to_end(
+        self,
+        model: PreTrainedModel,
+        preprocess: Callable | torch.nn.Module | None,
+        post_process: Callable | torch.nn.Module | None,
+        sample_inputs: MutableMapping[str, torch.Tensor],
+        config: ExportConfigMixin | dict[str, Any],
+    ):
+        """
+        Export preprocessing, the model forward, and post-processing as a **single** graph.
+
+        Chains the three stages into one [`~exporters.utils.EndToEndModel`] and calls
+        [`~HfExporter.export`] on it, so the artifact takes raw inputs (uint8 images, an audio
+        waveform, …) and returns final outputs (top-k labels, rescaled boxes, …). The runtime then
+        needs no Python-side processor. If you need the intermediate module (to run it eagerly for
+        verification, or to reuse it with a different config), build `EndToEndModel` directly.
+
+        Both stages are traced, so both must be written in tensor ops. Python control flow over
+        tensor *values* (`.item()`, `.tolist()`, `nonzero()`, thresholding that changes output
+        shape) and PIL/NumPy calls are not traceable — that rules out tokenizers and the slow
+        (PIL-based) image processors, and any post-processor whose output shape depends on the
+        data. Rewrite those steps in tensor ops, or keep them outside the graph and use
+        [`~HfExporter.export`].
+
+        Args:
+            model ([`PreTrainedModel`]):
+                The model to export.
+            preprocess (`Callable` or `torch.nn.Module`, *optional*):
+                Maps the raw inputs it claims to a mapping of `model.forward` kwargs. `None`
+                passes them straight to the forward.
+            post_process (`Callable` or `torch.nn.Module`, *optional*):
+                Called as `post_process(model_outputs, **claimed_inputs)`; its return value becomes
+                the graph output. `None` returns the model outputs unchanged.
+            sample_inputs (`dict[str, torch.Tensor]`):
+                **Raw** inputs — what you'd pass to the pipeline, not to `model.forward`. Each key
+                is routed to the stage that declares it as a parameter; a stage declaring `**kwargs`
+                takes everything the other stage doesn't declare explicitly (see
+                [`~exporters.utils.route_end_to_end_inputs`]). A key claimed by neither stage raises.
+            config ([`~transformers.exporters.configs.ExportConfigMixin`]):
+                Backend-specific configuration, forwarded to [`~HfExporter.export`].
+
+        Returns:
+            Backend-specific export artifact, as returned by [`~HfExporter.export`].
+        """
+        from .utils import EndToEndModel
+
+        end_to_end_model = EndToEndModel(
+            model, input_names=list(sample_inputs), preprocess=preprocess, post_process=post_process
+        )
+        try:
+            return self.export(end_to_end_model, sample_inputs, config=config)
+        except Exception as e:
+            raise RuntimeError(
+                f"{type(self).__name__}.export failed on the end-to-end graph for {type(model).__name__} "
+                f"(preprocess inputs={end_to_end_model.preprocess_names}, post-process inputs="
+                f"{end_to_end_model.post_process_names}). Export the model alone with `export` to tell a "
+                f"model-side failure from a pre/post-processing one — the stages are traced too, so a "
+                f"data-dependent op in either of them fails here."
+            ) from e
 
     def export_for_generation(
         self,

--- a/src/transformers/exporters/base.py
+++ b/src/transformers/exporters/base.py
@@ -32,6 +32,8 @@ logger = logging.get_logger(__name__)
 
 
 if TYPE_CHECKING:
+    from ..image_processing_backends import TorchvisionBackend
+
     if is_torch_available():
         import torch
 
@@ -130,67 +132,6 @@ class HfExporter(ABC):
             "and returns the runtime artifact."
         )
 
-    @requires(backends=("torch",))
-    def export_end_to_end(
-        self,
-        model: PreTrainedModel,
-        preprocess: Callable | torch.nn.Module | None,
-        post_process: Callable | torch.nn.Module | None,
-        sample_inputs: MutableMapping[str, torch.Tensor],
-        config: ExportConfigMixin | dict[str, Any],
-    ):
-        """
-        Export preprocessing, the model forward, and post-processing as a **single** graph.
-
-        Chains the three stages into one [`~exporters.utils.EndToEndModel`] and calls
-        [`~HfExporter.export`] on it, so the artifact takes raw inputs (uint8 images, an audio
-        waveform, …) and returns final outputs (top-k labels, rescaled boxes, …). The runtime then
-        needs no Python-side processor. If you need the intermediate module (to run it eagerly for
-        verification, or to reuse it with a different config), build `EndToEndModel` directly.
-
-        Both stages are traced, so both must be written in tensor ops. Python control flow over
-        tensor *values* (`.item()`, `.tolist()`, `nonzero()`, thresholding that changes output
-        shape) and PIL/NumPy calls are not traceable — that rules out tokenizers and the slow
-        (PIL-based) image processors, and any post-processor whose output shape depends on the
-        data. Rewrite those steps in tensor ops, or keep them outside the graph and use
-        [`~HfExporter.export`].
-
-        Args:
-            model ([`PreTrainedModel`]):
-                The model to export.
-            preprocess (`Callable` or `torch.nn.Module`, *optional*):
-                Maps the raw inputs it claims to a mapping of `model.forward` kwargs. `None`
-                passes them straight to the forward.
-            post_process (`Callable` or `torch.nn.Module`, *optional*):
-                Called as `post_process(model_outputs, **claimed_inputs)`; its return value becomes
-                the graph output. `None` returns the model outputs unchanged.
-            sample_inputs (`dict[str, torch.Tensor]`):
-                **Raw** inputs — what you'd pass to the pipeline, not to `model.forward`. Each key
-                is routed to the stage that declares it as a parameter; a stage declaring `**kwargs`
-                takes everything the other stage doesn't declare explicitly (see
-                [`~exporters.utils.route_end_to_end_inputs`]). A key claimed by neither stage raises.
-            config ([`~transformers.exporters.configs.ExportConfigMixin`]):
-                Backend-specific configuration, forwarded to [`~HfExporter.export`].
-
-        Returns:
-            Backend-specific export artifact, as returned by [`~HfExporter.export`].
-        """
-        from .utils import EndToEndModel
-
-        end_to_end_model = EndToEndModel(
-            model, input_names=list(sample_inputs), preprocess=preprocess, post_process=post_process
-        )
-        try:
-            return self.export(end_to_end_model, sample_inputs, config=config)
-        except Exception as e:
-            raise RuntimeError(
-                f"{type(self).__name__}.export failed on the end-to-end graph for {type(model).__name__} "
-                f"(preprocess inputs={end_to_end_model.preprocess_names}, post-process inputs="
-                f"{end_to_end_model.post_process_names}). Export the model alone with `export` to tell a "
-                f"model-side failure from a pre/post-processing one — the stages are traced too, so a "
-                f"data-dependent op in either of them fails here."
-            ) from e
-
     def export_for_generation(
         self,
         model: PreTrainedModel,
@@ -264,3 +205,71 @@ class HfExporter(ABC):
                 ) from e
 
         return exported
+
+    @requires(backends=("torch",))
+    def export_end_to_end(
+        self,
+        model: PreTrainedModel,
+        preprocess: TorchvisionBackend | Callable | None,
+        post_process: Callable | None,
+        sample_inputs: MutableMapping[str, torch.Tensor],
+        config: ExportConfigMixin | dict[str, Any],
+    ):
+        """
+        Export preprocessing, the model forward, and post-processing as a **single** graph.
+
+        Chains the three stages into one [`~exporters.utils.EndToEndModel`] and calls
+        [`~HfExporter.export`] on it, so the artifact takes raw inputs (uint8 images, an audio
+        waveform, …) and returns final outputs (top-k labels, rescaled boxes, …). The runtime then
+        needs no Python-side processor. If you need the intermediate module (to run it eagerly for
+        verification, or to reuse it with a different config), build `EndToEndModel` directly.
+
+        Both stages are traced, so anything either of them computes in Python runs once at trace
+        time and is frozen into the graph. Tokenizers are out entirely. The Transformers image and
+        video processors are torchvision-backed and do trace, but one that derives its output size
+        in Python from the input size (an aspect-ratio-preserving resize) freezes that arithmetic
+        into a shape guard, pinning the graph to the traced resolution; a processor with a fixed
+        target size stays resolution-agnostic.
+
+        Data-dependent output *shapes* (`scores[scores > threshold]`) are a softer constraint:
+        `torch.export` resolves the surviving count to an unbacked symbol, so the stock detection
+        post-processors trace as-is, but a backend that requires static shapes will reject the
+        result — prefer a fixed-size top-k there and let the caller threshold.
+
+        Args:
+            model ([`PreTrainedModel`]):
+                The model to export.
+            preprocess (`TorchvisionBackend` or `Callable`, *optional*):
+                A torchvision-backed image or video processor, called with `return_tensors="pt"`,
+                or any callable mapping the raw inputs it claims to a mapping of `model.forward`
+                kwargs. `None` passes them straight to the forward. Pass an `nn.Module` when the
+                preprocessing owns tensors so they're lifted into the graph as buffers.
+            post_process (`Callable`, *optional*):
+                Called as `post_process(model_outputs, **claimed_inputs)`; its return value becomes
+                the graph output. `None` returns the model outputs unchanged.
+            sample_inputs (`dict[str, torch.Tensor]`):
+                **Raw** inputs — what you'd pass to the pipeline, not to `model.forward`. Each key
+                is routed to the stage that declares it as a parameter; a stage declaring `**kwargs`
+                takes everything the other stage doesn't declare explicitly (see
+                [`~exporters.utils.route_end_to_end_inputs`]). A key claimed by neither stage raises.
+            config ([`~transformers.exporters.configs.ExportConfigMixin`]):
+                Backend-specific configuration, forwarded to [`~HfExporter.export`].
+
+        Returns:
+            Backend-specific export artifact, as returned by [`~HfExporter.export`].
+        """
+        from .utils import EndToEndModel
+
+        end_to_end_model = EndToEndModel(
+            model, input_names=list(sample_inputs), preprocess=preprocess, post_process=post_process
+        )
+        try:
+            return self.export(end_to_end_model, sample_inputs, config=config)
+        except Exception as e:
+            raise RuntimeError(
+                f"{type(self).__name__}.export failed on the end-to-end graph for {type(model).__name__} "
+                f"(preprocess inputs={end_to_end_model.preprocess_names}, post-process inputs="
+                f"{end_to_end_model.post_process_names}). Export the model alone with `export` to tell a "
+                f"model-side failure from a pre/post-processing one — the stages are traced too, so a "
+                f"data-dependent op in either of them fails here."
+            ) from e

--- a/src/transformers/exporters/base.py
+++ b/src/transformers/exporters/base.py
@@ -236,6 +236,12 @@ class HfExporter(ABC):
         post-processors trace as-is, but a backend that requires static shapes will reject the
         result — prefer a fixed-size top-k there and let the caller threshold.
 
+        A Transformers post-processor can be passed as-is: the arguments that decide between its
+        traceable and its eager branch are filled in by
+        [`~exporters.utils.bind_static_post_process_kwargs`], so `return_traceable_outputs=True` and a
+        constant-folded `target_sizes` need no `functools.partial` from the caller. Reshape the
+        tensor tuple the artifact returns with the processor's matching `build_*_outputs` method.
+
         Args:
             model ([`PreTrainedModel`]):
                 The model to export.
@@ -252,14 +258,17 @@ class HfExporter(ABC):
                 is routed to the stage that declares it as a parameter; a stage declaring `**kwargs`
                 takes everything the other stage doesn't declare explicitly (see
                 [`~exporters.utils.route_end_to_end_inputs`]). A key claimed by neither stage raises.
+                A `target_sizes` is traced as a constant rather than routed (see
+                [`~exporters.utils.bind_static_post_process_kwargs`]).
             config ([`~transformers.exporters.configs.ExportConfigMixin`]):
                 Backend-specific configuration, forwarded to [`~HfExporter.export`].
 
         Returns:
             Backend-specific export artifact, as returned by [`~HfExporter.export`].
         """
-        from .utils import EndToEndModel
+        from .utils import EndToEndModel, bind_static_post_process_kwargs
 
+        post_process, sample_inputs = bind_static_post_process_kwargs(post_process, sample_inputs)
         end_to_end_model = EndToEndModel(
             model, input_names=list(sample_inputs), preprocess=preprocess, post_process=post_process
         )

--- a/src/transformers/exporters/exporter_onnx.py
+++ b/src/transformers/exporters/exporter_onnx.py
@@ -387,6 +387,32 @@ def _patch_reshape(original):
     return patch
 
 
+@register_patch("onnx", "torch.Tensor.contiguous")
+def _patch_contiguous(original):
+    """Materialise via `clone` instead of a bare `contiguous()` call.
+
+    `_patch_reshape` protects a non-contiguous tensor that flows straight into a `reshape`/`view`
+    call, but plenty of attention code (e.g. `eager_attention_forward`'s `attn_output.transpose(1,
+    2).contiguous()`) calls `.contiguous()` on its own, then hands the result to a *caller* that
+    reshapes it later — often after being handed across a function return, so by the time the
+    reshape runs, `is_contiguous()` (checked at trace time, when the real `.contiguous()` call
+    already ran) correctly reports "already contiguous" and `_patch_reshape` rightly does nothing.
+    But a bare `aten.contiguous` is exactly the op the ONNX optimizer folds away as a no-op when the
+    graph is re-decomposed for ONNX (see `_patch_reshape`'s docstring) — so the materialization this
+    call was supposed to perform never survives into the ONNX graph, and the *later* reshape/view
+    then fails there against the still-non-contiguous tensor (`Cannot view a tensor with shape ...`).
+    `clone(memory_format=...)` survives that fold, so redirect there whenever a copy is actually
+    needed; an already-contiguous tensor is returned unchanged either way.
+    """
+
+    def patch(input, memory_format=torch.contiguous_format):
+        if isinstance(input, torch.Tensor) and not input.is_contiguous(memory_format=memory_format):
+            return input.clone(memory_format=memory_format)
+        return original(input, memory_format=memory_format)
+
+    return patch
+
+
 @register_patch("onnx", "torch.exp", "torch.Tensor.exp")
 def _patch_exp(original):
     """Lower `exp` on complex tensors via Euler — onnxscript has no dispatch for `aten.exp` on

--- a/src/transformers/exporters/utils.py
+++ b/src/transformers/exporters/utils.py
@@ -954,8 +954,13 @@ def _patch_fuse_mean_std_and_rescale_factor(original):
     trace puts in it are handed back to every later call — poisoning the next export ("we found a
     fake tensor in the exported program constant's list") and eager preprocessing alike. Tracing
     without the cache recreates them per call and leaves the pre-export entries untouched.
+
+    Registered under both "dynamo" and "onnx", and `OnnxExporter.export` nests `apply_patches("onnx")`
+    around `DynamoExporter.export`'s `apply_patches("dynamo")` — so this runs twice against the same
+    class attribute. `original` has no `__wrapped__` the second time (it's already unwrapped), so fall
+    back to `original` unchanged rather than raising.
     """
-    return original.__wrapped__
+    return getattr(original, "__wrapped__", original)
 
 
 def _stage_input_names(stage: TorchvisionBackend | Callable, *, skip_first: bool = False) -> tuple[list[str], bool]:

--- a/src/transformers/exporters/utils.py
+++ b/src/transformers/exporters/utils.py
@@ -46,9 +46,10 @@ import enum
 import functools
 import inspect
 import sys
-from collections.abc import MutableMapping
+from collections.abc import Callable, MutableMapping
 from typing import Any
 
+from ..image_processing_backends import TorchvisionBackend
 from ..utils import logging
 from ..utils.generic import get_max_seqlen
 from ..utils.import_utils import is_torch_available
@@ -941,7 +942,7 @@ def decompose_for_generation(
 # is a one-liner over it.
 
 
-def _stage_input_names(stage: Any, *, skip_first: bool = False) -> tuple[list[str], bool]:
+def _stage_input_names(stage: TorchvisionBackend | Callable, *, skip_first: bool = False) -> tuple[list[str], bool]:
     """Return `(declared_parameter_names, accepts_var_keyword)` for a preprocess/post-process stage.
 
     `skip_first` drops the leading positional parameter — for `post_process` that slot holds the
@@ -967,7 +968,9 @@ def _stage_input_names(stage: Any, *, skip_first: bool = False) -> tuple[list[st
     return declared, var_keyword
 
 
-def route_end_to_end_inputs(input_names: list[str], preprocess: Any, post_process: Any) -> tuple[list[str], list[str]]:
+def route_end_to_end_inputs(
+    input_names: list[str], preprocess: TorchvisionBackend | Callable | None, post_process: Callable | None
+) -> tuple[list[str], list[str]]:
     """Split `input_names` into the names `preprocess` consumes and the names `post_process` consumes.
 
     A stage claims the names it declares explicitly. A stage that declares `**kwargs` claims
@@ -1023,12 +1026,13 @@ if is_torch_available():
             input_names (`list[str]`):
                 Keys of the `sample_inputs` the module will be called with, used to route each
                 input to the stage that declares it (see [`~exporters.utils.route_end_to_end_inputs`]).
-            preprocess (`Callable` or `torch.nn.Module`, *optional*):
-                Maps the raw inputs it claims to a mapping of `model.forward` kwargs (a `dict` or
-                `BatchFeature`). `None` passes the claimed inputs straight to `model.forward`.
-                Pass an `nn.Module` when the preprocessing owns tensors (mel filters, anchor
-                grids) so they're lifted into the graph as buffers.
-            post_process (`Callable` or `torch.nn.Module`, *optional*):
+            preprocess (`TorchvisionBackend` or `Callable`, *optional*):
+                A torchvision-backed image or video processor, called with `return_tensors="pt"`,
+                or any callable mapping the raw inputs it claims to a mapping of `model.forward`
+                kwargs (a `dict` or `BatchFeature`). `None` passes the claimed inputs straight to
+                `model.forward`. Pass an `nn.Module` when the preprocessing owns tensors (mel
+                filters, anchor grids) so they're lifted into the graph as buffers.
+            post_process (`Callable`, *optional*):
                 Called as `post_process(model_outputs, **claimed_inputs)`; its return value is the
                 module's output. `None` returns the model outputs unchanged.
         """
@@ -1037,8 +1041,8 @@ if is_torch_available():
             self,
             model: PreTrainedModel,
             input_names: list[str],
-            preprocess: Any = None,
-            post_process: Any = None,
+            preprocess: TorchvisionBackend | Callable | None = None,
+            post_process: Callable | None = None,
         ):
             super().__init__()
             if preprocess is None and post_process is None:
@@ -1061,7 +1065,10 @@ if is_torch_available():
         def forward(self, **kwargs):
             model_inputs = {name: kwargs[name] for name in self.preprocess_names if name in kwargs}
             if self.preprocess is not None:
-                model_inputs = self.preprocess(**model_inputs)
+                if isinstance(self.preprocess, TorchvisionBackend):
+                    model_inputs = self.preprocess(**model_inputs, return_tensors="pt")
+                else:
+                    model_inputs = self.preprocess(**model_inputs)
                 if not isinstance(model_inputs, MutableMapping):
                     raise TypeError(
                         f"`preprocess` must return a mapping of `model.forward` kwargs (dict, BatchFeature), "

--- a/src/transformers/exporters/utils.py
+++ b/src/transformers/exporters/utils.py
@@ -15,7 +15,7 @@
 
 """Shared export utilities used by all exporter backends.
 
-Organised into five sections (search for the `# ── Name ──` banners):
+Organised into six sections (search for the `# ── Name ──` banners):
 
 - **Patch and fix registries** — backend-keyed `_PATCHES` / `_FX_NODE_FIXES` /
   `_FX_PROGRAM_FIXES` populated via `@register_patch(backend, *paths)` /
@@ -32,6 +32,10 @@ Organised into five sections (search for the `# ── Name ──` banners):
 - **Decomposition** — `decompose_prefill_decode` (split a generative forward
   into prefill + decode) and `decompose_multimodal` + `is_multimodal` (split a
   multimodal forward into one entry per submodule), backed by `_capture_forward`.
+- **End-to-end composition** — the inverse of decomposition: `EndToEndModel` chains
+  preprocessing, the model forward and post-processing into one `nn.Module` (with
+  `route_end_to_end_inputs` deciding which input feeds which stage) so the whole
+  pipeline exports as a single graph.
 """
 
 from __future__ import annotations
@@ -927,3 +931,153 @@ def decompose_for_generation(
     components = decompose_multimodal(prefill_model, prefill_inputs)
     components["decode"] = stages["decode"]
     return components
+
+
+# ── End-to-end composition ────────────────────────────────────────────────────
+# Chain preprocessing, the model forward and post-processing into a single `nn.Module` so
+# a backend's `export` traces all three stages into one graph. `EndToEndModel` owns the
+# plumbing — routing `sample_inputs` to the stage that declares them, and aligning the
+# preprocess output with the model's dtype/device — and `HfExporter.export_end_to_end`
+# is a one-liner over it.
+
+
+def _stage_input_names(stage: Any, *, skip_first: bool = False) -> tuple[list[str], bool]:
+    """Return `(declared_parameter_names, accepts_var_keyword)` for a preprocess/post-process stage.
+
+    `skip_first` drops the leading positional parameter — for `post_process` that slot holds the
+    model outputs, not one of `sample_inputs`. Callables that expose no signature (builtins, C
+    extensions) are treated as `**kwargs`-only.
+    """
+    target = stage.forward if isinstance(stage, torch.nn.Module) else stage
+    try:
+        parameters = list(inspect.signature(target).parameters.values())
+    except (TypeError, ValueError):
+        return [], True
+
+    positional = (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    if skip_first and parameters and parameters[0].kind in positional:
+        parameters = parameters[1:]
+
+    declared = [
+        param.name
+        for param in parameters
+        if param.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    ]
+    var_keyword = any(param.kind is inspect.Parameter.VAR_KEYWORD for param in parameters)
+    return declared, var_keyword
+
+
+def route_end_to_end_inputs(input_names: list[str], preprocess: Any, post_process: Any) -> tuple[list[str], list[str]]:
+    """Split `input_names` into the names `preprocess` consumes and the names `post_process` consumes.
+
+    A stage claims the names it declares explicitly. A stage that declares `**kwargs` claims
+    everything the *other* stage doesn't declare explicitly — so a `target_sizes` declared by
+    `post_process` isn't also handed to a processor's `__call__(images, **kwargs)`. A `None`
+    `preprocess` acts as the identity and claims names the same way (they go straight to the model
+    forward); a `None` `post_process` claims nothing.
+
+    Returns:
+        `tuple[list[str], list[str]]`: `(preprocess_names, post_process_names)`.
+
+    Raises:
+        `ValueError`: if a name is claimed by neither stage — it would become a graph input that
+            nothing reads.
+    """
+    pre_declared, pre_var_keyword = ([], True) if preprocess is None else _stage_input_names(preprocess)
+    post_declared, post_var_keyword = (
+        ([], False) if post_process is None else _stage_input_names(post_process, skip_first=True)
+    )
+
+    pre_explicit = [name for name in input_names if name in pre_declared]
+    post_explicit = [name for name in input_names if name in post_declared]
+    preprocess_names = [name for name in input_names if name not in post_explicit] if pre_var_keyword else pre_explicit
+    post_process_names = (
+        [name for name in input_names if name not in pre_explicit] if post_var_keyword else post_explicit
+    )
+
+    unclaimed = [name for name in input_names if name not in preprocess_names and name not in post_process_names]
+    if unclaimed:
+        raise ValueError(
+            f"Inputs {unclaimed} are consumed by neither `preprocess` nor `post_process`, so they would "
+            f"become graph inputs that nothing reads. Declare them as parameters of the stage that needs "
+            f"them (`preprocess` declares {pre_declared or 'nothing'}, `post_process` declares "
+            f"{post_declared or 'nothing'}), or drop them from `sample_inputs`."
+        )
+    return preprocess_names, post_process_names
+
+
+if is_torch_available():
+
+    class EndToEndModel(torch.nn.Module):
+        """Single `nn.Module` chaining `preprocess` → `model.forward` → `post_process`.
+
+        Exporting this module yields one graph that goes from raw inputs (uint8 images, an audio
+        waveform, …) to final outputs (top-k labels, rescaled boxes, …), so the runtime doesn't
+        have to reimplement the Python pre/post-processing. Both stages are traced, so both must be
+        written in tensor ops — Python control flow over tensor *values*, `.item()`, `.tolist()`,
+        `nonzero()`, or PIL/NumPy calls are not traceable.
+
+        Args:
+            model ([`PreTrainedModel`]):
+                The model whose `forward` is the middle stage.
+            input_names (`list[str]`):
+                Keys of the `sample_inputs` the module will be called with, used to route each
+                input to the stage that declares it (see [`~exporters.utils.route_end_to_end_inputs`]).
+            preprocess (`Callable` or `torch.nn.Module`, *optional*):
+                Maps the raw inputs it claims to a mapping of `model.forward` kwargs (a `dict` or
+                `BatchFeature`). `None` passes the claimed inputs straight to `model.forward`.
+                Pass an `nn.Module` when the preprocessing owns tensors (mel filters, anchor
+                grids) so they're lifted into the graph as buffers.
+            post_process (`Callable` or `torch.nn.Module`, *optional*):
+                Called as `post_process(model_outputs, **claimed_inputs)`; its return value is the
+                module's output. `None` returns the model outputs unchanged.
+        """
+
+        def __init__(
+            self,
+            model: PreTrainedModel,
+            input_names: list[str],
+            preprocess: Any = None,
+            post_process: Any = None,
+        ):
+            super().__init__()
+            if preprocess is None and post_process is None:
+                raise ValueError(
+                    "`EndToEndModel` needs at least one of `preprocess` / `post_process`. With neither "
+                    "there is nothing to chain — export the model directly with `export`."
+                )
+
+            self.preprocess_names, self.post_process_names = route_end_to_end_inputs(
+                input_names, preprocess=preprocess, post_process=post_process
+            )
+            # `model` is registered first so `module_dtype` / `module_device` resolve to the model's
+            # parameters rather than a stage's buffers.
+            self.model = model
+            self.preprocess = preprocess
+            self.post_process = post_process
+            if hasattr(model, "config"):
+                self.config = model.config
+
+        def forward(self, **kwargs):
+            model_inputs = {name: kwargs[name] for name in self.preprocess_names if name in kwargs}
+            if self.preprocess is not None:
+                model_inputs = self.preprocess(**model_inputs)
+                if not isinstance(model_inputs, MutableMapping):
+                    raise TypeError(
+                        f"`preprocess` must return a mapping of `model.forward` kwargs (dict, BatchFeature), "
+                        f"got {type(model_inputs).__name__}."
+                    )
+                model_inputs = dict(model_inputs)
+
+            # Preprocessing produces float32 while the model may hold bfloat16/float16 weights, so
+            # align the stage boundary instead of failing the trace on a dtype mismatch.
+            dtype, device = module_dtype(self.model), module_device(self.model)
+            if dtype is not None or device is not None:
+                model_inputs = cast_leaf_tensors(model_inputs, dtype=dtype, device=device)
+
+            outputs = self.model(**model_inputs)
+
+            if self.post_process is not None:
+                post_process_inputs = {name: kwargs[name] for name in self.post_process_names if name in kwargs}
+                outputs = self.post_process(outputs, **post_process_inputs)
+            return outputs

--- a/src/transformers/exporters/utils.py
+++ b/src/transformers/exporters/utils.py
@@ -34,7 +34,8 @@ Organised into six sections (search for the `# ── Name ──` banners):
   multimodal forward into one entry per submodule), backed by `_capture_forward`.
 - **End-to-end composition** — the inverse of decomposition: `EndToEndModel` chains
   preprocessing, the model forward and post-processing into one `nn.Module` (with
-  `route_end_to_end_inputs` deciding which input feeds which stage) so the whole
+  `route_end_to_end_inputs` deciding which input feeds which stage and
+  `bind_static_post_process_kwargs` folding the rest into constants) so the whole
   pipeline exports as a single graph.
 """
 
@@ -939,7 +940,22 @@ def decompose_for_generation(
 # a backend's `export` traces all three stages into one graph. `EndToEndModel` owns the
 # plumbing — routing `sample_inputs` to the stage that declares them, and aligning the
 # preprocess output with the model's dtype/device — and `HfExporter.export_end_to_end`
-# is a one-liner over it.
+# is a one-liner over it plus `bind_static_post_process_kwargs`.
+
+
+@register_patch(
+    "dynamo", "transformers.image_processing_backends.TorchvisionBackend._fuse_mean_std_and_rescale_factor"
+)
+@register_patch("onnx", "transformers.image_processing_backends.TorchvisionBackend._fuse_mean_std_and_rescale_factor")
+def _patch_fuse_mean_std_and_rescale_factor(original):
+    """Drop the `lru_cache` around the fused mean/std tensors while a preprocessing stage is traced.
+
+    The cache is keyed on the processor and its normalization kwargs, so the fake tensors the first
+    trace puts in it are handed back to every later call — poisoning the next export ("we found a
+    fake tensor in the exported program constant's list") and eager preprocessing alike. Tracing
+    without the cache recreates them per call and leaves the pre-export entries untouched.
+    """
+    return original.__wrapped__
 
 
 def _stage_input_names(stage: TorchvisionBackend | Callable, *, skip_first: bool = False) -> tuple[list[str], bool]:
@@ -1009,6 +1025,56 @@ def route_end_to_end_inputs(
     return preprocess_names, post_process_names
 
 
+def bind_static_post_process_kwargs(
+    post_process: Callable | None, sample_inputs: MutableMapping[str, Any]
+) -> tuple[Callable | None, dict[str, Any]]:
+    """Freeze the `post_process` arguments a tracer can't take as graph inputs, and drop them from `sample_inputs`.
+
+    Two arguments of the Transformers post-processors are resolved here instead of being exposed on
+    the exported graph:
+
+    - `return_traceable_outputs` is set to `True` whenever the post-processor declares it, selecting the branch
+      that returns a tuple of fixed-shape tensors over the list of dicts / `ModelOutput` it builds
+      eagerly. Reshape the tuple after running the artifact with the matching `build_*_outputs`
+      method of the same processor.
+    - `target_sizes` is read on the Python side by every post-processor that takes it — `.tolist()`,
+      `len(set(...))` to check the sizes agree, a comparison against the batch size — to pick the
+      size it interpolates to, none of which a tracer can do on a graph input. So it is normalised
+      to a list of `(height, width)` tuples once, here, and passed in as a Python constant: those
+      reads then run at trace time over `int`s and fold away, leaving the sizes baked into the
+      graph. The artifact is pinned to them — export again to target others.
+
+    Anything else in `sample_inputs` is left alone, and so is a `post_process` declaring neither
+    name (a plain callable of the model outputs, say).
+
+    Returns:
+        `tuple[Callable | None, dict[str, Any]]`: the `post_process` to trace — a `functools.partial`
+        over the original when anything was bound — and `sample_inputs` without the bound names.
+    """
+    sample_inputs = dict(sample_inputs)
+    if post_process is None:
+        return post_process, sample_inputs
+
+    declared, _ = _stage_input_names(post_process, skip_first=True)
+    bound: dict[str, Any] = {}
+
+    if "return_traceable_outputs" in declared:
+        bound["return_traceable_outputs"] = True
+
+    if "target_sizes" in declared and "target_sizes" in sample_inputs:
+        target_sizes = sample_inputs.pop("target_sizes")
+        if target_sizes is not None:
+            # Covers a tensor and an ndarray — one transfer here, none inside the traced code
+            if hasattr(target_sizes, "tolist"):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
+        bound["target_sizes"] = target_sizes
+
+    if bound:
+        post_process = functools.partial(post_process, **bound)
+    return post_process, sample_inputs
+
+
 if is_torch_available():
 
     class EndToEndModel(torch.nn.Module):
@@ -1034,7 +1100,10 @@ if is_torch_available():
                 filters, anchor grids) so they're lifted into the graph as buffers.
             post_process (`Callable`, *optional*):
                 Called as `post_process(model_outputs, **claimed_inputs)`; its return value is the
-                module's output. `None` returns the model outputs unchanged.
+                module's output. `None` returns the model outputs unchanged. Pass a Transformers
+                post-processor through [`~exporters.utils.bind_static_post_process_kwargs`] first
+                to pick up its traceable branch and a constant `target_sizes` —
+                [`~HfExporter.export_end_to_end`] does that for you.
         """
 
         def __init__(

--- a/src/transformers/models/mask2former/image_processing_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_mask2former.py
@@ -554,7 +554,8 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
 
             When `return_traceable_outputs=True`, a tuple `(semantic_map,)` of shape `(batch_size, height, width)`,
             extended with the segmentation scores of shape `(batch_size, num_classes, height, width)` if
-            `return_segmentation_scores=True`. Everything up to that tuple is traceable, so passing it to
+            `return_segmentation_scores=True`. The maps are already resized to the target size, so they can be used
+            as is; passing `segmentation_scores` to
             [`~Mask2FormerImageProcessor.build_semantic_segmentation_outputs`] outside of the traced code gives the
             same output as `return_traceable_outputs=False`.
         """
@@ -572,8 +573,7 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                 raise ValueError(
                     "Make sure that you pass in as many target sizes as the batch dimension of the logits"
                 )
-            num_unique_target_sizes = len(set(target_sizes))
-            if return_traceable_outputs and num_unique_target_sizes != 1:
+            if return_traceable_outputs and len(set(target_sizes)) != 1:
                 raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
 
         # Scale back to preprocessed image size - (384, 384) for all models
@@ -584,39 +584,22 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
         # Semantic segmentation logits of shape (batch_size, num_classes, height, width), without the null class
         masks_classes = class_queries_logits.softmax(dim=-1)[..., :-1]
         masks_probs = masks_queries_logits.sigmoid()  # [batch_size, num_queries, height, width]
-        segmentation = masks_classes.transpose(1, 2) @ masks_probs.flatten(start_dim=2)
-        segmentation = segmentation.unflatten(dim=-1, sizes=masks_probs.shape[-2:])
+        segmentation_scores = masks_classes.transpose(1, 2) @ masks_probs.flatten(start_dim=2)
+        segmentation_scores = segmentation_scores.unflatten(dim=-1, sizes=masks_probs.shape[-2:])
 
-        # Resize logits and compute semantic segmentation maps
-        if target_sizes is not None:
-            if num_unique_target_sizes == 1:
-                resized_logits = torch.nn.functional.interpolate(
-                    segmentation, size=target_sizes[0], mode="bilinear", align_corners=False
-                )
-                semantic_map = resized_logits.argmax(dim=1)
-            else:
-                resized_logits = []
-                semantic_map = []
-                for idx in range(batch_size):
-                    logits = torch.nn.functional.interpolate(
-                        segmentation[idx].unsqueeze(dim=0),
-                        size=target_sizes[idx],
-                        mode="bilinear",
-                        align_corners=False,
-                    )
-                    resized_logits.append(logits[0])
-                    semantic_map.append(logits[0].argmax(dim=0))
-
-        else:
-            resized_logits = segmentation
-            semantic_map = resized_logits.argmax(dim=1)
-
+        # Logits are resized before the argmax only in the traceable branch,
+        # `build_semantic_segmentation_outputs` resizes them otherwise
         if return_traceable_outputs:
-            return (semantic_map, resized_logits) if return_segmentation_scores else (semantic_map,)
+            if target_sizes is not None:
+                segmentation_scores = torch.nn.functional.interpolate(
+                    segmentation_scores, size=target_sizes[0], mode="bilinear", align_corners=False
+                )
+            semantic_map = segmentation_scores.argmax(dim=1)
+            return (semantic_map, segmentation_scores) if return_segmentation_scores else (semantic_map,)
 
         return self.build_semantic_segmentation_outputs(
-            semantic_map=semantic_map,
-            segmentation_scores=resized_logits,
+            segmentation_scores=segmentation_scores,
+            target_sizes=target_sizes,
             return_segmentation_scores=return_segmentation_scores,
         )
 
@@ -851,29 +834,46 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
 
     def build_semantic_segmentation_outputs(
         self,
-        semantic_map: torch.Tensor | list[torch.Tensor],
-        segmentation_scores: torch.Tensor | list[torch.Tensor] | None = None,
+        segmentation_scores: torch.Tensor,
+        target_sizes: list[tuple[int, int]] | None = None,
         return_segmentation_scores: bool = False,
     ) -> "list[torch.Tensor] | list[SemanticSegmentationPostProcessorOutput]":
         """
         Builds semantic segmentation maps from the tensors returned by
         `post_process_semantic_segmentation(..., return_traceable_outputs=True)`. See
         [`~Mask2FormerImageProcessor.post_process_semantic_segmentation`] for the arguments and the returned values.
+        `target_sizes` must be left to `None` if the logits were already resized by
+        `post_process_semantic_segmentation`.
         """
-        if return_segmentation_scores:
-            if segmentation_scores is None:
-                raise ValueError("`segmentation_scores` are required when `return_segmentation_scores=True`.")
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
 
-            semantic_segmentation = [
-                SemanticSegmentationPostProcessorOutput(
-                    data={"segmentation": segmentation, "segmentation_scores": scores}
+        if target_sizes is None or len(set(target_sizes)) == 1:
+            if target_sizes is not None:
+                segmentation_scores = torch.nn.functional.interpolate(
+                    segmentation_scores, size=target_sizes[0], mode="bilinear", align_corners=False
                 )
-                for segmentation, scores in zip(semantic_map, segmentation_scores)
-            ]
+            semantic_map = segmentation_scores.argmax(dim=1)
         else:
-            semantic_segmentation = list(semantic_map)
+            segmentation_scores = [
+                torch.nn.functional.interpolate(
+                    image_scores.unsqueeze(dim=0), size=target_size, mode="bilinear", align_corners=False
+                )[0]
+                for image_scores, target_size in zip(segmentation_scores, target_sizes)
+            ]
+            semantic_map = [image_scores.argmax(dim=0) for image_scores in segmentation_scores]
 
-        return semantic_segmentation
+        if not return_segmentation_scores:
+            return list(semantic_map)
+
+        return [
+            SemanticSegmentationPostProcessorOutput(
+                data={"segmentation": segmentation, "segmentation_scores": image_scores}
+            )
+            for segmentation, image_scores in zip(semantic_map, segmentation_scores)
+        ]
 
     def build_instance_segmentation_outputs(
         self,

--- a/src/transformers/models/mask2former/image_processing_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_mask2former.py
@@ -773,26 +773,26 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                   Multiple instances of the same class / label were fused and assigned a single `segment_id`.
                 - **score** -- Prediction score of segment with `segment_id`.
 
-            When `return_traceable_outputs=True`, a tuple `(mask_probs, scores, labels, keep_queries)` of tensors with
-            a static `num_queries` dimension: `mask_probs` of shape `(batch_size, num_queries, height, width)`,
-            `scores` and `labels` of shape `(batch_size, num_queries)`, and `keep_queries` of shape `(batch_size,
-            num_queries)`, `True` for the queries that are above `threshold` and do not predict the null class.
+            When `return_traceable_outputs=True`, a tuple `(masks, scores, classes, keep_instances)` of tensors with a
+            static `num_queries` dimension: `masks` of shape `(batch_size, num_queries, height, width)` with mask
+            probabilities, `scores` and `classes` of shape `(batch_size, num_queries)`, and `keep_instances` of shape
+            `(batch_size, num_queries)`, `True` for the instances that are above `threshold` and do not predict the
+            null class.
             Everything up to that tuple is traceable, so passing it to
             [`~Mask2FormerImageProcessor.build_panoptic_segmentation_outputs`] outside of the traced code gives the
             same output as `return_traceable_outputs=False`.
         """
+        class_queries_logits = outputs.class_queries_logits  # [batch_size, num_queries, num_classes+1]
+        masks_queries_logits = outputs.masks_queries_logits  # [batch_size, num_queries, height, width]
+
+        batch_size = class_queries_logits.shape[0]
+        num_classes = class_queries_logits.shape[-1] - 1
+
         if target_sizes is not None:
             if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
                 target_sizes = target_sizes.tolist()
             target_sizes = [tuple(size) for size in target_sizes]
 
-        class_queries_logits = outputs.class_queries_logits  # [batch_size, num_queries, num_classes+1]
-        masks_queries_logits = outputs.masks_queries_logits  # [batch_size, num_queries, height, width]
-
-        batch_size = class_queries_logits.shape[0]
-        num_labels = class_queries_logits.shape[-1] - 1
-
-        if target_sizes is not None:
             if batch_size != len(target_sizes):
                 raise ValueError(
                     "Make sure that you pass in as many target sizes as the batch dimension of the logits"
@@ -801,31 +801,29 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                 raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
 
         # Scale back to preprocessed image size - (384, 384) for all models
-        mask_probs = torch.nn.functional.interpolate(
+        masks = torch.nn.functional.interpolate(
             masks_queries_logits, size=(384, 384), mode="bilinear", align_corners=False
         ).sigmoid()  # [batch_size, num_queries, height, width]
 
         # Predicted label and score of each query (batch_size, num_queries)
-        scores, labels = nn.functional.softmax(class_queries_logits, dim=-1).max(-1)
+        scores, classes = nn.functional.softmax(class_queries_logits, dim=-1).max(-1)
 
         # Masks are resized before filtering only in the traceable branch, `build_panoptic_segmentation_outputs`
         # resizes the remaining masks otherwise
         if return_traceable_outputs and target_sizes is not None:
-            mask_probs = torch.nn.functional.interpolate(
-                mask_probs, size=target_sizes[0], mode="bilinear", align_corners=False
-            )
+            masks = torch.nn.functional.interpolate(masks, size=target_sizes[0], mode="bilinear", align_corners=False)
 
-        # Discard queries with a low score or predicting the null class
-        keep_queries = labels.ne(num_labels) & (scores > threshold)
+        # Discard instances with a low score or predicting the null class
+        keep_instances = classes.ne(num_classes) & (scores > threshold)
 
         if return_traceable_outputs:
-            return mask_probs, scores, labels, keep_queries
+            return masks, scores, classes, keep_instances
 
         return self.build_panoptic_segmentation_outputs(
-            mask_probs=mask_probs,
+            masks=masks,
             scores=scores,
-            labels=labels,
-            keep_queries=keep_queries,
+            classes=classes,
+            keep_instances=keep_instances,
             mask_threshold=mask_threshold,
             overlap_mask_area_threshold=overlap_mask_area_threshold,
             label_ids_to_fuse=label_ids_to_fuse,
@@ -946,10 +944,10 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
 
     def build_panoptic_segmentation_outputs(
         self,
-        mask_probs: torch.Tensor,
+        masks: torch.Tensor,
         scores: torch.Tensor,
-        labels: torch.Tensor,
-        keep_queries: torch.Tensor,
+        classes: torch.Tensor,
+        keep_instances: torch.Tensor,
         mask_threshold: float = 0.5,
         overlap_mask_area_threshold: float = 0.8,
         label_ids_to_fuse: set[int] | None = None,
@@ -972,17 +970,17 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
             target_sizes = [tuple(size) for size in target_sizes]
 
         results: list[dict[str, TensorType]] = []
-        for idx, (image_mask_probs, image_scores, image_labels, image_keep) in enumerate(
-            zip(mask_probs, scores, labels, keep_queries)
+        for idx, (image_masks, image_scores, image_classes, image_keep) in enumerate(
+            zip(masks, scores, classes, keep_instances)
         ):
-            image_mask_probs = image_mask_probs[image_keep]
+            image_masks = image_masks[image_keep]
             image_scores = image_scores[image_keep]
-            image_labels = image_labels[image_keep]
+            image_classes = image_classes[image_keep]
             target_size = target_sizes[idx] if target_sizes is not None else None
 
             # No mask found
-            if image_mask_probs.shape[0] <= 0:
-                height, width = target_size if target_size is not None else image_mask_probs.shape[1:]
+            if image_masks.shape[0] <= 0:
+                height, width = target_size if target_size is not None else image_masks.shape[1:]
                 segmentation = torch.zeros((height, width)) - 1
                 results.append({"segmentation": segmentation, "segments_info": []})
                 continue
@@ -990,9 +988,9 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
             # Get segmentation map and segment information of batch item, resizing the masks here keeps the
             # interpolation off the queries that were filtered out
             segmentation, segments = compute_segments(
-                mask_probs=image_mask_probs,
+                mask_probs=image_masks,
                 pred_scores=image_scores,
-                pred_labels=image_labels,
+                pred_labels=image_classes,
                 mask_threshold=mask_threshold,
                 overlap_mask_area_threshold=overlap_mask_area_threshold,
                 label_ids_to_fuse=label_ids_to_fuse,

--- a/src/transformers/models/mask2former/image_processing_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_mask2former.py
@@ -581,12 +581,11 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
             masks_queries_logits, size=(384, 384), mode="bilinear", align_corners=False
         )
 
-        # Remove the null class `[..., :-1]`
+        # Semantic segmentation logits of shape (batch_size, num_classes, height, width), without the null class
         masks_classes = class_queries_logits.softmax(dim=-1)[..., :-1]
         masks_probs = masks_queries_logits.sigmoid()  # [batch_size, num_queries, height, width]
-
-        # Semantic segmentation logits of shape (batch_size, num_classes, height, width)
-        segmentation = torch.einsum("bqc, bqhw -> bchw", masks_classes, masks_probs)
+        segmentation = masks_classes.transpose(1, 2) @ masks_probs.flatten(start_dim=2)
+        segmentation = segmentation.unflatten(dim=-1, sizes=masks_probs.shape[-2:])
 
         # Resize logits and compute semantic segmentation maps
         if target_sizes is not None:
@@ -670,11 +669,11 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                 - **label_id** -- An integer representing the label / semantic class id corresponding to `segment_id`.
                 - **score** -- Prediction score of segment with `segment_id`.
 
-            When `return_traceable_outputs=True`, a tuple `(pred_masks, pred_scores, pred_classes, keep)` of tensors
-            with a static `num_queries` dimension: `pred_masks` of shape `(batch_size, num_queries, height, width)`
-            with binary instance masks, `pred_scores` and `pred_classes` of shape `(batch_size, num_queries)`, and
-            `keep` of shape `(batch_size, num_queries)`, `True` for the instances that are above `threshold` and have a
-            non-empty mask. Everything up to that tuple is traceable, so passing it to
+            When `return_traceable_outputs=True`, a tuple `(masks, scores, classes, keep_instances)` of tensors with a
+            static `num_queries` dimension: `masks` of shape `(batch_size, num_queries, height, width)` with binary
+            instance masks, `scores` and `classes` of shape `(batch_size, num_queries)`, and `keep_instances` of shape
+            `(batch_size, num_queries)`, `True` for the instances that are above `threshold` and have a non-empty mask.
+            Everything up to that tuple is traceable, so passing it to
             [`~Mask2FormerImageProcessor.build_instance_segmentation_outputs`] outside of the traced code gives the
             same output as `return_traceable_outputs=False`.
         """
@@ -710,35 +709,33 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
 
         # Remove the null class `[..., :-1]` and keep the `num_queries` highest scoring (query, class) pairs
         scores = torch.nn.functional.softmax(class_queries_logits, dim=-1)[..., :-1]
-        pred_scores, topk_indices = scores.flatten(1, 2).topk(num_queries, dim=-1, sorted=False)
-        pred_classes = topk_indices % num_classes
+        scores, topk_indices = scores.flatten(1, 2).topk(num_queries, dim=-1, sorted=False)
+        classes = topk_indices % num_classes
         query_indices = torch.div(topk_indices, num_classes, rounding_mode="floor")
 
         mask_logits = masks_queries_logits.gather(
             dim=1, index=query_indices[..., None, None].expand(-1, -1, height, width)
         )
-        pred_masks = (mask_logits > 0).to(mask_logits.dtype)
+        masks = (mask_logits > 0).to(mask_logits.dtype)
 
         # Calculate average mask prob
-        mask_scores = (mask_logits.sigmoid().flatten(2) * pred_masks.flatten(2)).sum(-1) / (
-            pred_masks.flatten(2).sum(-1) + 1e-6
-        )
-        pred_scores = pred_scores * mask_scores
+        mask_scores = (mask_logits.sigmoid().flatten(2) * masks.flatten(2)).sum(-1) / (masks.flatten(2).sum(-1) + 1e-6)
+        scores = scores * mask_scores
 
         if return_traceable_outputs and target_sizes is not None:
-            pred_masks = torch.nn.functional.interpolate(pred_masks, size=target_sizes[0], mode="nearest")
+            masks = torch.nn.functional.interpolate(masks, size=target_sizes[0], mode="nearest")
 
         # Discard instances with a low score or an empty mask
-        keep = (pred_scores >= threshold) & pred_masks.flatten(2).any(dim=-1)
+        keep_instances = (scores >= threshold) & masks.flatten(2).any(dim=-1)
 
         if return_traceable_outputs:
-            return pred_masks, pred_scores, pred_classes, keep
+            return masks, scores, classes, keep_instances
 
         return self.build_instance_segmentation_outputs(
-            pred_masks=pred_masks,
-            pred_scores=pred_scores,
-            pred_classes=pred_classes,
-            keep=keep,
+            masks=masks,
+            scores=scores,
+            classes=classes,
+            keep_instances=keep_instances,
             target_sizes=target_sizes,
             return_coco_annotation=return_coco_annotation,
             return_binary_maps=return_binary_maps,
@@ -793,9 +790,9 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                   Multiple instances of the same class / label were fused and assigned a single `segment_id`.
                 - **score** -- Prediction score of segment with `segment_id`.
 
-            When `return_traceable_outputs=True`, a tuple `(mask_probs, pred_scores, pred_labels, keep)` of tensors
-            with a static `num_queries` dimension: `mask_probs` of shape `(batch_size, num_queries, height, width)`,
-            `pred_scores` and `pred_labels` of shape `(batch_size, num_queries)`, and `keep` of shape `(batch_size,
+            When `return_traceable_outputs=True`, a tuple `(mask_probs, scores, labels, keep_queries)` of tensors with
+            a static `num_queries` dimension: `mask_probs` of shape `(batch_size, num_queries, height, width)`,
+            `scores` and `labels` of shape `(batch_size, num_queries)`, and `keep_queries` of shape `(batch_size,
             num_queries)`, `True` for the queries that are above `threshold` and do not predict the null class.
             Everything up to that tuple is traceable, so passing it to
             [`~Mask2FormerImageProcessor.build_panoptic_segmentation_outputs`] outside of the traced code gives the
@@ -821,14 +818,12 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                 raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
 
         # Scale back to preprocessed image size - (384, 384) for all models
-        masks_queries_logits = torch.nn.functional.interpolate(
+        mask_probs = torch.nn.functional.interpolate(
             masks_queries_logits, size=(384, 384), mode="bilinear", align_corners=False
-        )
-
-        mask_probs = masks_queries_logits.sigmoid()  # [batch_size, num_queries, height, width]
+        ).sigmoid()  # [batch_size, num_queries, height, width]
 
         # Predicted label and score of each query (batch_size, num_queries)
-        pred_scores, pred_labels = nn.functional.softmax(class_queries_logits, dim=-1).max(-1)
+        scores, labels = nn.functional.softmax(class_queries_logits, dim=-1).max(-1)
 
         # Masks are resized before filtering only in the traceable branch, `build_panoptic_segmentation_outputs`
         # resizes the remaining masks otherwise
@@ -838,16 +833,16 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
             )
 
         # Discard queries with a low score or predicting the null class
-        keep = pred_labels.ne(num_labels) & (pred_scores > threshold)
+        keep_queries = labels.ne(num_labels) & (scores > threshold)
 
         if return_traceable_outputs:
-            return mask_probs, pred_scores, pred_labels, keep
+            return mask_probs, scores, labels, keep_queries
 
         return self.build_panoptic_segmentation_outputs(
             mask_probs=mask_probs,
-            pred_scores=pred_scores,
-            pred_labels=pred_labels,
-            keep=keep,
+            scores=scores,
+            labels=labels,
+            keep_queries=keep_queries,
             mask_threshold=mask_threshold,
             overlap_mask_area_threshold=overlap_mask_area_threshold,
             label_ids_to_fuse=label_ids_to_fuse,
@@ -882,10 +877,10 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
 
     def build_instance_segmentation_outputs(
         self,
-        pred_masks: torch.Tensor,
-        pred_scores: torch.Tensor,
-        pred_classes: torch.Tensor,
-        keep: torch.Tensor,
+        masks: torch.Tensor,
+        scores: torch.Tensor,
+        classes: torch.Tensor,
+        keep_instances: torch.Tensor,
         target_sizes: list[tuple[int, int]] | None = None,
         return_coco_annotation: bool | None = False,
         return_binary_maps: bool | None = False,
@@ -906,33 +901,35 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
             target_sizes = [tuple(size) for size in target_sizes]
 
         results: list[dict[str, TensorType]] = []
-        for idx, (masks, scores, classes, keep_item) in enumerate(zip(pred_masks, pred_scores, pred_classes, keep)):
-            masks = masks[keep_item]
-            scores = scores[keep_item]
-            classes = classes[keep_item]
+        for idx, (image_masks, image_scores, image_classes, image_keep) in enumerate(
+            zip(masks, scores, classes, keep_instances)
+        ):
+            image_masks = image_masks[image_keep]
+            image_scores = image_scores[image_keep]
+            image_classes = image_classes[image_keep]
 
             # Resizing is done after filtering, interpolating all masks to the target size is expensive
-            if target_sizes is not None and masks.shape[0] != 0:
-                masks = torch.nn.functional.interpolate(
-                    masks.unsqueeze(dim=0), size=target_sizes[idx], mode="nearest"
+            if target_sizes is not None and image_masks.shape[0] != 0:
+                image_masks = torch.nn.functional.interpolate(
+                    image_masks.unsqueeze(dim=0), size=target_sizes[idx], mode="nearest"
                 )[0]
                 # Masks can become empty when downsampled
-                non_empty_masks = masks.flatten(1).any(dim=-1)
-                masks = masks[non_empty_masks]
-                scores = scores[non_empty_masks]
-                classes = classes[non_empty_masks]
+                non_empty_masks = image_masks.flatten(1).any(dim=-1)
+                image_masks = image_masks[non_empty_masks]
+                image_scores = image_scores[non_empty_masks]
+                image_classes = image_classes[non_empty_masks]
 
-            height, width = target_sizes[idx] if target_sizes is not None else masks.shape[-2:]
+            height, width = target_sizes[idx] if target_sizes is not None else image_masks.shape[-2:]
             segmentation = torch.zeros((height, width)) - 1
             segments = []
-            for segment_id in range(masks.shape[0]):
-                segmentation[masks[segment_id] == 1] = segment_id
+            for segment_id in range(image_masks.shape[0]):
+                segmentation[image_masks[segment_id] == 1] = segment_id
                 segments.append(
                     {
                         "id": segment_id,
-                        "label_id": classes[segment_id].item(),
+                        "label_id": image_classes[segment_id].item(),
                         "was_fused": False,
-                        "score": round(scores[segment_id].item(), 6),
+                        "score": round(image_scores[segment_id].item(), 6),
                     }
                 )
 
@@ -941,8 +938,8 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                 segmentation = convert_segmentation_to_rle(segmentation)
 
             # Return a concatenated tensor of binary instance maps
-            if return_binary_maps and masks.shape[0] != 0:
-                segmentation = masks
+            if return_binary_maps and image_masks.shape[0] != 0:
+                segmentation = image_masks
 
             results.append({"segmentation": segmentation, "segments_info": segments})
         return results
@@ -950,9 +947,9 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
     def build_panoptic_segmentation_outputs(
         self,
         mask_probs: torch.Tensor,
-        pred_scores: torch.Tensor,
-        pred_labels: torch.Tensor,
-        keep: torch.Tensor,
+        scores: torch.Tensor,
+        labels: torch.Tensor,
+        keep_queries: torch.Tensor,
         mask_threshold: float = 0.5,
         overlap_mask_area_threshold: float = 0.8,
         label_ids_to_fuse: set[int] | None = None,
@@ -975,15 +972,17 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
             target_sizes = [tuple(size) for size in target_sizes]
 
         results: list[dict[str, TensorType]] = []
-        for idx, (masks, scores, labels, keep_item) in enumerate(zip(mask_probs, pred_scores, pred_labels, keep)):
-            masks = masks[keep_item]
-            scores = scores[keep_item]
-            labels = labels[keep_item]
+        for idx, (image_mask_probs, image_scores, image_labels, image_keep) in enumerate(
+            zip(mask_probs, scores, labels, keep_queries)
+        ):
+            image_mask_probs = image_mask_probs[image_keep]
+            image_scores = image_scores[image_keep]
+            image_labels = image_labels[image_keep]
             target_size = target_sizes[idx] if target_sizes is not None else None
 
             # No mask found
-            if masks.shape[0] <= 0:
-                height, width = target_size if target_size is not None else masks.shape[1:]
+            if image_mask_probs.shape[0] <= 0:
+                height, width = target_size if target_size is not None else image_mask_probs.shape[1:]
                 segmentation = torch.zeros((height, width)) - 1
                 results.append({"segmentation": segmentation, "segments_info": []})
                 continue
@@ -991,9 +990,9 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
             # Get segmentation map and segment information of batch item, resizing the masks here keeps the
             # interpolation off the queries that were filtered out
             segmentation, segments = compute_segments(
-                mask_probs=masks,
-                pred_scores=scores,
-                pred_labels=labels,
+                mask_probs=image_mask_probs,
+                pred_scores=image_scores,
+                pred_labels=image_labels,
                 mask_threshold=mask_threshold,
                 overlap_mask_area_threshold=overlap_mask_area_threshold,
                 label_ids_to_fuse=label_ids_to_fuse,

--- a/src/transformers/models/mask2former/image_processing_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_mask2former.py
@@ -118,34 +118,6 @@ def convert_segmentation_to_rle(segmentation):
     return run_length_encodings
 
 
-def remove_low_and_no_objects(masks, scores, labels, object_mask_threshold, num_labels):
-    """
-    Binarize the given masks using `object_mask_threshold`, it returns the associated values of `masks`, `scores` and
-    `labels`.
-
-    Args:
-        masks (`torch.Tensor`):
-            A tensor of shape `(num_queries, height, width)`.
-        scores (`torch.Tensor`):
-            A tensor of shape `(num_queries)`.
-        labels (`torch.Tensor`):
-            A tensor of shape `(num_queries)`.
-        object_mask_threshold (`float`):
-            A number between 0 and 1 used to binarize the masks.
-    Raises:
-        `ValueError`: Raised when the first dimension doesn't match in all input tensors.
-    Returns:
-        `tuple[`torch.Tensor`, `torch.Tensor`, `torch.Tensor`]`: The `masks`, `scores` and `labels` without the region
-        < `object_mask_threshold`.
-    """
-    if not (masks.shape[0] == scores.shape[0] == labels.shape[0]):
-        raise ValueError("mask, scores and labels must have the same shape!")
-
-    to_keep = labels.ne(num_labels) & (scores > object_mask_threshold)
-
-    return masks[to_keep], scores[to_keep], labels[to_keep]
-
-
 def check_segment_validity(mask_labels, mask_probs, k, mask_threshold=0.5, overlap_mask_area_threshold=0.8):
     # Get the mask associated with the k class
     mask_k = mask_labels == k
@@ -552,6 +524,7 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
         outputs,
         target_sizes: list[tuple[int, int]] | None = None,
         return_segmentation_scores: bool = False,
+        return_traceable_outputs: bool = False,
     ) -> "list[torch.Tensor] | list[SemanticSegmentationPostProcessorOutput]":
         """
         Converts the output of [`Mask2FormerForUniversalSegmentation`] into semantic segmentation maps. Only supports
@@ -567,6 +540,9 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                 Whether to return segmentation scores alongside the segmentation map. When `True`, each element of
                 the returned list is a [`SemanticSegmentationPostProcessorOutput`] with fields `segmentation`
                 (class IDs, shape `(height, width)`) and `segmentation_scores` (shape `(num_classes, height, width)`).
+            return_traceable_outputs (`bool`, *optional*, defaults to `False`):
+                If set to `True`, a tuple of tensors is returned instead of a list, see the returns section below.
+                All target sizes must be equal in that case.
 
         Returns:
             `list[torch.Tensor]` or `list[SemanticSegmentationPostProcessorOutput]`: When
@@ -575,9 +551,30 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
             a list of [`SemanticSegmentationPostProcessorOutput`] with fields `segmentation` (class IDs, shape
             `(height, width)`) and `segmentation_scores` (shape `(num_classes, height, width)`). In both cases,
             `(height, width)` corresponds to the target size (if `target_sizes` is specified).
+
+            When `return_traceable_outputs=True`, a tuple `(semantic_map,)` of shape `(batch_size, height, width)`,
+            extended with the segmentation scores of shape `(batch_size, num_classes, height, width)` if
+            `return_segmentation_scores=True`. Everything up to that tuple is traceable, so passing it to
+            [`~Mask2FormerImageProcessor.build_semantic_segmentation_outputs`] outside of the traced code gives the
+            same output as `return_traceable_outputs=False`.
         """
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
+
         class_queries_logits = outputs.class_queries_logits  # [batch_size, num_queries, num_classes+1]
         masks_queries_logits = outputs.masks_queries_logits  # [batch_size, num_queries, height, width]
+        batch_size = class_queries_logits.shape[0]
+
+        if target_sizes is not None:
+            if batch_size != len(target_sizes):
+                raise ValueError(
+                    "Make sure that you pass in as many target sizes as the batch dimension of the logits"
+                )
+            num_unique_target_sizes = len(set(target_sizes))
+            if return_traceable_outputs and num_unique_target_sizes != 1:
+                raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
 
         # Scale back to preprocessed image size - (384, 384) for all models
         masks_queries_logits = torch.nn.functional.interpolate(
@@ -590,39 +587,39 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
 
         # Semantic segmentation logits of shape (batch_size, num_classes, height, width)
         segmentation = torch.einsum("bqc, bqhw -> bchw", masks_classes, masks_probs)
-        batch_size = class_queries_logits.shape[0]
 
         # Resize logits and compute semantic segmentation maps
         if target_sizes is not None:
-            if batch_size != len(target_sizes):
-                raise ValueError(
-                    "Make sure that you pass in as many target sizes as the batch dimension of the logits"
-                )
-
-            semantic_segmentation = []
-            for idx in range(batch_size):
+            if num_unique_target_sizes == 1:
                 resized_logits = torch.nn.functional.interpolate(
-                    segmentation[idx].unsqueeze(dim=0), size=target_sizes[idx], mode="bilinear", align_corners=False
+                    segmentation, size=target_sizes[0], mode="bilinear", align_corners=False
                 )
-                semantic_map = resized_logits[0].argmax(dim=0)
-                semantic_segmentation.append(
-                    SemanticSegmentationPostProcessorOutput(
-                        data={"segmentation": semantic_map, "segmentation_scores": resized_logits[0]}
+                semantic_map = resized_logits.argmax(dim=1)
+            else:
+                resized_logits = []
+                semantic_map = []
+                for idx in range(batch_size):
+                    logits = torch.nn.functional.interpolate(
+                        segmentation[idx].unsqueeze(dim=0),
+                        size=target_sizes[idx],
+                        mode="bilinear",
+                        align_corners=False,
                     )
-                )
+                    resized_logits.append(logits[0])
+                    semantic_map.append(logits[0].argmax(dim=0))
+
         else:
-            semantic_map = segmentation.argmax(dim=1)
-            semantic_segmentation = [
-                SemanticSegmentationPostProcessorOutput(
-                    data={"segmentation": semantic_map[i], "segmentation_scores": segmentation[i]}
-                )
-                for i in range(batch_size)
-            ]
+            resized_logits = segmentation
+            semantic_map = resized_logits.argmax(dim=1)
 
-        if not return_segmentation_scores:
-            semantic_segmentation = [item.segmentation for item in semantic_segmentation]
+        if return_traceable_outputs:
+            return (semantic_map, resized_logits) if return_segmentation_scores else (semantic_map,)
 
-        return semantic_segmentation
+        return self.build_semantic_segmentation_outputs(
+            semantic_map=semantic_map,
+            segmentation_scores=resized_logits,
+            return_segmentation_scores=return_segmentation_scores,
+        )
 
     def post_process_instance_segmentation(
         self,
@@ -633,6 +630,7 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
         target_sizes: list[tuple[int, int]] | None = None,
         return_coco_annotation: bool | None = False,
         return_binary_maps: bool | None = False,
+        return_traceable_outputs: bool = False,
     ) -> list[dict]:
         """
         Converts the output of [`Mask2FormerForUniversalSegmentationOutput`] into instance segmentation predictions.
@@ -657,6 +655,10 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
             return_binary_maps (`bool`, *optional*, defaults to `False`):
                 If set to `True`, segmentation maps are returned as a concatenated tensor of binary segmentation maps
                 (one per detected instance).
+            return_traceable_outputs (`bool`, *optional*, defaults to `False`):
+                If set to `True`, a tuple of tensors with static shapes is returned instead of a list of
+                dictionaries, see the returns section below. All target sizes must be equal in that case.
+
         Returns:
             `List[Dict]`: A list of dictionaries, one per image, each dictionary containing two keys:
             - **segmentation** -- A tensor of shape `(height, width)` where each pixel represents a `segment_id`, or
@@ -667,6 +669,14 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                 - **id** -- An integer representing the `segment_id`.
                 - **label_id** -- An integer representing the label / semantic class id corresponding to `segment_id`.
                 - **score** -- Prediction score of segment with `segment_id`.
+
+            When `return_traceable_outputs=True`, a tuple `(pred_masks, pred_scores, pred_classes, keep)` of tensors
+            with a static `num_queries` dimension: `pred_masks` of shape `(batch_size, num_queries, height, width)`
+            with binary instance masks, `pred_scores` and `pred_classes` of shape `(batch_size, num_queries)`, and
+            `keep` of shape `(batch_size, num_queries)`, `True` for the instances that are above `threshold` and have a
+            non-empty mask. Everything up to that tuple is traceable, so passing it to
+            [`~Mask2FormerImageProcessor.build_instance_segmentation_outputs`] outside of the traced code gives the
+            same output as `return_traceable_outputs=False`.
         """
         if return_coco_annotation and return_binary_maps:
             raise ValueError("return_coco_annotation and return_binary_maps can not be both set to True.")
@@ -676,74 +686,63 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
         # [batch_size, num_queries, height, width]
         masks_queries_logits = outputs.masks_queries_logits
 
+        batch_size = class_queries_logits.shape[0]
+        num_classes = class_queries_logits.shape[-1] - 1
+        num_queries = class_queries_logits.shape[-2]
+
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
+
+            if batch_size != len(target_sizes):
+                raise ValueError(
+                    "Make sure that you pass in as many target sizes as the batch dimension of the logits"
+                )
+            if return_traceable_outputs and len(set(target_sizes)) != 1:
+                raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
+
         # Scale back to preprocessed image size - (384, 384) for all models
         masks_queries_logits = torch.nn.functional.interpolate(
             masks_queries_logits, size=(384, 384), mode="bilinear", align_corners=False
         )
+        height, width = masks_queries_logits.shape[-2:]
 
-        device = masks_queries_logits.device
-        num_classes = class_queries_logits.shape[-1] - 1
-        num_queries = class_queries_logits.shape[-2]
+        # Remove the null class `[..., :-1]` and keep the `num_queries` highest scoring (query, class) pairs
+        scores = torch.nn.functional.softmax(class_queries_logits, dim=-1)[..., :-1]
+        pred_scores, topk_indices = scores.flatten(1, 2).topk(num_queries, dim=-1, sorted=False)
+        pred_classes = topk_indices % num_classes
+        query_indices = torch.div(topk_indices, num_classes, rounding_mode="floor")
 
-        # Loop over items in batch size
-        results: list[dict[str, TensorType]] = []
+        mask_logits = masks_queries_logits.gather(
+            dim=1, index=query_indices[..., None, None].expand(-1, -1, height, width)
+        )
+        pred_masks = (mask_logits > 0).to(mask_logits.dtype)
 
-        for i in range(class_queries_logits.shape[0]):
-            mask_pred = masks_queries_logits[i]
-            mask_cls = class_queries_logits[i]
+        # Calculate average mask prob
+        mask_scores = (mask_logits.sigmoid().flatten(2) * pred_masks.flatten(2)).sum(-1) / (
+            pred_masks.flatten(2).sum(-1) + 1e-6
+        )
+        pred_scores = pred_scores * mask_scores
 
-            scores = torch.nn.functional.softmax(mask_cls, dim=-1)[:, :-1]
-            labels = torch.arange(num_classes, device=device).unsqueeze(0).repeat(num_queries, 1).flatten(0, 1)
+        if return_traceable_outputs and target_sizes is not None:
+            pred_masks = torch.nn.functional.interpolate(pred_masks, size=target_sizes[0], mode="nearest")
 
-            scores_per_image, topk_indices = scores.flatten(0, 1).topk(num_queries, sorted=False)
-            labels_per_image = labels[topk_indices]
+        # Discard instances with a low score or an empty mask
+        keep = (pred_scores >= threshold) & pred_masks.flatten(2).any(dim=-1)
 
-            topk_indices = torch.div(topk_indices, num_classes, rounding_mode="floor")
-            mask_pred = mask_pred[topk_indices]
-            pred_masks = (mask_pred > 0).float()
+        if return_traceable_outputs:
+            return pred_masks, pred_scores, pred_classes, keep
 
-            # Calculate average mask prob
-            mask_scores_per_image = (mask_pred.sigmoid().flatten(1) * pred_masks.flatten(1)).sum(1) / (
-                pred_masks.flatten(1).sum(1) + 1e-6
-            )
-            pred_scores = scores_per_image * mask_scores_per_image
-            pred_classes = labels_per_image
-
-            segmentation = torch.zeros((384, 384)) - 1
-            if target_sizes is not None:
-                segmentation = torch.zeros(target_sizes[i]) - 1
-                pred_masks = torch.nn.functional.interpolate(
-                    pred_masks.unsqueeze(0), size=target_sizes[i], mode="nearest"
-                )[0]
-
-            instance_maps, segments = [], []
-            current_segment_id = 0
-            for j in range(num_queries):
-                score = pred_scores[j].item()
-
-                if not torch.all(pred_masks[j] == 0) and score >= threshold:
-                    segmentation[pred_masks[j] == 1] = current_segment_id
-                    segments.append(
-                        {
-                            "id": current_segment_id,
-                            "label_id": pred_classes[j].item(),
-                            "was_fused": False,
-                            "score": round(score, 6),
-                        }
-                    )
-                    current_segment_id += 1
-                    instance_maps.append(pred_masks[j])
-
-            # Return segmentation map in run-length encoding (RLE) format
-            if return_coco_annotation:
-                segmentation = convert_segmentation_to_rle(segmentation)
-
-            # Return a concatenated tensor of binary instance maps
-            if return_binary_maps and len(instance_maps) != 0:
-                segmentation = torch.stack(instance_maps, dim=0)
-
-            results.append({"segmentation": segmentation, "segments_info": segments})
-        return results
+        return self.build_instance_segmentation_outputs(
+            pred_masks=pred_masks,
+            pred_scores=pred_scores,
+            pred_classes=pred_classes,
+            keep=keep,
+            target_sizes=target_sizes,
+            return_coco_annotation=return_coco_annotation,
+            return_binary_maps=return_binary_maps,
+        )
 
     def post_process_panoptic_segmentation(
         self,
@@ -753,6 +752,7 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
         overlap_mask_area_threshold: float = 0.8,
         label_ids_to_fuse: set[int] | None = None,
         target_sizes: list[tuple[int, int]] | None = None,
+        return_traceable_outputs: bool = False,
     ) -> list[dict]:
         """
         Converts the output of [`Mask2FormerForUniversalSegmentationOutput`] into image panoptic segmentation
@@ -776,6 +776,10 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                 List of length (batch_size), where each list item (`Tuple[int, int]]`) corresponds to the requested
                 final size (height, width) of each prediction in batch. If left to None, predictions will not be
                 resized.
+            return_traceable_outputs (`bool`, *optional*, defaults to `False`):
+                If set to `True`, a tuple of tensors with static shapes is returned instead of a list of
+                dictionaries, see the returns section below. All target sizes must be equal in that case and
+                `label_ids_to_fuse` is unused.
 
         Returns:
             `List[Dict]`: A list of dictionaries, one per image, each dictionary containing two keys:
@@ -788,49 +792,208 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                 - **was_fused** -- a boolean, `True` if `label_id` was in `label_ids_to_fuse`, `False` otherwise.
                   Multiple instances of the same class / label were fused and assigned a single `segment_id`.
                 - **score** -- Prediction score of segment with `segment_id`.
-        """
 
-        if label_ids_to_fuse is None:
-            logger.warning("`label_ids_to_fuse` unset. No instance will be fused.")
-            label_ids_to_fuse = set()
+            When `return_traceable_outputs=True`, a tuple `(mask_probs, pred_scores, pred_labels, keep)` of tensors
+            with a static `num_queries` dimension: `mask_probs` of shape `(batch_size, num_queries, height, width)`,
+            `pred_scores` and `pred_labels` of shape `(batch_size, num_queries)`, and `keep` of shape `(batch_size,
+            num_queries)`, `True` for the queries that are above `threshold` and do not predict the null class.
+            Everything up to that tuple is traceable, so passing it to
+            [`~Mask2FormerImageProcessor.build_panoptic_segmentation_outputs`] outside of the traced code gives the
+            same output as `return_traceable_outputs=False`.
+        """
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
 
         class_queries_logits = outputs.class_queries_logits  # [batch_size, num_queries, num_classes+1]
         masks_queries_logits = outputs.masks_queries_logits  # [batch_size, num_queries, height, width]
+
+        batch_size = class_queries_logits.shape[0]
+        num_labels = class_queries_logits.shape[-1] - 1
+
+        if target_sizes is not None:
+            if batch_size != len(target_sizes):
+                raise ValueError(
+                    "Make sure that you pass in as many target sizes as the batch dimension of the logits"
+                )
+            if return_traceable_outputs and len(set(target_sizes)) != 1:
+                raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
 
         # Scale back to preprocessed image size - (384, 384) for all models
         masks_queries_logits = torch.nn.functional.interpolate(
             masks_queries_logits, size=(384, 384), mode="bilinear", align_corners=False
         )
 
-        batch_size = class_queries_logits.shape[0]
-        num_labels = class_queries_logits.shape[-1] - 1
-
         mask_probs = masks_queries_logits.sigmoid()  # [batch_size, num_queries, height, width]
 
         # Predicted label and score of each query (batch_size, num_queries)
         pred_scores, pred_labels = nn.functional.softmax(class_queries_logits, dim=-1).max(-1)
 
-        # Loop over items in batch size
-        results: list[dict[str, TensorType]] = []
-
-        for i in range(batch_size):
-            mask_probs_item, pred_scores_item, pred_labels_item = remove_low_and_no_objects(
-                mask_probs[i], pred_scores[i], pred_labels[i], threshold, num_labels
+        # Masks are resized before filtering only in the traceable branch, `build_panoptic_segmentation_outputs`
+        # resizes the remaining masks otherwise
+        if return_traceable_outputs and target_sizes is not None:
+            mask_probs = torch.nn.functional.interpolate(
+                mask_probs, size=target_sizes[0], mode="bilinear", align_corners=False
             )
 
+        # Discard queries with a low score or predicting the null class
+        keep = pred_labels.ne(num_labels) & (pred_scores > threshold)
+
+        if return_traceable_outputs:
+            return mask_probs, pred_scores, pred_labels, keep
+
+        return self.build_panoptic_segmentation_outputs(
+            mask_probs=mask_probs,
+            pred_scores=pred_scores,
+            pred_labels=pred_labels,
+            keep=keep,
+            mask_threshold=mask_threshold,
+            overlap_mask_area_threshold=overlap_mask_area_threshold,
+            label_ids_to_fuse=label_ids_to_fuse,
+            target_sizes=target_sizes,
+        )
+
+    def build_semantic_segmentation_outputs(
+        self,
+        semantic_map: torch.Tensor | list[torch.Tensor],
+        segmentation_scores: torch.Tensor | list[torch.Tensor] | None = None,
+        return_segmentation_scores: bool = False,
+    ) -> "list[torch.Tensor] | list[SemanticSegmentationPostProcessorOutput]":
+        """
+        Builds semantic segmentation maps from the tensors returned by
+        `post_process_semantic_segmentation(..., return_traceable_outputs=True)`. See
+        [`~Mask2FormerImageProcessor.post_process_semantic_segmentation`] for the arguments and the returned values.
+        """
+        if return_segmentation_scores:
+            if segmentation_scores is None:
+                raise ValueError("`segmentation_scores` are required when `return_segmentation_scores=True`.")
+
+            semantic_segmentation = [
+                SemanticSegmentationPostProcessorOutput(
+                    data={"segmentation": segmentation, "segmentation_scores": scores}
+                )
+                for segmentation, scores in zip(semantic_map, segmentation_scores)
+            ]
+        else:
+            semantic_segmentation = list(semantic_map)
+
+        return semantic_segmentation
+
+    def build_instance_segmentation_outputs(
+        self,
+        pred_masks: torch.Tensor,
+        pred_scores: torch.Tensor,
+        pred_classes: torch.Tensor,
+        keep: torch.Tensor,
+        target_sizes: list[tuple[int, int]] | None = None,
+        return_coco_annotation: bool | None = False,
+        return_binary_maps: bool | None = False,
+    ) -> list[dict]:
+        """
+        Builds instance segmentation predictions from the tensors returned by
+        `post_process_instance_segmentation(..., return_traceable_outputs=True)`. See
+        [`~Mask2FormerImageProcessor.post_process_instance_segmentation`] for the arguments and the returned values.
+        `target_sizes` must be left to `None` if the masks were already resized by
+        `post_process_instance_segmentation`.
+        """
+        if return_coco_annotation and return_binary_maps:
+            raise ValueError("return_coco_annotation and return_binary_maps can not be both set to True.")
+
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
+
+        results: list[dict[str, TensorType]] = []
+        for idx, (masks, scores, classes, keep_item) in enumerate(zip(pred_masks, pred_scores, pred_classes, keep)):
+            masks = masks[keep_item]
+            scores = scores[keep_item]
+            classes = classes[keep_item]
+
+            # Resizing is done after filtering, interpolating all masks to the target size is expensive
+            if target_sizes is not None and masks.shape[0] != 0:
+                masks = torch.nn.functional.interpolate(
+                    masks.unsqueeze(dim=0), size=target_sizes[idx], mode="nearest"
+                )[0]
+                # Masks can become empty when downsampled
+                non_empty_masks = masks.flatten(1).any(dim=-1)
+                masks = masks[non_empty_masks]
+                scores = scores[non_empty_masks]
+                classes = classes[non_empty_masks]
+
+            height, width = target_sizes[idx] if target_sizes is not None else masks.shape[-2:]
+            segmentation = torch.zeros((height, width)) - 1
+            segments = []
+            for segment_id in range(masks.shape[0]):
+                segmentation[masks[segment_id] == 1] = segment_id
+                segments.append(
+                    {
+                        "id": segment_id,
+                        "label_id": classes[segment_id].item(),
+                        "was_fused": False,
+                        "score": round(scores[segment_id].item(), 6),
+                    }
+                )
+
+            # Return segmentation map in run-length encoding (RLE) format
+            if return_coco_annotation:
+                segmentation = convert_segmentation_to_rle(segmentation)
+
+            # Return a concatenated tensor of binary instance maps
+            if return_binary_maps and masks.shape[0] != 0:
+                segmentation = masks
+
+            results.append({"segmentation": segmentation, "segments_info": segments})
+        return results
+
+    def build_panoptic_segmentation_outputs(
+        self,
+        mask_probs: torch.Tensor,
+        pred_scores: torch.Tensor,
+        pred_labels: torch.Tensor,
+        keep: torch.Tensor,
+        mask_threshold: float = 0.5,
+        overlap_mask_area_threshold: float = 0.8,
+        label_ids_to_fuse: set[int] | None = None,
+        target_sizes: list[tuple[int, int]] | None = None,
+    ) -> list[dict]:
+        """
+        Builds panoptic segmentation predictions from the tensors returned by
+        `post_process_panoptic_segmentation(..., return_traceable_outputs=True)`. See
+        [`~Mask2FormerImageProcessor.post_process_panoptic_segmentation`] for the arguments and the returned values.
+        `target_sizes` must be left to `None` if the masks were already resized by
+        `post_process_panoptic_segmentation`.
+        """
+        if label_ids_to_fuse is None:
+            logger.warning("`label_ids_to_fuse` unset. No instance will be fused.")
+            label_ids_to_fuse = set()
+
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
+
+        results: list[dict[str, TensorType]] = []
+        for idx, (masks, scores, labels, keep_item) in enumerate(zip(mask_probs, pred_scores, pred_labels, keep)):
+            masks = masks[keep_item]
+            scores = scores[keep_item]
+            labels = labels[keep_item]
+            target_size = target_sizes[idx] if target_sizes is not None else None
+
             # No mask found
-            if mask_probs_item.shape[0] <= 0:
-                height, width = target_sizes[i] if target_sizes is not None else mask_probs_item.shape[1:]
+            if masks.shape[0] <= 0:
+                height, width = target_size if target_size is not None else masks.shape[1:]
                 segmentation = torch.zeros((height, width)) - 1
                 results.append({"segmentation": segmentation, "segments_info": []})
                 continue
 
-            # Get segmentation map and segment information of batch item
-            target_size = target_sizes[i] if target_sizes is not None else None
+            # Get segmentation map and segment information of batch item, resizing the masks here keeps the
+            # interpolation off the queries that were filtered out
             segmentation, segments = compute_segments(
-                mask_probs=mask_probs_item,
-                pred_scores=pred_scores_item,
-                pred_labels=pred_labels_item,
+                mask_probs=masks,
+                pred_scores=scores,
+                pred_labels=labels,
                 mask_threshold=mask_threshold,
                 overlap_mask_area_threshold=overlap_mask_area_threshold,
                 label_ids_to_fuse=label_ids_to_fuse,

--- a/src/transformers/models/mask2former/image_processing_pil_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_pil_mask2former.py
@@ -18,7 +18,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import math
 from typing import Any
 

--- a/src/transformers/models/mask2former/modular_mask2former.py
+++ b/src/transformers/models/mask2former/modular_mask2former.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import torch
 from torch import nn
 
@@ -40,6 +41,7 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
         outputs,
         target_sizes: list[tuple[int, int]] | None = None,
         return_segmentation_scores: bool = False,
+        return_traceable_outputs: bool = False,
     ) -> "list[torch.Tensor] | list[SemanticSegmentationPostProcessorOutput]":
         """
         Converts the output of [`Mask2FormerForUniversalSegmentation`] into semantic segmentation maps. Only supports
@@ -55,6 +57,9 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
                 Whether to return segmentation scores alongside the segmentation map. When `True`, each element of
                 the returned list is a [`SemanticSegmentationPostProcessorOutput`] with fields `segmentation`
                 (class IDs, shape `(height, width)`) and `segmentation_scores` (shape `(num_classes, height, width)`).
+            return_traceable_outputs (`bool`, *optional*, defaults to `False`):
+                If set to `True`, a tuple of tensors is returned instead of a list, see the returns section below.
+                All target sizes must be equal in that case.
 
         Returns:
             `list[torch.Tensor]` or `list[SemanticSegmentationPostProcessorOutput]`: When
@@ -63,9 +68,30 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
             a list of [`SemanticSegmentationPostProcessorOutput`] with fields `segmentation` (class IDs, shape
             `(height, width)`) and `segmentation_scores` (shape `(num_classes, height, width)`). In both cases,
             `(height, width)` corresponds to the target size (if `target_sizes` is specified).
+
+            When `return_traceable_outputs=True`, a tuple `(semantic_map,)` of shape `(batch_size, height, width)`,
+            extended with the segmentation scores of shape `(batch_size, num_classes, height, width)` if
+            `return_segmentation_scores=True`. Everything up to that tuple is traceable, so passing it to
+            [`~Mask2FormerImageProcessor.build_semantic_segmentation_outputs`] outside of the traced code gives the
+            same output as `return_traceable_outputs=False`.
         """
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
+
         class_queries_logits = outputs.class_queries_logits  # [batch_size, num_queries, num_classes+1]
         masks_queries_logits = outputs.masks_queries_logits  # [batch_size, num_queries, height, width]
+        batch_size = class_queries_logits.shape[0]
+
+        if target_sizes is not None:
+            if batch_size != len(target_sizes):
+                raise ValueError(
+                    "Make sure that you pass in as many target sizes as the batch dimension of the logits"
+                )
+            num_unique_target_sizes = len(set(target_sizes))
+            if return_traceable_outputs and num_unique_target_sizes != 1:
+                raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
 
         # Scale back to preprocessed image size - (384, 384) for all models
         masks_queries_logits = torch.nn.functional.interpolate(
@@ -78,37 +104,63 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
 
         # Semantic segmentation logits of shape (batch_size, num_classes, height, width)
         segmentation = torch.einsum("bqc, bqhw -> bchw", masks_classes, masks_probs)
-        batch_size = class_queries_logits.shape[0]
 
         # Resize logits and compute semantic segmentation maps
         if target_sizes is not None:
-            if batch_size != len(target_sizes):
-                raise ValueError(
-                    "Make sure that you pass in as many target sizes as the batch dimension of the logits"
-                )
-
-            semantic_segmentation = []
-            for idx in range(batch_size):
+            if num_unique_target_sizes == 1:
                 resized_logits = torch.nn.functional.interpolate(
-                    segmentation[idx].unsqueeze(dim=0), size=target_sizes[idx], mode="bilinear", align_corners=False
+                    segmentation, size=target_sizes[0], mode="bilinear", align_corners=False
                 )
-                semantic_map = resized_logits[0].argmax(dim=0)
-                semantic_segmentation.append(
-                    SemanticSegmentationPostProcessorOutput(
-                        data={"segmentation": semantic_map, "segmentation_scores": resized_logits[0]}
+                semantic_map = resized_logits.argmax(dim=1)
+            else:
+                resized_logits = []
+                semantic_map = []
+                for idx in range(batch_size):
+                    logits = torch.nn.functional.interpolate(
+                        segmentation[idx].unsqueeze(dim=0),
+                        size=target_sizes[idx],
+                        mode="bilinear",
+                        align_corners=False,
                     )
-                )
+                    resized_logits.append(logits[0])
+                    semantic_map.append(logits[0].argmax(dim=0))
+
         else:
-            semantic_map = segmentation.argmax(dim=1)
+            resized_logits = segmentation
+            semantic_map = resized_logits.argmax(dim=1)
+
+        if return_traceable_outputs:
+            return (semantic_map, resized_logits) if return_segmentation_scores else (semantic_map,)
+
+        return self.build_semantic_segmentation_outputs(
+            semantic_map=semantic_map,
+            segmentation_scores=resized_logits,
+            return_segmentation_scores=return_segmentation_scores,
+        )
+
+    def build_semantic_segmentation_outputs(
+        self,
+        semantic_map: torch.Tensor | list[torch.Tensor],
+        segmentation_scores: torch.Tensor | list[torch.Tensor] | None = None,
+        return_segmentation_scores: bool = False,
+    ) -> "list[torch.Tensor] | list[SemanticSegmentationPostProcessorOutput]":
+        """
+        Builds semantic segmentation maps from the tensors returned by
+        `post_process_semantic_segmentation(..., return_traceable_outputs=True)`. See
+        [`~Mask2FormerImageProcessor.post_process_semantic_segmentation`] for the arguments and the returned values.
+        """
+        if return_segmentation_scores:
+            if segmentation_scores is None:
+                raise ValueError("`segmentation_scores` are required when `return_segmentation_scores=True`.")
+
             semantic_segmentation = [
                 SemanticSegmentationPostProcessorOutput(
-                    data={"segmentation": semantic_map[i], "segmentation_scores": segmentation[i]}
+                    data={"segmentation": segmentation, "segmentation_scores": scores}
                 )
-                for i in range(batch_size)
+                for segmentation, scores in zip(semantic_map, segmentation_scores)
             ]
-
-        if not return_segmentation_scores:
-            semantic_segmentation = [item.segmentation for item in semantic_segmentation]
+        else:
+            semantic_segmentation = list(semantic_map)
 
         return semantic_segmentation
 
@@ -121,6 +173,7 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
         target_sizes: list[tuple[int, int]] | None = None,
         return_coco_annotation: bool | None = False,
         return_binary_maps: bool | None = False,
+        return_traceable_outputs: bool = False,
     ) -> list[dict]:
         """
         Converts the output of [`Mask2FormerForUniversalSegmentationOutput`] into instance segmentation predictions.
@@ -145,6 +198,10 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
             return_binary_maps (`bool`, *optional*, defaults to `False`):
                 If set to `True`, segmentation maps are returned as a concatenated tensor of binary segmentation maps
                 (one per detected instance).
+            return_traceable_outputs (`bool`, *optional*, defaults to `False`):
+                If set to `True`, a tuple of tensors with static shapes is returned instead of a list of
+                dictionaries, see the returns section below. All target sizes must be equal in that case.
+
         Returns:
             `List[Dict]`: A list of dictionaries, one per image, each dictionary containing two keys:
             - **segmentation** -- A tensor of shape `(height, width)` where each pixel represents a `segment_id`, or
@@ -155,6 +212,14 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
                 - **id** -- An integer representing the `segment_id`.
                 - **label_id** -- An integer representing the label / semantic class id corresponding to `segment_id`.
                 - **score** -- Prediction score of segment with `segment_id`.
+
+            When `return_traceable_outputs=True`, a tuple `(pred_masks, pred_scores, pred_classes, keep)` of tensors
+            with a static `num_queries` dimension: `pred_masks` of shape `(batch_size, num_queries, height, width)`
+            with binary instance masks, `pred_scores` and `pred_classes` of shape `(batch_size, num_queries)`, and
+            `keep` of shape `(batch_size, num_queries)`, `True` for the instances that are above `threshold` and have a
+            non-empty mask. Everything up to that tuple is traceable, so passing it to
+            [`~Mask2FormerImageProcessor.build_instance_segmentation_outputs`] outside of the traced code gives the
+            same output as `return_traceable_outputs=False`.
         """
         if return_coco_annotation and return_binary_maps:
             raise ValueError("return_coco_annotation and return_binary_maps can not be both set to True.")
@@ -164,71 +229,127 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
         # [batch_size, num_queries, height, width]
         masks_queries_logits = outputs.masks_queries_logits
 
+        batch_size = class_queries_logits.shape[0]
+        num_classes = class_queries_logits.shape[-1] - 1
+        num_queries = class_queries_logits.shape[-2]
+
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
+
+            if batch_size != len(target_sizes):
+                raise ValueError(
+                    "Make sure that you pass in as many target sizes as the batch dimension of the logits"
+                )
+            if return_traceable_outputs and len(set(target_sizes)) != 1:
+                raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
+
         # Scale back to preprocessed image size - (384, 384) for all models
         masks_queries_logits = torch.nn.functional.interpolate(
             masks_queries_logits, size=(384, 384), mode="bilinear", align_corners=False
         )
+        height, width = masks_queries_logits.shape[-2:]
 
-        device = masks_queries_logits.device
-        num_classes = class_queries_logits.shape[-1] - 1
-        num_queries = class_queries_logits.shape[-2]
+        # Remove the null class `[..., :-1]` and keep the `num_queries` highest scoring (query, class) pairs
+        scores = torch.nn.functional.softmax(class_queries_logits, dim=-1)[..., :-1]
+        pred_scores, topk_indices = scores.flatten(1, 2).topk(num_queries, dim=-1, sorted=False)
+        pred_classes = topk_indices % num_classes
+        query_indices = torch.div(topk_indices, num_classes, rounding_mode="floor")
 
-        # Loop over items in batch size
+        mask_logits = masks_queries_logits.gather(
+            dim=1, index=query_indices[..., None, None].expand(-1, -1, height, width)
+        )
+        pred_masks = (mask_logits > 0).to(mask_logits.dtype)
+
+        # Calculate average mask prob
+        mask_scores = (mask_logits.sigmoid().flatten(2) * pred_masks.flatten(2)).sum(-1) / (
+            pred_masks.flatten(2).sum(-1) + 1e-6
+        )
+        pred_scores = pred_scores * mask_scores
+
+        if return_traceable_outputs and target_sizes is not None:
+            pred_masks = torch.nn.functional.interpolate(pred_masks, size=target_sizes[0], mode="nearest")
+
+        # Discard instances with a low score or an empty mask
+        keep = (pred_scores >= threshold) & pred_masks.flatten(2).any(dim=-1)
+
+        if return_traceable_outputs:
+            return pred_masks, pred_scores, pred_classes, keep
+
+        return self.build_instance_segmentation_outputs(
+            pred_masks=pred_masks,
+            pred_scores=pred_scores,
+            pred_classes=pred_classes,
+            keep=keep,
+            target_sizes=target_sizes,
+            return_coco_annotation=return_coco_annotation,
+            return_binary_maps=return_binary_maps,
+        )
+
+    def build_instance_segmentation_outputs(
+        self,
+        pred_masks: torch.Tensor,
+        pred_scores: torch.Tensor,
+        pred_classes: torch.Tensor,
+        keep: torch.Tensor,
+        target_sizes: list[tuple[int, int]] | None = None,
+        return_coco_annotation: bool | None = False,
+        return_binary_maps: bool | None = False,
+    ) -> list[dict]:
+        """
+        Builds instance segmentation predictions from the tensors returned by
+        `post_process_instance_segmentation(..., return_traceable_outputs=True)`. See
+        [`~Mask2FormerImageProcessor.post_process_instance_segmentation`] for the arguments and the returned values.
+        `target_sizes` must be left to `None` if the masks were already resized by
+        `post_process_instance_segmentation`.
+        """
+        if return_coco_annotation and return_binary_maps:
+            raise ValueError("return_coco_annotation and return_binary_maps can not be both set to True.")
+
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
+
         results: list[dict[str, TensorType]] = []
+        for idx, (masks, scores, classes, keep_item) in enumerate(zip(pred_masks, pred_scores, pred_classes, keep)):
+            masks = masks[keep_item]
+            scores = scores[keep_item]
+            classes = classes[keep_item]
 
-        for i in range(class_queries_logits.shape[0]):
-            mask_pred = masks_queries_logits[i]
-            mask_cls = class_queries_logits[i]
-
-            scores = torch.nn.functional.softmax(mask_cls, dim=-1)[:, :-1]
-            labels = torch.arange(num_classes, device=device).unsqueeze(0).repeat(num_queries, 1).flatten(0, 1)
-
-            scores_per_image, topk_indices = scores.flatten(0, 1).topk(num_queries, sorted=False)
-            labels_per_image = labels[topk_indices]
-
-            topk_indices = torch.div(topk_indices, num_classes, rounding_mode="floor")
-            mask_pred = mask_pred[topk_indices]
-            pred_masks = (mask_pred > 0).float()
-
-            # Calculate average mask prob
-            mask_scores_per_image = (mask_pred.sigmoid().flatten(1) * pred_masks.flatten(1)).sum(1) / (
-                pred_masks.flatten(1).sum(1) + 1e-6
-            )
-            pred_scores = scores_per_image * mask_scores_per_image
-            pred_classes = labels_per_image
-
-            segmentation = torch.zeros((384, 384)) - 1
-            if target_sizes is not None:
-                segmentation = torch.zeros(target_sizes[i]) - 1
-                pred_masks = torch.nn.functional.interpolate(
-                    pred_masks.unsqueeze(0), size=target_sizes[i], mode="nearest"
+            # Resizing is done after filtering, interpolating all masks to the target size is expensive
+            if target_sizes is not None and masks.shape[0] != 0:
+                masks = torch.nn.functional.interpolate(
+                    masks.unsqueeze(dim=0), size=target_sizes[idx], mode="nearest"
                 )[0]
+                # Masks can become empty when downsampled
+                non_empty_masks = masks.flatten(1).any(dim=-1)
+                masks = masks[non_empty_masks]
+                scores = scores[non_empty_masks]
+                classes = classes[non_empty_masks]
 
-            instance_maps, segments = [], []
-            current_segment_id = 0
-            for j in range(num_queries):
-                score = pred_scores[j].item()
-
-                if not torch.all(pred_masks[j] == 0) and score >= threshold:
-                    segmentation[pred_masks[j] == 1] = current_segment_id
-                    segments.append(
-                        {
-                            "id": current_segment_id,
-                            "label_id": pred_classes[j].item(),
-                            "was_fused": False,
-                            "score": round(score, 6),
-                        }
-                    )
-                    current_segment_id += 1
-                    instance_maps.append(pred_masks[j])
+            height, width = target_sizes[idx] if target_sizes is not None else masks.shape[-2:]
+            segmentation = torch.zeros((height, width)) - 1
+            segments = []
+            for segment_id in range(masks.shape[0]):
+                segmentation[masks[segment_id] == 1] = segment_id
+                segments.append(
+                    {
+                        "id": segment_id,
+                        "label_id": classes[segment_id].item(),
+                        "was_fused": False,
+                        "score": round(scores[segment_id].item(), 6),
+                    }
+                )
 
             # Return segmentation map in run-length encoding (RLE) format
             if return_coco_annotation:
                 segmentation = convert_segmentation_to_rle(segmentation)
 
             # Return a concatenated tensor of binary instance maps
-            if return_binary_maps and len(instance_maps) != 0:
-                segmentation = torch.stack(instance_maps, dim=0)
+            if return_binary_maps and masks.shape[0] != 0:
+                segmentation = masks
 
             results.append({"segmentation": segmentation, "segments_info": segments})
         return results
@@ -241,6 +362,7 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
         overlap_mask_area_threshold: float = 0.8,
         label_ids_to_fuse: set[int] | None = None,
         target_sizes: list[tuple[int, int]] | None = None,
+        return_traceable_outputs: bool = False,
     ) -> list[dict]:
         """
         Converts the output of [`Mask2FormerForUniversalSegmentationOutput`] into image panoptic segmentation
@@ -264,6 +386,10 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
                 List of length (batch_size), where each list item (`Tuple[int, int]]`) corresponds to the requested
                 final size (height, width) of each prediction in batch. If left to None, predictions will not be
                 resized.
+            return_traceable_outputs (`bool`, *optional*, defaults to `False`):
+                If set to `True`, a tuple of tensors with static shapes is returned instead of a list of
+                dictionaries, see the returns section below. All target sizes must be equal in that case and
+                `label_ids_to_fuse` is unused.
 
         Returns:
             `List[Dict]`: A list of dictionaries, one per image, each dictionary containing two keys:
@@ -276,49 +402,115 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
                 - **was_fused** -- a boolean, `True` if `label_id` was in `label_ids_to_fuse`, `False` otherwise.
                   Multiple instances of the same class / label were fused and assigned a single `segment_id`.
                 - **score** -- Prediction score of segment with `segment_id`.
-        """
 
-        if label_ids_to_fuse is None:
-            logger.warning("`label_ids_to_fuse` unset. No instance will be fused.")
-            label_ids_to_fuse = set()
+            When `return_traceable_outputs=True`, a tuple `(mask_probs, pred_scores, pred_labels, keep)` of tensors
+            with a static `num_queries` dimension: `mask_probs` of shape `(batch_size, num_queries, height, width)`,
+            `pred_scores` and `pred_labels` of shape `(batch_size, num_queries)`, and `keep` of shape `(batch_size,
+            num_queries)`, `True` for the queries that are above `threshold` and do not predict the null class.
+            Everything up to that tuple is traceable, so passing it to
+            [`~Mask2FormerImageProcessor.build_panoptic_segmentation_outputs`] outside of the traced code gives the
+            same output as `return_traceable_outputs=False`.
+        """
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
 
         class_queries_logits = outputs.class_queries_logits  # [batch_size, num_queries, num_classes+1]
         masks_queries_logits = outputs.masks_queries_logits  # [batch_size, num_queries, height, width]
+
+        batch_size = class_queries_logits.shape[0]
+        num_labels = class_queries_logits.shape[-1] - 1
+
+        if target_sizes is not None:
+            if batch_size != len(target_sizes):
+                raise ValueError(
+                    "Make sure that you pass in as many target sizes as the batch dimension of the logits"
+                )
+            if return_traceable_outputs and len(set(target_sizes)) != 1:
+                raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
 
         # Scale back to preprocessed image size - (384, 384) for all models
         masks_queries_logits = torch.nn.functional.interpolate(
             masks_queries_logits, size=(384, 384), mode="bilinear", align_corners=False
         )
 
-        batch_size = class_queries_logits.shape[0]
-        num_labels = class_queries_logits.shape[-1] - 1
-
         mask_probs = masks_queries_logits.sigmoid()  # [batch_size, num_queries, height, width]
 
         # Predicted label and score of each query (batch_size, num_queries)
         pred_scores, pred_labels = nn.functional.softmax(class_queries_logits, dim=-1).max(-1)
 
-        # Loop over items in batch size
-        results: list[dict[str, TensorType]] = []
-
-        for i in range(batch_size):
-            mask_probs_item, pred_scores_item, pred_labels_item = remove_low_and_no_objects(
-                mask_probs[i], pred_scores[i], pred_labels[i], threshold, num_labels
+        # Masks are resized before filtering only in the traceable branch, `build_panoptic_segmentation_outputs`
+        # resizes the remaining masks otherwise
+        if return_traceable_outputs and target_sizes is not None:
+            mask_probs = torch.nn.functional.interpolate(
+                mask_probs, size=target_sizes[0], mode="bilinear", align_corners=False
             )
 
+        # Discard queries with a low score or predicting the null class
+        keep = pred_labels.ne(num_labels) & (pred_scores > threshold)
+
+        if return_traceable_outputs:
+            return mask_probs, pred_scores, pred_labels, keep
+
+        return self.build_panoptic_segmentation_outputs(
+            mask_probs=mask_probs,
+            pred_scores=pred_scores,
+            pred_labels=pred_labels,
+            keep=keep,
+            mask_threshold=mask_threshold,
+            overlap_mask_area_threshold=overlap_mask_area_threshold,
+            label_ids_to_fuse=label_ids_to_fuse,
+            target_sizes=target_sizes,
+        )
+
+    def build_panoptic_segmentation_outputs(
+        self,
+        mask_probs: torch.Tensor,
+        pred_scores: torch.Tensor,
+        pred_labels: torch.Tensor,
+        keep: torch.Tensor,
+        mask_threshold: float = 0.5,
+        overlap_mask_area_threshold: float = 0.8,
+        label_ids_to_fuse: set[int] | None = None,
+        target_sizes: list[tuple[int, int]] | None = None,
+    ) -> list[dict]:
+        """
+        Builds panoptic segmentation predictions from the tensors returned by
+        `post_process_panoptic_segmentation(..., return_traceable_outputs=True)`. See
+        [`~Mask2FormerImageProcessor.post_process_panoptic_segmentation`] for the arguments and the returned values.
+        `target_sizes` must be left to `None` if the masks were already resized by
+        `post_process_panoptic_segmentation`.
+        """
+        if label_ids_to_fuse is None:
+            logger.warning("`label_ids_to_fuse` unset. No instance will be fused.")
+            label_ids_to_fuse = set()
+
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
+
+        results: list[dict[str, TensorType]] = []
+        for idx, (masks, scores, labels, keep_item) in enumerate(zip(mask_probs, pred_scores, pred_labels, keep)):
+            masks = masks[keep_item]
+            scores = scores[keep_item]
+            labels = labels[keep_item]
+            target_size = target_sizes[idx] if target_sizes is not None else None
+
             # No mask found
-            if mask_probs_item.shape[0] <= 0:
-                height, width = target_sizes[i] if target_sizes is not None else mask_probs_item.shape[1:]
+            if masks.shape[0] <= 0:
+                height, width = target_size if target_size is not None else masks.shape[1:]
                 segmentation = torch.zeros((height, width)) - 1
                 results.append({"segmentation": segmentation, "segments_info": []})
                 continue
 
-            # Get segmentation map and segment information of batch item
-            target_size = target_sizes[i] if target_sizes is not None else None
+            # Get segmentation map and segment information of batch item, resizing the masks here keeps the
+            # interpolation off the queries that were filtered out
             segmentation, segments = compute_segments(
-                mask_probs=mask_probs_item,
-                pred_scores=pred_scores_item,
-                pred_labels=pred_labels_item,
+                mask_probs=masks,
+                pred_scores=scores,
+                pred_labels=labels,
                 mask_threshold=mask_threshold,
                 overlap_mask_area_threshold=overlap_mask_area_threshold,
                 label_ids_to_fuse=label_ids_to_fuse,

--- a/src/transformers/models/mask2former/modular_mask2former.py
+++ b/src/transformers/models/mask2former/modular_mask2former.py
@@ -402,26 +402,26 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
                   Multiple instances of the same class / label were fused and assigned a single `segment_id`.
                 - **score** -- Prediction score of segment with `segment_id`.
 
-            When `return_traceable_outputs=True`, a tuple `(mask_probs, scores, labels, keep_queries)` of tensors with
-            a static `num_queries` dimension: `mask_probs` of shape `(batch_size, num_queries, height, width)`,
-            `scores` and `labels` of shape `(batch_size, num_queries)`, and `keep_queries` of shape `(batch_size,
-            num_queries)`, `True` for the queries that are above `threshold` and do not predict the null class.
+            When `return_traceable_outputs=True`, a tuple `(masks, scores, classes, keep_instances)` of tensors with a
+            static `num_queries` dimension: `masks` of shape `(batch_size, num_queries, height, width)` with mask
+            probabilities, `scores` and `classes` of shape `(batch_size, num_queries)`, and `keep_instances` of shape
+            `(batch_size, num_queries)`, `True` for the instances that are above `threshold` and do not predict the
+            null class.
             Everything up to that tuple is traceable, so passing it to
             [`~Mask2FormerImageProcessor.build_panoptic_segmentation_outputs`] outside of the traced code gives the
             same output as `return_traceable_outputs=False`.
         """
+        class_queries_logits = outputs.class_queries_logits  # [batch_size, num_queries, num_classes+1]
+        masks_queries_logits = outputs.masks_queries_logits  # [batch_size, num_queries, height, width]
+
+        batch_size = class_queries_logits.shape[0]
+        num_classes = class_queries_logits.shape[-1] - 1
+
         if target_sizes is not None:
             if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
                 target_sizes = target_sizes.tolist()
             target_sizes = [tuple(size) for size in target_sizes]
 
-        class_queries_logits = outputs.class_queries_logits  # [batch_size, num_queries, num_classes+1]
-        masks_queries_logits = outputs.masks_queries_logits  # [batch_size, num_queries, height, width]
-
-        batch_size = class_queries_logits.shape[0]
-        num_labels = class_queries_logits.shape[-1] - 1
-
-        if target_sizes is not None:
             if batch_size != len(target_sizes):
                 raise ValueError(
                     "Make sure that you pass in as many target sizes as the batch dimension of the logits"
@@ -430,31 +430,29 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
                 raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
 
         # Scale back to preprocessed image size - (384, 384) for all models
-        mask_probs = torch.nn.functional.interpolate(
+        masks = torch.nn.functional.interpolate(
             masks_queries_logits, size=(384, 384), mode="bilinear", align_corners=False
         ).sigmoid()  # [batch_size, num_queries, height, width]
 
         # Predicted label and score of each query (batch_size, num_queries)
-        scores, labels = nn.functional.softmax(class_queries_logits, dim=-1).max(-1)
+        scores, classes = nn.functional.softmax(class_queries_logits, dim=-1).max(-1)
 
         # Masks are resized before filtering only in the traceable branch, `build_panoptic_segmentation_outputs`
         # resizes the remaining masks otherwise
         if return_traceable_outputs and target_sizes is not None:
-            mask_probs = torch.nn.functional.interpolate(
-                mask_probs, size=target_sizes[0], mode="bilinear", align_corners=False
-            )
+            masks = torch.nn.functional.interpolate(masks, size=target_sizes[0], mode="bilinear", align_corners=False)
 
-        # Discard queries with a low score or predicting the null class
-        keep_queries = labels.ne(num_labels) & (scores > threshold)
+        # Discard instances with a low score or predicting the null class
+        keep_instances = classes.ne(num_classes) & (scores > threshold)
 
         if return_traceable_outputs:
-            return mask_probs, scores, labels, keep_queries
+            return masks, scores, classes, keep_instances
 
         return self.build_panoptic_segmentation_outputs(
-            mask_probs=mask_probs,
+            masks=masks,
             scores=scores,
-            labels=labels,
-            keep_queries=keep_queries,
+            classes=classes,
+            keep_instances=keep_instances,
             mask_threshold=mask_threshold,
             overlap_mask_area_threshold=overlap_mask_area_threshold,
             label_ids_to_fuse=label_ids_to_fuse,
@@ -463,10 +461,10 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
 
     def build_panoptic_segmentation_outputs(
         self,
-        mask_probs: torch.Tensor,
+        masks: torch.Tensor,
         scores: torch.Tensor,
-        labels: torch.Tensor,
-        keep_queries: torch.Tensor,
+        classes: torch.Tensor,
+        keep_instances: torch.Tensor,
         mask_threshold: float = 0.5,
         overlap_mask_area_threshold: float = 0.8,
         label_ids_to_fuse: set[int] | None = None,
@@ -489,17 +487,17 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
             target_sizes = [tuple(size) for size in target_sizes]
 
         results: list[dict[str, TensorType]] = []
-        for idx, (image_mask_probs, image_scores, image_labels, image_keep) in enumerate(
-            zip(mask_probs, scores, labels, keep_queries)
+        for idx, (image_masks, image_scores, image_classes, image_keep) in enumerate(
+            zip(masks, scores, classes, keep_instances)
         ):
-            image_mask_probs = image_mask_probs[image_keep]
+            image_masks = image_masks[image_keep]
             image_scores = image_scores[image_keep]
-            image_labels = image_labels[image_keep]
+            image_classes = image_classes[image_keep]
             target_size = target_sizes[idx] if target_sizes is not None else None
 
             # No mask found
-            if image_mask_probs.shape[0] <= 0:
-                height, width = target_size if target_size is not None else image_mask_probs.shape[1:]
+            if image_masks.shape[0] <= 0:
+                height, width = target_size if target_size is not None else image_masks.shape[1:]
                 segmentation = torch.zeros((height, width)) - 1
                 results.append({"segmentation": segmentation, "segments_info": []})
                 continue
@@ -507,9 +505,9 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
             # Get segmentation map and segment information of batch item, resizing the masks here keeps the
             # interpolation off the queries that were filtered out
             segmentation, segments = compute_segments(
-                mask_probs=image_mask_probs,
+                mask_probs=image_masks,
                 pred_scores=image_scores,
-                pred_labels=image_labels,
+                pred_labels=image_classes,
                 mask_threshold=mask_threshold,
                 overlap_mask_area_threshold=overlap_mask_area_threshold,
                 label_ids_to_fuse=label_ids_to_fuse,

--- a/src/transformers/models/mask2former/modular_mask2former.py
+++ b/src/transformers/models/mask2former/modular_mask2former.py
@@ -71,7 +71,8 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
 
             When `return_traceable_outputs=True`, a tuple `(semantic_map,)` of shape `(batch_size, height, width)`,
             extended with the segmentation scores of shape `(batch_size, num_classes, height, width)` if
-            `return_segmentation_scores=True`. Everything up to that tuple is traceable, so passing it to
+            `return_segmentation_scores=True`. The maps are already resized to the target size, so they can be used
+            as is; passing `segmentation_scores` to
             [`~Mask2FormerImageProcessor.build_semantic_segmentation_outputs`] outside of the traced code gives the
             same output as `return_traceable_outputs=False`.
         """
@@ -89,8 +90,7 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
                 raise ValueError(
                     "Make sure that you pass in as many target sizes as the batch dimension of the logits"
                 )
-            num_unique_target_sizes = len(set(target_sizes))
-            if return_traceable_outputs and num_unique_target_sizes != 1:
+            if return_traceable_outputs and len(set(target_sizes)) != 1:
                 raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
 
         # Scale back to preprocessed image size - (384, 384) for all models
@@ -101,67 +101,67 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
         # Semantic segmentation logits of shape (batch_size, num_classes, height, width), without the null class
         masks_classes = class_queries_logits.softmax(dim=-1)[..., :-1]
         masks_probs = masks_queries_logits.sigmoid()  # [batch_size, num_queries, height, width]
-        segmentation = masks_classes.transpose(1, 2) @ masks_probs.flatten(start_dim=2)
-        segmentation = segmentation.unflatten(dim=-1, sizes=masks_probs.shape[-2:])
+        segmentation_scores = masks_classes.transpose(1, 2) @ masks_probs.flatten(start_dim=2)
+        segmentation_scores = segmentation_scores.unflatten(dim=-1, sizes=masks_probs.shape[-2:])
 
-        # Resize logits and compute semantic segmentation maps
-        if target_sizes is not None:
-            if num_unique_target_sizes == 1:
-                resized_logits = torch.nn.functional.interpolate(
-                    segmentation, size=target_sizes[0], mode="bilinear", align_corners=False
-                )
-                semantic_map = resized_logits.argmax(dim=1)
-            else:
-                resized_logits = []
-                semantic_map = []
-                for idx in range(batch_size):
-                    logits = torch.nn.functional.interpolate(
-                        segmentation[idx].unsqueeze(dim=0),
-                        size=target_sizes[idx],
-                        mode="bilinear",
-                        align_corners=False,
-                    )
-                    resized_logits.append(logits[0])
-                    semantic_map.append(logits[0].argmax(dim=0))
-
-        else:
-            resized_logits = segmentation
-            semantic_map = resized_logits.argmax(dim=1)
-
+        # Logits are resized before the argmax only in the traceable branch,
+        # `build_semantic_segmentation_outputs` resizes them otherwise
         if return_traceable_outputs:
-            return (semantic_map, resized_logits) if return_segmentation_scores else (semantic_map,)
+            if target_sizes is not None:
+                segmentation_scores = torch.nn.functional.interpolate(
+                    segmentation_scores, size=target_sizes[0], mode="bilinear", align_corners=False
+                )
+            semantic_map = segmentation_scores.argmax(dim=1)
+            return (semantic_map, segmentation_scores) if return_segmentation_scores else (semantic_map,)
 
         return self.build_semantic_segmentation_outputs(
-            semantic_map=semantic_map,
-            segmentation_scores=resized_logits,
+            segmentation_scores=segmentation_scores,
+            target_sizes=target_sizes,
             return_segmentation_scores=return_segmentation_scores,
         )
 
     def build_semantic_segmentation_outputs(
         self,
-        semantic_map: torch.Tensor | list[torch.Tensor],
-        segmentation_scores: torch.Tensor | list[torch.Tensor] | None = None,
+        segmentation_scores: torch.Tensor,
+        target_sizes: list[tuple[int, int]] | None = None,
         return_segmentation_scores: bool = False,
     ) -> "list[torch.Tensor] | list[SemanticSegmentationPostProcessorOutput]":
         """
         Builds semantic segmentation maps from the tensors returned by
         `post_process_semantic_segmentation(..., return_traceable_outputs=True)`. See
         [`~Mask2FormerImageProcessor.post_process_semantic_segmentation`] for the arguments and the returned values.
+        `target_sizes` must be left to `None` if the logits were already resized by
+        `post_process_semantic_segmentation`.
         """
-        if return_segmentation_scores:
-            if segmentation_scores is None:
-                raise ValueError("`segmentation_scores` are required when `return_segmentation_scores=True`.")
+        if target_sizes is not None:
+            if isinstance(target_sizes, (torch.Tensor, np.ndarray)):
+                target_sizes = target_sizes.tolist()
+            target_sizes = [tuple(size) for size in target_sizes]
 
-            semantic_segmentation = [
-                SemanticSegmentationPostProcessorOutput(
-                    data={"segmentation": segmentation, "segmentation_scores": scores}
+        if target_sizes is None or len(set(target_sizes)) == 1:
+            if target_sizes is not None:
+                segmentation_scores = torch.nn.functional.interpolate(
+                    segmentation_scores, size=target_sizes[0], mode="bilinear", align_corners=False
                 )
-                for segmentation, scores in zip(semantic_map, segmentation_scores)
-            ]
+            semantic_map = segmentation_scores.argmax(dim=1)
         else:
-            semantic_segmentation = list(semantic_map)
+            segmentation_scores = [
+                torch.nn.functional.interpolate(
+                    image_scores.unsqueeze(dim=0), size=target_size, mode="bilinear", align_corners=False
+                )[0]
+                for image_scores, target_size in zip(segmentation_scores, target_sizes)
+            ]
+            semantic_map = [image_scores.argmax(dim=0) for image_scores in segmentation_scores]
 
-        return semantic_segmentation
+        if not return_segmentation_scores:
+            return list(semantic_map)
+
+        return [
+            SemanticSegmentationPostProcessorOutput(
+                data={"segmentation": segmentation, "segmentation_scores": image_scores}
+            )
+            for segmentation, image_scores in zip(semantic_map, segmentation_scores)
+        ]
 
     def post_process_instance_segmentation(
         self,

--- a/src/transformers/models/mask2former/modular_mask2former.py
+++ b/src/transformers/models/mask2former/modular_mask2former.py
@@ -98,12 +98,11 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
             masks_queries_logits, size=(384, 384), mode="bilinear", align_corners=False
         )
 
-        # Remove the null class `[..., :-1]`
+        # Semantic segmentation logits of shape (batch_size, num_classes, height, width), without the null class
         masks_classes = class_queries_logits.softmax(dim=-1)[..., :-1]
         masks_probs = masks_queries_logits.sigmoid()  # [batch_size, num_queries, height, width]
-
-        # Semantic segmentation logits of shape (batch_size, num_classes, height, width)
-        segmentation = torch.einsum("bqc, bqhw -> bchw", masks_classes, masks_probs)
+        segmentation = masks_classes.transpose(1, 2) @ masks_probs.flatten(start_dim=2)
+        segmentation = segmentation.unflatten(dim=-1, sizes=masks_probs.shape[-2:])
 
         # Resize logits and compute semantic segmentation maps
         if target_sizes is not None:
@@ -213,11 +212,11 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
                 - **label_id** -- An integer representing the label / semantic class id corresponding to `segment_id`.
                 - **score** -- Prediction score of segment with `segment_id`.
 
-            When `return_traceable_outputs=True`, a tuple `(pred_masks, pred_scores, pred_classes, keep)` of tensors
-            with a static `num_queries` dimension: `pred_masks` of shape `(batch_size, num_queries, height, width)`
-            with binary instance masks, `pred_scores` and `pred_classes` of shape `(batch_size, num_queries)`, and
-            `keep` of shape `(batch_size, num_queries)`, `True` for the instances that are above `threshold` and have a
-            non-empty mask. Everything up to that tuple is traceable, so passing it to
+            When `return_traceable_outputs=True`, a tuple `(masks, scores, classes, keep_instances)` of tensors with a
+            static `num_queries` dimension: `masks` of shape `(batch_size, num_queries, height, width)` with binary
+            instance masks, `scores` and `classes` of shape `(batch_size, num_queries)`, and `keep_instances` of shape
+            `(batch_size, num_queries)`, `True` for the instances that are above `threshold` and have a non-empty mask.
+            Everything up to that tuple is traceable, so passing it to
             [`~Mask2FormerImageProcessor.build_instance_segmentation_outputs`] outside of the traced code gives the
             same output as `return_traceable_outputs=False`.
         """
@@ -253,35 +252,33 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
 
         # Remove the null class `[..., :-1]` and keep the `num_queries` highest scoring (query, class) pairs
         scores = torch.nn.functional.softmax(class_queries_logits, dim=-1)[..., :-1]
-        pred_scores, topk_indices = scores.flatten(1, 2).topk(num_queries, dim=-1, sorted=False)
-        pred_classes = topk_indices % num_classes
+        scores, topk_indices = scores.flatten(1, 2).topk(num_queries, dim=-1, sorted=False)
+        classes = topk_indices % num_classes
         query_indices = torch.div(topk_indices, num_classes, rounding_mode="floor")
 
         mask_logits = masks_queries_logits.gather(
             dim=1, index=query_indices[..., None, None].expand(-1, -1, height, width)
         )
-        pred_masks = (mask_logits > 0).to(mask_logits.dtype)
+        masks = (mask_logits > 0).to(mask_logits.dtype)
 
         # Calculate average mask prob
-        mask_scores = (mask_logits.sigmoid().flatten(2) * pred_masks.flatten(2)).sum(-1) / (
-            pred_masks.flatten(2).sum(-1) + 1e-6
-        )
-        pred_scores = pred_scores * mask_scores
+        mask_scores = (mask_logits.sigmoid().flatten(2) * masks.flatten(2)).sum(-1) / (masks.flatten(2).sum(-1) + 1e-6)
+        scores = scores * mask_scores
 
         if return_traceable_outputs and target_sizes is not None:
-            pred_masks = torch.nn.functional.interpolate(pred_masks, size=target_sizes[0], mode="nearest")
+            masks = torch.nn.functional.interpolate(masks, size=target_sizes[0], mode="nearest")
 
         # Discard instances with a low score or an empty mask
-        keep = (pred_scores >= threshold) & pred_masks.flatten(2).any(dim=-1)
+        keep_instances = (scores >= threshold) & masks.flatten(2).any(dim=-1)
 
         if return_traceable_outputs:
-            return pred_masks, pred_scores, pred_classes, keep
+            return masks, scores, classes, keep_instances
 
         return self.build_instance_segmentation_outputs(
-            pred_masks=pred_masks,
-            pred_scores=pred_scores,
-            pred_classes=pred_classes,
-            keep=keep,
+            masks=masks,
+            scores=scores,
+            classes=classes,
+            keep_instances=keep_instances,
             target_sizes=target_sizes,
             return_coco_annotation=return_coco_annotation,
             return_binary_maps=return_binary_maps,
@@ -289,10 +286,10 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
 
     def build_instance_segmentation_outputs(
         self,
-        pred_masks: torch.Tensor,
-        pred_scores: torch.Tensor,
-        pred_classes: torch.Tensor,
-        keep: torch.Tensor,
+        masks: torch.Tensor,
+        scores: torch.Tensor,
+        classes: torch.Tensor,
+        keep_instances: torch.Tensor,
         target_sizes: list[tuple[int, int]] | None = None,
         return_coco_annotation: bool | None = False,
         return_binary_maps: bool | None = False,
@@ -313,33 +310,35 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
             target_sizes = [tuple(size) for size in target_sizes]
 
         results: list[dict[str, TensorType]] = []
-        for idx, (masks, scores, classes, keep_item) in enumerate(zip(pred_masks, pred_scores, pred_classes, keep)):
-            masks = masks[keep_item]
-            scores = scores[keep_item]
-            classes = classes[keep_item]
+        for idx, (image_masks, image_scores, image_classes, image_keep) in enumerate(
+            zip(masks, scores, classes, keep_instances)
+        ):
+            image_masks = image_masks[image_keep]
+            image_scores = image_scores[image_keep]
+            image_classes = image_classes[image_keep]
 
             # Resizing is done after filtering, interpolating all masks to the target size is expensive
-            if target_sizes is not None and masks.shape[0] != 0:
-                masks = torch.nn.functional.interpolate(
-                    masks.unsqueeze(dim=0), size=target_sizes[idx], mode="nearest"
+            if target_sizes is not None and image_masks.shape[0] != 0:
+                image_masks = torch.nn.functional.interpolate(
+                    image_masks.unsqueeze(dim=0), size=target_sizes[idx], mode="nearest"
                 )[0]
                 # Masks can become empty when downsampled
-                non_empty_masks = masks.flatten(1).any(dim=-1)
-                masks = masks[non_empty_masks]
-                scores = scores[non_empty_masks]
-                classes = classes[non_empty_masks]
+                non_empty_masks = image_masks.flatten(1).any(dim=-1)
+                image_masks = image_masks[non_empty_masks]
+                image_scores = image_scores[non_empty_masks]
+                image_classes = image_classes[non_empty_masks]
 
-            height, width = target_sizes[idx] if target_sizes is not None else masks.shape[-2:]
+            height, width = target_sizes[idx] if target_sizes is not None else image_masks.shape[-2:]
             segmentation = torch.zeros((height, width)) - 1
             segments = []
-            for segment_id in range(masks.shape[0]):
-                segmentation[masks[segment_id] == 1] = segment_id
+            for segment_id in range(image_masks.shape[0]):
+                segmentation[image_masks[segment_id] == 1] = segment_id
                 segments.append(
                     {
                         "id": segment_id,
-                        "label_id": classes[segment_id].item(),
+                        "label_id": image_classes[segment_id].item(),
                         "was_fused": False,
-                        "score": round(scores[segment_id].item(), 6),
+                        "score": round(image_scores[segment_id].item(), 6),
                     }
                 )
 
@@ -348,8 +347,8 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
                 segmentation = convert_segmentation_to_rle(segmentation)
 
             # Return a concatenated tensor of binary instance maps
-            if return_binary_maps and masks.shape[0] != 0:
-                segmentation = masks
+            if return_binary_maps and image_masks.shape[0] != 0:
+                segmentation = image_masks
 
             results.append({"segmentation": segmentation, "segments_info": segments})
         return results
@@ -403,9 +402,9 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
                   Multiple instances of the same class / label were fused and assigned a single `segment_id`.
                 - **score** -- Prediction score of segment with `segment_id`.
 
-            When `return_traceable_outputs=True`, a tuple `(mask_probs, pred_scores, pred_labels, keep)` of tensors
-            with a static `num_queries` dimension: `mask_probs` of shape `(batch_size, num_queries, height, width)`,
-            `pred_scores` and `pred_labels` of shape `(batch_size, num_queries)`, and `keep` of shape `(batch_size,
+            When `return_traceable_outputs=True`, a tuple `(mask_probs, scores, labels, keep_queries)` of tensors with
+            a static `num_queries` dimension: `mask_probs` of shape `(batch_size, num_queries, height, width)`,
+            `scores` and `labels` of shape `(batch_size, num_queries)`, and `keep_queries` of shape `(batch_size,
             num_queries)`, `True` for the queries that are above `threshold` and do not predict the null class.
             Everything up to that tuple is traceable, so passing it to
             [`~Mask2FormerImageProcessor.build_panoptic_segmentation_outputs`] outside of the traced code gives the
@@ -431,14 +430,12 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
                 raise ValueError("All target sizes must be identical when `return_traceable_outputs=True`.")
 
         # Scale back to preprocessed image size - (384, 384) for all models
-        masks_queries_logits = torch.nn.functional.interpolate(
+        mask_probs = torch.nn.functional.interpolate(
             masks_queries_logits, size=(384, 384), mode="bilinear", align_corners=False
-        )
-
-        mask_probs = masks_queries_logits.sigmoid()  # [batch_size, num_queries, height, width]
+        ).sigmoid()  # [batch_size, num_queries, height, width]
 
         # Predicted label and score of each query (batch_size, num_queries)
-        pred_scores, pred_labels = nn.functional.softmax(class_queries_logits, dim=-1).max(-1)
+        scores, labels = nn.functional.softmax(class_queries_logits, dim=-1).max(-1)
 
         # Masks are resized before filtering only in the traceable branch, `build_panoptic_segmentation_outputs`
         # resizes the remaining masks otherwise
@@ -448,16 +445,16 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
             )
 
         # Discard queries with a low score or predicting the null class
-        keep = pred_labels.ne(num_labels) & (pred_scores > threshold)
+        keep_queries = labels.ne(num_labels) & (scores > threshold)
 
         if return_traceable_outputs:
-            return mask_probs, pred_scores, pred_labels, keep
+            return mask_probs, scores, labels, keep_queries
 
         return self.build_panoptic_segmentation_outputs(
             mask_probs=mask_probs,
-            pred_scores=pred_scores,
-            pred_labels=pred_labels,
-            keep=keep,
+            scores=scores,
+            labels=labels,
+            keep_queries=keep_queries,
             mask_threshold=mask_threshold,
             overlap_mask_area_threshold=overlap_mask_area_threshold,
             label_ids_to_fuse=label_ids_to_fuse,
@@ -467,9 +464,9 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
     def build_panoptic_segmentation_outputs(
         self,
         mask_probs: torch.Tensor,
-        pred_scores: torch.Tensor,
-        pred_labels: torch.Tensor,
-        keep: torch.Tensor,
+        scores: torch.Tensor,
+        labels: torch.Tensor,
+        keep_queries: torch.Tensor,
         mask_threshold: float = 0.5,
         overlap_mask_area_threshold: float = 0.8,
         label_ids_to_fuse: set[int] | None = None,
@@ -492,15 +489,17 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
             target_sizes = [tuple(size) for size in target_sizes]
 
         results: list[dict[str, TensorType]] = []
-        for idx, (masks, scores, labels, keep_item) in enumerate(zip(mask_probs, pred_scores, pred_labels, keep)):
-            masks = masks[keep_item]
-            scores = scores[keep_item]
-            labels = labels[keep_item]
+        for idx, (image_mask_probs, image_scores, image_labels, image_keep) in enumerate(
+            zip(mask_probs, scores, labels, keep_queries)
+        ):
+            image_mask_probs = image_mask_probs[image_keep]
+            image_scores = image_scores[image_keep]
+            image_labels = image_labels[image_keep]
             target_size = target_sizes[idx] if target_sizes is not None else None
 
             # No mask found
-            if masks.shape[0] <= 0:
-                height, width = target_size if target_size is not None else masks.shape[1:]
+            if image_mask_probs.shape[0] <= 0:
+                height, width = target_size if target_size is not None else image_mask_probs.shape[1:]
                 segmentation = torch.zeros((height, width)) - 1
                 results.append({"segmentation": segmentation, "segments_info": []})
                 continue
@@ -508,9 +507,9 @@ class Mask2FormerImageProcessor(MaskFormerImageProcessor):
             # Get segmentation map and segment information of batch item, resizing the masks here keeps the
             # interpolation off the queries that were filtered out
             segmentation, segments = compute_segments(
-                mask_probs=masks,
-                pred_scores=scores,
-                pred_labels=labels,
+                mask_probs=image_mask_probs,
+                pred_scores=image_scores,
+                pred_labels=image_labels,
                 mask_threshold=mask_threshold,
                 overlap_mask_area_threshold=overlap_mask_area_threshold,
                 label_ids_to_fuse=label_ids_to_fuse,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48151)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48151)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

PoC to export models end to end with the new exporters from `transformers/exporters`. 

Main changes:
* Add `HfExporter.export_end_to_end`
* Add `return_traceable_outputs` to post process methods (by default `False`)
* Split each `post_process_xyz` method into `post_process_xyz` and `build_xyz_outputs`. All traceable code stays in the body of `post_process_xyz` which finishes with the call to the untraceable `build_xyz_outputs`. 

The motivation to expose `return_traceable_outputs` as a flag is that you can call it also from normal torch outside of an export context. This simplifies testing and any downstream applications that take either a plain torch model or an exported model as input.

The motivation to expose `build_xyz_outputs` as a public method is that you want to be able to call it on the outputs from the exported model to get the final, clean outputs which match normal torch post processing outputs. Note that depending on the task it is not necessary to call this method. For example, semantic segmentation can return final label predictions directly from the traced code. For other tasks like object detection and instance segmentation there will always be some extra post-processing required.

Example code:
```
import numpy as np
import torch
from PIL import Image
from transformers import AutoImageProcessor, Mask2FormerForUniversalSegmentation
from transformers.exporters.exporter_onnx import OnnxConfig, OnnxExporter

checkpoint = "facebook/mask2former-swin-tiny-ade-semantic"
processor = AutoImageProcessor.from_pretrained(checkpoint)
model = Mask2FormerForUniversalSegmentation.from_pretrained(checkpoint).eval()

image = Image.open("coco_sample.jpg").convert("RGB")
image_tensor = torch.from_numpy(np.array(image)).permute(2, 0, 1).contiguous()  # raw uint8 CHW
target_sizes = [(image_tensor.shape[-2], image_tensor.shape[-1])]   # output at original resolution

exporter = OnnxExporter()
config = OnnxConfig(dynamic=False, output_path="mask2former_semantic.onnx")

onnx_program = exporter.export_end_to_end(
    model,
    preprocess=processor,
    post_process=processor.post_process_semantic_segmentation,
    sample_inputs={"images": image_tensor, "target_sizes": target_sizes},
    config=config,
)

(semantic_map,) = onnx_program(images=image_tensor)
segmentation = processor.build_semantic_segmentation_outputs(semantic_map=semantic_map)[0]

# equivalent to
inputs = processor(image).to("cuda")
outputs = model(**inputs)
segmentation = processor.post_process_semantic_segmentation(outputs, target_sizes=target_sizes)
```

This is still very much WIP and not cleaned up. Docstrings are too verbose for now.

cc @molbap @IlyasMoutawwakil