### PR TITLE
[Mistral3] Fix batched integration tests: padding_side=left + update expected values

### DIFF
--- a/tests/models/mistral3/test_modeling_mistral3.py
+++ b/tests/models/mistral3/test_modeling_mistral3.py
@@ -300,7 +300,7 @@ class Mistral3IntegrationTest(unittest.TestCase):
         expected_outputs = Expectations(
             {
                 ("xpu", 3): "The image features two tabby cats lying on a pink surface, which appears to be a cushion or",
-                ("cuda", 8): 'The image features two cats lying on a pink surface, which appears to be a couch or a bed',
+                ("cuda", 8): 'The image features two tabby cats lying on a pink surface, which appears to be a couch or',
                 ("rocm", (9, 4)): "The image features two cats lying on a pink surface, which appears to be a couch or a bed",
                 ("rocm", (9, 5)): "The image features two tabby cats lying on a pink surface, which appears to be a cushion or"
             }
@@ -311,6 +311,7 @@ class Mistral3IntegrationTest(unittest.TestCase):
     @require_deterministic_for_xpu
     def test_mistral3_integration_batched_generate(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
+        processor.tokenizer.padding_side = "left"
         processor.chat_template = processor.chat_template.replace('strftime_now("%Y-%m-%d")', '"2025-06-20"')
         messages = [
             [
@@ -354,7 +355,7 @@ class Mistral3IntegrationTest(unittest.TestCase):
             {
                 ("xpu", 3): "Calm lake's mirror gleams,\nWhispering pines stand in silence,\nPath to peace begins.",
                 ("cuda", (8, 0)): "Wooden path to calm,\nReflections whisper secrets,\nNature's peace unfolds.",
-                ("cuda", (8, 6)): "Calm waters reflect\nWooden path to distant shore\nSilence in the woods",
+                ("cuda", (8, 6)): "Calm waters reflect\nWooden path to distant shore\nSilence in the scene",
                 ("rocm", (9, 5)): "Calm waters reflect\nWooden path to distant shore\nSilence in the scene"
             }
         )  # fmt: skip
@@ -383,6 +384,7 @@ class Mistral3IntegrationTest(unittest.TestCase):
     @require_deterministic_for_xpu
     def test_mistral3_integration_batched_generate_multi_image(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
+        processor.tokenizer.padding_side = "left"
         processor.chat_template = processor.chat_template.replace('strftime_now("%Y-%m-%d")', '"2025-06-20"')
 
         # Prepare inputs
@@ -430,7 +432,7 @@ class Mistral3IntegrationTest(unittest.TestCase):
         decoded_output = processor.decode(gen_tokens[0], skip_special_tokens=True)
         expected_outputs = Expectations(
             {
-                ("cuda", 8): "Calm waters reflect\nWooden path to distant shore\nPeace in nature's hold",
+                ("cuda", 8): "Calm waters reflect\nWooden path to distant shore\nSilence in the scene",
                 ("rocm", (9, 4)): "Calm waters reflect\nWooden path to distant shore\nSilence in the pines"
             }
         )  # fmt: skip


### PR DESCRIPTION
## What does this PR do?

Fixes 3 failing Mistral3 integration tests on CUDA 8.6 (A10G).

### Root cause

PR #43734 (*Prepare and keep track of position ids in `generate`*) changed how position IDs are managed during generation: they are now cached and incremented rather than recomputed each step. This breaks batched generation with **right padding** (the default), because right-padded tokens get incorrect position IDs that are never fixed. The model then ignores its instruction (e.g., "Write a haiku") and generates unrelated text.

Mistral3's two batched tests were not included in the slow test runs for PR #43734, so the breakage went undetected before merge.

### Fix

- Set `processor.tokenizer.padding_side = "left"` in `test_mistral3_integration_batched_generate` and `test_mistral3_integration_batched_generate_multi_image` (same fix applied to other models broken by #43734).
- Update stale expected values for `("cuda", 8)` in all 3 integration tests, verified on A10G CUDA 8.6, torch 2.13, `HF_HOME=/mnt/cache`.

### Verified outputs (A10G, CUDA sm_86, torch 2.13)

| Test | output[0] | output[1] |
|------|-----------|-----------|
| `test_generate` | `'The image features two tabby cats lying on a pink surface, which appears to be a couch or'` | — |
| `test_batched_generate` | `'Calm waters reflect\nWooden path to distant shore\nSilence in the scene'` | `'The image depicts a street scene in what appears to be a Chinatown district. The focal point is a traditional Chinese arch'` |
| `test_batched_generate_multi_image` | `'Calm waters reflect\nWooden path to distant shore\nSilence in the scene'` | `'Certainly! The images depict two famous landmarks in the United States:\n\n1. The first image shows the Statue of Liberty,'` |

### Cross-commit output consistency (on current CI env.)

Running the tests on different historical commits confirms the outputs are stable and the fix is correct:

**`test_mistral3_integration_generate`** produces identical output on all 3 commits:
- Mar 14, 2026 CI run `23079104187` (`6133195dcb`) — this test **passed** in CI
- Mar 15, 2026 CI run `23102426112` (`c0fe6164d0`) — this test **failed** in CI (stale expected value, not a model change; commit `c0fe6164d0` updated the Nvidia CI docker image to torch 2.10, which changed model numerics slightly)
- Our PR commit (`e71d15c60a`)

**`test_mistral3_integration_batched_generate`** and **`test_mistral3_integration_batched_generate_multi_image`** produce identical outputs on both commits:
- Dec 9, 2025 CI run `20050230485` (`745ad8c7c4`) — Mistral3 had no failures in CI at this point
- Our PR commit (`e71d15c60a`)

This confirms that `padding_side="left"` with the new position ID tracking (post-#43734) produces exactly the same model outputs as the old code with right padding did at Dec 9, fully restoring pre-regression behavior.

See also PR #48157 for full investigation of the output drift history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)