### PR TITLE
 doc: Fix typo in SigLIP2 Flash Attention code example

### DIFF
--- a/docs/source/en/model_doc/siglip2.md
+++ b/docs/source/en/model_doc/siglip2.md
@@ -229,9 +229,9 @@ inputs = tokenizer(
     ```py
     # pip install -U flash-attn --no-build-isolation
 
-    from transformers import SiglipModel
+    from transformers import Siglip2Model
 
-    model = SiglipModel.from_pretrained(
+    model = Siglip2Model.from_pretrained(
         "google/siglip2-so400m-patch14-384",
         attn_implementation="flash_attention_2",
         device_map="auto",


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48197&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48197) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48197&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48197)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes a minor typo in the SigLIP2 documentation where the Flash Attention code example incorrectly imports and uses `SiglipModel` (the older version) instead of `Siglip2Model`.

## Code Agent Policy

- [x] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent (I am manually driving this PR and verifying the changes).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Documentation: @stevhliu
Multimodal models: @zucchini-nlp