### PR TITLE
Fix DeepSeek V2 default vocab size

### DIFF
--- a/src/transformers/models/deepseek_ocr2/configuration_deepseek_ocr2.py
+++ b/src/transformers/models/deepseek_ocr2/configuration_deepseek_ocr2.py
@@ -216,7 +216,7 @@ class DeepseekOcr2TextConfig(PreTrainedConfig):
         "norm": (["hidden_states"], ["hidden_states"]),
     }
 
-    vocab_size: int = 32000
+    vocab_size: int = 102400
     hidden_size: int = 4096
     intermediate_size: int = 11008
     num_hidden_layers: int = 32

--- a/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
@@ -73,7 +73,7 @@ class DeepseekV2Config(PreTrainedConfig):
         "norm": (["hidden_states"], ["hidden_states"]),
     }
 
-    vocab_size: int = 32000
+    vocab_size: int = 102400
     hidden_size: int = 4096
     intermediate_size: int = 11008
     num_hidden_layers: int = 32

--- a/src/transformers/models/deepseek_v2/modular_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/modular_deepseek_v2.py
@@ -96,7 +96,7 @@ class DeepseekV2Config(LlamaConfig):
         "num_experts": "n_routed_experts",
     }
 
-    vocab_size: int = 32000
+    vocab_size: int = 102400
     hidden_size: int = 4096
     intermediate_size: int = 11008
     num_hidden_layers: int = 32


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48159)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48159)
<!-- ci-dashboard-badge:end -->

32k is not the right vocab size for this model. All checkpoints and the paper specify 100k (`102400` specifically).

This PR updates the default to 100k so that checkpoints which ommit `vocab_size` (some DeepSeek VL V2 checkpoints) load correctly in the libraries that can load them (vLLM).