### PR TITLE
`force_accelerate_hooks` should not hide the signature it wraps

### DIFF
--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -17,6 +17,7 @@ and simplicity/ease of use.
 """
 
 import copy
+import functools
 import inspect
 import os
 import re
@@ -932,6 +933,7 @@ def force_accelerate_hooks(child_module_names: str | list[str]) -> Callable:
         child_module_names = [child_module_names]
 
     def decorator(forward_func: Callable) -> Callable:
+        @functools.wraps(forward_func)
         def wrapped(self, *args, **kwargs):
             hooked_modules = []
             for child_module_name in child_module_names:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48156)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48156)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This PR fixes an issue with `force_accelerate_hooks`. The wrapper is declared (self, *args, **kwargs) and doesn't use functools.wraps, so from the outside the decorated forward is (self, *args, **kwargs).  its real parameters are invisible to `inspect.signature`. One potential issue is with kernels as when swapping modules, we check if the arguments matches or not. 

```
inspect.signature(Qwen3_5GatedDeltaNet.forward)
(self, *args, **kwargs)          # before
(self, hidden_states, cache_params=None, attention_mask=None, **kwargs)   # after
```