### PR TITLE
[generate] Fix CUDAGraphs tensor overwrite for encoder-decoder static cache

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1900,13 +1900,13 @@ class GenerationMixin(ContinuousMixin):
             init_shape = self._get_static_cache_init_shape()
             if init_shape is not None:
                 num_heads, head_dim = init_shape
-                early_init_kwargs = dict(
-                    batch_size=batch_size,
-                    num_heads=num_heads,
-                    head_dim=head_dim,
-                    dtype=self.dtype,
-                    device=self.device,
-                )
+                early_init_kwargs = {
+                    "batch_size": batch_size,
+                    "num_heads": num_heads,
+                    "head_dim": head_dim,
+                    "dtype": self.dtype,
+                    "device": self.device,
+                }
                 cache.self_attention_cache.early_initialization(**early_init_kwargs)
                 cache.cross_attention_cache.early_initialization(**early_init_kwargs)
         elif prefill_chunk_size is not None:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1885,19 +1885,32 @@ class GenerationMixin(ContinuousMixin):
                 "offloading": offload_cache,
             }
             cache = EncoderDecoderCache(cache, StaticCache(**cross_attention_cache_kwargs))
-        elif prefill_chunk_size is not None:
-            # Chunked prefill compiles the prefill, so eagerly init the fresh cache to avoid a recompile next call
-            # (#46421). Skipped (-> lazy init) when it can't be initialized on a single device.
-            init_shape = self._get_static_cache_init_shape()
-            if init_shape is not None:
-                num_heads, head_dim = init_shape
-                cache.early_initialization(
-                    batch_size=batch_size,
-                    num_heads=num_heads,
-                    head_dim=head_dim,
-                    dtype=self.dtype,
-                    device=self.device,
-                )
+
+        # Eagerly initialize the K/V buffers so that `mark_static_address` is applied before any
+        # `torch.compile` / CUDAGraph capture context. Without this, `lazy_initialization` runs inside graph
+        # capture (where `is_torchdynamo_compiling()` is True), causing `mark_static_address` to be skipped.
+        # CUDAGraphs then treats those tensors as pooled memory and can overwrite them between runs, raising:
+        #   "accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run"
+        # For encoder-decoder models, BOTH self-attention and cross-attention caches need early init:
+        # cross-attention K/V are computed from encoder hidden states on the first decode step, which
+        # happens inside the compiled graph, so they suffer the same lazy-init-inside-capture problem.
+        # This also covers the chunked-prefill case (#46421), so the previous `elif prefill_chunk_size` block
+        # is folded in here. Skipped when the cache cannot be initialized on a single device.
+        init_shape = self._get_static_cache_init_shape()
+        if init_shape is not None:
+            num_heads, head_dim = init_shape
+            early_init_kwargs = dict(
+                batch_size=batch_size,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                dtype=self.dtype,
+                device=self.device,
+            )
+            if self.config.is_encoder_decoder:
+                cache.self_attention_cache.early_initialization(**early_init_kwargs)
+                cache.cross_attention_cache.early_initialization(**early_init_kwargs)
+            else:
+                cache.early_initialization(**early_init_kwargs)
 
         # Set the current length on the current model, to avoid recompilation later if we can
         self._previous_max_cache_length = effective_length

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1895,7 +1895,8 @@ class GenerationMixin(ContinuousMixin):
         # cross-attention K/V are computed from encoder hidden states on the first decode step, which
         # happens inside the compiled graph, so they suffer the same lazy-init-inside-capture problem.
         # Note: chunked prefill previously had its own `elif prefill_chunk_size` block for the same reason
-        # (#46446); it is folded here since the fix applies equally to all compiled generate calls.
+        # (#46446); that block is removed and its logic absorbed here, since the fix applies equally to
+        # all compiled generate calls, not just chunked prefill.
         # Skipped when the cache cannot be initialized on a single device.
         init_shape = self._get_static_cache_init_shape()
         if init_shape is not None:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1894,8 +1894,9 @@ class GenerationMixin(ContinuousMixin):
         # For encoder-decoder models, BOTH self-attention and cross-attention caches need early init:
         # cross-attention K/V are computed from encoder hidden states on the first decode step, which
         # happens inside the compiled graph, so they suffer the same lazy-init-inside-capture problem.
-        # This also covers the chunked-prefill case (#46421), so the previous `elif prefill_chunk_size` block
-        # is folded in here. Skipped when the cache cannot be initialized on a single device.
+        # Note: chunked prefill previously had its own `elif prefill_chunk_size` block for the same reason
+        # (#46421); it is folded here since the fix applies equally to all compiled generate calls.
+        # Skipped when the cache cannot be initialized on a single device.
         init_shape = self._get_static_cache_init_shape()
         if init_shape is not None:
             num_heads, head_dim = init_shape

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1887,6 +1887,7 @@ class GenerationMixin(ContinuousMixin):
             cache = EncoderDecoderCache(cache, StaticCache(**cross_attention_cache_kwargs))
 
         if self.config.is_encoder_decoder:
+            assert isinstance(cache, EncoderDecoderCache)  # always true: assigned above when is_encoder_decoder
             # Eagerly initialize the K/V buffers so that `mark_static_address` is applied before any
             # `torch.compile` / CUDAGraph capture context. Without this, `lazy_initialization` runs inside
             # graph capture (where `is_torchdynamo_compiling()` is True), causing `mark_static_address` to

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1895,7 +1895,7 @@ class GenerationMixin(ContinuousMixin):
         # cross-attention K/V are computed from encoder hidden states on the first decode step, which
         # happens inside the compiled graph, so they suffer the same lazy-init-inside-capture problem.
         # Note: chunked prefill previously had its own `elif prefill_chunk_size` block for the same reason
-        # (#46421); it is folded here since the fix applies equally to all compiled generate calls.
+        # (#46446); it is folded here since the fix applies equally to all compiled generate calls.
         # Skipped when the cache cannot be initialized on a single device.
         init_shape = self._get_static_cache_init_shape()
         if init_shape is not None:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1886,33 +1886,42 @@ class GenerationMixin(ContinuousMixin):
             }
             cache = EncoderDecoderCache(cache, StaticCache(**cross_attention_cache_kwargs))
 
-        # Eagerly initialize the K/V buffers so that `mark_static_address` is applied before any
-        # `torch.compile` / CUDAGraph capture context. Without this, `lazy_initialization` runs inside graph
-        # capture (where `is_torchdynamo_compiling()` is True), causing `mark_static_address` to be skipped.
-        # CUDAGraphs then treats those tensors as pooled memory and can overwrite them between runs, raising:
-        #   "accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run"
-        # For encoder-decoder models, BOTH self-attention and cross-attention caches need early init:
-        # cross-attention K/V are computed from encoder hidden states on the first decode step, which
-        # happens inside the compiled graph, so they suffer the same lazy-init-inside-capture problem.
-        # Note: chunked prefill previously had its own `elif prefill_chunk_size` block for the same reason
-        # (#46446); that block is removed and its logic absorbed here, since the fix applies equally to
-        # all compiled generate calls, not just chunked prefill.
-        # Skipped when the cache cannot be initialized on a single device.
-        init_shape = self._get_static_cache_init_shape()
-        if init_shape is not None:
-            num_heads, head_dim = init_shape
-            early_init_kwargs = dict(
-                batch_size=batch_size,
-                num_heads=num_heads,
-                head_dim=head_dim,
-                dtype=self.dtype,
-                device=self.device,
-            )
-            if self.config.is_encoder_decoder:
+        if self.config.is_encoder_decoder:
+            # Eagerly initialize the K/V buffers so that `mark_static_address` is applied before any
+            # `torch.compile` / CUDAGraph capture context. Without this, `lazy_initialization` runs inside
+            # graph capture (where `is_torchdynamo_compiling()` is True), causing `mark_static_address` to
+            # be skipped. CUDAGraphs then treats those tensors as pooled memory and can overwrite them
+            # between runs, raising:
+            #   "accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run"
+            # BOTH self-attention and cross-attention caches need early init: cross-attention K/V are
+            # computed from encoder hidden states on the first decode step, which happens inside the
+            # compiled graph, so they suffer the same lazy-init-inside-capture problem.
+            # Skipped when the cache cannot be initialized on a single device.
+            init_shape = self._get_static_cache_init_shape()
+            if init_shape is not None:
+                num_heads, head_dim = init_shape
+                early_init_kwargs = dict(
+                    batch_size=batch_size,
+                    num_heads=num_heads,
+                    head_dim=head_dim,
+                    dtype=self.dtype,
+                    device=self.device,
+                )
                 cache.self_attention_cache.early_initialization(**early_init_kwargs)
                 cache.cross_attention_cache.early_initialization(**early_init_kwargs)
-            else:
-                cache.early_initialization(**early_init_kwargs)
+        elif prefill_chunk_size is not None:
+            # Chunked prefill compiles the prefill, so eagerly init the fresh cache to avoid a recompile
+            # next call (#46446). Skipped (-> lazy init) when it can't be initialized on a single device.
+            init_shape = self._get_static_cache_init_shape()
+            if init_shape is not None:
+                num_heads, head_dim = init_shape
+                cache.early_initialization(
+                    batch_size=batch_size,
+                    num_heads=num_heads,
+                    head_dim=head_dim,
+                    dtype=self.dtype,
+                    device=self.device,
+                )
 
         # Set the current length on the current model, to avoid recompilation later if we can
         self._previous_max_cache_length = effective_length


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48199&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48199) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48199&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48199)
<!-- ci-dashboard-badge:end -->

## What

Fixes `T5ModelIntegrationTests::test_compile_static_cache` which fails with:

```
RuntimeError: Error: accessing tensor output of CUDAGraphs that has been
overwritten by a subsequent run.
```

## Root cause

`_prepare_static_cache` must call `early_initialization` on cache buffers
**before** any CUDAGraph capture so that `mark_static_address` is applied
while `is_torchdynamo_compiling()` is False. Without it, `lazy_initialization`
runs inside the capture context, `mark_static_address` is skipped, and
CUDAGraphs pools the tensor memory — overwriting it on the next replay.

For encoder-decoder models **both** the self-attention and cross-attention
caches need early init. The self-attention cache is straightforward, but the
**cross-attention** cache is the key issue: its K/V tensors are computed from
encoder hidden states on the **first decode step**, which happens inside the
compiled graph. So `lazy_initialization` runs inside graph capture, and
`mark_static_address` is never called.

**Regression introduced by #47731** ("Stop setting the static cache as an
attribute to save memory"): before that PR, `_prepare_static_cache` reused
`self._cache` across `generate` calls, so `lazy_initialization` had already
run outside any compiled context on the first call. After #47731, a fresh
`StaticCache` is always created, making eager initialization necessary.

### Decoder-only models (e.g. afmoe) — also affected, not yet fixed here

The same regression from #47731 also affects decoder-only models with
`test_compile_static_cache`. Before #47731, `self._cache` was reused across
`generate` calls, so `cumulative_length` (and other buffers) always had the
same tensor address. After #47731, a fresh `StaticCache` is created on every
call, so `cumulative_length` is at a different memory address each time —
CUDAGraph replay references the old address and triggers the overwrite error.

Confirmed: `afmoe::test_compile_static_cache` fails with the same
`RuntimeError: Error: accessing tensor output of CUDAGraphs` on the Aug 05 CI
commit (`9f66415aec`). The existing `elif prefill_chunk_size` block does not
cover this case.

**This PR only fixes the encoder-decoder path (T5).** The decoder-only fix
needs a separate look — would like @CyrilVallez to have a first look before
going further.

## Changes

- `_prepare_static_cache`: add an `if self.config.is_encoder_decoder` branch
  that calls `early_initialization` on **both** `self_attention_cache` and
  `cross_attention_cache` before graph capture.
- The existing `elif prefill_chunk_size` decoder-only block is **unchanged**.

## Test plan

- [x] `T5ModelIntegrationTests::test_compile_static_cache` — verified PASS on A10G runner (torch 2.13, sm_86)
- [x] All 14 `T5ModelIntegrationTests` pass