### PR TITLE
Simplify group images by shape

### DIFF
--- a/src/transformers/image_processing_backends.py
+++ b/src/transformers/image_processing_backends.py
@@ -176,7 +176,7 @@ class TorchvisionBackend(BaseImageProcessor):
         )
         processed_images_grouped = {}
         processed_masks_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             image_size = stacked_images.shape[-2:]
             padding_height = pad_size[0] - image_size[0]
             padding_width = pad_size[1] - image_size[1]
@@ -188,12 +188,12 @@ class TorchvisionBackend(BaseImageProcessor):
             if image_size != pad_size:
                 padding = (0, 0, padding_width, padding_height)
                 stacked_images = tvF.pad(stacked_images, padding, fill=fill_value, padding_mode=padding_mode)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
             if return_mask:
                 stacked_masks = torch.zeros_like(stacked_images, dtype=torch.int64)[..., 0, :, :]
                 stacked_masks[..., : image_size[0], : image_size[1]] = 1
-                processed_masks_grouped[shape] = stacked_masks
+                processed_masks_grouped[key] = stacked_masks
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         if return_mask:
@@ -388,23 +388,23 @@ class TorchvisionBackend(BaseImageProcessor):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         if do_pad:

--- a/src/transformers/image_processing_backends.py
+++ b/src/transformers/image_processing_backends.py
@@ -195,9 +195,9 @@ class TorchvisionBackend(BaseImageProcessor):
                 stacked_masks[..., : image_size[0], : image_size[1]] = 1
                 processed_masks_grouped[shape] = stacked_masks
 
-        processed_images = reorder_images(processed_images_grouped, grouped_images_index, is_nested=is_nested)
+        processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         if return_mask:
-            processed_masks = reorder_images(processed_masks_grouped, grouped_images_index, is_nested=is_nested)
+            processed_masks = reorder_images(processed_masks_grouped, grouped_images_index)
             return processed_images, processed_masks
 
         return processed_images

--- a/src/transformers/image_processing_utils.py
+++ b/src/transformers/image_processing_utils.py
@@ -120,12 +120,12 @@ class BaseImageProcessor(ImageProcessingMixin):
                 # Group images by shape for efficient batched operations
                 grouped_images, grouped_images_index = group_images_by_shape(images)
                 processed_groups = {}
-                for shape, stacked_images in grouped_images.items():
+                for key, stacked_images in grouped_images.items():
                     if do_resize:
                         stacked_images = self.resize(stacked_images, size=size)
                     if do_normalize:
                         stacked_images = self.normalize(stacked_images, mean=image_mean, std=image_std)
-                    processed_groups[shape] = stacked_images
+                    processed_groups[key] = stacked_images
                 processed_images = reorder_images(processed_groups, grouped_images_index)
                 return BatchFeature(data={"pixel_values": processed_images})
 

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
 from collections.abc import Collection, Iterable
+from dataclasses import dataclass
 from math import ceil
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 
@@ -862,105 +862,6 @@ def divide_to_patches(
     return patches
 
 
-def _group_images_by_shape(nested_images, *paired_inputs, is_nested: bool = False):
-    """
-    Helper function to flatten a single level of nested image and batch structures and group by shape.
-    Args:
-        nested_images (list):
-            A list of images or a single tensor
-        paired_inputs (Any, *optional*):
-            Zero or more lists that mirror the structure of `nested_images` (flat list, or list of lists when
-            `is_nested=True`). Each element is paired 1:1 with the corresponding image so it can be grouped by the
-            same shape key. These paired values are grouped alongside `nested_images` but are not stacked in the output, so
-            they do not need to be tensors.
-        is_nested (bool, *optional*, defaults to False):
-            Whether the images are nested.
-    Returns:
-        tuple[dict, ...]:
-            - A dictionary with shape as key and list of images with that shape as value
-            - A dictionary with shape as key and list of paired values with that shape as value
-            - A dictionary mapping original indices to (shape, index) tuples
-            - A dictionary mapping original indices to (shape, index) tuples for each paired input
-    """
-    grouped_images = defaultdict(list)
-    grouped_images_index = {}
-    paired_grouped_values = [defaultdict(list) for _ in paired_inputs]
-
-    # Normalize inputs to consistent nested structure
-    normalized_images = [nested_images] if not is_nested else nested_images
-    normalized_paired = []
-    for paired_input in paired_inputs:
-        normalized_paired.append([paired_input] if not is_nested else paired_input)
-
-    # Process each image and group by shape
-    for i, (sublist, *paired_sublists) in enumerate(zip(normalized_images, *normalized_paired)):
-        for j, (image, *paired_values) in enumerate(zip(sublist, *paired_sublists)):
-            key = (i, j) if is_nested else j
-            shape = image.shape[1:]
-
-            # Add to grouped structures
-            grouped_images[shape].append(image)
-            for paired_index, paired_value in enumerate(paired_values):
-                paired_grouped_values[paired_index][shape].append(paired_value)
-            grouped_images_index[key] = (shape, len(grouped_images[shape]) - 1)
-
-    # Store structure size for nested inputs to handle empty sublists during reconstruction
-    if is_nested:
-        grouped_images_index["_num_sublists"] = len(normalized_images)
-
-    return grouped_images, *paired_grouped_values, grouped_images_index
-
-
-def _reconstruct_nested_structure(indices, processed_images):
-    """Helper function to reconstruct a single level nested structure."""
-    # Get the number of sublists (handles empty sublists like in [[], [image]])
-    num_sublists = indices.pop("_num_sublists", None)
-
-    # Group indices by outer index
-    nested_indices = defaultdict(list)
-    for i, j in indices:
-        nested_indices[i].append(j)
-
-    # Determine the number of outer sublists
-    if num_sublists is not None:
-        max_outer_idx = num_sublists - 1
-    elif nested_indices:
-        max_outer_idx = max(nested_indices.keys())
-    else:
-        return []
-
-    # Create the result structure
-    result = []
-    for i in range(max_outer_idx + 1):
-        if i not in nested_indices:
-            result.append([])
-        else:
-            inner_max_idx = max(nested_indices[i])
-            inner_list = [None] * (inner_max_idx + 1)
-            for j in nested_indices[i]:
-                shape, idx = indices[(i, j)]
-                inner_list[j] = processed_images[shape][idx]
-            result.append(inner_list)
-
-    return result
-
-
-def _iterate_items(items, is_nested: bool):
-    """
-    Helper function to iterate over items yielding (key, item) pairs.
-
-    For nested structures, yields ((row_index, col_index), item).
-    For flat structures, yields (index, item).
-    """
-    if is_nested:
-        for i, row in enumerate(items):
-            for j, item in enumerate(row):
-                yield (i, j), item
-    else:
-        for i, item in enumerate(items):
-            yield i, item
-
-
 def _get_device_from_images(images, is_nested: bool) -> "torch.device":
     """
     Get the device from the first non-empty element in a (potentially nested) list of images.
@@ -976,6 +877,26 @@ def _get_device_from_images(images, is_nested: bool) -> "torch.device":
     return images[0].device
 
 
+@dataclass
+class GroupedImagesIndex:
+    """
+    Args:
+        positions (`dict`):
+            Maps the `(sublist_index, image_index)` position of every input image to the `(group_key, index_in_group)`
+            of its grouped image. Flat inputs count as a single sublist, so their positions are `(0, image_index)`.
+            Group keys are opaque and must only be used to access or update grouped dictionaries.
+        sublist_lengths (`list[int]`):
+            The length of every input sublist, which cannot be recovered from `positions` alone as empty sublists have
+            no position of their own.
+        is_nested (`bool`):
+            The structure of the input, so that [`reorder_images`] can restore the original nested structure.
+    """
+
+    positions: dict[tuple[int, int], tuple[Any, int]]
+    sublist_lengths: list[int]
+    is_nested: bool
+
+
 def group_images_by_shape(
     images: Union[list["torch.Tensor"], "torch.Tensor"],
     *paired_inputs,
@@ -983,11 +904,8 @@ def group_images_by_shape(
     is_nested: bool = False,
 ) -> tuple[dict, ...]:
     """
-    Groups images by shape.
-    Returns a dictionary with the shape or index as key and a list of images with that shape as value,
-    and a dictionary with the index of the image in the original list as key and the shape and index in the grouped list as value.
+    Groups images by shape so that they can be processed as a single batch.
 
-    The function supports both flat lists of tensors and nested structures.
     The input must be either all flat or all nested, not a mix of both.
 
     Args:
@@ -996,8 +914,9 @@ def group_images_by_shape(
         paired_inputs (Any, *optional*):
             Zero or more lists that mirror the structure of `images` (flat list, or list of lists when
             `is_nested=True`). Each element is paired 1:1 with the corresponding image so it can be grouped by the
-            same shape key. These paired values are grouped alongside `images` but are not stacked in the output, so
-            they do not need to be tensors.
+            same key. These paired values are grouped alongside `images` but are not stacked in the output, so
+            they do not need to be tensors. A paired input can also be `None`, in which case it is grouped as `None`
+            for every key so that callers can index it like the others.
         disable_grouping (bool):
             Whether to disable grouping. If None, will be set to True if the images are on CPU, and False otherwise.
             This choice is based on empirical observations, as detailed here: https://github.com/huggingface/transformers/pull/38157
@@ -1006,83 +925,100 @@ def group_images_by_shape(
 
     Returns:
         tuple[dict, ...]:
-            - A dictionary with shape or index as key and list/batch of images with that shape as value.
-              The key is the shape of the images if `disable_grouping` evaluates to True, and the index
-              of the image in the original list otherwise.
-            - Zero or more dictionaries (one per argument in `*paired_inputs`) grouped consistently with `images`; these carry
-              the corresponding per-item values and are not stacked
-            - A dictionary mapping original indices to (shape, index) tuples
+            - A dictionary mapping each group key to the batch of images with that shape. Grouping is disabled by
+              giving every image its own key, so that each one ends up in a batch of a single image.
+            - Zero or more dictionaries (one per argument in `*paired_inputs`) grouped consistently with `images`;
+              these carry the corresponding per-item values as lists and are not stacked, or `None` for every key
+              if the corresponding paired input is `None`.
+            - A [`GroupedImagesIndex`], to pass to [`reorder_images`] to restore the original order and structure.
     """
     # If disable grouping is not explicitly provided, we favor disabling it if the images are on CPU, and enabling it otherwise.
     if disable_grouping is None:
         device = _get_device_from_images(images, is_nested)
         disable_grouping = device.type == "cpu"
 
-    if disable_grouping:
-        grouped_images_index = {key: (key, 0) for key, _ in _iterate_items(images, is_nested)}
-        if is_nested:
-            grouped_images_index["_num_sublists"] = len(images)
-
-        return (
-            {key: img.unsqueeze(0) for key, img in _iterate_items(images, is_nested)},
-            *[
-                {key: item.unsqueeze(0) for key, item in _iterate_items(paired_list, is_nested)}
-                for paired_list in paired_inputs
-            ],
-            grouped_images_index,
-        )
-
     # A batched tensor is already a single group of images sharing the same shape, no need to unbind and re-stack it.
-    if isinstance(images, torch.Tensor) and not is_nested and len(images) > 0:
-        shape = images.shape[2:]
+    if not disable_grouping and not is_nested and isinstance(images, torch.Tensor) and len(images) > 0:
+        # Choice of key doesn't matter as there is a single group. We keep shape for consistency.
+        key = images.shape[1:]
         return (
-            {shape: images},
-            *[{shape: list(paired_list)} for paired_list in paired_inputs],
-            {index: (shape, index) for index in range(len(images))},
+            {key: images},
+            *[{key: None if paired_input is None else list(paired_input)} for paired_input in paired_inputs],
+            GroupedImagesIndex(
+                positions={(0, index): (key, index) for index in range(len(images))},
+                sublist_lengths=[len(images)],
+                is_nested=is_nested,
+            ),
         )
 
-    # Handle single level nested structure
-    grouped_images, *paired_grouped_values, grouped_images_index = _group_images_by_shape(
-        images, *paired_inputs, is_nested=is_nested
-    )
+    # Normalize flat inputs to a single sublist so that both cases share one code path.
+    nested_images = images if is_nested else [images]
+    nested_paired_inputs = [
+        paired_input if is_nested or paired_input is None else [paired_input] for paired_input in paired_inputs
+    ]
 
-    # Stack images with the same shape. Groups holding a single image are unsqueezed instead, as stacking would copy
-    # the image for no reason.
+    # Group images and paired inputs
+    grouped_images = {}
+    paired_inputs_groups = [{} for _ in paired_inputs]
+    positions = {}
+    for sublist_index, sublist in enumerate(nested_images):
+        for image_index, image in enumerate(sublist):
+            position = (sublist_index, image_index)
+            key = position if disable_grouping else image.shape
+            group = grouped_images.setdefault(key, [])
+            index_in_group = len(group)
+            positions[position] = (key, index_in_group)
+            group.append(image)
+            for group_paired, inputs in zip(paired_inputs_groups, nested_paired_inputs):
+                if inputs is None:
+                    group_paired[key] = None
+                else:
+                    group_paired.setdefault(key, []).append(inputs[sublist_index][image_index])
+
+    # Stack images sharing the same shape. Groups holding a single image are unsqueezed instead, as stacking would
+    # copy the tensor for no reason.
     grouped_images = {
-        shape: images_list[0].unsqueeze(0) if len(images_list) == 1 else torch.stack(images_list, dim=0)
-        for shape, images_list in grouped_images.items()
+        key: images_group[0].unsqueeze(0) if len(images_group) == 1 else torch.stack(images_group, dim=0)
+        for key, images_group in grouped_images.items()
     }
 
-    return grouped_images, *paired_grouped_values, grouped_images_index
+    return (
+        grouped_images,
+        *paired_inputs_groups,
+        GroupedImagesIndex(
+            positions=positions,
+            sublist_lengths=[len(sublist) for sublist in nested_images],
+            is_nested=is_nested,
+        ),
+    )
 
 
 def reorder_images(
-    processed_images: dict[tuple[int, int], "torch.Tensor"],
-    grouped_images_index: dict[int | tuple[int, int], tuple[tuple[int, int], int]],
-    is_nested: bool = False,
+    processed_images: dict,
+    grouped_images_index: GroupedImagesIndex,
 ) -> Union[list["torch.Tensor"], "torch.Tensor"]:
     """
     Reconstructs images in the original order, preserving the original structure (nested or not).
-    The input structure is either all flat or all nested.
 
     Args:
-        processed_images (dict[tuple[int, int], "torch.Tensor"]):
-            Dictionary mapping shapes to batched processed images.
-        grouped_images_index (dict[Union[int, tuple[int, int]], tuple[tuple[int, int], int]]):
-            Dictionary mapping original indices to (shape, index) tuples.
-        is_nested (bool, *optional*, defaults to False):
-            Whether the images are nested. Cannot be inferred from the input, as some processing functions outputs nested images.
-            even with non nested images, e.g. functions splitting images into patches. We thus can't deduce is_nested from the input.
-
+        processed_images (dict):
+            Dictionary mapping group keys to batched processed images.
+        grouped_images_index (`GroupedImagesIndex`):
+            The index returned by [`group_images_by_shape`] for these images. It carries the structure of the
+            original input.
 
     Returns:
         Union[list["torch.Tensor"], "torch.Tensor"]:
             Images in the original structure.
     """
-    if not is_nested:
-        return [
-            processed_images[grouped_images_index[i][0]][grouped_images_index[i][1]]
-            for i in range(len(grouped_images_index))
-        ]
+    # Positions are stored in the original order, so iterating over them rebuilds the flat sequence of images.
+    images = [processed_images[key][index] for key, index in grouped_images_index.positions.values()]
+    if not grouped_images_index.is_nested:
+        return images
 
-    return _reconstruct_nested_structure(grouped_images_index, processed_images)
+    nested_images = []
+    start = 0
+    for length in grouped_images_index.sublist_lengths:
+        nested_images.append(images[start : start + length])
+        start += length
+    return nested_images

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -940,7 +940,7 @@ def group_images_by_shape(
     # A batched tensor is already a single group of images sharing the same shape, no need to unbind and re-stack it.
     if not disable_grouping and not is_nested and isinstance(images, torch.Tensor) and len(images) > 0:
         # Choice of key doesn't matter as there is a single group. We keep shape for consistency.
-        key = images.shape[1:]
+        key = images.shape[-2:]
         return (
             {key: images},
             *[{key: None if paired_input is None else list(paired_input)} for paired_input in paired_inputs],
@@ -964,7 +964,7 @@ def group_images_by_shape(
     for sublist_index, sublist in enumerate(nested_images):
         for image_index, image in enumerate(sublist):
             position = (sublist_index, image_index)
-            key = position if disable_grouping else image.shape
+            key = position if disable_grouping else image.shape[-2:]
             group = grouped_images.setdefault(key, [])
             index_in_group = len(group)
             positions[position] = (key, index_in_group)

--- a/src/transformers/models/beit/image_processing_beit.py
+++ b/src/transformers/models/beit/image_processing_beit.py
@@ -158,23 +158,23 @@ class BeitImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Use fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/bridgetower/image_processing_bridgetower.py
+++ b/src/transformers/models/bridgetower/image_processing_bridgetower.py
@@ -147,16 +147,16 @@ class BridgeTowerImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size=size, resample=resample, size_divisor=size_divisor)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(
                     stacked_images, size=SizeDict(height=crop_size.shortest_edge, width=crop_size.shortest_edge)
@@ -165,7 +165,7 @@ class BridgeTowerImageProcessor(TorchvisionBackend):
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/chmv2/image_processing_chmv2.py
+++ b/src/transformers/models/chmv2/image_processing_chmv2.py
@@ -217,7 +217,7 @@ class CHMv2ImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     image=stacked_images,
@@ -226,14 +226,14 @@ class CHMv2ImageProcessor(TorchvisionBackend):
                     ensure_multiple_of=ensure_multiple_of,
                     keep_aspect_ratio=keep_aspect_ratio,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
@@ -242,7 +242,7 @@ class CHMv2ImageProcessor(TorchvisionBackend):
             )
             if do_pad:
                 stacked_images = self.pad_image(stacked_images, size_divisor)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/cohere2_vision/image_processing_cohere2_vision.py
+++ b/src/transformers/models/cohere2_vision/image_processing_cohere2_vision.py
@@ -213,7 +213,7 @@ class Cohere2VisionImageProcessor(TorchvisionBackend):
             grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
             processed_images_grouped = {}
             num_patches = {}
-            for shape, stacked_images in grouped_images.items():
+            for key, stacked_images in grouped_images.items():
                 stacked_images = self.crop_image_to_patches(
                     stacked_images,
                     min_patches,
@@ -221,8 +221,8 @@ class Cohere2VisionImageProcessor(TorchvisionBackend):
                     patch_size=size,
                     resample=resample,
                 )
-                processed_images_grouped[shape] = stacked_images
-                num_patches[shape] = [stacked_images.shape[1]] * stacked_images.shape[0]
+                processed_images_grouped[key] = stacked_images
+                num_patches[key] = [stacked_images.shape[1]] * stacked_images.shape[0]
             images = reorder_images(processed_images_grouped, grouped_images_index)
             images = [image for images_list in images for image in images_list]
             num_patches = reorder_images(num_patches, grouped_images_index)
@@ -232,21 +232,21 @@ class Cohere2VisionImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/cohere_compass/image_processing_cohere_compass.py
+++ b/src/transformers/models/cohere_compass/image_processing_cohere_compass.py
@@ -211,7 +211,7 @@ class CohereCompassImageProcessor(TorchvisionBackend):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -219,13 +219,13 @@ class CohereCompassImageProcessor(TorchvisionBackend):
                     resample=resample,
                     factor=patch_size * merge_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -236,8 +236,8 @@ class CohereCompassImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/convnext/image_processing_convnext.py
+++ b/src/transformers/models/convnext/image_processing_convnext.py
@@ -121,21 +121,21 @@ class ConvNextImageProcessor(TorchvisionBackend):
         """Custom preprocessing for ConvNeXT."""
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample, crop_pct)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/cosmos3_edge/image_processing_cosmos3_edge.py
+++ b/src/transformers/models/cosmos3_edge/image_processing_cosmos3_edge.py
@@ -189,7 +189,7 @@ class Cosmos3EdgeImageProcessor(TorchvisionBackend):
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -198,7 +198,7 @@ class Cosmos3EdgeImageProcessor(TorchvisionBackend):
                     factor=patch_size * merge_size,
                     temporal_factor=temporal_patch_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
 
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
@@ -206,7 +206,7 @@ class Cosmos3EdgeImageProcessor(TorchvisionBackend):
         processed_images_grouped = {}
         processed_grids = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -218,8 +218,8 @@ class Cosmos3EdgeImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/deepseek_vl/image_processing_deepseek_vl.py
+++ b/src/transformers/models/deepseek_vl/image_processing_deepseek_vl.py
@@ -158,24 +158,24 @@ class DeepseekVLImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, min_size=min_size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_pad:
                 stacked_images = self.pad_to_square(stacked_images, background_color=self.background_color)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/deepseek_vl_hybrid/image_processing_deepseek_vl_hybrid.py
+++ b/src/transformers/models/deepseek_vl_hybrid/image_processing_deepseek_vl_hybrid.py
@@ -190,12 +190,12 @@ class DeepseekVLHybridImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         high_res_resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_high_res_images = self.resize(
                     image=stacked_images, size=high_res_size, min_size=min_size, resample=high_res_resample
                 )
-            high_res_resized_images_grouped[shape] = stacked_high_res_images
+            high_res_resized_images_grouped[key] = stacked_high_res_images
         high_res_resized_images = reorder_images(high_res_resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
@@ -205,12 +205,12 @@ class DeepseekVLHybridImageProcessor(TorchvisionBackend):
         )
         high_res_padded_images = {}
         high_res_processed_images_grouped = {}
-        for shape, stacked_high_res_images in grouped_high_res_images.items():
+        for key, stacked_high_res_images in grouped_high_res_images.items():
             if do_pad:
                 stacked_high_res_images = self.pad_to_square(
                     stacked_high_res_images, background_color=self.high_res_background_color
                 )
-                high_res_padded_images[shape] = stacked_high_res_images
+                high_res_padded_images[key] = stacked_high_res_images
             # Fused rescale and normalize
             stacked_high_res_images = self.rescale_and_normalize(
                 stacked_high_res_images,
@@ -220,30 +220,30 @@ class DeepseekVLHybridImageProcessor(TorchvisionBackend):
                 high_res_image_mean,
                 high_res_image_std,
             )
-            high_res_processed_images_grouped[shape] = stacked_high_res_images
+            high_res_processed_images_grouped[key] = stacked_high_res_images
         high_res_processed_images = reorder_images(high_res_processed_images_grouped, grouped_high_res_images_index)
 
         resized_images_grouped = {}
-        for shape, stacked_high_res_padded_images in high_res_padded_images.items():
+        for key, stacked_high_res_padded_images in high_res_padded_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     image=stacked_high_res_padded_images, size=size, min_size=min_size, resample=resample
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_high_res_images_index)
 
         grouped_resized_images, grouped_resized_images_index = group_images_by_shape(
             resized_images, disable_grouping=disable_grouping
         )
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_resized_images.items():
+        for key, stacked_images in grouped_resized_images.items():
             if do_pad:
                 stacked_images = self.pad_to_square(stacked_images, background_color=self.background_color)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_resized_images_index)
 
         return BatchFeature(

--- a/src/transformers/models/deepseek_vl_hybrid/modular_deepseek_vl_hybrid.py
+++ b/src/transformers/models/deepseek_vl_hybrid/modular_deepseek_vl_hybrid.py
@@ -622,12 +622,12 @@ class DeepseekVLHybridImageProcessor(DeepseekVLImageProcessor):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         high_res_resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_high_res_images = self.resize(
                     image=stacked_images, size=high_res_size, min_size=min_size, resample=high_res_resample
                 )
-            high_res_resized_images_grouped[shape] = stacked_high_res_images
+            high_res_resized_images_grouped[key] = stacked_high_res_images
         high_res_resized_images = reorder_images(high_res_resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
@@ -637,12 +637,12 @@ class DeepseekVLHybridImageProcessor(DeepseekVLImageProcessor):
         )
         high_res_padded_images = {}
         high_res_processed_images_grouped = {}
-        for shape, stacked_high_res_images in grouped_high_res_images.items():
+        for key, stacked_high_res_images in grouped_high_res_images.items():
             if do_pad:
                 stacked_high_res_images = self.pad_to_square(
                     stacked_high_res_images, background_color=self.high_res_background_color
                 )
-                high_res_padded_images[shape] = stacked_high_res_images
+                high_res_padded_images[key] = stacked_high_res_images
             # Fused rescale and normalize
             stacked_high_res_images = self.rescale_and_normalize(
                 stacked_high_res_images,
@@ -652,30 +652,30 @@ class DeepseekVLHybridImageProcessor(DeepseekVLImageProcessor):
                 high_res_image_mean,
                 high_res_image_std,
             )
-            high_res_processed_images_grouped[shape] = stacked_high_res_images
+            high_res_processed_images_grouped[key] = stacked_high_res_images
         high_res_processed_images = reorder_images(high_res_processed_images_grouped, grouped_high_res_images_index)
 
         resized_images_grouped = {}
-        for shape, stacked_high_res_padded_images in high_res_padded_images.items():
+        for key, stacked_high_res_padded_images in high_res_padded_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     image=stacked_high_res_padded_images, size=size, min_size=min_size, resample=resample
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_high_res_images_index)
 
         grouped_resized_images, grouped_resized_images_index = group_images_by_shape(
             resized_images, disable_grouping=disable_grouping
         )
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_resized_images.items():
+        for key, stacked_images in grouped_resized_images.items():
             if do_pad:
                 stacked_images = self.pad_to_square(stacked_images, background_color=self.background_color)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_resized_images_index)
 
         return BatchFeature(

--- a/src/transformers/models/depth_pro/image_processing_depth_pro.py
+++ b/src/transformers/models/depth_pro/image_processing_depth_pro.py
@@ -70,7 +70,7 @@ class DepthProImageProcessor(TorchvisionBackend):
         """Custom preprocessing for DepthPro: rescale+normalize FIRST, then resize."""
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Rescale and normalize FIRST
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
@@ -78,7 +78,7 @@ class DepthProImageProcessor(TorchvisionBackend):
             # Then resize (using torch interpolation to handle negative values)
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample, antialias=False)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
 

--- a/src/transformers/models/dinov3_vit/image_processing_dinov3_vit.py
+++ b/src/transformers/models/dinov3_vit/image_processing_dinov3_vit.py
@@ -62,24 +62,24 @@ class DINOv3ViTImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_rescale:
                 stacked_images = self.rescale(stacked_images, rescale_factor)
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample, antialias=True)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             if do_normalize:
                 stacked_images = self.normalize(stacked_images, image_mean, image_std)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/donut/image_processing_donut.py
+++ b/src/transformers/models/donut/image_processing_donut.py
@@ -176,7 +176,7 @@ class DonutImageProcessor(TorchvisionBackend):
         """Custom preprocessing for Donut."""
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_align_long_axis:
                 stacked_images = self.align_long_axis(stacked_images, size)
             if do_resize:
@@ -186,18 +186,18 @@ class DonutImageProcessor(TorchvisionBackend):
                 stacked_images = self.thumbnail(stacked_images, size, resample)
             if do_pad:
                 stacked_images = self.pad_image(stacked_images, size, random_padding=False)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)

--- a/src/transformers/models/dpt/image_processing_dpt.py
+++ b/src/transformers/models/dpt/image_processing_dpt.py
@@ -227,7 +227,7 @@ class DPTImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     image=stacked_images,
@@ -236,14 +236,14 @@ class DPTImageProcessor(TorchvisionBackend):
                     ensure_multiple_of=ensure_multiple_of,
                     keep_aspect_ratio=keep_aspect_ratio,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
@@ -252,7 +252,7 @@ class DPTImageProcessor(TorchvisionBackend):
             )
             if do_pad:
                 stacked_images = self.pad_image(stacked_images, size_divisor)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/dpt/modular_dpt.py
+++ b/src/transformers/models/dpt/modular_dpt.py
@@ -214,7 +214,7 @@ class DPTImageProcessor(BeitImageProcessor):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     image=stacked_images,
@@ -223,14 +223,14 @@ class DPTImageProcessor(BeitImageProcessor):
                     ensure_multiple_of=ensure_multiple_of,
                     keep_aspect_ratio=keep_aspect_ratio,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
@@ -239,7 +239,7 @@ class DPTImageProcessor(BeitImageProcessor):
             )
             if do_pad:
                 stacked_images = self.pad_image(stacked_images, size_divisor)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/efficientloftr/image_processing_efficientloftr.py
+++ b/src/transformers/models/efficientloftr/image_processing_efficientloftr.py
@@ -150,20 +150,20 @@ class EfficientLoFTRImageProcessor(TorchvisionBackend):
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size=size, resample=resample)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         resized_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_rescale:
                 stacked_images = self.rescale(stacked_images, rescale_factor)
             if do_grayscale:
                 stacked_images = convert_to_grayscale(stacked_images)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/efficientnet/image_processing_efficientnet.py
+++ b/src/transformers/models/efficientnet/image_processing_efficientnet.py
@@ -146,15 +146,15 @@ class EfficientNetImageProcessor(TorchvisionBackend):
         """Custom preprocessing for EfficientNet."""
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             stacked_images = self.rescale_and_normalize_efficientnet(
@@ -162,7 +162,7 @@ class EfficientNetImageProcessor(TorchvisionBackend):
             )
             if include_top:
                 stacked_images = self.normalize(stacked_images, 0, image_std)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
 

--- a/src/transformers/models/eomt/image_processing_eomt.py
+++ b/src/transformers/models/eomt/image_processing_eomt.py
@@ -385,38 +385,36 @@ class EomtImageProcessor(TorchvisionBackend):
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         images = reorder_images(resized_images_grouped, grouped_images_index)
 
         if do_split_image:
-            grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
+            # Group the image indices along with the images, as patch offsets refer back to the original image.
+            grouped_images, grouped_indices, _ = group_images_by_shape(
+                images, list(range(len(images))), disable_grouping=disable_grouping
+            )
             patches, patch_offsets = [], []
-            for shape, stacked_images in grouped_images.items():
-                original_indices = [
-                    original_idx for original_idx, (img_shape, _) in grouped_images_index.items() if img_shape == shape
-                ]
-                split_patches, offsets = self._split_image(stacked_images, size, original_indices)
+            for key, stacked_images in grouped_images.items():
+                split_patches, offsets = self._split_image(stacked_images, size, grouped_indices[key])
                 patches.extend(split_patches)
                 patch_offsets.extend(offsets)
             images, patch_offsets = reorder_patches_and_offsets(patches, patch_offsets)
 
         if do_pad:
             grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
-            padded_grouped = {
-                shape: self._pad(stacked_images, size) for shape, stacked_images in grouped_images.items()
-            }
+            padded_grouped = {key: self._pad(stacked_images, size) for key, stacked_images in grouped_images.items()}
             images = reorder_images(padded_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         return processed_images, patch_offsets

--- a/src/transformers/models/ernie4_5_vl_moe/image_processing_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/image_processing_ernie4_5_vl_moe.py
@@ -187,7 +187,7 @@ class Ernie4_5_VLMoeImageProcessor(TorchvisionBackend):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -195,13 +195,13 @@ class Ernie4_5_VLMoeImageProcessor(TorchvisionBackend):
                     resample=resample,
                     factor=patch_size * merge_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -212,8 +212,8 @@ class Ernie4_5_VLMoeImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/flava/image_processing_flava.py
+++ b/src/transformers/models/flava/image_processing_flava.py
@@ -352,17 +352,17 @@ class FlavaImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
@@ -371,7 +371,7 @@ class FlavaImageProcessor(TorchvisionBackend):
             )
             if do_map_pixels:
                 stacked_images = self.map_pixels(image=stacked_images)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/fuyu/image_processing_fuyu.py
+++ b/src/transformers/models/fuyu/image_processing_fuyu.py
@@ -168,10 +168,10 @@ class FuyuImageProcessor(TorchvisionBackend):
             images, disable_grouping=disable_grouping, is_nested=True
         )
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         image_sizes = [batch_image[0].shape[-2:] for batch_image in resized_images if batch_image]
@@ -196,12 +196,12 @@ class FuyuImageProcessor(TorchvisionBackend):
             resized_images, disable_grouping=disable_grouping, is_nested=True
         )
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         images_tensor = torch.stack([torch.stack(batch) for batch in processed_images if batch])

--- a/src/transformers/models/fuyu/image_processing_fuyu.py
+++ b/src/transformers/models/fuyu/image_processing_fuyu.py
@@ -172,7 +172,7 @@ class FuyuImageProcessor(TorchvisionBackend):
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
             resized_images_grouped[shape] = stacked_images
-        resized_images = reorder_images(resized_images_grouped, grouped_images_index, is_nested=True)
+        resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         image_sizes = [batch_image[0].shape[-2:] for batch_image in resized_images if batch_image]
         image_unpadded_heights = [[image_size[0]] for image_size in image_sizes]
@@ -202,7 +202,7 @@ class FuyuImageProcessor(TorchvisionBackend):
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
             processed_images_grouped[shape] = stacked_images
-        processed_images = reorder_images(processed_images_grouped, grouped_images_index, is_nested=True)
+        processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         images_tensor = torch.stack([torch.stack(batch) for batch in processed_images if batch])
         return BatchFeature(

--- a/src/transformers/models/gemma3/image_processing_gemma3.py
+++ b/src/transformers/models/gemma3/image_processing_gemma3.py
@@ -187,7 +187,7 @@ class Gemma3ImageProcessor(TorchvisionBackend):
         processed_images_grouped = {}
         num_crops_grouped = {}
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
-        for shape_images, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_pan_and_scan:
                 pas_images, num_crops = self._process_images_for_pan_and_scan(
                     images=stacked_images,
@@ -203,13 +203,13 @@ class Gemma3ImageProcessor(TorchvisionBackend):
                 grouped_image_patches, grouped_image_patches_index = group_images_by_shape(
                     stacked_images, disable_grouping=disable_grouping
                 )
-                for shape, stacked_image_patches in grouped_image_patches.items():
+                for patches_key, stacked_image_patches in grouped_image_patches.items():
                     stacked_image_patches = self.resize(
                         image=stacked_image_patches,
                         size=size,
                         resample=resample,
                     )
-                    processed_image_patches_grouped[shape] = stacked_image_patches
+                    processed_image_patches_grouped[patches_key] = stacked_image_patches
                 processed_image_patches = reorder_images(processed_image_patches_grouped, grouped_image_patches_index)
                 # Transpose to have the thumbnails with their corresponding patches
                 stacked_images = torch.stack(processed_image_patches, dim=0).transpose(0, 1).contiguous()
@@ -222,8 +222,8 @@ class Gemma3ImageProcessor(TorchvisionBackend):
                         size=size,
                         resample=resample,
                     )
-            num_crops_grouped[shape_images] = num_crops
-            processed_images_grouped[shape_images] = stacked_images
+            num_crops_grouped[key] = num_crops
+            processed_images_grouped[key] = stacked_images
         resized_images = reorder_images(processed_images_grouped, grouped_images_index)
         # If pan and scan is enabled, we need to flatten the list of images
         if do_pan_and_scan:
@@ -234,12 +234,12 @@ class Gemma3ImageProcessor(TorchvisionBackend):
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         return BatchFeature(

--- a/src/transformers/models/glm46v/image_processing_glm46v.py
+++ b/src/transformers/models/glm46v/image_processing_glm46v.py
@@ -190,7 +190,7 @@ class Glm46VImageProcessor(TorchvisionBackend):
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -199,7 +199,7 @@ class Glm46VImageProcessor(TorchvisionBackend):
                     factor=patch_size * merge_size,
                     temporal_factor=temporal_patch_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
 
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
@@ -207,7 +207,7 @@ class Glm46VImageProcessor(TorchvisionBackend):
         processed_images_grouped = {}
         processed_grids = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -219,8 +219,8 @@ class Glm46VImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/glm4v/image_processing_glm4v.py
+++ b/src/transformers/models/glm4v/image_processing_glm4v.py
@@ -193,7 +193,7 @@ class Glm4vImageProcessor(TorchvisionBackend):
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -202,7 +202,7 @@ class Glm4vImageProcessor(TorchvisionBackend):
                     factor=patch_size * merge_size,
                     temporal_factor=temporal_patch_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
 
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
@@ -210,7 +210,7 @@ class Glm4vImageProcessor(TorchvisionBackend):
         processed_images_grouped = {}
         processed_grids = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -222,8 +222,8 @@ class Glm4vImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/glm_image/image_processing_glm_image.py
+++ b/src/transformers/models/glm_image/image_processing_glm_image.py
@@ -223,7 +223,7 @@ class GlmImageImageProcessor(TorchvisionBackend):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -231,13 +231,13 @@ class GlmImageImageProcessor(TorchvisionBackend):
                     resample=resample,
                     factor=patch_size * merge_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -248,8 +248,8 @@ class GlmImageImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/glmga/image_processing_glmga.py
+++ b/src/transformers/models/glmga/image_processing_glmga.py
@@ -194,7 +194,7 @@ class GlmgaImageProcessor(TorchvisionBackend):
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -203,14 +203,14 @@ class GlmgaImageProcessor(TorchvisionBackend):
                     factor=patch_size * merge_size * patch_expand_factor,
                     temporal_factor=temporal_patch_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -221,8 +221,8 @@ class GlmgaImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/glmga/modular_glmga.py
+++ b/src/transformers/models/glmga/modular_glmga.py
@@ -111,7 +111,7 @@ class GlmgaImageProcessor(Glm46VImageProcessor):
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -120,14 +120,14 @@ class GlmgaImageProcessor(Glm46VImageProcessor):
                     factor=patch_size * merge_size * patch_expand_factor,
                     temporal_factor=temporal_patch_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -138,8 +138,8 @@ class GlmgaImageProcessor(Glm46VImageProcessor):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/glpn/image_processing_glpn.py
+++ b/src/transformers/models/glpn/image_processing_glpn.py
@@ -113,13 +113,13 @@ class GLPNImageProcessor(TorchvisionBackend):
         """Custom preprocessing for GLPN."""
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample, size_divisor=size_divisor)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
 

--- a/src/transformers/models/got_ocr2/image_processing_got_ocr2.py
+++ b/src/transformers/models/got_ocr2/image_processing_got_ocr2.py
@@ -227,7 +227,7 @@ class GotOcr2ImageProcessor(TorchvisionBackend):
             grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
             processed_images_grouped = {}
             num_patches = {}
-            for shape, stacked_images in grouped_images.items():
+            for key, stacked_images in grouped_images.items():
                 stacked_images = self.crop_image_to_patches(
                     stacked_images,
                     min_patches,
@@ -235,8 +235,8 @@ class GotOcr2ImageProcessor(TorchvisionBackend):
                     patch_size=size,
                     resample=resample,
                 )
-                processed_images_grouped[shape] = stacked_images
-                num_patches[shape] = [stacked_images.shape[1]] * stacked_images.shape[0]
+                processed_images_grouped[key] = stacked_images
+                num_patches[key] = [stacked_images.shape[1]] * stacked_images.shape[0]
             images = reorder_images(processed_images_grouped, grouped_images_index)
             images = [image for images_list in images for image in images_list]
             num_patches = reorder_images(num_patches, grouped_images_index)
@@ -246,21 +246,21 @@ class GotOcr2ImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/hunyuan_vl/image_processing_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/image_processing_hunyuan_vl.py
@@ -216,7 +216,7 @@ class HunYuanVLImageProcessor(TorchvisionBackend):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -224,13 +224,13 @@ class HunYuanVLImageProcessor(TorchvisionBackend):
                     resample=resample,
                     factor=patch_size * merge_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -241,8 +241,8 @@ class HunYuanVLImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/idefics2/image_processing_idefics2.py
+++ b/src/transformers/models/idefics2/image_processing_idefics2.py
@@ -225,10 +225,10 @@ class Idefics2ImageProcessor(TorchvisionBackend):
             images, disable_grouping=disable_grouping, is_nested=True
         )
         split_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_image_splitting:
                 stacked_images = self.split_images(stacked_images)
-            split_images_grouped[shape] = stacked_images
+            split_images_grouped[key] = stacked_images
         split_images = reorder_images(split_images_grouped, grouped_images_index)
         if do_image_splitting:
             for i, group_images in enumerate(split_images):
@@ -238,21 +238,21 @@ class Idefics2ImageProcessor(TorchvisionBackend):
             split_images, disable_grouping=disable_grouping, is_nested=True
         )
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(
             resized_images, disable_grouping=disable_grouping, is_nested=True
         )
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         if do_pad:

--- a/src/transformers/models/idefics2/image_processing_idefics2.py
+++ b/src/transformers/models/idefics2/image_processing_idefics2.py
@@ -229,7 +229,7 @@ class Idefics2ImageProcessor(TorchvisionBackend):
             if do_image_splitting:
                 stacked_images = self.split_images(stacked_images)
             split_images_grouped[shape] = stacked_images
-        split_images = reorder_images(split_images_grouped, grouped_images_index, is_nested=True)
+        split_images = reorder_images(split_images_grouped, grouped_images_index)
         if do_image_splitting:
             for i, group_images in enumerate(split_images):
                 split_images[i] = [image for sublist in group_images for image in sublist]
@@ -242,7 +242,7 @@ class Idefics2ImageProcessor(TorchvisionBackend):
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample=resample)
             resized_images_grouped[shape] = stacked_images
-        resized_images = reorder_images(resized_images_grouped, grouped_images_index, is_nested=True)
+        resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(
             resized_images, disable_grouping=disable_grouping, is_nested=True
@@ -253,7 +253,7 @@ class Idefics2ImageProcessor(TorchvisionBackend):
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
             processed_images_grouped[shape] = stacked_images
-        processed_images = reorder_images(processed_images_grouped, grouped_images_index, is_nested=True)
+        processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         if do_pad:
             max_num_images = max(len(images_) for images_ in processed_images)

--- a/src/transformers/models/idefics3/image_processing_idefics3.py
+++ b/src/transformers/models/idefics3/image_processing_idefics3.py
@@ -408,7 +408,7 @@ class Idefics3ImageProcessor(TorchvisionBackend):
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample=resample)
             resized_images_grouped[shape] = stacked_images
-        resized_images = reorder_images(resized_images_grouped, grouped_images_index, is_nested=True)
+        resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(
             resized_images, is_nested=True, disable_grouping=disable_grouping
@@ -427,9 +427,9 @@ class Idefics3ImageProcessor(TorchvisionBackend):
                 split_images_grouped[shape] = stacked_images
                 rows_grouped[shape] = rows
                 cols_grouped[shape] = cols
-            processed_images = reorder_images(split_images_grouped, grouped_images_index, is_nested=True)
-            rows = reorder_images(rows_grouped, grouped_images_index, is_nested=True)
-            cols = reorder_images(cols_grouped, grouped_images_index, is_nested=True)
+            processed_images = reorder_images(split_images_grouped, grouped_images_index)
+            rows = reorder_images(rows_grouped, grouped_images_index)
+            cols = reorder_images(cols_grouped, grouped_images_index)
             # flattenened the doubly nested list to a nested list
             for i, group_images in enumerate(processed_images):
                 processed_images[i] = [image for sublist in group_images for image in sublist]
@@ -442,7 +442,7 @@ class Idefics3ImageProcessor(TorchvisionBackend):
                     resample=resample,
                 )
                 split_images_grouped[shape] = stacked_images
-            processed_images = reorder_images(split_images_grouped, grouped_images_index, is_nested=True)
+            processed_images = reorder_images(split_images_grouped, grouped_images_index)
             rows = [[0] * len(images) for images in processed_images]
             cols = [[0] * len(images) for images in processed_images]
         # Group images by size for further processing
@@ -457,7 +457,7 @@ class Idefics3ImageProcessor(TorchvisionBackend):
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
             processed_images_grouped[shape] = stacked_images
-        processed_images = reorder_images(processed_images_grouped, grouped_images_index, is_nested=True)
+        processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         if do_pad:
             # Get max images per batch
             max_num_images = max(len(images_) for images_ in processed_images)

--- a/src/transformers/models/idefics3/image_processing_idefics3.py
+++ b/src/transformers/models/idefics3/image_processing_idefics3.py
@@ -404,10 +404,10 @@ class Idefics3ImageProcessor(TorchvisionBackend):
             images, is_nested=True, disable_grouping=disable_grouping
         )
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(
@@ -417,16 +417,16 @@ class Idefics3ImageProcessor(TorchvisionBackend):
         if do_image_splitting:
             rows_grouped = {}
             cols_grouped = {}
-            for shape, stacked_images in grouped_images.items():
+            for key, stacked_images in grouped_images.items():
                 stacked_images = self.resize_for_vision_encoder(
                     stacked_images, max_image_size["longest_edge"], resample=resample
                 )
                 stacked_images, rows, cols = self.split_images(
                     stacked_images, max_image_size=max_image_size, resample=resample
                 )
-                split_images_grouped[shape] = stacked_images
-                rows_grouped[shape] = rows
-                cols_grouped[shape] = cols
+                split_images_grouped[key] = stacked_images
+                rows_grouped[key] = rows
+                cols_grouped[key] = cols
             processed_images = reorder_images(split_images_grouped, grouped_images_index)
             rows = reorder_images(rows_grouped, grouped_images_index)
             cols = reorder_images(cols_grouped, grouped_images_index)
@@ -434,14 +434,14 @@ class Idefics3ImageProcessor(TorchvisionBackend):
             for i, group_images in enumerate(processed_images):
                 processed_images[i] = [image for sublist in group_images for image in sublist]
         else:
-            for shape, stacked_images in grouped_images.items():
+            for key, stacked_images in grouped_images.items():
                 # We square the images to max_image_size
                 stacked_images = self.resize(
                     image=stacked_images,
                     size=SizeDict(height=max_image_size["longest_edge"], width=max_image_size["longest_edge"]),
                     resample=resample,
                 )
-                split_images_grouped[shape] = stacked_images
+                split_images_grouped[key] = stacked_images
             processed_images = reorder_images(split_images_grouped, grouped_images_index)
             rows = [[0] * len(images) for images in processed_images]
             cols = [[0] * len(images) for images in processed_images]
@@ -451,12 +451,12 @@ class Idefics3ImageProcessor(TorchvisionBackend):
             processed_images, is_nested=True, disable_grouping=disable_grouping
         )
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         if do_pad:
             # Get max images per batch

--- a/src/transformers/models/imagegpt/image_processing_imagegpt.py
+++ b/src/transformers/models/imagegpt/image_processing_imagegpt.py
@@ -127,24 +127,24 @@ class ImageGPTImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         pixel_values = reorder_images(processed_images_grouped, grouped_images_index)
 
@@ -166,11 +166,11 @@ class ImageGPTImageProcessor(TorchvisionBackend):
             # Process each group
             input_ids_grouped = {}
 
-            for shape, stacked_images in grouped_images.items():
+            for key, stacked_images in grouped_images.items():
                 input_ids = color_quantize_torch(
                     stacked_images.permute(0, 2, 3, 1).reshape(-1, 3), clusters_torch
                 )  # (B*H*W, C)
-                input_ids_grouped[shape] = input_ids.reshape(stacked_images.shape[0], -1).reshape(
+                input_ids_grouped[key] = input_ids.reshape(stacked_images.shape[0], -1).reshape(
                     stacked_images.shape[0], -1
                 )  # (B, H, W)
 

--- a/src/transformers/models/janus/image_processing_janus.py
+++ b/src/transformers/models/janus/image_processing_janus.py
@@ -161,24 +161,24 @@ class JanusImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, min_size=min_size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_pad:
                 stacked_images = self.pad_to_square(stacked_images, background_color=self.background_color)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/kimi_k25/image_processing_kimi_k25.py
+++ b/src/transformers/models/kimi_k25/image_processing_kimi_k25.py
@@ -169,7 +169,7 @@ class Kimi_K25ImageProcessor(TorchvisionBackend):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             height, width = stacked_images.shape[-2:]
             if do_resize:
                 (resized_height, resized_width), (pad_height, pad_width) = navit_resize(
@@ -186,13 +186,13 @@ class Kimi_K25ImageProcessor(TorchvisionBackend):
                     resample=resample,
                 )
                 stacked_images = self.pad(stacked_images, pad_size=SizeDict(height=pad_height, width=pad_width))
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             resized_height, resized_width = stacked_images.shape[-2:]
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
@@ -203,8 +203,8 @@ class Kimi_K25ImageProcessor(TorchvisionBackend):
                 patch_size=patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/kosmos2_5/image_processing_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/image_processing_kosmos2_5.py
@@ -221,7 +221,7 @@ class Kosmos2_5ImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         processed_image_patches_grouped = {}
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_normalize:
                 stacked_images = self.normalize(stacked_images, **kwargs)
 
@@ -237,8 +237,8 @@ class Kosmos2_5ImageProcessor(TorchvisionBackend):
             cols.extend([n_columns] * n_of_stacked_images)
             # create attention mask
             attention_masks.extend(list((patches.sum(axis=-1) != 0).to(dtype=torch.float32)))
-            processed_image_patches_grouped[shape] = list(patches)
-            for x in processed_image_patches_grouped[shape]:
+            processed_image_patches_grouped[key] = list(patches)
+            for x in processed_image_patches_grouped[key]:
                 current_index += 1
                 obj_idx_to_new_index_map[id(x)] = current_index
 

--- a/src/transformers/models/layoutlmv2/image_processing_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/image_processing_layoutlmv2.py
@@ -164,20 +164,20 @@ class LayoutLMv2ImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # flip color channels from RGB to BGR (as Detectron2 requires this)
             stacked_images = stacked_images.flip(1)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/layoutlmv3/image_processing_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/image_processing_layoutlmv3.py
@@ -180,24 +180,24 @@ class LayoutLMv3ImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/lfm2_vl/image_processing_lfm2_vl.py
+++ b/src/transformers/models/lfm2_vl/image_processing_lfm2_vl.py
@@ -537,12 +537,12 @@ class Lfm2VlImageProcessor(TorchvisionBackend):
 
             processed_images_grouped[shape] = stacked_images
 
-        processed_images = reorder_images(processed_images_grouped, grouped_images_index, is_nested=True)
+        processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         data = {"pixel_values": torch.cat([torch.stack(images) for images in processed_images])}
 
         if do_pad:
-            processed_masks = reorder_images(processed_masks, grouped_images_index, is_nested=True)
-            processed_spatial_shapes = reorder_images(processed_spatial_shapes, grouped_images_index, is_nested=True)
+            processed_masks = reorder_images(processed_masks, grouped_images_index)
+            processed_spatial_shapes = reorder_images(processed_spatial_shapes, grouped_images_index)
             processed_masks = torch.cat([torch.stack(masks) for masks in processed_masks])
             processed_spatial_shapes = torch.cat(
                 [torch.tensor(spatial_shape) for spatial_shape in processed_spatial_shapes]

--- a/src/transformers/models/lfm2_vl/image_processing_lfm2_vl.py
+++ b/src/transformers/models/lfm2_vl/image_processing_lfm2_vl.py
@@ -482,7 +482,7 @@ class Lfm2VlImageProcessor(TorchvisionBackend):
         resized_images_grouped = {}
         resized_image_sizes = {}
         rows_grouped, cols_grouped = {}, {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             num_rows = [1] * stacked_images.shape[0]
             num_cols = [1] * stacked_images.shape[0]
             height, width = stacked_images.shape[-2:]
@@ -504,10 +504,10 @@ class Lfm2VlImageProcessor(TorchvisionBackend):
                     resample=resample,
                 )
 
-            rows_grouped[shape] = num_rows
-            cols_grouped[shape] = num_cols
-            resized_image_sizes[shape] = image_sizes
-            resized_images_grouped[shape] = stacked_images
+            rows_grouped[key] = num_rows
+            cols_grouped[key] = num_cols
+            resized_image_sizes[key] = image_sizes
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
         batch_rows = reorder_images(rows_grouped, grouped_images_index)
         batch_cols = reorder_images(cols_grouped, grouped_images_index)
@@ -519,7 +519,7 @@ class Lfm2VlImageProcessor(TorchvisionBackend):
 
         processed_images_grouped = {}
         processed_masks, processed_spatial_shapes = {}, {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
@@ -529,13 +529,13 @@ class Lfm2VlImageProcessor(TorchvisionBackend):
             num_patches_width = width // encoder_patch_size
 
             stacked_images = convert_image_to_patches(stacked_images, encoder_patch_size)
-            processed_spatial_shapes[shape] = [[num_patches_height, num_patches_width]] * batch_size
+            processed_spatial_shapes[key] = [[num_patches_height, num_patches_width]] * batch_size
 
             if do_pad:
                 stacked_images, pixel_mask = pad_along_first_dim(stacked_images, max_num_patches)
-                processed_masks[shape] = [pixel_mask] * batch_size
+                processed_masks[key] = [pixel_mask] * batch_size
 
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         data = {"pixel_values": torch.cat([torch.stack(images) for images in processed_images])}

--- a/src/transformers/models/lightglue/image_processing_lightglue.py
+++ b/src/transformers/models/lightglue/image_processing_lightglue.py
@@ -161,20 +161,20 @@ class LightGlueImageProcessor(TorchvisionBackend):
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size=size, resample=resample)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         resized_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_rescale:
                 stacked_images = self.rescale(stacked_images, rescale_factor)
             if do_grayscale:
                 stacked_images = convert_to_grayscale(stacked_images)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/llama4/image_processing_llama4.py
+++ b/src/transformers/models/llama4/image_processing_llama4.py
@@ -367,7 +367,7 @@ class Llama4ImageProcessor(TorchvisionBackend):
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         grouped_processed_images = {}
         grouped_aspect_ratios = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             image_size = stacked_images.shape[-2:]
             target_size = get_best_fit(image_size, possible_resolutions, resize_to_max_canvas=resize_to_max_canvas)
             # If target_size requires upscaling, we might want to limit the upscaling to max_upscaling_size
@@ -403,8 +403,8 @@ class Llama4ImageProcessor(TorchvisionBackend):
             )
             # split into tiles
             processed_images = split_to_tiles(processed_images, ratio_h, ratio_w)
-            grouped_processed_images[shape] = processed_images
-            grouped_aspect_ratios[shape] = torch.tensor(
+            grouped_processed_images[key] = processed_images
+            grouped_aspect_ratios[key] = torch.tensor(
                 [[ratio_h, ratio_w]] * stacked_images.shape[0], device=images[0].device
             )
 
@@ -418,7 +418,7 @@ class Llama4ImageProcessor(TorchvisionBackend):
                 global_tiles = self.rescale_and_normalize(
                     global_tiles, do_rescale, rescale_factor, do_normalize, image_mean, image_std
                 )
-                grouped_processed_images[shape] = torch.cat([processed_images, global_tiles.unsqueeze(1)], dim=1)
+                grouped_processed_images[key] = torch.cat([processed_images, global_tiles.unsqueeze(1)], dim=1)
         processed_images = reorder_images(grouped_processed_images, grouped_images_index)
         aspect_ratios = reorder_images(grouped_aspect_ratios, grouped_images_index)
 

--- a/src/transformers/models/llava/image_processing_llava.py
+++ b/src/transformers/models/llava/image_processing_llava.py
@@ -116,36 +116,36 @@ class LlavaImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_pad:
                 stacked_images = self.pad_to_square(
                     images=stacked_images, background_color=tuple(int(x * 255) for x in image_mean)
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         padded_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for batched resizing
         # Needed in case do_pad is False, or padding returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(padded_images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/llava_next/image_processing_llava_next.py
+++ b/src/transformers/models/llava_next/image_processing_llava_next.py
@@ -210,7 +210,7 @@ class LlavaNextImageProcessor(TorchvisionBackend):
             grouped_image_patches, grouped_image_patches_index = group_images_by_shape(
                 image_patches, disable_grouping=disable_grouping
             )
-            for shape, stacked_image_patches in grouped_image_patches.items():
+            for key, stacked_image_patches in grouped_image_patches.items():
                 if do_resize:
                     stacked_image_patches = self.resize(
                         image=stacked_image_patches,
@@ -226,7 +226,7 @@ class LlavaNextImageProcessor(TorchvisionBackend):
                 stacked_image_patches = self.rescale_and_normalize(
                     stacked_image_patches, do_rescale, rescale_factor, do_normalize, image_mean_tuple, image_std_tuple
                 )
-                processed_image_patches_grouped[shape] = stacked_image_patches
+                processed_image_patches_grouped[key] = stacked_image_patches
             processed_image_patches = reorder_images(processed_image_patches_grouped, grouped_image_patches_index)
             processed_image_patches = torch.stack(processed_image_patches, dim=0)
             processed_images.append(processed_image_patches)

--- a/src/transformers/models/llava_onevision/image_processing_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/image_processing_llava_onevision.py
@@ -226,7 +226,7 @@ class LlavaOnevisionImageProcessor(TorchvisionBackend):
             grouped_image_patches, grouped_image_patches_index = group_images_by_shape(
                 image_patches, disable_grouping=disable_grouping
             )
-            for shape, stacked_image_patches in grouped_image_patches.items():
+            for key, stacked_image_patches in grouped_image_patches.items():
                 if do_resize:
                     stacked_image_patches = self.resize(
                         image=stacked_image_patches,
@@ -239,7 +239,7 @@ class LlavaOnevisionImageProcessor(TorchvisionBackend):
                 stacked_image_patches = self.rescale_and_normalize(
                     stacked_image_patches, do_rescale, rescale_factor, do_normalize, image_mean, image_std
                 )
-                processed_image_patches_grouped[shape] = stacked_image_patches
+                processed_image_patches_grouped[key] = stacked_image_patches
             processed_image_patches = reorder_images(processed_image_patches_grouped, grouped_image_patches_index)
             processed_image_patches = torch.stack(processed_image_patches, dim=0)
             processed_images.append(processed_image_patches)

--- a/src/transformers/models/llava_onevision/modular_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/modular_llava_onevision.py
@@ -190,7 +190,7 @@ class LlavaOnevisionImageProcessor(LlavaNextImageProcessor):
             grouped_image_patches, grouped_image_patches_index = group_images_by_shape(
                 image_patches, disable_grouping=disable_grouping
             )
-            for shape, stacked_image_patches in grouped_image_patches.items():
+            for key, stacked_image_patches in grouped_image_patches.items():
                 if do_resize:
                     stacked_image_patches = self.resize(
                         image=stacked_image_patches,
@@ -203,7 +203,7 @@ class LlavaOnevisionImageProcessor(LlavaNextImageProcessor):
                 stacked_image_patches = self.rescale_and_normalize(
                     stacked_image_patches, do_rescale, rescale_factor, do_normalize, image_mean, image_std
                 )
-                processed_image_patches_grouped[shape] = stacked_image_patches
+                processed_image_patches_grouped[key] = stacked_image_patches
             processed_image_patches = reorder_images(processed_image_patches_grouped, grouped_image_patches_index)
             processed_image_patches = torch.stack(processed_image_patches, dim=0)
             processed_images.append(processed_image_patches)

--- a/src/transformers/models/mask2former/image_processing_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_mask2former.py
@@ -459,13 +459,13 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                 segmentation_maps, disable_grouping=disable_grouping
             )
             resized_segmentation_maps_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     image=stacked_images, size=size, size_divisor=size_divisor, resample=resample
                 )
             if segmentation_maps is not None:
-                stacked_segmentation_maps = grouped_segmentation_maps[shape]
+                stacked_segmentation_maps = grouped_segmentation_maps[key]
                 if do_resize:
                     stacked_segmentation_maps = self.resize(
                         image=stacked_segmentation_maps,
@@ -473,9 +473,9 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
                         size_divisor=size_divisor,
                         resample=tvF.InterpolationMode.NEAREST_EXACT,
                     )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
             if segmentation_maps is not None:
-                resized_segmentation_maps_grouped[shape] = stacked_segmentation_maps
+                resized_segmentation_maps_grouped[key] = stacked_segmentation_maps
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
         if segmentation_maps is not None:
             resized_segmentation_maps = reorder_images(
@@ -517,21 +517,21 @@ class Mask2FormerImageProcessor(TorchvisionBackend):
             )
         processed_images_grouped = {}
         processed_pixel_masks_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
             padded_images, pixel_masks, padded_segmentation_maps = self.pad(
                 images=stacked_images,
-                segmentation_maps=grouped_segmentation_maps[shape] if segmentation_maps is not None else None,
+                segmentation_maps=grouped_segmentation_maps[key] if segmentation_maps is not None else None,
                 padded_size=padded_size,
                 ignore_index=ignore_index,
             )
-            processed_images_grouped[shape] = padded_images
-            processed_pixel_masks_grouped[shape] = pixel_masks
+            processed_images_grouped[key] = padded_images
+            processed_pixel_masks_grouped[key] = pixel_masks
             if segmentation_maps is not None:
-                processed_segmentation_maps_grouped[shape] = padded_segmentation_maps
+                processed_segmentation_maps_grouped[key] = padded_segmentation_maps
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_pixel_masks = reorder_images(processed_pixel_masks_grouped, grouped_images_index)

--- a/src/transformers/models/maskformer/image_processing_maskformer.py
+++ b/src/transformers/models/maskformer/image_processing_maskformer.py
@@ -455,13 +455,13 @@ class MaskFormerImageProcessor(TorchvisionBackend):
                 segmentation_maps, disable_grouping=disable_grouping
             )
             resized_segmentation_maps_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     image=stacked_images, size=size, size_divisor=size_divisor, resample=resample
                 )
             if segmentation_maps is not None:
-                stacked_segmentation_maps = grouped_segmentation_maps[shape]
+                stacked_segmentation_maps = grouped_segmentation_maps[key]
                 if do_resize:
                     stacked_segmentation_maps = self.resize(
                         image=stacked_segmentation_maps,
@@ -469,9 +469,9 @@ class MaskFormerImageProcessor(TorchvisionBackend):
                         size_divisor=size_divisor,
                         resample=tvF.InterpolationMode.NEAREST_EXACT,
                     )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
             if segmentation_maps is not None:
-                resized_segmentation_maps_grouped[shape] = stacked_segmentation_maps
+                resized_segmentation_maps_grouped[key] = stacked_segmentation_maps
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
         if segmentation_maps is not None:
             resized_segmentation_maps = reorder_images(
@@ -513,21 +513,21 @@ class MaskFormerImageProcessor(TorchvisionBackend):
             )
         processed_images_grouped = {}
         processed_pixel_masks_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
             padded_images, pixel_masks, padded_segmentation_maps = self.pad(
                 images=stacked_images,
-                segmentation_maps=grouped_segmentation_maps[shape] if segmentation_maps is not None else None,
+                segmentation_maps=grouped_segmentation_maps[key] if segmentation_maps is not None else None,
                 padded_size=padded_size,
                 ignore_index=ignore_index,
             )
-            processed_images_grouped[shape] = padded_images
-            processed_pixel_masks_grouped[shape] = pixel_masks
+            processed_images_grouped[key] = padded_images
+            processed_pixel_masks_grouped[key] = pixel_masks
             if segmentation_maps is not None:
-                processed_segmentation_maps_grouped[shape] = padded_segmentation_maps
+                processed_segmentation_maps_grouped[key] = padded_segmentation_maps
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_pixel_masks = reorder_images(processed_pixel_masks_grouped, grouped_images_index)

--- a/src/transformers/models/minicpmv4_6/image_processing_minicpmv4_6.py
+++ b/src/transformers/models/minicpmv4_6/image_processing_minicpmv4_6.py
@@ -227,11 +227,11 @@ class MiniCPMV4_6ImageProcessor(TorchvisionBackend):
             # Group patches by shape and batch rescale + normalize
             grouped_patches, grouped_index = group_images_by_shape(image_patches, disable_grouping=disable_grouping)
             processed_grouped = {}
-            for shape, stacked in grouped_patches.items():
+            for key, stacked in grouped_patches.items():
                 stacked = self.rescale_and_normalize(
                     stacked.float(), do_rescale, rescale_factor, do_normalize, image_mean, image_std
                 )
-                processed_grouped[shape] = stacked
+                processed_grouped[key] = stacked
             processed_patches = reorder_images(processed_grouped, grouped_index)
 
             image_pv = [self.reshape_by_patch(processed_patches[0], patch_size)]

--- a/src/transformers/models/minimax_m3_vl/image_processing_minimax_m3_vl.py
+++ b/src/transformers/models/minimax_m3_vl/image_processing_minimax_m3_vl.py
@@ -215,7 +215,7 @@ class MiniMaxM3VLImageProcessor(TorchvisionBackend):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -223,13 +223,13 @@ class MiniMaxM3VLImageProcessor(TorchvisionBackend):
                     resample=resample,
                     factor=patch_size * merge_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -240,8 +240,8 @@ class MiniMaxM3VLImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/mllama/image_processing_mllama.py
+++ b/src/transformers/models/mllama/image_processing_mllama.py
@@ -515,8 +515,8 @@ class MllamaImageProcessor(TorchvisionBackend):
             )
             split_images_grouped[shape] = split_images
 
-        split_images = reorder_images(split_images_grouped, grouped_images_index, is_nested=True)
-        aspect_ratios = reorder_images(aspect_ratio_grouped, grouped_images_index, is_nested=True)
+        split_images = reorder_images(split_images_grouped, grouped_images_index)
+        aspect_ratios = reorder_images(aspect_ratio_grouped, grouped_images_index)
 
         split_images, num_tiles = pad_batches_and_tiles(split_images, max_image_tiles)
 

--- a/src/transformers/models/mllama/image_processing_mllama.py
+++ b/src/transformers/models/mllama/image_processing_mllama.py
@@ -495,7 +495,7 @@ class MllamaImageProcessor(TorchvisionBackend):
         )
         split_images_grouped = {}
         aspect_ratio_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images, aspect_ratio = self.resize(
                 image=stacked_images, size=size, resample=resample, max_image_tiles=max_image_tiles
             )
@@ -505,7 +505,7 @@ class MllamaImageProcessor(TorchvisionBackend):
                 aspect_ratio=aspect_ratio,
             )
             num_tiles_height, num_tiles_width = aspect_ratio
-            aspect_ratio_grouped[shape] = [aspect_ratio] * len(stacked_images)
+            aspect_ratio_grouped[key] = [aspect_ratio] * len(stacked_images)
             # same aspect ratio for all images in the batch
             split_images = split_to_tiles(stacked_images, num_tiles_height, num_tiles_width)
 
@@ -513,7 +513,7 @@ class MllamaImageProcessor(TorchvisionBackend):
             split_images = self.rescale_and_normalize(
                 split_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            split_images_grouped[shape] = split_images
+            split_images_grouped[key] = split_images
 
         split_images = reorder_images(split_images_grouped, grouped_images_index)
         aspect_ratios = reorder_images(aspect_ratio_grouped, grouped_images_index)

--- a/src/transformers/models/mobilenet_v2/image_processing_mobilenet_v2.py
+++ b/src/transformers/models/mobilenet_v2/image_processing_mobilenet_v2.py
@@ -162,21 +162,21 @@ class MobileNetV2ImageProcessor(TorchvisionBackend):
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         return processed_images

--- a/src/transformers/models/mobilevit/image_processing_mobilevit.py
+++ b/src/transformers/models/mobilevit/image_processing_mobilevit.py
@@ -186,22 +186,22 @@ class MobileViTImageProcessor(TorchvisionBackend):
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             if do_rescale:
                 stacked_images = self.rescale(stacked_images, rescale_factor)
             if do_flip_channel_order:
                 stacked_images = self.flip_channel_order(stacked_images)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         return processed_images
 

--- a/src/transformers/models/muse_glimmer/image_processing_muse_glimmer.py
+++ b/src/transformers/models/muse_glimmer/image_processing_muse_glimmer.py
@@ -187,7 +187,7 @@ class MuseGlimmerImageProcessor(TorchvisionBackend):
         """
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 # Unlike Glm4v's `smart_resize`, the target size keeps aspect ratio under a token cap.
                 stacked_images = self.resize(
@@ -197,13 +197,13 @@ class MuseGlimmerImageProcessor(TorchvisionBackend):
                     max_tokens=max_image_tokens,
                     resample=resample,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -213,8 +213,8 @@ class MuseGlimmerImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/muse_glimmer/modular_muse_glimmer.py
+++ b/src/transformers/models/muse_glimmer/modular_muse_glimmer.py
@@ -219,7 +219,7 @@ class MuseGlimmerImageProcessor(Glm4vImageProcessor):
         """
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 # Unlike Glm4v's `smart_resize`, the target size keeps aspect ratio under a token cap.
                 stacked_images = self.resize(
@@ -229,13 +229,13 @@ class MuseGlimmerImageProcessor(Glm4vImageProcessor):
                     max_tokens=max_image_tokens,
                     resample=resample,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -245,8 +245,8 @@ class MuseGlimmerImageProcessor(Glm4vImageProcessor):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/nougat/image_processing_nougat.py
+++ b/src/transformers/models/nougat/image_processing_nougat.py
@@ -273,7 +273,7 @@ class NougatImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_align_long_axis:
                 stacked_images = self.align_long_axis(image=stacked_images, size=size)
             if do_resize:
@@ -282,19 +282,19 @@ class NougatImageProcessor(TorchvisionBackend):
                 stacked_images = self.thumbnail(image=stacked_images, size=size)
             if do_pad:
                 stacked_images = self.pad_images(image=stacked_images, size=size)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/oneformer/image_processing_oneformer.py
+++ b/src/transformers/models/oneformer/image_processing_oneformer.py
@@ -369,13 +369,13 @@ class OneFormerImageProcessor(TorchvisionBackend):
 
         processed_images_grouped = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         processed_segmentation_maps = None
@@ -384,12 +384,12 @@ class OneFormerImageProcessor(TorchvisionBackend):
                 segmentation_maps, disable_grouping=disable_grouping
             )
             processed_segmentation_maps_grouped = {}
-            for shape, stacked_segmentation_maps in grouped_segmentation_maps.items():
+            for key, stacked_segmentation_maps in grouped_segmentation_maps.items():
                 if do_resize:
                     stacked_segmentation_maps = self.resize(
                         stacked_segmentation_maps, size=size, resample=tvF.InterpolationMode.NEAREST_EXACT
                     )
-                processed_segmentation_maps_grouped[shape] = stacked_segmentation_maps
+                processed_segmentation_maps_grouped[key] = stacked_segmentation_maps
             processed_segmentation_maps = reorder_images(
                 processed_segmentation_maps_grouped, grouped_segmentation_maps_index
             )

--- a/src/transformers/models/ovis2/image_processing_ovis2.py
+++ b/src/transformers/models/ovis2/image_processing_ovis2.py
@@ -281,7 +281,7 @@ class Ovis2ImageProcessor(TorchvisionBackend):
             grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
             processed_images_grouped = {}
             grids = {}
-            for shape, stacked_images in grouped_images.items():
+            for key, stacked_images in grouped_images.items():
                 stacked_images, grid = self.crop_image_to_patches(
                     stacked_images,
                     min_patches,
@@ -290,8 +290,8 @@ class Ovis2ImageProcessor(TorchvisionBackend):
                     use_covering_area_grid=use_covering_area_grid,
                     resample=resample,
                 )
-                processed_images_grouped[shape] = stacked_images
-                grids[shape] = grid
+                processed_images_grouped[key] = stacked_images
+                grids[key] = grid
             images = reorder_images(processed_images_grouped, grouped_images_index)
             images = [image for images_list in images for image in images_list]
             grids = reorder_images(grids, grouped_images_index)
@@ -301,24 +301,24 @@ class Ovis2ImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         return BatchFeature(data={"pixel_values": processed_images, "grids": grids}, tensor_type=return_tensors)

--- a/src/transformers/models/owlv2/image_processing_owlv2.py
+++ b/src/transformers/models/owlv2/image_processing_owlv2.py
@@ -289,12 +289,12 @@ class Owlv2ImageProcessor(TorchvisionBackend):
         """
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self._pad_images(
                 stacked_images,
                 constant_value=constant_value,
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
@@ -374,12 +374,12 @@ class Owlv2ImageProcessor(TorchvisionBackend):
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Rescale images before other operations as done in original implementation
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, False, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
@@ -390,22 +390,22 @@ class Owlv2ImageProcessor(TorchvisionBackend):
             processed_images, disable_grouping=disable_grouping
         )
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 resized_stack = self.resize(image=stacked_images, size=size, resample=resample)
-                resized_images_grouped[shape] = resized_stack
+                resized_images_grouped[key] = resized_stack
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, False, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/owlv2/modular_owlv2.py
+++ b/src/transformers/models/owlv2/modular_owlv2.py
@@ -188,12 +188,12 @@ class Owlv2ImageProcessor(OwlViTImageProcessor):
         """
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self._pad_images(
                 stacked_images,
                 constant_value=constant_value,
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
@@ -273,12 +273,12 @@ class Owlv2ImageProcessor(OwlViTImageProcessor):
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Rescale images before other operations as done in original implementation
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, False, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
@@ -289,22 +289,22 @@ class Owlv2ImageProcessor(OwlViTImageProcessor):
             processed_images, disable_grouping=disable_grouping
         )
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 resized_stack = self.resize(image=stacked_images, size=size, resample=resample)
-                resized_images_grouped[shape] = resized_stack
+                resized_images_grouped[key] = resized_stack
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, False, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/paddleocr_vl/image_processing_paddleocr_vl.py
+++ b/src/transformers/models/paddleocr_vl/image_processing_paddleocr_vl.py
@@ -215,7 +215,7 @@ class PaddleOCRVLImageProcessor(TorchvisionBackend):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -223,13 +223,13 @@ class PaddleOCRVLImageProcessor(TorchvisionBackend):
                     resample=resample,
                     factor=patch_size * merge_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -240,8 +240,8 @@ class PaddleOCRVLImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/perceiver/image_processing_perceiver.py
+++ b/src/transformers/models/perceiver/image_processing_perceiver.py
@@ -95,27 +95,27 @@ class PerceiverImageProcessor(TorchvisionBackend):
         """Custom preprocessing for Perceiver: center_crop -> resize -> rescale and normalize."""
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         cropped_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, size=size, crop_size=crop_size)
-            cropped_images_grouped[shape] = stacked_images
+            cropped_images_grouped[key] = stacked_images
         cropped_images = reorder_images(cropped_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(cropped_images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)

--- a/src/transformers/models/perception_lm/image_processing_perception_lm.py
+++ b/src/transformers/models/perception_lm/image_processing_perception_lm.py
@@ -271,7 +271,7 @@ class PerceptionLMImageProcessor(TorchvisionBackend):
         # Group images by size for batched transformation
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 if vision_input_type == "thumb+tile":
                     thumbnails, _ = self.resize(stacked_images, tile_size, max_num_tiles=1, resample=resample)
@@ -283,12 +283,12 @@ class PerceptionLMImageProcessor(TorchvisionBackend):
                 else:  # vanilla single tile for low memory devices
                     stacked_images, _ = self.resize(stacked_images, tile_size, max_num_tiles=1, resample=resample)
 
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images,
@@ -298,7 +298,7 @@ class PerceptionLMImageProcessor(TorchvisionBackend):
                 image_mean,
                 image_std,
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_images = [p[None] if p.ndim == 3 else p for p in processed_images]  # add tiles dimension if needed
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)

--- a/src/transformers/models/pix2struct/image_processing_pix2struct.py
+++ b/src/transformers/models/pix2struct/image_processing_pix2struct.py
@@ -400,7 +400,7 @@ class Pix2StructImageProcessor(TorchvisionBackend):
         flattened_patches_grouped = {}
         attention_masks_grouped = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Convert to float if needed (for resize and other operations)
             if stacked_images.dtype == torch.uint8:
                 stacked_images = stacked_images.float()
@@ -414,8 +414,8 @@ class Pix2StructImageProcessor(TorchvisionBackend):
             )
             masks = (patches.sum(dim=-1) != 0).float()
 
-            flattened_patches_grouped[shape] = patches
-            attention_masks_grouped[shape] = masks
+            flattened_patches_grouped[key] = patches
+            attention_masks_grouped[key] = masks
 
         flattened_patches = reorder_images(flattened_patches_grouped, grouped_images_index)
         attention_masks = reorder_images(attention_masks_grouped, grouped_images_index)

--- a/src/transformers/models/poolformer/image_processing_poolformer.py
+++ b/src/transformers/models/poolformer/image_processing_poolformer.py
@@ -109,21 +109,21 @@ class PoolFormerImageProcessor(TorchvisionBackend):
         """Custom preprocessing for PoolFormer (pass crop_pct to resize)."""
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample, crop_pct=crop_pct)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         if do_pad:

--- a/src/transformers/models/pp_doclayout_v2/image_processing_pp_doclayout_v2.py
+++ b/src/transformers/models/pp_doclayout_v2/image_processing_pp_doclayout_v2.py
@@ -63,24 +63,24 @@ class PPDocLayoutV2ImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample, antialias=False)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         if do_pad:

--- a/src/transformers/models/pp_doclayout_v3/image_processing_pp_doclayout_v3.py
+++ b/src/transformers/models/pp_doclayout_v3/image_processing_pp_doclayout_v3.py
@@ -68,24 +68,24 @@ class PPDocLayoutV3ImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample, antialias=False)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         if do_pad:

--- a/src/transformers/models/pp_doclayout_v3/modular_pp_doclayout_v3.py
+++ b/src/transformers/models/pp_doclayout_v3/modular_pp_doclayout_v3.py
@@ -264,24 +264,24 @@ class PPDocLayoutV3ImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample, antialias=False)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         if do_pad:

--- a/src/transformers/models/pp_formulanet/image_processing_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/image_processing_pp_formulanet.py
@@ -267,7 +267,7 @@ class PPFormulaNetImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_align_long_axis:
                 stacked_images = self.align_long_axis(image=stacked_images, size=size)
             if do_resize:
@@ -276,19 +276,19 @@ class PPFormulaNetImageProcessor(TorchvisionBackend):
                 stacked_images = self.thumbnail(image=stacked_images, size=size)
             if do_pad:
                 stacked_images = self.pad_images(image=stacked_images, size=size)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/pp_lcnet/image_processing_pp_lcnet.py
+++ b/src/transformers/models/pp_lcnet/image_processing_pp_lcnet.py
@@ -83,7 +83,7 @@ class PPLCNetImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 # Unlike TorchvisionBackend, which resizes to a fixed target,
                 # this implementation first calculates the target size dynamically to preserve
@@ -94,19 +94,19 @@ class PPLCNetImageProcessor(TorchvisionBackend):
                         stacked_images[0], target_short_edge=resize_short, size_divisor=size_divisor
                     )
                 stacked_images = self.resize(stacked_images, size=resize_size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         # RGB -> BGR

--- a/src/transformers/models/pp_lcnet/modular_pp_lcnet.py
+++ b/src/transformers/models/pp_lcnet/modular_pp_lcnet.py
@@ -175,7 +175,7 @@ class PPLCNetImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 # Unlike TorchvisionBackend, which resizes to a fixed target,
                 # this implementation first calculates the target size dynamically to preserve
@@ -186,19 +186,19 @@ class PPLCNetImageProcessor(TorchvisionBackend):
                         stacked_images[0], target_short_edge=resize_short, size_divisor=size_divisor
                     )
                 stacked_images = self.resize(stacked_images, size=resize_size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         # RGB -> BGR

--- a/src/transformers/models/pp_ocrv5_server_det/image_processing_pp_ocrv5_server_det.py
+++ b/src/transformers/models/pp_ocrv5_server_det/image_processing_pp_ocrv5_server_det.py
@@ -91,34 +91,34 @@ class PPOCRV5ServerDetImageProcessor(TorchvisionBackend):
         # Group images by their original spatial shape to enable batched resizing (optimization for efficiency)
         # [Key Change] Unlike the original implementation, we now track target shapes for each original shape group
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
-        # Store resized image batches mapped to their original shape keys
+        # Store resized image batches mapped to their group keys
         resized_images_grouped = {}
-        # [Key Change] Core addition: Mapping from original image shape to target resize shape
-        # This dict ensures consistent target shape handling across all subsequent operations (resize/processing)
-        target_shape_per_shape = {}
-        for shape, stacked_images in grouped_images.items():
+        # [Key Change] Core addition: the target resize shape of every group, spread back over its images below.
+        # This ensures consistent target shape handling across all subsequent operations (resize/processing)
+        target_shapes_grouped = {}
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 resize_size, target_shape = self.get_image_size(
                     stacked_images[0], limit_side_len, limit_type, max_side_limit
                 )
-                target_shape_per_shape[shape] = target_shape
+                target_shapes_grouped[key] = [target_shape] * len(stacked_images)
                 stacked_images = self.resize(image=stacked_images.float(), size=resize_size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
 
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
         if do_resize:
-            target_sizes = [target_shape_per_shape[grouped_images_index[i][0]] for i in range(len(images))]
+            target_sizes = reorder_images(target_shapes_grouped, grouped_images_index)
 
         # Group images by size for further processing
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
             # BGR to RGB conversion
             stacked_images = stacked_images[:, [2, 1, 0], :, :]
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         pixel_values = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/pp_ocrv5_server_det/modular_pp_ocrv5_server_det.py
+++ b/src/transformers/models/pp_ocrv5_server_det/modular_pp_ocrv5_server_det.py
@@ -162,34 +162,34 @@ class PPOCRV5ServerDetImageProcessor(TorchvisionBackend):
         # Group images by their original spatial shape to enable batched resizing (optimization for efficiency)
         # [Key Change] Unlike the original implementation, we now track target shapes for each original shape group
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
-        # Store resized image batches mapped to their original shape keys
+        # Store resized image batches mapped to their group keys
         resized_images_grouped = {}
-        # [Key Change] Core addition: Mapping from original image shape to target resize shape
-        # This dict ensures consistent target shape handling across all subsequent operations (resize/processing)
-        target_shape_per_shape = {}
-        for shape, stacked_images in grouped_images.items():
+        # [Key Change] Core addition: the target resize shape of every group, spread back over its images below.
+        # This ensures consistent target shape handling across all subsequent operations (resize/processing)
+        target_shapes_grouped = {}
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 resize_size, target_shape = self.get_image_size(
                     stacked_images[0], limit_side_len, limit_type, max_side_limit
                 )
-                target_shape_per_shape[shape] = target_shape
+                target_shapes_grouped[key] = [target_shape] * len(stacked_images)
                 stacked_images = self.resize(image=stacked_images.float(), size=resize_size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
 
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
         if do_resize:
-            target_sizes = [target_shape_per_shape[grouped_images_index[i][0]] for i in range(len(images))]
+            target_sizes = reorder_images(target_shapes_grouped, grouped_images_index)
 
         # Group images by size for further processing
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
             # BGR to RGB conversion
             stacked_images = stacked_images[:, [2, 1, 0], :, :]
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         pixel_values = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/prompt_depth_anything/image_processing_prompt_depth_anything.py
+++ b/src/transformers/models/prompt_depth_anything/image_processing_prompt_depth_anything.py
@@ -282,7 +282,7 @@ class PromptDepthAnythingImageProcessor(TorchvisionBackend):
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize_with_aspect_ratio(
                     image=stacked_images,
@@ -291,14 +291,14 @@ class PromptDepthAnythingImageProcessor(TorchvisionBackend):
                     ensure_multiple_of=ensure_multiple_of,
                     resample=resample,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
 
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -306,7 +306,7 @@ class PromptDepthAnythingImageProcessor(TorchvisionBackend):
             if do_pad and size_divisor is not None:
                 stacked_images = self.pad_image(stacked_images, size_divisor)
 
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
@@ -217,7 +217,7 @@ class Qwen2VLImageProcessor(TorchvisionBackend):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -225,13 +225,13 @@ class Qwen2VLImageProcessor(TorchvisionBackend):
                     resample=resample,
                     factor=patch_size * merge_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -242,8 +242,8 @@ class Qwen2VLImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/sam/image_processing_sam.py
+++ b/src/transformers/models/sam/image_processing_sam.py
@@ -223,10 +223,10 @@ class SamImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
         reshaped_input_sizes = [image.shape[-2:] for image in resized_images]
 
@@ -234,14 +234,14 @@ class SamImageProcessor(TorchvisionBackend):
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         if do_pad:

--- a/src/transformers/models/sapiens2/image_processing_sapiens2.py
+++ b/src/transformers/models/sapiens2/image_processing_sapiens2.py
@@ -424,7 +424,7 @@ class Sapiens2ImageProcessor(TorchvisionBackend):
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 if do_pad:
                     # Resize while preserving aspect ratio. Then add symmetric padding on all sides to reach the target size.
@@ -433,18 +433,18 @@ class Sapiens2ImageProcessor(TorchvisionBackend):
                     stacked_images = self.center_crop(stacked_images, size)
                 else:
                     stacked_images = self.resize(stacked_images, size, resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         return reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/sapiens2/modular_sapiens2.py
+++ b/src/transformers/models/sapiens2/modular_sapiens2.py
@@ -500,7 +500,7 @@ class Sapiens2ImageProcessor(BeitImageProcessor):
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 if do_pad:
                     # Resize while preserving aspect ratio. Then add symmetric padding on all sides to reach the target size.
@@ -509,18 +509,18 @@ class Sapiens2ImageProcessor(BeitImageProcessor):
                     stacked_images = self.center_crop(stacked_images, size)
                 else:
                     stacked_images = self.resize(stacked_images, size, resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         return reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/segformer/image_processing_segformer.py
+++ b/src/transformers/models/segformer/image_processing_segformer.py
@@ -169,21 +169,21 @@ class SegformerImageProcessor(TorchvisionBackend):
         if do_resize:
             grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
             resized_images_grouped = {}
-            for shape, stacked_images in grouped_images.items():
+            for key, stacked_images in grouped_images.items():
                 resized_stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-                resized_images_grouped[shape] = resized_stacked_images
+                resized_images_grouped[key] = resized_stacked_images
             resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing (rescale/normalize)
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/segformer/modular_segformer.py
+++ b/src/transformers/models/segformer/modular_segformer.py
@@ -136,21 +136,21 @@ class SegformerImageProcessor(BeitImageProcessor):
         if do_resize:
             grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
             resized_images_grouped = {}
-            for shape, stacked_images in grouped_images.items():
+            for key, stacked_images in grouped_images.items():
                 resized_stacked_images = self.resize(image=stacked_images, size=size, resample=resample)
-                resized_images_grouped[shape] = resized_stacked_images
+                resized_images_grouped[key] = resized_stacked_images
             resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing (rescale/normalize)
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/seggpt/image_processing_seggpt.py
+++ b/src/transformers/models/seggpt/image_processing_seggpt.py
@@ -236,19 +236,19 @@ class SegGptImageProcessor(TorchvisionBackend):
     ) -> list["torch.Tensor"]:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         return reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/slanext/image_processing_slanext.py
+++ b/src/transformers/models/slanext/image_processing_slanext.py
@@ -140,24 +140,24 @@ class SLANeXtImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self._resize(image=stacked_images, size=size)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         if do_pad:

--- a/src/transformers/models/slanext/modular_slanext.py
+++ b/src/transformers/models/slanext/modular_slanext.py
@@ -415,24 +415,24 @@ class SLANeXtImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self._resize(image=stacked_images, size=size)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         # Needed in case do_resize is False, or resize returns images with different sizes
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         if do_pad:

--- a/src/transformers/models/smolvlm/image_processing_smolvlm.py
+++ b/src/transformers/models/smolvlm/image_processing_smolvlm.py
@@ -397,7 +397,7 @@ class SmolVLMImageProcessor(TorchvisionBackend):
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample=resample)
             resized_images_grouped[shape] = stacked_images
-        resized_images = reorder_images(resized_images_grouped, grouped_images_index, is_nested=True)
+        resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(
             resized_images, is_nested=True, disable_grouping=disable_grouping
@@ -416,9 +416,9 @@ class SmolVLMImageProcessor(TorchvisionBackend):
                 split_images_grouped[shape] = stacked_images
                 rows_grouped[shape] = rows
                 cols_grouped[shape] = cols
-            processed_images = reorder_images(split_images_grouped, grouped_images_index, is_nested=True)
-            rows = reorder_images(rows_grouped, grouped_images_index, is_nested=True)
-            cols = reorder_images(cols_grouped, grouped_images_index, is_nested=True)
+            processed_images = reorder_images(split_images_grouped, grouped_images_index)
+            rows = reorder_images(rows_grouped, grouped_images_index)
+            cols = reorder_images(cols_grouped, grouped_images_index)
             # flattenened the doubly nested list to a nested list
             for i, group_images in enumerate(processed_images):
                 processed_images[i] = [image for sublist in group_images for image in sublist]
@@ -431,7 +431,7 @@ class SmolVLMImageProcessor(TorchvisionBackend):
                     resample=resample,
                 )
                 split_images_grouped[shape] = stacked_images
-            processed_images = reorder_images(split_images_grouped, grouped_images_index, is_nested=True)
+            processed_images = reorder_images(split_images_grouped, grouped_images_index)
             rows = [[0] * len(images) for images in processed_images]
             cols = [[0] * len(images) for images in processed_images]
         # Group images by size for further processing
@@ -446,7 +446,7 @@ class SmolVLMImageProcessor(TorchvisionBackend):
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
             processed_images_grouped[shape] = stacked_images
-        processed_images = reorder_images(processed_images_grouped, grouped_images_index, is_nested=True)
+        processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         if do_pad:
             # Get max images per batch
             max_num_images = max(len(images_) for images_ in processed_images)

--- a/src/transformers/models/smolvlm/image_processing_smolvlm.py
+++ b/src/transformers/models/smolvlm/image_processing_smolvlm.py
@@ -393,10 +393,10 @@ class SmolVLMImageProcessor(TorchvisionBackend):
             images, is_nested=True, disable_grouping=disable_grouping
         )
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample=resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(
@@ -406,16 +406,16 @@ class SmolVLMImageProcessor(TorchvisionBackend):
         if do_image_splitting:
             rows_grouped = {}
             cols_grouped = {}
-            for shape, stacked_images in grouped_images.items():
+            for key, stacked_images in grouped_images.items():
                 stacked_images = self.resize_for_vision_encoder(
                     stacked_images, max_image_size["longest_edge"], resample=resample
                 )
                 stacked_images, rows, cols = self.split_images(
                     stacked_images, max_image_size=max_image_size, resample=resample
                 )
-                split_images_grouped[shape] = stacked_images
-                rows_grouped[shape] = rows
-                cols_grouped[shape] = cols
+                split_images_grouped[key] = stacked_images
+                rows_grouped[key] = rows
+                cols_grouped[key] = cols
             processed_images = reorder_images(split_images_grouped, grouped_images_index)
             rows = reorder_images(rows_grouped, grouped_images_index)
             cols = reorder_images(cols_grouped, grouped_images_index)
@@ -423,14 +423,14 @@ class SmolVLMImageProcessor(TorchvisionBackend):
             for i, group_images in enumerate(processed_images):
                 processed_images[i] = [image for sublist in group_images for image in sublist]
         else:
-            for shape, stacked_images in grouped_images.items():
+            for key, stacked_images in grouped_images.items():
                 # We square the images to max_image_size
                 stacked_images = self.resize(
                     image=stacked_images,
                     size=SizeDict(height=max_image_size["longest_edge"], width=max_image_size["longest_edge"]),
                     resample=resample,
                 )
-                split_images_grouped[shape] = stacked_images
+                split_images_grouped[key] = stacked_images
             processed_images = reorder_images(split_images_grouped, grouped_images_index)
             rows = [[0] * len(images) for images in processed_images]
             cols = [[0] * len(images) for images in processed_images]
@@ -440,12 +440,12 @@ class SmolVLMImageProcessor(TorchvisionBackend):
             processed_images, is_nested=True, disable_grouping=disable_grouping
         )
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         if do_pad:
             # Get max images per batch

--- a/src/transformers/models/step3p7/image_processing_step3p7.py
+++ b/src/transformers/models/step3p7/image_processing_step3p7.py
@@ -249,14 +249,14 @@ class Step3p7ImageProcessor(TorchvisionBackend):
             grouped_patches, grouped_index = group_images_by_shape(
                 nested_patches, is_nested=True, disable_grouping=disable_grouping
             )
-            for shape, stacked_patches in grouped_patches.items():
+            for key, stacked_patches in grouped_patches.items():
                 resized = self.resize(
                     stacked_patches, SizeDict(height=patch_size, width=patch_size), resample=resample
                 )
-                grouped_patches[shape] = self.rescale_and_normalize(
+                grouped_patches[key] = self.rescale_and_normalize(
                     resized, do_rescale, rescale_factor, do_normalize, image_mean, image_std
                 )
-            nested_pixel_values_local = reorder_images(grouped_patches, grouped_index, is_nested=True)
+            nested_pixel_values_local = reorder_images(grouped_patches, grouped_index)
             # Flatten back to (total_patches, C, H, W): `Step3p7Model.get_image_features` slices this
             # flat tensor per image using `num_local_patches`.
             result["pixel_values_local"] = torch.stack(

--- a/src/transformers/models/step3p7/modular_step3p7.py
+++ b/src/transformers/models/step3p7/modular_step3p7.py
@@ -561,14 +561,14 @@ class Step3p7ImageProcessor(TorchvisionBackend):
             grouped_patches, grouped_index = group_images_by_shape(
                 nested_patches, is_nested=True, disable_grouping=disable_grouping
             )
-            for shape, stacked_patches in grouped_patches.items():
+            for key, stacked_patches in grouped_patches.items():
                 resized = self.resize(
                     stacked_patches, SizeDict(height=patch_size, width=patch_size), resample=resample
                 )
-                grouped_patches[shape] = self.rescale_and_normalize(
+                grouped_patches[key] = self.rescale_and_normalize(
                     resized, do_rescale, rescale_factor, do_normalize, image_mean, image_std
                 )
-            nested_pixel_values_local = reorder_images(grouped_patches, grouped_index, is_nested=True)
+            nested_pixel_values_local = reorder_images(grouped_patches, grouped_index)
             # Flatten back to (total_patches, C, H, W): `Step3p7Model.get_image_features` slices this
             # flat tensor per image using `num_local_patches`.
             result["pixel_values_local"] = torch.stack(

--- a/src/transformers/models/superglue/image_processing_superglue.py
+++ b/src/transformers/models/superglue/image_processing_superglue.py
@@ -164,20 +164,20 @@ class SuperGlueImageProcessor(TorchvisionBackend):
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size=size, resample=resample)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         resized_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_rescale:
                 stacked_images = self.rescale(stacked_images, rescale_factor)
             if do_grayscale:
                 stacked_images = convert_to_grayscale(stacked_images)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/superpoint/image_processing_superpoint.py
+++ b/src/transformers/models/superpoint/image_processing_superpoint.py
@@ -97,7 +97,7 @@ class SuperPointImageProcessor(TorchvisionBackend):
         # Group images by size for batched processing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Apply grayscale conversion before resize (if requested)
             if do_grayscale:
                 stacked_images = convert_to_grayscale(stacked_images)
@@ -107,7 +107,7 @@ class SuperPointImageProcessor(TorchvisionBackend):
             # Rescale
             if do_rescale:
                 stacked_images = self.rescale(stacked_images, rescale_factor)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
 

--- a/src/transformers/models/swin2sr/image_processing_swin2sr.py
+++ b/src/transformers/models/swin2sr/image_processing_swin2sr.py
@@ -99,12 +99,12 @@ class Swin2SRImageProcessor(TorchvisionBackend):
         """Custom preprocessing for Swin2SR."""
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_rescale:
                 stacked_images = self.rescale(stacked_images, rescale_factor)
             if do_pad:
                 stacked_images = self.pad(stacked_images, pad_size=pad_size, size_divisor=size_divisor)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
 

--- a/src/transformers/models/textnet/image_processing_textnet.py
+++ b/src/transformers/models/textnet/image_processing_textnet.py
@@ -119,21 +119,21 @@ class TextNetImageProcessor(TorchvisionBackend):
         """Custom preprocessing for TextNet."""
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample, size_divisor=size_divisor)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
 

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -197,7 +197,7 @@ class TvpImageProcessor(TorchvisionBackend):
             images, disable_grouping=disable_grouping, is_nested=True
         )
         processed_images_grouped = {}
-        for shape, stacked_frames in grouped_images.items():
+        for key, stacked_frames in grouped_images.items():
             # Resize if needed
             if do_resize:
                 stacked_frames = self.resize(stacked_frames, size, resample)
@@ -220,7 +220,7 @@ class TvpImageProcessor(TorchvisionBackend):
             if do_flip_channel_order:
                 stacked_frames = self._flip_channel_order(stacked_frames)
 
-            processed_images_grouped[shape] = stacked_frames
+            processed_images_grouped[key] = stacked_frames
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         if return_tensors == "pt":

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -222,7 +222,7 @@ class TvpImageProcessor(TorchvisionBackend):
 
             processed_images_grouped[shape] = stacked_frames
 
-        processed_images = reorder_images(processed_images_grouped, grouped_images_index, is_nested=True)
+        processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         if return_tensors == "pt":
             processed_images = [torch.stack(images, dim=0) for images in processed_images]
             processed_images = torch.stack(processed_images, dim=0)

--- a/src/transformers/models/uvdoc/image_processing_uvdoc.py
+++ b/src/transformers/models/uvdoc/image_processing_uvdoc.py
@@ -55,13 +55,13 @@ class UVDocImageProcessor(TorchvisionBackend):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
             # RGB to BGR conversion
             stacked_images = stacked_images[:, [2, 1, 0], :, :]
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         rescale_and_normalize_images = reorder_images(processed_images_grouped, grouped_images_index)
 
@@ -72,13 +72,13 @@ class UVDocImageProcessor(TorchvisionBackend):
         )
         interpolated_images_grouped = {}
         # Upsample images and extract originals for post-processing
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Interpolate to target size (use interpolate with align_corners=True to match original implementation)
             if do_resize:
                 stacked_images = F.interpolate(
                     stacked_images, size=(size.height, size.width), mode="bilinear", align_corners=True
                 )
-            interpolated_images_grouped[shape] = stacked_images
+            interpolated_images_grouped[key] = stacked_images
 
         pixel_values = reorder_images(interpolated_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/uvdoc/modular_uvdoc.py
+++ b/src/transformers/models/uvdoc/modular_uvdoc.py
@@ -182,13 +182,13 @@ class UVDocImageProcessor(TorchvisionBackend):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
             # RGB to BGR conversion
             stacked_images = stacked_images[:, [2, 1, 0], :, :]
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         rescale_and_normalize_images = reorder_images(processed_images_grouped, grouped_images_index)
 
@@ -199,13 +199,13 @@ class UVDocImageProcessor(TorchvisionBackend):
         )
         interpolated_images_grouped = {}
         # Upsample images and extract originals for post-processing
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Interpolate to target size (use interpolate with align_corners=True to match original implementation)
             if do_resize:
                 stacked_images = F.interpolate(
                     stacked_images, size=(size.height, size.width), mode="bilinear", align_corners=True
                 )
-            interpolated_images_grouped[shape] = stacked_images
+            interpolated_images_grouped[key] = stacked_images
 
         pixel_values = reorder_images(interpolated_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/video_llama_3/image_processing_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/image_processing_video_llama_3.py
@@ -214,7 +214,7 @@ class VideoLlama3ImageProcessor(TorchvisionBackend):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -222,13 +222,13 @@ class VideoLlama3ImageProcessor(TorchvisionBackend):
                     resample=resample,
                     factor=patch_size * merge_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -239,8 +239,8 @@ class VideoLlama3ImageProcessor(TorchvisionBackend):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/video_llama_3/modular_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/modular_video_llama_3.py
@@ -1081,7 +1081,7 @@ class VideoLlama3ImageProcessor(Qwen2VLImageProcessor):
     ) -> BatchFeature:
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(
                     images=stacked_images,
@@ -1089,13 +1089,13 @@ class VideoLlama3ImageProcessor(Qwen2VLImageProcessor):
                     resample=resample,
                     factor=patch_size * merge_size,
                 )
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
         processed_grids = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
@@ -1106,8 +1106,8 @@ class VideoLlama3ImageProcessor(Qwen2VLImageProcessor):
                 temporal_patch_size=temporal_patch_size,
             )
 
-            processed_images_grouped[shape] = patches
-            processed_grids[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+            processed_images_grouped[key] = patches
+            processed_grids[key] = [[1, grid_h, grid_w]] * len(stacked_images)
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -85,7 +85,7 @@ class VideoMAEImageProcessor(TorchvisionBackend):
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample)
             resized_images_grouped[shape] = stacked_images
-        resized_images = reorder_images(resized_images_grouped, grouped_images_index, is_nested=True)
+        resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(
             resized_images, is_nested=True, disable_grouping=disable_grouping
@@ -98,7 +98,7 @@ class VideoMAEImageProcessor(TorchvisionBackend):
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
             processed_images_grouped[shape] = stacked_images
-        processed_images = reorder_images(processed_images_grouped, grouped_images_index, is_nested=True)
+        processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         # Stack frames per video: list[list[Tensor(C,H,W)]] → list[Tensor(num_frames,C,H,W)]
         pixel_values = [torch.stack(video_frames) for video_frames in processed_images]

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -81,23 +81,23 @@ class VideoMAEImageProcessor(TorchvisionBackend):
             images, is_nested=True, disable_grouping=disable_grouping
         )
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         grouped_images, grouped_images_index = group_images_by_shape(
             resized_images, is_nested=True, disable_grouping=disable_grouping
         )
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_center_crop:
                 stacked_images = self.center_crop(stacked_images, crop_size)
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
         # Stack frames per video: list[list[Tensor(C,H,W)]] → list[Tensor(num_frames,C,H,W)]

--- a/src/transformers/models/vilt/image_processing_vilt.py
+++ b/src/transformers/models/vilt/image_processing_vilt.py
@@ -139,7 +139,7 @@ class ViltImageProcessor(TorchvisionBackend):
         processed_images = {}
         processed_masks = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Create mask template for efficient masking
             if return_tensors == "pt" and len(stacked_images) > 0:
                 device = stacked_images.device
@@ -166,8 +166,8 @@ class ViltImageProcessor(TorchvisionBackend):
                 )
 
             # Store processed group
-            processed_images[shape] = padded_images
-            processed_masks[shape] = pixel_masks
+            processed_images[key] = padded_images
+            processed_masks[key] = pixel_masks
 
         # Reorder images back to original order
         padded_images = reorder_images(processed_images, grouped_images_index)
@@ -196,22 +196,22 @@ class ViltImageProcessor(TorchvisionBackend):
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_resize:
                 stacked_images = self.resize(stacked_images, size, resample, size_divisor)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         # Group images by size for further processing
         grouped_images, grouped_images_index = group_images_by_shape(resized_images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
 
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/vitmatte/image_processing_vitmatte.py
+++ b/src/transformers/models/vitmatte/image_processing_vitmatte.py
@@ -134,9 +134,9 @@ class VitMatteImageProcessor(TorchvisionBackend):
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         grouped_trimaps, grouped_trimaps_index = group_images_by_shape(trimaps, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape in grouped_images:
-            stacked_images = grouped_images[shape]
-            stacked_trimaps = grouped_trimaps[shape]
+        for key in grouped_images:
+            stacked_images = grouped_images[key]
+            stacked_trimaps = grouped_trimaps[key]
             # Fused rescale and normalize
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
@@ -147,7 +147,7 @@ class VitMatteImageProcessor(TorchvisionBackend):
             stacked_images = torch.cat([stacked_images, stacked_trimaps], dim=1)
             if do_pad:
                 stacked_images = self._pad_image(stacked_images, size_divisor)
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 

--- a/src/transformers/models/vitpose/image_processing_vitpose.py
+++ b/src/transformers/models/vitpose/image_processing_vitpose.py
@@ -439,11 +439,11 @@ class VitPoseImageProcessor(TorchvisionBackend):
 
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         processed_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             stacked_images = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            processed_images_grouped[shape] = stacked_images
+            processed_images_grouped[key] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
 

--- a/src/transformers/models/zoedepth/image_processing_zoedepth.py
+++ b/src/transformers/models/zoedepth/image_processing_zoedepth.py
@@ -206,7 +206,7 @@ class ZoeDepthImageProcessor(TorchvisionBackend):
         # Group images by size for batched resizing
         grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
         resized_images_grouped = {}
-        for shape, stacked_images in grouped_images.items():
+        for key, stacked_images in grouped_images.items():
             if do_rescale:
                 stacked_images = self.rescale(stacked_images, rescale_factor)
             if do_pad:
@@ -215,7 +215,7 @@ class ZoeDepthImageProcessor(TorchvisionBackend):
                 stacked_images = self.resize(stacked_images, size, keep_aspect_ratio, ensure_multiple_of, resample)
             if do_normalize:
                 stacked_images = self.normalize(stacked_images, image_mean, image_std)
-            resized_images_grouped[shape] = stacked_images
+            resized_images_grouped[key] = stacked_images
         processed_images = reorder_images(resized_images_grouped, grouped_images_index)
 
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48192&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48192) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48192&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48192)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

* Simplifies `group_images_by_shape` and moves all logic into one function
* Allow passing `None` as `paired_input`, required for https://github.com/huggingface/transformers/pull/48066
* Remove need for `is_nested` in `reorder_images` as the index keeps track of it
* Updated models that referred to `key` as `shape` which is not always true

Follow-up from https://github.com/huggingface/transformers/pull/47964#discussion_r3782734308

Ran slow image processing tests for all models locally.

CC @zucchini-nlp