### PR TITLE
fix(processing): convert tensor to numpy array before np.cumsum in processors (#48177)

### DIFF
--- a/src/transformers/models/internvl/processing_internvl.py
+++ b/src/transformers/models/internvl/processing_internvl.py
@@ -20,7 +20,7 @@ from ...image_processing_utils import BatchFeature
 from ...image_utils import ImageInput, concatenate_list
 from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
-from ...utils import auto_docstring
+from ...utils import auto_docstring, to_numpy
 from ...video_utils import VideoInput
 
 
@@ -107,7 +107,7 @@ class InternVLProcessor(ProcessorMixin):
 
         # Merge image and video pixel into a single array, as model expects only `pixel_values` as arg
         if images is not None:
-            image_num_patches_indices = np.cumsum(model_inputs.pop("num_patches"))
+            image_num_patches_indices = np.cumsum(to_numpy(model_inputs.pop("num_patches")))
         if videos is not None:
             video_pixel_values = model_inputs.pop("pixel_values_videos")
             batch_size, num_frames, *_ = video_pixel_values.shape

--- a/src/transformers/models/kimi_k25/modular_kimi_k25.py
+++ b/src/transformers/models/kimi_k25/modular_kimi_k25.py
@@ -31,6 +31,7 @@ from ...utils import (
     auto_docstring,
     can_return_tuple,
     logging,
+    to_numpy,
     torch_compilable_check,
 )
 from ...utils.generic import get_max_seqlen, is_flash_attention_requested, maybe_autocast
@@ -779,7 +780,7 @@ class Kimi_K25Processor(Qwen2VLProcessor):
         temporal_patch_size = self.video_processor.temporal_patch_size
 
         num_chunks = video_inputs["num_chunks_per_video"][video_idx]
-        start = 0 if video_idx == 0 else np.cumsum(video_inputs["num_chunks_per_video"])[video_idx - 1]
+        start = 0 if video_idx == 0 else np.cumsum(to_numpy(video_inputs["num_chunks_per_video"]))[video_idx - 1]
         video_grid_thw = video_inputs["video_grid_thw"][start : start + num_chunks]
         video_structure = ""
 

--- a/src/transformers/models/kimi_k25/processing_kimi_k25.py
+++ b/src/transformers/models/kimi_k25/processing_kimi_k25.py
@@ -22,7 +22,7 @@ import time
 import numpy as np
 
 from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin
-from ...utils import auto_docstring, logging
+from ...utils import auto_docstring, logging, to_numpy
 
 
 logger = logging.get_logger(__name__)
@@ -76,7 +76,7 @@ class Kimi_K25Processor(ProcessorMixin):
         temporal_patch_size = self.video_processor.temporal_patch_size
 
         num_chunks = video_inputs["num_chunks_per_video"][video_idx]
-        start = 0 if video_idx == 0 else np.cumsum(video_inputs["num_chunks_per_video"])[video_idx - 1]
+        start = 0 if video_idx == 0 else np.cumsum(to_numpy(video_inputs["num_chunks_per_video"]))[video_idx - 1]
         video_grid_thw = video_inputs["video_grid_thw"][start : start + num_chunks]
         video_structure = ""
 

--- a/src/transformers/models/minicpmv4_6/processing_minicpmv4_6.py
+++ b/src/transformers/models/minicpmv4_6/processing_minicpmv4_6.py
@@ -17,7 +17,7 @@ import numpy as np
 from ...image_utils import ImageInput, make_flat_list_of_images
 from ...processing_utils import BatchFeature, ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
-from ...utils import auto_docstring, logging
+from ...utils import auto_docstring, logging, to_numpy
 from ...video_utils import VideoInput, make_batched_videos
 
 
@@ -148,7 +148,7 @@ class MiniCPMV4_6Processor(ProcessorMixin):
         num_patches_per_image = image_inputs["num_patches_per_image"]
         target_sizes = image_inputs["target_sizes"]
 
-        cum_patches = np.cumsum(num_patches_per_image)
+        cum_patches = np.cumsum(to_numpy(num_patches_per_image))
         start_idx = cum_patches[image_idx - 1] if image_idx > 0 else 0
         end_idx = cum_patches[image_idx]
         img_target_sizes = target_sizes[start_idx:end_idx]
@@ -189,8 +189,8 @@ class MiniCPMV4_6Processor(ProcessorMixin):
         num_patches_per_frame = video_grids.prod(-1) + 1
 
         num_frames = num_frames_per_video[video_idx]
-        cum_patches_per_frame = np.cumsum(num_patches_per_frame)
-        num_past_frames = np.cumsum(num_frames_per_video)[video_idx] - num_frames
+        cum_patches_per_frame = np.cumsum(to_numpy(num_patches_per_frame))
+        num_past_frames = np.cumsum(to_numpy(num_frames_per_video))[video_idx] - num_frames
 
         video_placeholder = ""
         for frame_idx in range(num_frames):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48179)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48179)
<!-- ci-dashboard-badge:end -->

## Summary

Fixes #48177.

When multimodal processors like `InternVLProcessor`, `MiniCPMV4_6Processor`, and `Kimi_K25Processor` process batches with `return_tensors="pt"`, slice/patch counts (such as `num_patches`, `num_patches_per_image`, `num_frames_per_video`, `num_chunks_per_video`) are returned as PyTorch tensors.

Passing a `torch.Tensor` directly into `np.cumsum` causes NumPy to fall back to `_wrapit` and invoke `torch.Tensor.__array_wrap__`, triggering a `DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)` on every call that processes inputs with images/videos.

## Changes

- Use `to_numpy(...)` on the tensor operands before calling `np.cumsum(...)` in:
  - `src/transformers/models/internvl/processing_internvl.py`
  - `src/transformers/models/minicpmv4_6/processing_minicpmv4_6.py`
  - `src/transformers/models/kimi_k25/modular_kimi_k25.py` and `src/transformers/models/kimi_k25/processing_kimi_k25.py`