### PR TITLE
fix(glm): validate num_attention_heads is divisible by num_key_value_heads in GlmConfig

### DIFF
--- a/src/transformers/models/glm/configuration_glm.py
+++ b/src/transformers/models/glm/configuration_glm.py
@@ -79,5 +79,14 @@ class GlmConfig(PreTrainedConfig):
             self.eos_token_id = [151329, 151336, 151338]
         super().__post_init__(**kwargs)
 
+    def validate_architecture(self):
+        """Part of `@strict`-powered validation. Validates the architecture of the config."""
+        super().validate_architecture()
+        if self.num_attention_heads % self.num_key_value_heads != 0:
+            raise ValueError(
+                f"`num_attention_heads` ({self.num_attention_heads}) must be a multiple of "
+                f"`num_key_value_heads` ({self.num_key_value_heads})."
+            )
+
 
 __all__ = ["GlmConfig"]

--- a/tests/models/glm/test_modeling_glm.py
+++ b/tests/models/glm/test_modeling_glm.py
@@ -55,6 +55,18 @@ class GlmModelTester(CausalLMModelTester):
 class GlmModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = GlmModelTester
 
+    def test_gqa_heads_validation(self):
+        from transformers import GlmConfig
+
+        # Incompatible head counts should raise ValueError / Strict validation error
+        with self.assertRaises(Exception) as ctx:
+            GlmConfig(num_attention_heads=7, num_key_value_heads=2)
+        self.assertIn("must be a multiple of", str(ctx.exception))
+
+        # Compatible head counts should instantiate and pass validation
+        valid_config = GlmConfig(num_attention_heads=8, num_key_value_heads=2)
+        valid_config.validate_architecture()
+
 
 @slow
 @require_torch_large_accelerator


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48203&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48203) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48203&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48203)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Enforces that `num_attention_heads` must be a multiple of `num_key_value_heads` in `GlmConfig.validate_architecture()`.

Fixes #48169

## Rationale

GLM uses grouped-query attention (GQA) where `num_key_value_groups = config.num_attention_heads // config.num_key_value_heads`. When `num_attention_heads` is not divisible by `num_key_value_heads` (e.g. `num_attention_heads=7`, `num_key_value_heads=2`), config validation previously passed, but the first forward pass failed with a PyTorch RuntimeError.

Aligning `GlmConfig.validate_architecture()` with standard architecture validation ensures invalid head count configurations are caught early at config instantiation / validation time.

## Before submitting a pull request
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?