### PR TITLE
Fix expert parallelism through Trainer

### DIFF
--- a/src/transformers/distributed/mixin.py
+++ b/src/transformers/distributed/mixin.py
@@ -190,6 +190,10 @@ class DistributedMixin:
         if device_mesh is not None:
             model.config.distributed_config = distributed_config
             model._device_mesh = device_mesh
+            # `Trainer` reads this to build accelerate's `ParallelismConfig`. Without it accelerate
+            # sees `world_size` unaccounted-for ranks and wraps the already-sharded model in DDP,
+            # which rejects DTensor parameters.
+            model._tp_size = distributed_config.tp_size
 
             if distributed_config.tp_size > 1:
                 tp_mesh = device_mesh["tp"] if device_mesh.ndim > 1 else device_mesh

--- a/src/transformers/distributed/mixin.py
+++ b/src/transformers/distributed/mixin.py
@@ -190,9 +190,6 @@ class DistributedMixin:
         if device_mesh is not None:
             model.config.distributed_config = distributed_config
             model._device_mesh = device_mesh
-            # `Trainer` reads this to build accelerate's `ParallelismConfig`. Without it accelerate
-            # sees `world_size` unaccounted-for ranks and wraps the already-sharded model in DDP,
-            # which rejects DTensor parameters.
             model._tp_size = distributed_config.tp_size
 
             if distributed_config.tp_size > 1:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2658,9 +2658,7 @@ class Trainer:
         if self._mixed_mesh_grads is None:
             from .trainer_optimizer import has_mixed_dtensor
 
-            self._mixed_mesh_grads = has_mixed_dtensor(
-                p.grad for p in model.parameters() if p.grad is not None
-            )
+            self._mixed_mesh_grads = has_mixed_dtensor(p.grad for p in model.parameters() if p.grad is not None)
         return self._mixed_mesh_grads
 
     def _clip_grad_norm(self, model):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2613,17 +2613,69 @@ class Trainer:
         input_tokens = torch.as_tensor(input_tokens, device=self.args.device, dtype=torch.int64)
         self.state.num_input_tokens_seen += self.accelerator.gather(input_tokens).sum().item()
 
+    def _mixed_mesh_grad_norm(self, model, max_norm):
+        """Gradient norm (and clip) when only some parameters are sharded, as under expert parallelism.
+
+        Expert parallelism shards the expert weights and leaves everything else replicated, so
+        `model.parameters()` holds a mix of `DTensor` and plain tensors and `_foreach_norm` cannot span
+        both. Take the two groups separately: the sharded gradients contribute their local norms summed
+        across the mesh, the replicated ones are identical on every rank and are counted once.
+        """
+        from torch.distributed.tensor import DTensor
+
+        sharded, replicated = [], []
+        for param in model.parameters():
+            if param.grad is None:
+                continue
+            (sharded if isinstance(param.grad, DTensor) else replicated).append(param.grad)
+
+        device = (sharded or replicated)[0].device
+        replicated_sq = torch.zeros((), device=device, dtype=torch.float32)
+        if replicated:
+            replicated_sq = torch.linalg.vector_norm(torch.stack([g.norm(2) for g in replicated])) ** 2
+
+        sharded_sq = torch.zeros((), device=device, dtype=torch.float32)
+        if sharded:
+            local = [g.to_local() for g in sharded]
+            sharded_sq = torch.linalg.vector_norm(torch.stack([g.norm(2) for g in local])) ** 2
+            # Sum the per-shard contributions over the mesh the experts are sharded on.
+            torch.distributed.all_reduce(sharded_sq, group=sharded[0].device_mesh.get_group())
+
+        total_norm = (replicated_sq + sharded_sq).sqrt()
+        if max_norm != float("inf"):
+            clip = (max_norm / (total_norm + 1e-6)).clamp(max=1.0)
+            for g in replicated:
+                g.mul_(clip)
+            for g in sharded:
+                g.to_local().mul_(clip)
+        return total_norm
+
+    def _has_mixed_mesh_grads(self, model) -> bool:
+        from torch.distributed.tensor import DTensor
+
+        grads = [p.grad for p in model.parameters() if p.grad is not None]
+        return (
+            bool(grads)
+            and any(isinstance(g, DTensor) for g in grads)
+            and not all(isinstance(g, DTensor) for g in grads)
+        )
+
     def _clip_grad_norm(self, model):
         """Clip gradients to max_grad_norm. Returns the pre-clip gradient norm."""
         if is_sagemaker_mp_enabled() and self.args.fp16:
             return self.optimizer.clip_master_grads(self.args.max_grad_norm)
+        if self._has_mixed_mesh_grads(model):
+            return self._mixed_mesh_grad_norm(model, self.args.max_grad_norm)
         return self.accelerator.clip_grad_norm_(model.parameters(), self.args.max_grad_norm)
 
     def _get_grad_norm(self, model, grad_norm=None):
         """Return the gradient norm as a Python float."""
         if grad_norm is None:
             # Compute norm without clipping (inf means no actual clipping happens)
-            grad_norm = self.accelerator.clip_grad_norm_(model.parameters(), float("inf"))
+            if self._has_mixed_mesh_grads(model):
+                grad_norm = self._mixed_mesh_grad_norm(model, float("inf"))
+            else:
+                grad_norm = self.accelerator.clip_grad_norm_(model.parameters(), float("inf"))
 
         if self.accelerator.distributed_type == DistributedType.DEEPSPEED:
             if hasattr(grad_norm, "item"):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -610,6 +610,8 @@ class Trainer:
         self._train_batch_size = args.train_batch_size
         # Guards one-time LR scheduler creation in create_optimizer_and_scheduler
         self._created_lr_scheduler = False
+        # Resolved lazily at the first gradient clip; see `_has_mixed_mesh_grads`.
+        self._mixed_mesh_grads: bool | None = None
 
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
@@ -2651,14 +2653,15 @@ class Trainer:
         return total_norm
 
     def _has_mixed_mesh_grads(self, model) -> bool:
-        from torch.distributed.tensor import DTensor
+        # Static for the life of the run (sharding never changes after setup), so scan the
+        # parameters only on the first call.
+        if self._mixed_mesh_grads is None:
+            from .trainer_optimizer import has_mixed_dtensor
 
-        grads = [p.grad for p in model.parameters() if p.grad is not None]
-        return (
-            bool(grads)
-            and any(isinstance(g, DTensor) for g in grads)
-            and not all(isinstance(g, DTensor) for g in grads)
-        )
+            self._mixed_mesh_grads = has_mixed_dtensor(
+                p.grad for p in model.parameters() if p.grad is not None
+            )
+        return self._mixed_mesh_grads
 
     def _clip_grad_norm(self, model):
         """Clip gradients to max_grad_norm. Returns the pre-clip gradient norm."""

--- a/src/transformers/trainer_optimizer.py
+++ b/src/transformers/trainer_optimizer.py
@@ -205,7 +205,20 @@ def _get_adamw_torch(ctx: OptimizerContext) -> tuple[Any, dict[str, Any]]:
     ctx.optimizer_kwargs.update(ctx.adam_kwargs)
     if ctx.args.optim == OptimizerNames.ADAMW_TORCH_FUSED:
         ctx.optimizer_kwargs.update({"fused": True})
+    # HACK(ep-2d): expert parallelism leaves only the expert weights as DTensor, so the fused and
+    # foreach kernels cannot span the parameter set. Step per parameter instead.
+    if _has_mixed_dtensor_params(ctx.model):
+        ctx.optimizer_kwargs.update({"fused": False, "foreach": False})
     return AdamW, ctx.optimizer_kwargs
+
+
+def _has_mixed_dtensor_params(model) -> bool:
+    from torch.distributed.tensor import DTensor
+
+    if model is None:
+        return False
+    ps = [p for p in model.parameters() if p.requires_grad]
+    return bool(ps) and any(isinstance(p, DTensor) for p in ps) and not all(isinstance(p, DTensor) for p in ps)
 
 
 def _get_adamw_torch_xla(ctx: OptimizerContext) -> tuple[Any, dict[str, Any]]:

--- a/src/transformers/trainer_optimizer.py
+++ b/src/transformers/trainer_optimizer.py
@@ -207,18 +207,22 @@ def _get_adamw_torch(ctx: OptimizerContext) -> tuple[Any, dict[str, Any]]:
         ctx.optimizer_kwargs.update({"fused": True})
     # HACK(ep-2d): expert parallelism leaves only the expert weights as DTensor, so the fused and
     # foreach kernels cannot span the parameter set. Step per parameter instead.
-    if _has_mixed_dtensor_params(ctx.model):
+    if ctx.model is not None and has_mixed_dtensor(p for p in ctx.model.parameters() if p.requires_grad):
         ctx.optimizer_kwargs.update({"fused": False, "foreach": False})
     return AdamW, ctx.optimizer_kwargs
 
 
-def _has_mixed_dtensor_params(model) -> bool:
+def has_mixed_dtensor(tensors) -> bool:
+    """Whether `tensors` mixes `DTensor` and plain tensors, as expert parallelism leaves a model:
+    experts sharded, everything else replicated."""
     from torch.distributed.tensor import DTensor
 
-    if model is None:
-        return False
-    ps = [p for p in model.parameters() if p.requires_grad]
-    return bool(ps) and any(isinstance(p, DTensor) for p in ps) and not all(isinstance(p, DTensor) for p in ps)
+    tensors = list(tensors)
+    return (
+        bool(tensors)
+        and any(isinstance(t, DTensor) for t in tensors)
+        and not all(isinstance(t, DTensor) for t in tensors)
+    )
 
 
 def _get_adamw_torch_xla(ctx: OptimizerContext) -> tuple[Any, dict[str, Any]]:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48208&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48208) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48208&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48208)
<!-- ci-dashboard-badge:end -->

Stacked on #48200, this PR makes expert parallelism *reachable* through `Trainer`, and without the gradient fixes there, the training it unlocks is wrong.

Loading a model with `DistributedConfig(tp_size=N, enable_expert_parallel=True)` and handing it to `Trainer` fails on main before the first step completes, in three places:

1. `maybe_distribute_model` never assigns `model._tp_size` (the attribute is declared but dead), so the `Trainer` builds no `ParallelismConfig` and accelerate wraps the DTensor model in DDP: `ValueError: Your model contains DTensor parameters, which is incompatible with DDP`.
2. With that fixed, gradient clipping crashes: `_foreach_norm` cannot span a parameter set that mixes DTensors (the experts) and plain tensors (everything else).
3. Same for the optimizer: the fused/foreach AdamW kernels cannot span the mixed set.

The fix: assign `_tp_size` where the mesh is recorded; compute the gradient norm (and clip) per-gradient with replication-aware discounting when parameters live on different meshes; fall back to per-parameter AdamW stepping for mixed parameter sets.

### Validation

Together with #48205 (which fixes the gradients EP computes), expert-parallel **full fine-tuning through `Trainer` runs end-to-end** and tracks a single-GPU control step by step (OLMoE-1B-7B, `tp_size=4`, 4×H100, identical data):

```
EP via Trainer:   single GPU control:
12.13             12.13
12.44             12.45
11.52             11.51
11.22             11.26
11.12             11.15
11.04             11.09
```

<details><summary>Reproduction (each of the three failures appears on main as the previous one is fixed; on this branch it trains)</summary>

```python
# torchrun --nproc_per_node 4 repro.py
import torch
from torch.utils.data import Dataset

from transformers import AutoModelForCausalLM, Trainer, TrainingArguments
from transformers.distributed import DistributedConfig


class RandomTokens(Dataset):
    def __len__(self):
        return 512

    def __getitem__(self, i):
        g = torch.Generator().manual_seed(i)
        ids = torch.randint(0, 50000, (512,), generator=g)
        return {"input_ids": ids, "labels": ids.clone()}


model = AutoModelForCausalLM.from_pretrained(
    "allenai/OLMoE-1B-7B-0924",
    dtype=torch.bfloat16,
    distributed_config=DistributedConfig(tp_size=4, enable_expert_parallel=True),
)

trainer = Trainer(
    model=model,
    args=TrainingArguments(
        output_dir="/tmp/ep-trainer",
        per_device_train_batch_size=1,
        max_steps=8,
        logging_steps=1,
        report_to=[],
        save_strategy="no",
    ),
    train_dataset=RandomTokens(),
)
trainer.train()
```

</details>