### PR TITLE
[Optimization] Avoid redundant token length initialization loop in StopStringCriteria

### DIFF
--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -462,8 +462,9 @@ class StopStringCriteria(StoppingCriteria):
                     + max_valid_end_lens * i
                     + len(possible_end_lens),
                 ] = possible_end_lens
-            for token, token_idx in zip(token_list, token_indices):
-                gather_vec[token_idx, -1] = len(token)
+
+        for token, token_idx in zip(token_list, token_indices):
+            gather_vec[token_idx, -1] = len(token)
 
         gather_vec = torch.tensor(gather_vec, dtype=torch.int32)
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48195&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48195) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48195&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48195)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

In `StopStringCriteria._stop_string_create_embedding_vec`, the assignment:
```python
for token, token_idx in zip(token_list, token_indices):
    gather_vec[token_idx, -1] = len(token)
```
was located inside the outer loop `for i, stop_string in enumerate(stop_strings):`.

Because the token length entries in the final column (`gather_vec[token_idx, -1]`) are independent of each stop string index `i`, re-running this loop for every stop string in `stop_strings` performed redundant iterations ((|V| \times N)$ rather than (|V|)$).

This PR moves the token length assignment outside the stop strings loop, executing it once and avoiding redundant writes across large vocabularies.

## Before submitting
- [x] This PR optimizes generation stop string embedding creation.
- [x] Verified unit tests in `tests/generation/test_stopping_criteria.py` pass (19/19 passed).