### PR TITLE
Fix AutoTokenizer returning TokenizersBackend for DeepSeek-R1-Distill-Qwen models

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -422,7 +422,7 @@ TOKENIZER_MAPPING = _LazyAutoMapping(CONFIG_MAPPING_NAMES, TOKENIZER_MAPPING_NAM
 CONFIG_TO_TYPE = {v: k for k, v in CONFIG_MAPPING_NAMES.items()}
 
 MODEL_IDS_TO_TOKENIZERS_BACKEND = [
-    "deepseek-ai/deepseek-r1-distill-*",
+    "deepseek-ai/deepseek-r1-distill-llama-*",
     "deepseek-ai/deepseek-coder-*",
     "allenai/dolma2-tokenizer",
     "google/umt5-small",


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48211&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48211) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48211&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48211)
<!-- ci-dashboard-badge:end -->

## What

`MODEL_IDS_TO_TOKENIZERS_BACKEND` contained `"deepseek-ai/deepseek-r1-distill-*"` — a wildcard that is too broad. Since `_config_name_or_path` is lowercased before `fnmatch` matching, it also matches `DeepSeek-R1-Distill-Qwen-1.5B` (and all other Qwen-based distills), routing them to `TokenizersBackend` instead of the correct `Qwen2Tokenizer`.

## History

- `efe4049614` (Jun 19, #46091) — introduced `MODEL_IDS_TO_TOKENIZERS_BACKEND` with the specific entry `"deepseek-ai/deepseek-r1-distill-llama-8b"` (only the LLaMA-8B variant routes to `TokenizersBackend`)
- `35bb43e746` (Jul 13, #47296) — broadened it to `"deepseek-ai/deepseek-r1-distill-*"`, silently capturing all Qwen-based distills too — **regression introduced here**
- `e194978ab2` (Jul 15, #45936) — added the slow test asserting the Qwen variant uses `Qwen2Tokenizer`, which started failing immediately in CI

## Failure trace (on `35bb43e746`)

```
FAILED tests/models/auto/test_tokenization_auto.py::AutoTokenizerTest::test_deepseek_r1_distill_qwen_uses_qwen2_tokenizer

    @slow
    @require_tokenizers
    def test_deepseek_r1_distill_qwen_uses_qwen2_tokenizer(self):
        """Regression: qwen2 model with wrong Hub tokenizer_class='LlamaTokenizerFast' must use Qwen2Tokenizer."""
        tokenizer = AutoTokenizer.from_pretrained("deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")
>       self.assertIsInstance(tokenizer, Qwen2Tokenizer)
E       AssertionError: TokenizersBackend(name_or_path='deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B', vocab_size=151643, model_max_length=16384, ...,
E           151643: AddedToken("<｜end▁of▁sentence｜>", ...),
E           ...
E           151664: AddedToken("<|file_sep|>", ...),
E       }) is not an instance of <class 'transformers.models.qwen2.tokenization_qwen2.Qwen2Tokenizer'>

tests/models/auto/test_tokenization_auto.py:976: AssertionError
```

## Fix

Narrow the pattern to `deepseek-ai/deepseek-r1-distill-llama-*` so only LLaMA-based distills (which genuinely need `TokenizersBackend`) are captured. This preserves the intent of #47296 (all LLaMA distill sizes, not just `-llama-8b`) while correctly excluding Qwen-based distills, which follow the normal `qwen2` model-type mapping.

## Test

Existing slow test `AutoTokenizerTest::test_deepseek_r1_distill_qwen_uses_qwen2_tokenizer` — verified PASS on this fix and FAIL on `35bb43e746`.

```
run-slow: auto_tokenization
```