### PR TITLE
fix(data_collator): align TokenClassification numpy_call with torch_call

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -319,14 +319,16 @@ class DataCollatorForTokenClassification(DataCollatorMixin):
     def numpy_call(self, features):
         label_name = "label" if "label" in features[0] else "labels"
         labels = [feature[label_name] for feature in features] if label_name in features[0] else None
+
+        no_labels_features = [{k: v for k, v in feature.items() if k != label_name} for feature in features]
+
         batch = pad_without_fast_tokenizer_warning(
             self.tokenizer,
-            features,
+            no_labels_features,
             padding=self.padding,
             max_length=self.max_length,
             pad_to_multiple_of=self.pad_to_multiple_of,
-            # Conversion to tensors will fail if we have labels as they are not of the same length yet.
-            return_tensors="np" if labels is None else None,
+            return_tensors="np",
         )
 
         if labels is None:
@@ -335,15 +337,15 @@ class DataCollatorForTokenClassification(DataCollatorMixin):
         sequence_length = np.array(batch["input_ids"]).shape[1]
         padding_side = self.tokenizer.padding_side
         if padding_side == "right":
-            batch["labels"] = [
+            batch[label_name] = [
                 list(label) + [self.label_pad_token_id] * (sequence_length - len(label)) for label in labels
             ]
         else:
-            batch["labels"] = [
+            batch[label_name] = [
                 [self.label_pad_token_id] * (sequence_length - len(label)) + list(label) for label in labels
             ]
 
-        batch = {k: np.array(v, dtype=np.int64) for k, v in batch.items()}
+        batch[label_name] = np.array(batch[label_name], dtype=np.int64)
         return batch
 
 

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -526,6 +526,20 @@ class TestDataCollatorForTokenClassification(DataCollatorTestMixin, unittest.Tes
         self.assertEqual(batch["input_ids"].shape, (2, 6))
         self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2, -100, -100, -100])
 
+    def test_numpy_output_with_singular_label_key(self):
+        """Test with NumPy output when feature key is 'label' rather than 'labels'."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForTokenClassification(tokenizer, return_tensors="np")
+        features = [
+            {"input_ids": [0, 1, 2], "label": [0, 1, 2]},
+            {"input_ids": [0, 1, 2, 3, 4, 5], "label": [0, 1, 2, 3, 4, 5]},
+        ]
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, (2, 6))
+        self.assertIn("label", batch)
+        self.assertEqual(batch["label"][0].tolist(), [0, 1, 2, -100, -100, -100])
+
     def test_immutability(self):
         """Test that collation does not mutate input data."""
         tokenizer = BertTokenizer(self.vocab_file)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48212&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48212) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48212&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48212)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes alignment and key preservation in `DataCollatorForTokenClassification.numpy_call`:
1. Strips `label_name` from features before passing to `pad_without_fast_tokenizer_warning`, preventing padding issues with unpadded label sequences.
2. Dynamically assigns `batch[label_name]` matching `torch_call` instead of hardcoding `batch["labels"]` when the feature key is `"label"`.
3. Sets `dtype=np.int64` specifically on `batch[label_name]` rather than blindly casting every batch entry (which could disrupt non-integer metadata or attention masks).
4. Added test `test_numpy_output_with_singular_label_key` to `tests/trainer/test_data_collator.py`.

## Before submitting

- [x] This PR fixes a bug or adds a feature and conforms to the coding standards.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?