### PR TITLE
Fix loss inflation under gradient accumulation for ForImageClassifica…

### DIFF
--- a/src/transformers/models/beit/modeling_beit.py
+++ b/src/transformers/models/beit/modeling_beit.py
@@ -712,7 +712,7 @@ class BeitForImageClassification(BeitPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/beit/modular_beit.py
+++ b/src/transformers/models/beit/modular_beit.py
@@ -519,7 +519,7 @@ class BeitForImageClassification(BeitPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/bit/modeling_bit.py
+++ b/src/transformers/models/bit/modeling_bit.py
@@ -734,7 +734,7 @@ class BitForImageClassification(BitPreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -998,7 +998,7 @@ class CLIPForImageClassification(CLIPPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/convnext/modeling_convnext.py
+++ b/src/transformers/models/convnext/modeling_convnext.py
@@ -325,7 +325,7 @@ class ConvNextForImageClassification(ConvNextPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels=labels, pooled_logits=logits, config=self.config)
+            loss = self.loss_function(labels=labels, pooled_logits=logits, config=self.config, **kwargs)
 
         return ImageClassifierOutputWithNoAttention(
             loss=loss,

--- a/src/transformers/models/convnextv2/modeling_convnextv2.py
+++ b/src/transformers/models/convnextv2/modeling_convnextv2.py
@@ -348,7 +348,7 @@ class ConvNextV2ForImageClassification(ConvNextV2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels=labels, pooled_logits=logits, config=self.config)
+            loss = self.loss_function(labels=labels, pooled_logits=logits, config=self.config, **kwargs)
 
         return ImageClassifierOutputWithNoAttention(
             loss=loss,

--- a/src/transformers/models/cvt/modeling_cvt.py
+++ b/src/transformers/models/cvt/modeling_cvt.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass
 
 import torch
 from torch import nn
-from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from ... import initialization as init
 from ...modeling_outputs import ImageClassifierOutputWithNoAttention, ModelOutput
@@ -598,26 +597,7 @@ class CvtForImageClassification(CvtPreTrainedModel):
 
         loss = None
         if labels is not None:
-            if self.config.problem_type is None:
-                if self.config.num_labels == 1:
-                    self.config.problem_type = "regression"
-                elif self.config.num_labels > 1 and (labels.dtype == torch.long or labels.dtype == torch.int):
-                    self.config.problem_type = "single_label_classification"
-                else:
-                    self.config.problem_type = "multi_label_classification"
-
-            if self.config.problem_type == "regression":
-                loss_fct = MSELoss()
-                if self.config.num_labels == 1:
-                    loss = loss_fct(logits.squeeze(), labels.squeeze())
-                else:
-                    loss = loss_fct(logits, labels)
-            elif self.config.problem_type == "single_label_classification":
-                loss_fct = CrossEntropyLoss()
-                loss = loss_fct(logits.view(-1, self.config.num_labels), labels.view(-1))
-            elif self.config.problem_type == "multi_label_classification":
-                loss_fct = BCEWithLogitsLoss()
-                loss = loss_fct(logits, labels)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/data2vec/modeling_data2vec_vision.py
+++ b/src/transformers/models/data2vec/modeling_data2vec_vision.py
@@ -817,7 +817,7 @@ class Data2VecVisionForImageClassification(Data2VecVisionPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/dinat/modeling_dinat.py
+++ b/src/transformers/models/dinat/modeling_dinat.py
@@ -667,7 +667,7 @@ class DinatForImageClassification(DinatPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/donut/modeling_donut_swin.py
+++ b/src/transformers/models/donut/modeling_donut_swin.py
@@ -926,7 +926,7 @@ class DonutSwinForImageClassification(DonutSwinPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/efficientnet/modeling_efficientnet.py
+++ b/src/transformers/models/efficientnet/modeling_efficientnet.py
@@ -551,7 +551,7 @@ class EfficientNetForImageClassification(EfficientNetPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/focalnet/modeling_focalnet.py
+++ b/src/transformers/models/focalnet/modeling_focalnet.py
@@ -831,7 +831,7 @@ class FocalNetForImageClassification(FocalNetPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/hgnet_v2/modeling_hgnet_v2.py
+++ b/src/transformers/models/hgnet_v2/modeling_hgnet_v2.py
@@ -482,7 +482,7 @@ class HGNetV2ForImageClassification(HGNetV2PreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/hgnet_v2/modular_hgnet_v2.py
+++ b/src/transformers/models/hgnet_v2/modular_hgnet_v2.py
@@ -571,7 +571,7 @@ class HGNetV2ForImageClassification(HGNetV2PreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/hiera/modeling_hiera.py
+++ b/src/transformers/models/hiera/modeling_hiera.py
@@ -1256,7 +1256,7 @@ class HieraForImageClassification(HieraPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/imagegpt/modeling_imagegpt.py
+++ b/src/transformers/models/imagegpt/modeling_imagegpt.py
@@ -802,7 +802,7 @@ class ImageGPTForImageClassification(ImageGPTPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + transformer_outputs[1:]

--- a/src/transformers/models/levit/modeling_levit.py
+++ b/src/transformers/models/levit/modeling_levit.py
@@ -581,7 +581,7 @@ class LevitForImageClassification(LevitPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/metaclip_2/modeling_metaclip_2.py
+++ b/src/transformers/models/metaclip_2/modeling_metaclip_2.py
@@ -1153,7 +1153,7 @@ class MetaClip2ForImageClassification(MetaClip2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/mobilenet_v1/modeling_mobilenet_v1.py
+++ b/src/transformers/models/mobilenet_v1/modeling_mobilenet_v1.py
@@ -276,7 +276,7 @@ class MobileNetV1ForImageClassification(MobileNetV1PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/mobilenet_v2/modeling_mobilenet_v2.py
+++ b/src/transformers/models/mobilenet_v2/modeling_mobilenet_v2.py
@@ -412,7 +412,7 @@ class MobileNetV2ForImageClassification(MobileNetV2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/mobilevit/modeling_mobilevit.py
+++ b/src/transformers/models/mobilevit/modeling_mobilevit.py
@@ -733,7 +733,7 @@ class MobileViTForImageClassification(MobileViTPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/mobilevitv2/modeling_mobilevitv2.py
+++ b/src/transformers/models/mobilevitv2/modeling_mobilevitv2.py
@@ -709,7 +709,7 @@ class MobileViTV2ForImageClassification(MobileViTV2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/perceiver/modeling_perceiver.py
+++ b/src/transformers/models/perceiver/modeling_perceiver.py
@@ -1160,7 +1160,7 @@ class PerceiverForImageClassificationLearned(PerceiverPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]
@@ -1283,7 +1283,7 @@ class PerceiverForImageClassificationFourier(PerceiverPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]
@@ -1407,7 +1407,7 @@ class PerceiverForImageClassificationConvProcessing(PerceiverPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/poolformer/modeling_poolformer.py
+++ b/src/transformers/models/poolformer/modeling_poolformer.py
@@ -364,7 +364,7 @@ class PoolFormerForImageClassification(PoolFormerPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/pvt/modeling_pvt.py
+++ b/src/transformers/models/pvt/modeling_pvt.py
@@ -526,7 +526,7 @@ class PvtForImageClassification(PvtPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[1:]

--- a/src/transformers/models/pvt_v2/modeling_pvt_v2.py
+++ b/src/transformers/models/pvt_v2/modeling_pvt_v2.py
@@ -484,7 +484,7 @@ class PvtV2ForImageClassification(PvtV2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[1:]

--- a/src/transformers/models/regnet/modeling_regnet.py
+++ b/src/transformers/models/regnet/modeling_regnet.py
@@ -367,7 +367,7 @@ class RegNetForImageClassification(RegNetPreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/resnet/modeling_resnet.py
+++ b/src/transformers/models/resnet/modeling_resnet.py
@@ -375,7 +375,7 @@ class ResNetForImageClassification(ResNetPreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -913,7 +913,7 @@ class SiglipForImageClassification(SiglipPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/siglip2/modeling_siglip2.py
+++ b/src/transformers/models/siglip2/modeling_siglip2.py
@@ -1005,7 +1005,7 @@ class Siglip2ForImageClassification(Siglip2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/siglip2/modular_siglip2.py
+++ b/src/transformers/models/siglip2/modular_siglip2.py
@@ -571,7 +571,7 @@ class Siglip2ForImageClassification(SiglipForImageClassification):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/src/transformers/models/swiftformer/modeling_swiftformer.py
+++ b/src/transformers/models/swiftformer/modeling_swiftformer.py
@@ -499,7 +499,7 @@ class SwiftFormerForImageClassification(SwiftFormerPreTrainedModel):
         # calculate loss
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[1:]

--- a/src/transformers/models/swinv2/modeling_swinv2.py
+++ b/src/transformers/models/swinv2/modeling_swinv2.py
@@ -1152,7 +1152,7 @@ class Swinv2ForImageClassification(Swinv2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/textnet/modeling_textnet.py
+++ b/src/transformers/models/textnet/modeling_textnet.py
@@ -329,7 +329,7 @@ class TextNetForImageClassification(TextNetPreTrainedModel):
         loss = None
 
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -383,7 +383,7 @@ class TimmWrapperForImageClassification(TimmWrapperPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(labels, logits, self.config)
+            loss = self.loss_function(labels, logits, self.config, **kwargs)
 
         if not return_dict:
             outputs = (loss, logits, hidden_states)

--- a/src/transformers/models/vjepa2/modeling_vjepa2.py
+++ b/src/transformers/models/vjepa2/modeling_vjepa2.py
@@ -1042,7 +1042,7 @@ class VJEPA2ForVideoClassification(VJEPA2PreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(pooled_logits=logits, labels=labels, config=self.config)
+            loss = self.loss_function(pooled_logits=logits, labels=labels, config=self.config, **kwargs)
 
         return ImageClassifierOutput(
             loss=loss,

--- a/tests/models/shieldgemma2/test_modeling_shieldgemma2.py
+++ b/tests/models/shieldgemma2/test_modeling_shieldgemma2.py
@@ -185,6 +185,10 @@ class ShieldGemma2ModelTest(VLMModelTest, unittest.TestCase):
     def test_problem_types(self):
         pass
 
+    @unittest.skip(reason="ShieldGemma2ForImageClassification does not compute a training loss")
+    def test_image_classification_loss_respects_num_items_in_batch(self):
+        pass
+
     @unittest.skip(reason="ShieldGemma2ForImageClassification does not have a num_labels-based classifier head")
     def test_can_load_ignoring_mismatched_shapes(self):
         pass

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2680,8 +2680,10 @@ class ModelTesterMixin(ExportTesterMixin):
                             torch.testing.assert_close(
                                 v,
                                 reloaded_state[k],
-                                msg=lambda x: f"{model_class.__name__}: Tensor {k}: {x}.\n{v}\nvs\n{reloaded_state[k]}\n"
-                                "This probably means that it was not set with the correct value when tying.",
+                                msg=lambda x: (
+                                    f"{model_class.__name__}: Tensor {k}: {x}.\n{v}\nvs\n{reloaded_state[k]}\n"
+                                    "This probably means that it was not set with the correct value when tying."
+                                ),
                             )
 
                     # Checking the tensor sharing are correct on the new model (weights are properly tied in both cases)
@@ -2727,7 +2729,9 @@ class ModelTesterMixin(ExportTesterMixin):
                             torch.testing.assert_close(
                                 v,
                                 reloaded_state[k],
-                                msg=lambda x: f"{model_class.__name__}: Tensor {k}: {x}. Key {k} was serialized: {k in serialized_keys}. If `False`, this means it was probably aliased and safetensors removed it. If `True` it means `_init_weights` overwrote that key",
+                                msg=lambda x: (
+                                    f"{model_class.__name__}: Tensor {k}: {x}. Key {k} was serialized: {k in serialized_keys}. If `False`, this means it was probably aliased and safetensors removed it. If `True` it means `_init_weights` overwrote that key"
+                                ),
                             )
 
                 # Checking there was no complain of missing weights
@@ -3253,6 +3257,84 @@ class ModelTesterMixin(ExportTesterMixin):
                             )
 
                     loss.backward()
+
+    def test_image_classification_loss_respects_num_items_in_batch(self):
+        """
+        A `forward()` that declares `**kwargs` tells the `Trainer` "I accept loss kwargs", which makes
+        `Trainer.training_step` skip its own gradient-accumulation loss normalization (dividing by
+        `current_gradient_accumulation_steps`) on the assumption that the model already normalized using
+        `num_items_in_batch`. If the head drops `**kwargs` (or drops `num_items_in_batch` specifically) before
+        calling `self.loss_function`, neither normalization happens: the reported loss -- and its gradient --
+        end up inflated by roughly the accumulation step count. See #47688.
+
+        Rather than compare loss values (which requires per-architecture tolerances), this wraps
+        `loss_function` and checks the kwargs it actually receives, so the assertion is exact and architecture
+        agnostic. Gated to `MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING_NAMES`: every head registered there resolves
+        to `ForSequenceClassificationLoss` (via the `ForImageClassification` -> loss_type auto-detection), which
+        does use `num_items_in_batch` when given it, so every applicable class here is expected to pass.
+        """
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        applicable_classes = [
+            c for c in self.all_model_classes if c.__name__ in get_values(MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING_NAMES)
+        ]
+        if not applicable_classes:
+            self.skipTest(reason="No image classification head to check")
+
+        for model_class in applicable_classes:
+            with self.subTest(model_class.__name__):
+                forward_params = inspect.signature(model_class.forward).parameters
+
+                # A head whose forward() has no **kwargs can never receive num_items_in_batch in the first
+                # place; `Trainer.model_accepts_loss_kwargs` (a signature check) will be False for it, so the
+                # Trainer normalizes the loss itself. Nothing for this test to check there.
+                if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in forward_params.values()):
+                    continue
+
+                # Some heads registered under "ForImageClassification" (e.g. distillation-style "WithTeacher"
+                # variants) don't accept `labels` / compute a loss at all -- they're inference-only. Nothing to
+                # check there either.
+                if "labels" not in forward_params:
+                    continue
+
+                model = model_class(config)
+                model.to(torch_device)
+                model.eval()
+
+                received_kwargs = {}
+                original_loss_function = model.loss_function
+
+                def spy_loss_function(*args, **kwargs):
+                    received_kwargs.update(kwargs)
+                    return original_loss_function(*args, **kwargs)
+
+                model.loss_function = spy_loss_function
+
+                inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
+                try:
+                    with torch.no_grad():
+                        model(**inputs, num_items_in_batch=torch.tensor(4.0, device=torch_device))
+                except Exception as e:
+                    # This test only cares whether num_items_in_batch reaches loss_function once the model
+                    # runs. Whether the shared minimal tester config/inputs can drive this particular
+                    # architecture through a full forward pass at all is a different, pre-existing concern
+                    # that other tests (e.g. test_training) are responsible for -- so skip just this class
+                    # rather than failing (or aborting the remaining classes via self.skipTest).
+                    warnings.warn(
+                        f"Skipping {model_class.__name__} in test_image_classification_loss_respects_num_items_"
+                        f"in_batch: could not run forward() with the shared tester config/inputs (unrelated to "
+                        f"num_items_in_batch propagation): {e}",
+                        stacklevel=2,
+                    )
+                    continue
+
+                self.assertIn(
+                    "num_items_in_batch",
+                    received_kwargs,
+                    f"{model_class.__name__}.forward() declares **kwargs but does not forward it (or "
+                    "num_items_in_batch specifically) into self.loss_function(...). This silently defeats the "
+                    "Trainer's gradient-accumulation loss normalization -- see #47688.",
+                )
 
     def test_load_with_mismatched_shapes(self):
         if not self.test_mismatched_shapes:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48207&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48207) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48207&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48207)
<!-- ci-dashboard-badge:end -->

Part of #47688 

## The bug

`Trainer.training_step` decides whether to divide the loss by
`current_gradient_accumulation_steps` based on
`self.model_accepts_loss_kwargs`, which is set from a signature check: if a
model's `forward()` declares `**kwargs`, the Trainer assumes the model will
normalize the loss itself using `num_items_in_batch`, and skips its own
normalization.

Several `*ForImageClassification` / `*ForVideoClassification` heads declare
`**kwargs` in `forward()` but never forward it (or `num_items_in_batch`
specifically) into `self.loss_function(...)`. That satisfies the Trainer's
signature check without actually doing anything with it, so **neither**
normalization happens — the reported loss, and its gradient, end up inflated
by roughly the gradient-accumulation step count.

`SwinForImageClassification` already does this correctly
(`self.loss_function(labels, logits, self.config, **kwargs)`).
`Swinv2ForImageClassification`, right next to it, drops the `**kwargs`
(`self.loss_function(labels, logits, self.config)`) — same codebase, same
loss function, silently different behavior under gradient accumulation.

### Repro

```python
import torch
from transformers import SwinConfig, SwinForImageClassification, Swinv2Config, Swinv2ForImageClassification

kwargs = dict(image_size=32, patch_size=2, embed_dim=8, depths=[1, 1],
              num_heads=[1, 1], window_size=2, num_labels=3)
torch.manual_seed(0)
pixel_values, labels = torch.randn(4, 3, 32, 32), torch.tensor([0, 1, 2, 0])

for name, cls, cfg in [("Swin", SwinForImageClassification, SwinConfig),
                        ("Swinv2", Swinv2ForImageClassification, Swinv2Config)]:
    torch.manual_seed(0)
    model = cls(cfg(**kwargs)).eval()
    with torch.no_grad():
        l4 = model(pixel_values=pixel_values, labels=labels, num_items_in_batch=4).loss
        l8 = model(pixel_values=pixel_values, labels=labels, num_items_in_batch=8).loss
    print(name, "l4/l8 =", (l4 / l8).item(), "(want 2.0)")
```

```
Swin    l4/l8 = 2.0000   (correct: passing a smaller num_items_in_batch scales the loss up)
Swinv2  l4/l8 = 1.0000   (bug: num_items_in_batch is silently ignored)
```

## The fix

Forward `**kwargs` into `self.loss_function(...)` for every affected class,
matching Swin's existing pattern. Every class touched here is registered
under `MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING_NAMES`, which resolves to
`ForSequenceClassificationLoss` via the `ForImageClassification` → `loss_type`
auto-detection in `PreTrainedModel` — and that loss function *does* use
`num_items_in_batch` (via `fixed_cross_entropy`) when it's given, so the fix
is meaningful, not a no-op, for every one of these.

34 classes across 33 files:

`BeitForImageClassification`, `BitForImageClassification`,
`CLIPForImageClassification`, `ConvNextForImageClassification`,
`ConvNextV2ForImageClassification`, `Data2VecVisionForImageClassification`,
`DinatForImageClassification`, `DonutSwinForImageClassification`,
`EfficientNetForImageClassification`, `FocalNetForImageClassification`,
`HGNetV2ForImageClassification`, `HieraForImageClassification`,
`ImageGPTForImageClassification`, `LevitForImageClassification`,
`MetaClip2ForImageClassification`, `MobileNetV1ForImageClassification`,
`MobileNetV2ForImageClassification`, `MobileViTForImageClassification`,
`MobileViTV2ForImageClassification`, `PerceiverForImageClassificationLearned`,
`PerceiverForImageClassificationFourier`,
`PerceiverForImageClassificationConvProcessing`,
`PoolFormerForImageClassification`, `PvtForImageClassification`,
`PvtV2ForImageClassification`, `RegNetForImageClassification`,
`ResNetForImageClassification`, `SiglipForImageClassification`,
`Siglip2ForImageClassification`, `SwiftFormerForImageClassification`,
`Swinv2ForImageClassification`, `TextNetForImageClassification`,
`TimmWrapperForImageClassification`, `VJEPA2ForVideoClassification`.

Three of these are generated from `modular_*.py` sources
(`HGNetV2ForImageClassification`, `BeitForImageClassification` directly;
`Siglip2ForImageClassification` overrides `forward()` in its own modular
file rather than inheriting it). The fix is applied in the modular source in
those cases, and `modeling_*.py` regenerated via
`utils/modular_model_converter.py` — confirmed consistent with
`utils/check_modular_conversion.py` and `utils/check_copies.py`.

## Test

Added `test_image_classification_loss_respects_num_items_in_batch` to the
shared `ModelTesterMixin` in `tests/test_modeling_common.py`. Rather than
compare loss values (which needs per-architecture tolerances), it wraps
`loss_function` and asserts `num_items_in_batch` actually reaches it — so the
check is exact and architecture-agnostic. It's gated to
`MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING_NAMES`, so it automatically covers
every current and future model registered there, without needing a
per-model hand-written test.

I verified the test fails against the pre-fix code (reverted `Swinv2` locally
and reran) and passes after the fix, and ran the full non-slow suite for all
33 touched model test files plus this new test: **3405 passed, 0 failed**
(4652 skipped are the usual TF/Flax/slow-marked skips in this environment).

## Scope — what this PR does *not* fix

#47688 identifies ~65 classes across two different bug shapes:

- **Group 1** (`forward()` has `**kwargs`, the loss function *does* use
  `num_items_in_batch`, just needs the kwargs forwarded) — this PR fixes the
  34 image/video classification heads in this group. The issue also flags
  causal-LM/VL heads (e.g. `Qwen3VLForConditionalGeneration`) and text
  sequence/token-classification heads (e.g. `GPTNeoXForSequenceClassification`)
  in the same group — same fix shape, but different call signatures per
  family, so I scoped this PR to the one homogeneous, mechanically-verifiable
  pattern rather than touching ~45 more files with less uniform review risk.
- **Group 2** (DETR-family object detection, RNNT ASR heads) needs the
  opposite fix — `accepts_loss_kwargs = False` — since those loss functions
  don't use item counts at all. Not touched here.