### PR TITLE
Post two CI badges on a PR: CPU PR CI and GPU run-slow

### DIFF
--- a/tests/repo_utils/test_update_pr_ci_dashboard_recap.py
+++ b/tests/repo_utils/test_update_pr_ci_dashboard_recap.py
@@ -116,6 +116,30 @@ class RenderBadgeTest(unittest.TestCase):
         self.assertIn(f"{recap_mod.BADGE_URL}?pr=123", badge)
         self.assertIn("https://dash.example/d/x?var-pr=123", badge)
 
+    def test_render_ci_badge_emits_both_ci_streams(self):
+        """PR CI and run-slow GPU runs have separate verdicts, so each gets its
+        own badge asking the exporter for its own stream."""
+        badge = render_ci_badge(123, "https://dash.example/d/x?var-pr=123")
+        self.assertIn(f"{recap_mod.BADGE_URL}?pr=123&event=pr-ci", badge)
+        self.assertIn(f"{recap_mod.BADGE_URL}?pr=123&event=run-slow", badge)
+        self.assertIn("![CPU CI]", badge)
+        self.assertIn("![GPU run-slow]", badge)
+
+    def test_render_ci_badge_keeps_both_badges_on_one_line(self):
+        """The two badges must sit side by side; a newline between them would
+        stack them and push the PR description further down."""
+        badge = render_ci_badge(123, "https://dash.example/d/x?var-pr=123")
+        lines = badge.split("\n")
+        self.assertEqual(len(lines), 3)
+        self.assertEqual(lines[1].count("!["), 2)
+
+    def test_render_ci_badge_always_emits_the_run_slow_badge(self):
+        """It is unconditional by design: the body is only rewritten when PR CI
+        completes, so a run-slow that no push follows would otherwise never get a
+        badge. The exporter renders "not run" until a run-slow run exists."""
+        badge = render_ci_badge(999, "https://dash.example/d/x?var-pr=999")
+        self.assertIn("event=run-slow", badge)
+
 
 class RenderRecapTest(unittest.TestCase):
     def _recap(self, **overrides):

--- a/utils/update_pr_ci_dashboard_recap.py
+++ b/utils/update_pr_ci_dashboard_recap.py
@@ -194,12 +194,26 @@ def format_duration(seconds):
 
 
 def render_ci_badge(pr_number, dashboard_url):
-    """Render the CI dashboard badge block inserted at the top of the PR body."""
-    badge_url = f"{BADGE_URL}?pr={pr_number}"
+    """Render the CI dashboard badge block inserted at the top of the PR body.
+
+    Two badges on one line, one per CI stream a PR accumulates: regular PR CI on
+    CPU, and the GPU runs a maintainer asks for with a `run-slow: <models>`
+    comment. They have separate verdicts, so a single badge had to pick one and
+    would report whichever ran last -- against a dashboard link that showed the
+    other.
+
+    Both are always emitted, and the GPU badge renders "not run" until a run-slow
+    run exists. That is deliberate: this workflow only fires on PR CI completion,
+    so a badge written only when a run-slow already existed would stay missing
+    after a run-slow that no push follows. The SVGs are live, so the URLs written
+    here keep answering for the newest run of their stream with no rewrite.
+    """
+    cpu_url = f"{BADGE_URL}?pr={pr_number}&event=pr-ci"
+    gpu_url = f"{BADGE_URL}?pr={pr_number}&event=run-slow"
     return "\n".join(
         [
             BADGE_START,
-            f"[![CI]({badge_url})]({dashboard_url})",
+            f"[![CPU CI]({cpu_url})]({dashboard_url}) [![GPU run-slow]({gpu_url})]({dashboard_url})",
             BADGE_END,
         ]
     )


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48190)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48190)
<!-- ci-dashboard-badge:end -->

# What does this PR do?
A PR accumulates two independent CI streams -- regular PR CI on CPU, and the GPU runs a maintainer asks for with a `run-slow: <models>` comment. A single badge had to pick one, and picked whichever ran last, so a PR could carry a red badge sourced from a run-slow run beside a dashboard link explaining a different run. PR #48171 read "7 errors" against a dashboard reporting none.

Emit one badge per stream, side by side on one line, each asking the exporter for its own stream via the new ?event= parameter.

Both are always emitted. This workflow only fires on PR CI completion, so a GPU badge written only when a run-slow run already existed would stay missing after a run-slow that no push follows -- exactly the #48171 case. The badge SVGs are live, so the URLs written here pick up new runs of their stream with no rewrite, and the exporter renders the GPU badge as "not run" until there is something to report.

Requires the ?event= support in huggingface/transformers-ci; without it both URLs fall back to the same unfiltered badge, which is today's behaviour.