### PR TITLE
Apply context parallelism to the evaluation path

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2997,8 +2997,18 @@ class Trainer:
                     logits = smp_nested_concat(logits_mb)
             else:
                 if has_labels or loss_without_labels:
-                    with self.compute_loss_context_manager():
-                        num_items_in_batch = self._get_num_items_in_batch([inputs], self.args.device)
+                    # Shard the sequence exactly as `training_step` does. Context parallel ranks all
+                    # receive the same batch, and the loss is scaled by the number of processes to
+                    # undo the gradient reduction's averaging; evaluating without the sharding would
+                    # apply that scaling to a full, unsharded loss and report `cp_size` times the
+                    # real value.
+                    # Count the batch's items *before* sharding: entering the context parallel
+                    # region splits the buffers in place, and the count is expected to be the
+                    # unsharded one (this mirrors the training loop, which counts in
+                    # `get_batch_samples` before `training_step` shards).
+                    num_items_in_batch = self._get_num_items_in_batch([inputs], self.args.device)
+                    cp_context, inputs = self._prepare_context_parallel_inputs(model, inputs)
+                    with self.compute_loss_context_manager(), cp_context():
                         if self.args.use_liger_kernel and prediction_loss_only:
                             inputs = {**inputs, "skip_logits": True}
                         loss, outputs = self.compute_loss(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2997,15 +2997,7 @@ class Trainer:
                     logits = smp_nested_concat(logits_mb)
             else:
                 if has_labels or loss_without_labels:
-                    # Shard the sequence exactly as `training_step` does. Context parallel ranks all
-                    # receive the same batch, and the loss is scaled by the number of processes to
-                    # undo the gradient reduction's averaging; evaluating without the sharding would
-                    # apply that scaling to a full, unsharded loss and report `cp_size` times the
-                    # real value.
-                    # Count the batch's items *before* sharding: entering the context parallel
-                    # region splits the buffers in place, and the count is expected to be the
-                    # unsharded one (this mirrors the training loop, which counts in
-                    # `get_batch_samples` before `training_step` shards).
+                    # Count before sharding: `context_parallel` splits the buffers in place.
                     num_items_in_batch = self._get_num_items_in_batch([inputs], self.args.device)
                     cp_context, inputs = self._prepare_context_parallel_inputs(model, inputs)
                     with self.compute_loss_context_manager(), cp_context():


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48167)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48167)
<!-- ci-dashboard-badge:end -->

With context parallelism enabled, `eval_loss` is reported as `cp_size` times its true value. Training loss is correct; only evaluation is wrong. Same everything, varying only `cp_size`:

Run it once per `cp_size` (no config file needed):

```bash
FSDP="--use_fsdp --fsdp_version 2 --fsdp_auto_wrap_policy TRANSFORMER_BASED_WRAP"
accelerate launch --num_processes 1 $FSDP repro_cp_eval_loss.py
accelerate launch --num_processes 2 $FSDP --use_parallelism_config --parallelism_config_cp_size 2 repro_cp_eval_loss.py
accelerate launch --num_processes 4 $FSDP --use_parallelism_config --parallelism_config_cp_size 4 repro_cp_eval_loss.py
```

```
########## main ##########
cp_size=1  train_loss=7.0000  eval_loss=6.9805  ratio=1.00
cp_size=2  train_loss=7.0000  eval_loss=13.9609  ratio=1.99
cp_size=4  train_loss=6.9688  eval_loss=27.9219  ratio=4.01
########## this PR ##########
cp_size=1  train_loss=7.0000  eval_loss=6.9805  ratio=1.00
cp_size=2  train_loss=7.0000  eval_loss=6.9844  ratio=1.00
cp_size=4  train_loss=6.9688  eval_loss=6.9834  ratio=1.00
```

It is silent — the number is plausible, just wrong — and it feeds early stopping, `load_best_model_at_end` and every eval metric people monitor.

<details>
<summary><code>repro_cp_eval_loss.py</code></summary>

```python
import torch
from torch.utils.data import Dataset
from transformers import AutoModelForCausalLM, Qwen3Config, Trainer, TrainingArguments

SEQ, ROWS = 2048, 8


class Tokens(Dataset):
    def __init__(self):
        generator = torch.Generator().manual_seed(0)
        self.ids = torch.randint(0, 1024, (ROWS, SEQ), generator=generator)

    def __len__(self):
        return ROWS

    def __getitem__(self, index):
        ids = self.ids[index]
        return {"input_ids": ids, "labels": ids.clone(), "attention_mask": torch.ones_like(ids)}


def main():
    config = Qwen3Config(vocab_size=1024, hidden_size=256, intermediate_size=512, num_hidden_layers=2,
                         num_attention_heads=4, num_key_value_heads=2, head_dim=64,
                         attn_implementation="sdpa")
    torch.manual_seed(0)
    model = AutoModelForCausalLM.from_config(config, dtype=torch.bfloat16)

    args = TrainingArguments(output_dir="/tmp/cp_eval_repro", per_device_train_batch_size=1,
                             per_device_eval_batch_size=1, max_steps=1, learning_rate=0.0,
                             logging_strategy="no", save_strategy="no", report_to=[], bf16=True)
    dataset = Tokens()
    trainer = Trainer(model=model, args=args, train_dataset=dataset, eval_dataset=dataset)

    train = trainer.train().training_loss
    evaluation = trainer.evaluate()["eval_loss"]
    cp_size = trainer.accelerator.parallelism_config.cp_size if trainer.accelerator.parallelism_config else 1
    if trainer.accelerator.is_main_process:
        print(f"cp_size={cp_size}  train_loss={train:.4f}  eval_loss={evaluation:.4f}  "
              f"ratio={evaluation / train:.2f}")


if __name__ == "__main__":
    main()
```

</details>

### Cause

`training_step` shards the batch along the sequence with `_prepare_context_parallel_inputs`, and `compute_loss` multiplies the loss by `num_processes` to cancel the gradient reduction's averaging over the `dp_shard_cp` mesh. `prediction_step` calls `compute_loss` the same way, so it gets the same `× num_processes` factor, but never enters the context parallel region.
Every rank therefore computes the loss for the *whole* sequence, the scaling has nothing to cancel, and the eval loop's mean over ranks keeps the factor.

That also means evaluation does `cp_size`× the attention work it should, on every rank, without the memory savings context parallelism exists for: evaluating at a 1M-token sequence runs the full unsharded sequence per rank.

For the fix, the ordering matters and is the subtle part: `context_parallel` shards its buffers **in place**, so counting the batch's items after entering the region yields the local shard's count, which is then divided by `non_data_parallel_size` a second time in `_get_num_items_in_batch`. Counting first matches what the training loop does.

### Verified

| | before | after |
|---|---|---|
| eval loss, cp = 1 | 12.19 | 12.19 |
| eval loss, cp = 2 | 24.38 | **12.19** |
| eval loss, cp = 4 | 48.75 | **12.19** |

And at the scale where it matters most:
Qwen3-0.6B, a 1,048,576-token sequence, `cp_size = 8` on one 8×H100 node, the fix corrects the loss by exactly `cp_size` and makes the evaluation step 5.2× faster, because each rank now evaluates its own shard instead of the whole sequence:

| | before | after |
|---|---|---|
| eval loss | 121.5 | **15.17** (121.5 / 15.17 = 8.007) |
| eval runtime | 259.6 s | **50.3 s** |

Reproduce with any model and `eval_strategy="steps"` under an FSDP2 + `cp_size` accelerate config; the instrumented script I used is `scripts/debug_cp_eval.py` in this repo (it prints the item count and the per-rank sequence length, which makes both the sharding and the double division visible).