### PR TITLE
Fix nested optional kernel fallback resolution

### DIFF
--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -810,6 +810,9 @@ def use_kernel_func_from_hub_with_fallback(func_name: str, package: str, interna
         try:
             module = importlib.import_module(package)
             implementation = resolve_internal_import(module, full_path)
+            if implementation is None and internal_path is not None:
+                nested_module = importlib.import_module(f"{package}.{internal_path}")
+                implementation = getattr(nested_module, func_name, None)
         except Exception:
             implementation = torch_function
         finally:

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -51,8 +51,11 @@ from transformers.utils.kernel_config import add_to_mapping_local
 
 class TestUseKernelFuncFromHubWithFallback(TestCasePlus):
     def test_resolves_function_from_nested_optional_module(self):
-        torch_function = lambda: "torch"
-        nested_function = lambda: "nested"
+        def torch_function():
+            return "torch"
+
+        def nested_function():
+            return "nested"
         nested_module = types.SimpleNamespace(chunk_gated_delta_rule=nested_function)
         package_module = types.SimpleNamespace(ops=types.SimpleNamespace(gated_delta_rule=nested_module))
 

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -31,6 +31,7 @@ from transformers.integrations.hub_kernels import (
     is_kernel,
     lazy_load_kernel,
     load_and_register_attn_kernel,
+    use_kernel_func_from_hub_with_fallback,
 )
 from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
 from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
@@ -46,6 +47,25 @@ from transformers.testing_utils import (
 )
 from transformers.utils.import_utils import is_kernels_available
 from transformers.utils.kernel_config import add_to_mapping_local
+
+
+class TestUseKernelFuncFromHubWithFallback(TestCasePlus):
+    def test_resolves_function_from_nested_optional_module(self):
+        torch_function = lambda: "torch"
+        nested_function = lambda: "nested"
+        nested_module = types.SimpleNamespace(chunk_gated_delta_rule=nested_function)
+        package_module = types.SimpleNamespace(ops=types.SimpleNamespace(gated_delta_rule=nested_module))
+
+        with (
+            patch("transformers.integrations.hub_kernels.importlib.import_module", side_effect=[package_module, nested_module]),
+            patch("transformers.integrations.hub_kernels.resolve_internal_import", return_value=None),
+            patch("transformers.integrations.hub_kernels.use_kernel_forward_from_hub", side_effect=lambda _: lambda fn: fn),
+        ):
+            wrapped = use_kernel_func_from_hub_with_fallback(
+                "chunk_gated_delta_rule", "fla", internal_path="ops.gated_delta_rule"
+            )(torch_function)
+
+        self.assertIs(wrapped, nested_function)
 
 
 if is_kernels_available():


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48181)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48181)
<!-- ci-dashboard-badge:end -->

Fixes #48148\n\nWhen an optional backend exposes a kernel only from a nested module, package-root resolution returns None and the Torch fallback is retained. Import the configured nested module as a fallback and resolve the requested function there. Added a deterministic mock regression test.