### PR TITLE
Fix expert-parallel training: NaN gradients and missing gradient contributions

### DIFF
--- a/src/transformers/distributed/mixin.py
+++ b/src/transformers/distributed/mixin.py
@@ -190,6 +190,7 @@ class DistributedMixin:
         if device_mesh is not None:
             model.config.distributed_config = distributed_config
             model._device_mesh = device_mesh
+            model._tp_size = distributed_config.tp_size
 
             if distributed_config.tp_size > 1:
                 tp_mesh = device_mesh["tp"] if device_mesh.ndim > 1 else device_mesh

--- a/src/transformers/distributed/tensor_parallel.py
+++ b/src/transformers/distributed/tensor_parallel.py
@@ -709,10 +709,8 @@ class EpRouterParallel(TensorParallelLayer):
         num_local_experts = num_experts // ep_size
 
         router_logits, router_scores, router_indices, *extra_outputs = output
-        # The gradient reaching each rank's scores covers only the slots of its local experts (the
-        # non-local slots are zeroed by the mask below in backward). Sum the per-rank partial
-        # gradients BEFORE the mask so the gate weights and the hidden states upstream of the router
-        # receive the full gradient — each slot has exactly one owning rank, so the sum is exact.
+        # Each rank's score gradient covers only its local experts' slots; sum the per-rank partials
+        # before the mask (each slot has exactly one owning rank, so the sum is exact).
         process_group = mesh.get_group() if mesh.ndim == 1 else mesh.get_group("tp")
         router_scores = _AllReduceBackward.apply(router_scores, process_group)
         non_local_mask = (router_indices // num_local_experts) != ep_rank

--- a/src/transformers/distributed/tensor_parallel.py
+++ b/src/transformers/distributed/tensor_parallel.py
@@ -709,6 +709,12 @@ class EpRouterParallel(TensorParallelLayer):
         num_local_experts = num_experts // ep_size
 
         router_logits, router_scores, router_indices, *extra_outputs = output
+        # The gradient reaching each rank's scores covers only the slots of its local experts (the
+        # non-local slots are zeroed by the mask below in backward). Sum the per-rank partial
+        # gradients BEFORE the mask so the gate weights and the hidden states upstream of the router
+        # receive the full gradient — each slot has exactly one owning rank, so the sum is exact.
+        process_group = mesh.get_group() if mesh.ndim == 1 else mesh.get_group("tp")
+        router_scores = _AllReduceBackward.apply(router_scores, process_group)
         non_local_mask = (router_indices // num_local_experts) != ep_rank
         router_scores = router_scores.masked_fill(non_local_mask, 0.0)
         router_indices = router_indices.masked_fill(non_local_mask, -1)

--- a/src/transformers/distributed/tensor_parallel.py
+++ b/src/transformers/distributed/tensor_parallel.py
@@ -711,8 +711,9 @@ class EpRouterParallel(TensorParallelLayer):
         router_logits, router_scores, router_indices, *extra_outputs = output
         # Each rank's score gradient covers only its local experts' slots; sum the per-rank partials
         # before the mask (each slot has exactly one owning rank, so the sum is exact).
-        process_group = mesh.get_group() if mesh.ndim == 1 else mesh.get_group("tp")
-        router_scores = _AllReduceBackward.apply(router_scores, process_group)
+        if torch.is_grad_enabled() and router_scores.requires_grad:
+            process_group = mesh.get_group() if mesh.ndim == 1 else mesh.get_group("tp")
+            router_scores = _AllReduceBackward.apply(router_scores, process_group)
         non_local_mask = (router_indices // num_local_experts) != ep_rank
         router_scores = router_scores.masked_fill(non_local_mask, 0.0)
         router_indices = router_indices.masked_fill(non_local_mask, -1)

--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -441,6 +441,11 @@ def grouped_mm_experts_forward(
         selected_hidden_states_g, selected_weights, offsets, bias=selected_biases, is_transposed=self.is_transposed
     )  # (S, 2 * intermediate_dim) or  (S, intermediate_dim) depending on whether we have gating
 
+    # Mask the sentinel-tail rows the kernel left uninitialized, in forward AND backward: relying on
+    # the single post-mask lets NaN/Inf from the uninitialized rows transit through the activation and
+    # down-projection backward, where it can escape into finite gradients.
+    proj_out = proj_out.masked_fill(sentinel_mask, 0.0)
+
     # Apply gating or activation
     if self.has_gate:
         # for gated experts we apply the custom/default gating mechanism
@@ -457,6 +462,9 @@ def grouped_mm_experts_forward(
     proj_out = _grouped_linear(
         proj_out, selected_weights, offsets, bias=selected_biases, is_transposed=self.is_transposed
     )  # (S, hidden_dim)
+
+    # Same as above: zero the uninitialized sentinel-tail rows before anything consumes them.
+    proj_out = proj_out.masked_fill(sentinel_mask, 0.0)
 
     # Apply routing weights
     weighted_out = proj_out * sample_weights_g.unsqueeze(-1)  # (S, hidden_dim)

--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -441,9 +441,7 @@ def grouped_mm_experts_forward(
         selected_hidden_states_g, selected_weights, offsets, bias=selected_biases, is_transposed=self.is_transposed
     )  # (S, 2 * intermediate_dim) or  (S, intermediate_dim) depending on whether we have gating
 
-    # Mask the sentinel-tail rows the kernel left uninitialized, in forward AND backward: relying on
-    # the single post-mask lets NaN/Inf from the uninitialized rows transit through the activation and
-    # down-projection backward, where it can escape into finite gradients.
+    # Zero the sentinel-tail rows the kernel left uninitialized (fwd output and bwd `d_input`).
     proj_out = proj_out.masked_fill(sentinel_mask, 0.0)
 
     # Apply gating or activation
@@ -463,7 +461,7 @@ def grouped_mm_experts_forward(
         proj_out, selected_weights, offsets, bias=selected_biases, is_transposed=self.is_transposed
     )  # (S, hidden_dim)
 
-    # Same as above: zero the uninitialized sentinel-tail rows before anything consumes them.
+    # Same: zero the uninitialized sentinel-tail rows.
     proj_out = proj_out.masked_fill(sentinel_mask, 0.0)
 
     # Apply routing weights

--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -467,9 +467,6 @@ def grouped_mm_experts_forward(
     # Apply routing weights
     weighted_out = proj_out * sample_weights_g.unsqueeze(-1)  # (S, hidden_dim)
 
-    # Post-mask (fwd path).
-    weighted_out.masked_fill_(sentinel_mask, 0.0)
-
     # Restore original order
     inv_perm = torch.empty_like(perm)
     inv_perm[perm] = torch.arange(perm.size(0), device=device)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -610,6 +610,8 @@ class Trainer:
         self._train_batch_size = args.train_batch_size
         # Guards one-time LR scheduler creation in create_optimizer_and_scheduler
         self._created_lr_scheduler = False
+        # Resolved lazily at the first gradient clip; see `_has_mixed_mesh_grads`.
+        self._mixed_mesh_grads: bool | None = None
 
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
@@ -2613,17 +2615,68 @@ class Trainer:
         input_tokens = torch.as_tensor(input_tokens, device=self.args.device, dtype=torch.int64)
         self.state.num_input_tokens_seen += self.accelerator.gather(input_tokens).sum().item()
 
+    def _mixed_mesh_grad_norm(self, model, max_norm):
+        """Gradient norm (and clip) when only some parameters are sharded, as under expert parallelism.
+
+        Expert parallelism shards the expert weights and leaves everything else replicated, so
+        `model.parameters()` holds a mix of `DTensor` and plain tensors and `_foreach_norm` cannot span
+        both. Take the two groups separately: the sharded gradients contribute their local norms summed
+        across the mesh, the replicated ones are identical on every rank and are counted once.
+        """
+        from torch.distributed.tensor import DTensor
+
+        sharded, replicated = [], []
+        for param in model.parameters():
+            if param.grad is None:
+                continue
+            (sharded if isinstance(param.grad, DTensor) else replicated).append(param.grad)
+
+        device = (sharded or replicated)[0].device
+        replicated_sq = torch.zeros((), device=device, dtype=torch.float32)
+        if replicated:
+            replicated_sq = torch.linalg.vector_norm(torch.stack([g.norm(2) for g in replicated])) ** 2
+
+        sharded_sq = torch.zeros((), device=device, dtype=torch.float32)
+        if sharded:
+            local = [g.to_local() for g in sharded]
+            sharded_sq = torch.linalg.vector_norm(torch.stack([g.norm(2) for g in local])) ** 2
+            # Sum the per-shard contributions over the mesh the experts are sharded on.
+            torch.distributed.all_reduce(sharded_sq, group=sharded[0].device_mesh.get_group())
+
+        total_norm = (replicated_sq + sharded_sq).sqrt()
+        if max_norm != float("inf"):
+            clip = (max_norm / (total_norm + 1e-6)).clamp(max=1.0)
+            for g in replicated:
+                g.mul_(clip)
+            for g in sharded:
+                g.to_local().mul_(clip)
+        return total_norm
+
+    def _has_mixed_mesh_grads(self, model) -> bool:
+        # Static for the life of the run (sharding never changes after setup), so scan the
+        # parameters only on the first call.
+        if self._mixed_mesh_grads is None:
+            from .trainer_optimizer import has_mixed_dtensor
+
+            self._mixed_mesh_grads = has_mixed_dtensor(p.grad for p in model.parameters() if p.grad is not None)
+        return self._mixed_mesh_grads
+
     def _clip_grad_norm(self, model):
         """Clip gradients to max_grad_norm. Returns the pre-clip gradient norm."""
         if is_sagemaker_mp_enabled() and self.args.fp16:
             return self.optimizer.clip_master_grads(self.args.max_grad_norm)
+        if self._has_mixed_mesh_grads(model):
+            return self._mixed_mesh_grad_norm(model, self.args.max_grad_norm)
         return self.accelerator.clip_grad_norm_(model.parameters(), self.args.max_grad_norm)
 
     def _get_grad_norm(self, model, grad_norm=None):
         """Return the gradient norm as a Python float."""
         if grad_norm is None:
             # Compute norm without clipping (inf means no actual clipping happens)
-            grad_norm = self.accelerator.clip_grad_norm_(model.parameters(), float("inf"))
+            if self._has_mixed_mesh_grads(model):
+                grad_norm = self._mixed_mesh_grad_norm(model, float("inf"))
+            else:
+                grad_norm = self.accelerator.clip_grad_norm_(model.parameters(), float("inf"))
 
         if self.accelerator.distributed_type == DistributedType.DEEPSPEED:
             if hasattr(grad_norm, "item"):

--- a/src/transformers/trainer_optimizer.py
+++ b/src/transformers/trainer_optimizer.py
@@ -205,7 +205,24 @@ def _get_adamw_torch(ctx: OptimizerContext) -> tuple[Any, dict[str, Any]]:
     ctx.optimizer_kwargs.update(ctx.adam_kwargs)
     if ctx.args.optim == OptimizerNames.ADAMW_TORCH_FUSED:
         ctx.optimizer_kwargs.update({"fused": True})
+    # HACK(ep-2d): expert parallelism leaves only the expert weights as DTensor, so the fused and
+    # foreach kernels cannot span the parameter set. Step per parameter instead.
+    if ctx.model is not None and has_mixed_dtensor(p for p in ctx.model.parameters() if p.requires_grad):
+        ctx.optimizer_kwargs.update({"fused": False, "foreach": False})
     return AdamW, ctx.optimizer_kwargs
+
+
+def has_mixed_dtensor(tensors) -> bool:
+    """Whether `tensors` mixes `DTensor` and plain tensors, as expert parallelism leaves a model:
+    experts sharded, everything else replicated."""
+    from torch.distributed.tensor import DTensor
+
+    tensors = list(tensors)
+    return (
+        bool(tensors)
+        and any(isinstance(t, DTensor) for t in tensors)
+        and not all(isinstance(t, DTensor) for t in tensors)
+    )
 
 
 def _get_adamw_torch_xla(ctx: OptimizerContext) -> tuple[Any, dict[str, Any]]:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48205&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48205) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48205&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48205)
<!-- ci-dashboard-badge:end -->

Two bugs in expert-parallel training (`enable_expert_parallel=True`), found while validating FSDP2 × EP (#48204): full fine-tuning of an EP-sharded MoE trains on wrong gradients, then collapses to NaN on step 2. +14 lines total.

**1. NaN from uninitialized memory.** `torch._grouped_mm` leaves the sentinel-tail rows of its output and backward `d_input` uninitialized, and the NaN escapes through the `act_fn(gate) * up` backward (`0 × Inf`). Step 1 survives only because fresh CUDA memory is zeroed; step 2 reuses dirty memory → `grad_norm=nan`, loss → 0. Fix: mask the sentinel rows after each grouped GEMM.

**2. Missing gradient contributions for every non-expert parameter.** The router hook zeroes non-local score slots, so each rank's score gradient covers only its local experts, and the per-rank partials are never summed: everything upstream of each MoE block loses the gradient flowing through remote experts. Fix: allreduce-sum the score gradient before the mask (each slot has one owning rank, so the sum is exact).

### Certification

fp32 gradient diff vs a single-GPU reference (OLMoE-1B-7B, one batch, `tp_size=4`) — median relative error per class:

| class | main | this PR |
|---|---|---|
| attention (64) | 3.0e-1 | 7.8e-7 |
| norms (65) | 3.0e-1 | 7.7e-7 |
| router gates (16) | 1.0e+0 | 1.4e-6 |
| embed / lm_head (2) | 2.3e-1 | 1.5e-6 |
| experts (32) | 3.6e-1 | 1.3e-6 |

With this PR all 179 parameters match the reference (max rel err 2.5e-5). Same certification on real Qwen3-30B-A3B weights (first 4 layers): 47/47, max 2.7e-6; and on gpt-oss-20b (expert biases + sigmoid gate): 71/71, max 9.5e-3. In bf16, EP full fine-tuning goes `12.13 → nan/0` on main; with this PR it tracks a single-GPU control step by step (`12.13 → 12.45 → 11.52 → … → 11.04` vs `12.13 → 12.45 → 11.51 → … → 11.09`). Also fixes NaN under fused losses consuming EP outputs (e.g. TRL's chunked cross-entropy).

<details><summary>Certification script (raw forward/backward, EP through <code>Trainer</code> is separately broken on main, see #48204)</summary>

```python
# 1) python cert.py single ref.pt        (1 GPU)
# 2) torchrun --nproc_per_node 4 cert.py ep ref.pt
import sys

import torch
from torch.distributed.tensor import DTensor

from transformers import AutoModelForCausalLM
from transformers.distributed import DistributedConfig

mode, ref_path = sys.argv[1], sys.argv[2]

kwargs = {}
if mode == "ep":
    kwargs["distributed_config"] = DistributedConfig(tp_size=4, fsdp_size=1, enable_expert_parallel=True)
model = AutoModelForCausalLM.from_pretrained("allenai/OLMoE-1B-7B-0924", dtype=torch.float32, **kwargs)
if mode == "single":
    model.cuda()
model.train()

g = torch.Generator().manual_seed(0)
ids = torch.randint(0, 50000, (1, 512), generator=g).cuda()
out = model(input_ids=ids, labels=ids.clone())
out.loss.backward()

rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
if mode == "single":
    grads = {n: p.grad.detach().float().cpu() for n, p in model.named_parameters() if p.grad is not None}
    torch.save(grads, ref_path)
    print(f"saved {len(grads)} grads")
else:
    ref = torch.load(ref_path, weights_only=False) if rank == 0 else None
    bad = 0
    for name, p in model.named_parameters():
        if p.grad is None:
            continue
        gr = p.grad
        if isinstance(gr, DTensor):
            gr = gr.full_tensor()
        if rank == 0:
            ga = ref[name].cuda()
            rel = ((ga - gr.detach().float()).abs().max() / (ga.abs().max() + 1e-12)).item()
            bad += rel > 2e-2
    if rank == 0:
        print(f"{bad} parameters with relative error > 2e-2")
    torch.distributed.barrier()
    torch.distributed.destroy_process_group()
```

</details>
