### PR TITLE
Fix MPS async loading segfault when converting dtype

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1570,11 +1570,14 @@ def convert_and_load_state_dict_in_model(
     # we cannot use it either to control the memory as we are under memory constraints, so we need to be sequential.
     # When doing on-the-fly quantization, we also use sync loading to avoid worker threads loading full-precision
     # tensors to GPU faster than the main thread can quantize them, which would cause a large memory spike.
+    # We also disable threading on MPS devices because concurrent Metal allocations and dtype conversions cause segfaults.
     has_on_the_fly_quantization = hf_quantizer is not None and not hf_quantizer.pre_quantized
+    has_mps_device = any((d == "mps" or getattr(d, "type", None) == "mps") for d in device_map.values())
     if (
         is_env_variable_true("HF_DEACTIVATE_ASYNC_LOAD")
         or "disk" in device_map.values()
         or has_on_the_fly_quantization
+        or has_mps_device
     ):
         thread_pool = None
     else:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48196&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48196) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48196&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48196)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48029

### Motivation & Context
When loading a checkpoint with dtype conversion on Apple Silicon MPS (e.g. loading a `bfloat16` model with `dtype=torch.float32` and `device_map="auto"`), concurrent tensor allocations and dtype casting across `ThreadPoolExecutor` worker threads cause a race condition in the Apple Metal driver / PyTorch MPS backend, resulting in a segmentation fault (`SIGSEGV`) or deadlocks/hangs.

This PR disables the async thread pool when `mps` is detected in `device_map`, similar to existing carve-outs for disk offloading and on-the-fly quantization.

### Verification
Tested on Apple M4 (macOS 26.5, Python 3.13, PyTorch 2.13.0):
- **Before**: 100% crash (`SIGSEGV` at `_materialize_copy` or permanent hang at `0/25` weights).
- **After**: 10/10 consecutive runs load cleanly in < 1 second.

## Before submitting
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing)?
- [x] Was this discussed/approved via a Github issue? (Fixes #48029)
- [ ] Did you make sure to update the documentation with your changes? (N/A)
- [ ] Did you write any new necessary tests?

## Who can review?
- model loading: @Cyrilvallez