### PR TITLE
[Qwen2.5-Omni] Update stale expected values for cuda sm_86

### DIFF
--- a/tests/models/qwen2_5_omni/test_modeling_qwen2_5_omni.py
+++ b/tests/models/qwen2_5_omni/test_modeling_qwen2_5_omni.py
@@ -664,7 +664,7 @@ class Qwen2_5OmniModelIntegrationTest(unittest.TestCase):
 
         EXPECTED_DECODED_TEXT = Expectations({
             ("xpu", None): "system\nYou are a helpful assistant.\nuser\nWhat's that sound and what kind of dog is this?\nassistant\nThe sound is glass shattering, and the dog is a Labrador Retriever.",
-            ("cuda", (8, 6)): "system\nYou are a helpful assistant.\nuser\nWhat's that sound and what kind of dog is this?\nassistant\nThe sound is a glass shattering. The dog in the picture is a Labrador Retriever.",
+            ("cuda", (8, 6)): "system\nYou are a helpful assistant.\nuser\nWhat's that sound and what kind of dog is this?\nassistant\nThe sound is glass shattering, and the dog is a Labrador Retriever.",
             ("rocm", (9, 4)): "system\nYou are a helpful assistant.\nuser\nWhat's that sound and what kind of dog is this?\nassistant\nThe sound is glass shattering, and the dog is a Labrador Retriever.",
         }).get_expectation()  # fmt: skip
 
@@ -700,8 +700,8 @@ class Qwen2_5OmniModelIntegrationTest(unittest.TestCase):
                     "system\nYou are a helpful assistant.\nuser\nWhat's that sound and what kind of dog is this?\nassistant\nThe sound is of glass shattering, and the dog in the picture is a Labrador Retriever",
                 ],
                 ("cuda", 8): [
-                    "system\nYou are a helpful assistant.\nuser\nWhat's that sound and what kind of dog is this?\nassistant\nThe sound is a glass shattering. The dog in the picture is a Labrador Retriever.",
-                    "system\nYou are a helpful assistant.\nuser\nWhat's that sound and what kind of dog is this?\nassistant\nThe sound is a glass shattering. The dog in the picture is a Labrador Retriever.",
+                    "system\nYou are a helpful assistant.\nuser\nWhat's that sound and what kind of dog is this?\nassistant\nThe sound is glass shattering, and the dog is a Labrador Retriever.",
+                    "system\nYou are a helpful assistant.\nuser\nWhat's that sound and what kind of dog is this?\nassistant\nThe sound is glass shattering, and the dog is a Labrador Retriever.",
                 ],
                 ("rocm", (9, 4)): [
                     "system\nYou are a helpful assistant.\nuser\nWhat's that sound and what kind of dog is this?\nassistant\nThe sound is glass shattering, and the dog is a Labrador Retriever.",


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48164)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48164)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Updates stale expected values in `test_small_model_integration_test` and `test_small_model_integration_test_batch` for CUDA sm_86 (A10G).

### Root cause

Commit `c0fe6164d0` (*Update Nvidia CI docker file to use torch 2.10*, #44712, Mar 15, 2026) updated the Nvidia CI docker image to torch 2.10, which changed model numerics slightly. The expected values for `("cuda", (8, 6))` / `("cuda", 8)` became stale as a result — the CI passed on Mar 14 but failed on Mar 15 with a minor wording difference, with no code change to the model or test between the two runs.

### Cross-commit output consistency (on current CI env.)

Running the tests on different historical commits confirms the actual model output is stable across all commits — only the expected values in the test file were stale:

**`test_small_model_integration_test`** and **`test_small_model_integration_test_batch`** produce identical output on all 3 commits:
- Mar 14, 2026 CI run `23079104187` (`6133195dcb`) — tests **passed** in CI
- Mar 15, 2026 CI run `23102426112` (`c0fe6164d0`) — tests **failed** in CI (stale expected value, not a model change; this commit updated the Nvidia CI docker image to torch 2.10, which changed model numerics slightly)
- Our PR commit (`bb9fb091d1`)

### Verified outputs (A10G, CUDA sm_86, torch 2.13, HF_HOME=/mnt/cache)

Both tests produce:
```
"system\nYou are a helpful assistant.\nuser\nWhat's that sound and what kind of dog is this?\nassistant\nThe sound is glass shattering, and the dog is a Labrador Retriever."
```

Both tests confirmed PASSING on runner after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)