### PR TITLE
deterministic layer_types buffer registration in multiple models

### DIFF
--- a/src/transformers/models/cohere_compass/modeling_cohere_compass.py
+++ b/src/transformers/models/cohere_compass/modeling_cohere_compass.py
@@ -77,7 +77,7 @@ class CohereCompassRotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
+++ b/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
@@ -69,7 +69,7 @@ class DiffusionGemmaTextRotaryEmbedding(nn.Module):
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
-        self.layer_types = set(config.layer_types)
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_init_fns: dict[str, Callable[..., tuple[torch.Tensor, float]]] = {}
         self.rope_type: dict[str, str] = {}
 

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -160,7 +160,7 @@ class Gemma3RotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -272,7 +272,7 @@ class Gemma3RotaryEmbedding(Gemma2RotaryEmbedding):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/gemma3n/modeling_gemma3n.py
+++ b/src/transformers/models/gemma3n/modeling_gemma3n.py
@@ -1533,7 +1533,7 @@ class Gemma3nRotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1089,7 +1089,7 @@ class Gemma4TextRotaryEmbedding(nn.Module):
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
-        self.layer_types = set(config.layer_types)
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_init_fns: dict[str, Callable[..., tuple[torch.Tensor, float]]] = {}
         self.rope_type: dict[str, str] = {}
 

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -990,7 +990,7 @@ class Gemma4TextRotaryEmbedding(Gemma3RotaryEmbedding):
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
-        self.layer_types = set(config.layer_types)
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_init_fns: dict[str, Callable[..., tuple[torch.Tensor, float]]] = {}
         self.rope_type: dict[str, str] = {}
 

--- a/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py
+++ b/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py
@@ -190,7 +190,7 @@ class Gemma4UnifiedTextRotaryEmbedding(nn.Module):
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
-        self.layer_types = set(config.layer_types)
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_init_fns: dict[str, Callable[..., tuple[torch.Tensor, float]]] = {}
         self.rope_type: dict[str, str] = {}
 

--- a/src/transformers/models/laguna/modeling_laguna.py
+++ b/src/transformers/models/laguna/modeling_laguna.py
@@ -71,7 +71,7 @@ class LagunaRotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/mellum/modeling_mellum.py
+++ b/src/transformers/models/mellum/modeling_mellum.py
@@ -50,7 +50,7 @@ class MellumRotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/mimo_v2_flash/modeling_mimo_v2_flash.py
+++ b/src/transformers/models/mimo_v2_flash/modeling_mimo_v2_flash.py
@@ -71,7 +71,7 @@ class MiMoV2FlashRotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/modernbert/modeling_modernbert.py
+++ b/src/transformers/models/modernbert/modeling_modernbert.py
@@ -98,7 +98,7 @@ class ModernBertRotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/modernbert_decoder/modeling_modernbert_decoder.py
+++ b/src/transformers/models/modernbert_decoder/modeling_modernbert_decoder.py
@@ -95,7 +95,7 @@ class ModernBertDecoderRotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/olmo3/modeling_olmo3.py
+++ b/src/transformers/models/olmo3/modeling_olmo3.py
@@ -274,7 +274,7 @@ class Olmo3RotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/step3p7/modeling_step3p7.py
+++ b/src/transformers/models/step3p7/modeling_step3p7.py
@@ -439,7 +439,7 @@ class Step3p7RotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/t5gemma2/modeling_t5gemma2.py
+++ b/src/transformers/models/t5gemma2/modeling_t5gemma2.py
@@ -98,7 +98,7 @@ class T5Gemma2RotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]

--- a/src/transformers/models/zaya/modeling_zaya.py
+++ b/src/transformers/models/zaya/modeling_zaya.py
@@ -51,7 +51,7 @@ class ZayaRotaryEmbedding(nn.Module):
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
         self.config = config
-        self.layer_types = list(set(config.layer_types))
+        self.layer_types = sorted(set(config.layer_types))
         self.rope_type = {}
         for layer_type in self.layer_types:
             rope_params = self.config.rope_parameters[layer_type]


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48162&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48162) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48162&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48162)
<!-- ci-dashboard-badge:end -->

# deterministic layer_types buffer registration in multiple models

Hi,

i encountered a problem where when using Gemma3 during a `trl` `GRPOTrainer` run via `accelerate launch` in DDP mode (4x H200), some of the ranks always produced garbage tokens. Which ranks were affected was always random, so it lead me to believe its soem sort of DDP corruption bug.

The problem in the end was that python randomizes the order in which the result of `list(set(config.layer_types))` appears and it does this with a different initial randomness in each process, i.e. in each DDP rank.


DDP's `_sync_module_states` and `_broadcast_coalesced` synchronizes buffers across ranks based on iteration index rather than individual buffer name, which causes swapped RoPE buffers across these ranks.

When launching the `accelerate launch` process with the env variable `PYTHONHASHSEED=0` set (which uses the same seed for all processes, causing the order to be deterministic) everything works fine.

This fix uses `sorted(set())` instead of the non-deterministic `list(set())` and fixes this issue.


## TL;DR
* `modeling_gemma3.py` (and other models) uses `self.layer_types = list(set(config.layer_types))` before registering RoPE buffers (_inv_freq, _original_inv_freq).
* python randomizes string hash seeds per process by default which means the resulting `set()` order is different across DDP ranks
* During initialization, DDP (`_sync_module_states` / `_broadcast_coalesced`) synchronizes buffers across ddp ranks by set order instead of the buffer name
* this can cause global RoPE (\theta=10^6) and sliding-window RoPE (theta=10^4) frequencies being swapped on ranks where the set order does not match exactly the one in rank 0
* as those buffers are registered with `persistent=False` specified, they wont show up in the models `state_dict()` which causes rank weight hashes to be the same even though the buffers are swapped