### PR TITLE
fix(generation): validate non-negative bounds for min_length, min_new_tokens, and temperature

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -668,6 +668,12 @@ class GenerationConfig(PushToHubMixin):
             raise ValueError(f"`early_stopping` must be a boolean or 'never', but is {self.early_stopping}.")
         if self.max_new_tokens is not None and self.max_new_tokens <= 0:
             raise ValueError(f"`max_new_tokens` must be greater than 0, but is {self.max_new_tokens}.")
+        if self.min_length is not None and self.min_length < 0:
+            raise ValueError(f"`min_length` must be greater than or equal to 0, but is {self.min_length}.")
+        if self.min_new_tokens is not None and self.min_new_tokens < 0:
+            raise ValueError(f"`min_new_tokens` must be greater than or equal to 0, but is {self.min_new_tokens}.")
+        if self.temperature is not None and self.temperature < 0.0:
+            raise ValueError(f"`temperature` must be non-negative, but is {self.temperature}.")
         if self.assistant_ensemble_weight is not None and not (0.0 < self.assistant_ensemble_weight < 1.0):
             raise ValueError(
                 f"`assistant_ensemble_weight` must be in the open interval `(0.0, 1.0)`, "

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -43,7 +43,12 @@ if TYPE_CHECKING:
 
 
 logger = logging.get_logger(__name__)
-METADATA_FIELDS = ("_from_model_config", "_commit_hash", "_original_object_hash", "transformers_version")
+METADATA_FIELDS = (
+    "_from_model_config",
+    "_commit_hash",
+    "_original_object_hash",
+    "transformers_version",
+)
 STATIC_CACHE_IMPLEMENTATIONS = ("static", "offloaded_static")
 DYNAMIC_CACHE_IMPLEMENTATIONS = ("dynamic", "offloaded", "quantized")
 # All the following are redundant and deprecated, but kept for BC
@@ -54,23 +59,36 @@ DEPRECATED_STATIC_CACHE_IMPLEMENTATIONS = (
     "offloaded_hybrid",
     "offloaded_hybrid_chunked",
 )
-ALL_STATIC_CACHE_IMPLEMENTATIONS = STATIC_CACHE_IMPLEMENTATIONS + DEPRECATED_STATIC_CACHE_IMPLEMENTATIONS
-ALL_CACHE_IMPLEMENTATIONS = ALL_STATIC_CACHE_IMPLEMENTATIONS + DYNAMIC_CACHE_IMPLEMENTATIONS
+ALL_STATIC_CACHE_IMPLEMENTATIONS = (
+    STATIC_CACHE_IMPLEMENTATIONS + DEPRECATED_STATIC_CACHE_IMPLEMENTATIONS
+)
+ALL_CACHE_IMPLEMENTATIONS = (
+    ALL_STATIC_CACHE_IMPLEMENTATIONS + DYNAMIC_CACHE_IMPLEMENTATIONS
+)
 
 
 if is_torch_available():
-    from .logits_process import SynthIDTextWatermarkLogitsProcessor, WatermarkLogitsProcessor
+    from .logits_process import (
+        SynthIDTextWatermarkLogitsProcessor,
+        WatermarkLogitsProcessor,
+    )
 
 
-def _should_warn(outer_attr: str, inner_attr: str, user_set_attributes: set | None) -> bool:
+def _should_warn(
+    outer_attr: str, inner_attr: str, user_set_attributes: set | None
+) -> bool:
     """Determine if we should raise a warning for the combination `outer_attr` and `inner_attr`, based on whether
     they were provided explicitly, i.e. if they were in `user_set_attributes`.
     For example, if `outer_attr="do_sample"`, the warnings should be suppressed for `inner_attr` flags (e.g. "top_p") that weren't
     explicitly set by the caller. When `do_sample=False` is explicitly required by the user, values such as `top_p` inherited
     from a model's `generation_config.json` are harmless when the user opts for greedy decoding.
     """
-    outer_sample_set = user_set_attributes is not None and outer_attr in user_set_attributes
-    inner_attr_set = user_set_attributes is not None and inner_attr in user_set_attributes
+    outer_sample_set = (
+        user_set_attributes is not None and outer_attr in user_set_attributes
+    )
+    inner_attr_set = (
+        user_set_attributes is not None and inner_attr in user_set_attributes
+    )
     # We should warn only if both are explicitly set, none are set, or only the inner_attr is set while outer_attr is not
     return (
         (outer_sample_set and inner_attr_set)
@@ -371,7 +389,12 @@ class GenerationConfig(PushToHubMixin):
             need to use this flag.
     """
 
-    extra_output_flags = ("output_attentions", "output_hidden_states", "output_scores", "output_logits")
+    extra_output_flags = (
+        "output_attentions",
+        "output_hidden_states",
+        "output_scores",
+        "output_logits",
+    )
 
     # Tensor versions of token IDs, set by _prepare_special_tokens() at generation time
     _bos_token_tensor: "torch.Tensor | None"
@@ -426,7 +449,9 @@ class GenerationConfig(PushToHubMixin):
         self.forced_bos_token_id = kwargs.pop("forced_bos_token_id", None)
         self.forced_eos_token_id = kwargs.pop("forced_eos_token_id", None)
         self.remove_invalid_values = kwargs.pop("remove_invalid_values", None)
-        self.exponential_decay_length_penalty = kwargs.pop("exponential_decay_length_penalty", None)
+        self.exponential_decay_length_penalty = kwargs.pop(
+            "exponential_decay_length_penalty", None
+        )
         self.suppress_tokens = kwargs.pop("suppress_tokens", None)
         self.begin_suppress_tokens = kwargs.pop("begin_suppress_tokens", None)
         self.sequence_bias = kwargs.pop("sequence_bias", None)
@@ -435,7 +460,9 @@ class GenerationConfig(PushToHubMixin):
 
         self.watermarking_config = kwargs.pop("watermarking_config", None)
         if isinstance(self.watermarking_config, dict):
-            self.watermarking_config = WatermarkingConfig.from_dict(self.watermarking_config)
+            self.watermarking_config = WatermarkingConfig.from_dict(
+                self.watermarking_config
+            )
 
         # Parameters that define the output variables of `generate`
         self.num_return_sequences = kwargs.pop("num_return_sequences", None)
@@ -451,14 +478,20 @@ class GenerationConfig(PushToHubMixin):
         self.eos_token_id = kwargs.pop("eos_token_id", None)
 
         # Generation parameters exclusive to encoder-decoder models
-        self.encoder_no_repeat_ngram_size = kwargs.pop("encoder_no_repeat_ngram_size", None)
+        self.encoder_no_repeat_ngram_size = kwargs.pop(
+            "encoder_no_repeat_ngram_size", None
+        )
         self.decoder_start_token_id = kwargs.pop("decoder_start_token_id", None)
 
         # Assistant generation
         self.is_assistant = kwargs.pop("is_assistant", None)
         self.num_assistant_tokens = kwargs.pop("num_assistant_tokens", None)
-        self.num_assistant_tokens_schedule = kwargs.pop("num_assistant_tokens_schedule", None)
-        self.assistant_confidence_threshold = kwargs.pop("assistant_confidence_threshold", None)
+        self.num_assistant_tokens_schedule = kwargs.pop(
+            "num_assistant_tokens_schedule", None
+        )
+        self.assistant_confidence_threshold = kwargs.pop(
+            "assistant_confidence_threshold", None
+        )
         self.prompt_lookup_num_tokens = kwargs.pop("prompt_lookup_num_tokens", None)
         self.max_matching_ngram_size = kwargs.pop("max_matching_ngram_size", None)
         self.assistant_early_exit = kwargs.pop("assistant_early_exit", None)
@@ -524,14 +557,20 @@ class GenerationConfig(PushToHubMixin):
         if not isinstance(other, GenerationConfig):
             return False
 
-        self_without_metadata = self.to_json_string(use_diff=False, ignore_metadata=True)
-        other_without_metadata = other.to_json_string(use_diff=False, ignore_metadata=True)
+        self_without_metadata = self.to_json_string(
+            use_diff=False, ignore_metadata=True
+        )
+        other_without_metadata = other.to_json_string(
+            use_diff=False, ignore_metadata=True
+        )
         return self_without_metadata == other_without_metadata
 
     def __repr__(self):
         return f"{self.__class__.__name__} {self.to_json_string(ignore_metadata=True)}"
 
-    def get_generation_mode(self, assistant_model: Optional["PreTrainedModel"] = None) -> GenerationMode:
+    def get_generation_mode(
+        self, assistant_model: Optional["PreTrainedModel"] = None
+    ) -> GenerationMode:
         """
         Returns the generation mode triggered by the [`GenerationConfig`] instance.
 
@@ -665,16 +704,28 @@ class GenerationConfig(PushToHubMixin):
         # 1. Validation of individual attributes
         # 1.1. Decoding attributes
         if self.early_stopping not in {None, True, False, "never"}:
-            raise ValueError(f"`early_stopping` must be a boolean or 'never', but is {self.early_stopping}.")
+            raise ValueError(
+                f"`early_stopping` must be a boolean or 'never', but is {self.early_stopping}."
+            )
         if self.max_new_tokens is not None and self.max_new_tokens <= 0:
-            raise ValueError(f"`max_new_tokens` must be greater than 0, but is {self.max_new_tokens}.")
+            raise ValueError(
+                f"`max_new_tokens` must be greater than 0, but is {self.max_new_tokens}."
+            )
         if self.min_length is not None and self.min_length < 0:
-            raise ValueError(f"`min_length` must be greater than or equal to 0, but is {self.min_length}.")
+            raise ValueError(
+                f"`min_length` must be greater than or equal to 0, but is {self.min_length}."
+            )
         if self.min_new_tokens is not None and self.min_new_tokens < 0:
-            raise ValueError(f"`min_new_tokens` must be greater than or equal to 0, but is {self.min_new_tokens}.")
+            raise ValueError(
+                f"`min_new_tokens` must be greater than or equal to 0, but is {self.min_new_tokens}."
+            )
         if self.temperature is not None and self.temperature < 0.0:
-            raise ValueError(f"`temperature` must be non-negative, but is {self.temperature}.")
-        if self.assistant_ensemble_weight is not None and not (0.0 < self.assistant_ensemble_weight < 1.0):
+            raise ValueError(
+                f"`temperature` must be non-negative, but is {self.temperature}."
+            )
+        if self.assistant_ensemble_weight is not None and not (
+            0.0 < self.assistant_ensemble_weight < 1.0
+        ):
             raise ValueError(
                 f"`assistant_ensemble_weight` must be in the open interval `(0.0, 1.0)`, "
                 f"but is {self.assistant_ensemble_weight}. Use `None` for standard (lossless) speculative decoding."
@@ -689,18 +740,26 @@ class GenerationConfig(PushToHubMixin):
         # "paged" re-routes to continuous batching and so it is a valid cache implementation. But we do not want to test
         # it with the `generate` as the other would be, so we we cannot add it to ALL_CACHE_IMPLEMENTATIONS
         valid_cache_implementations = ALL_CACHE_IMPLEMENTATIONS + ("paged",)
-        if self.cache_implementation is not None and self.cache_implementation not in valid_cache_implementations:
+        if (
+            self.cache_implementation is not None
+            and self.cache_implementation not in valid_cache_implementations
+        ):
             raise ValueError(
                 f"Invalid `cache_implementation` ({self.cache_implementation}). Choose one of: "
                 f"{valid_cache_implementations}"
             )
-        if self.max_cache_len is not None and self.cache_implementation not in ALL_STATIC_CACHE_IMPLEMENTATIONS:
+        if (
+            self.max_cache_len is not None
+            and self.cache_implementation not in ALL_STATIC_CACHE_IMPLEMENTATIONS
+        ):
             logger.warning_once(
                 f"`max_cache_len` is only used with static caches ({STATIC_CACHE_IMPLEMENTATIONS}); it will be "
                 f"ignored with `cache_implementation={self.cache_implementation!r}`."
             )
         # 1.3. Performance attributes
-        if self.compile_config is not None and not isinstance(self.compile_config, CompileConfig):
+        if self.compile_config is not None and not isinstance(
+            self.compile_config, CompileConfig
+        ):
             raise ValueError(
                 f"You provided `compile_config` as an instance of {type(self.compile_config)}, but it must be an "
                 "instance of `CompileConfig`."
@@ -734,11 +793,21 @@ class GenerationConfig(PushToHubMixin):
                 and self.top_p != 1.0
                 and _should_warn("do_sample", "top_p", user_set_attributes)
             ):
-                minor_issues["top_p"] = greedy_wrong_parameter_msg.format(flag_name="top_p", flag_value=self.top_p)
-            if self.min_p is not None and _should_warn("do_sample", "min_p", user_set_attributes):
-                minor_issues["min_p"] = greedy_wrong_parameter_msg.format(flag_name="min_p", flag_value=self.min_p)
-            if self.top_h is not None and _should_warn("do_sample", "top_h", user_set_attributes):
-                minor_issues["top_h"] = greedy_wrong_parameter_msg.format(flag_name="top_h", flag_value=self.top_h)
+                minor_issues["top_p"] = greedy_wrong_parameter_msg.format(
+                    flag_name="top_p", flag_value=self.top_p
+                )
+            if self.min_p is not None and _should_warn(
+                "do_sample", "min_p", user_set_attributes
+            ):
+                minor_issues["min_p"] = greedy_wrong_parameter_msg.format(
+                    flag_name="min_p", flag_value=self.min_p
+                )
+            if self.top_h is not None and _should_warn(
+                "do_sample", "top_h", user_set_attributes
+            ):
+                minor_issues["top_h"] = greedy_wrong_parameter_msg.format(
+                    flag_name="top_h", flag_value=self.top_h
+                )
             if (
                 self.typical_p is not None
                 and self.typical_p != 1.0
@@ -747,8 +816,14 @@ class GenerationConfig(PushToHubMixin):
                 minor_issues["typical_p"] = greedy_wrong_parameter_msg.format(
                     flag_name="typical_p", flag_value=self.typical_p
                 )
-            if self.top_k is not None and self.top_k != 50 and _should_warn("do_sample", "top_k", user_set_attributes):
-                minor_issues["top_k"] = greedy_wrong_parameter_msg.format(flag_name="top_k", flag_value=self.top_k)
+            if (
+                self.top_k is not None
+                and self.top_k != 50
+                and _should_warn("do_sample", "top_k", user_set_attributes)
+            ):
+                minor_issues["top_k"] = greedy_wrong_parameter_msg.format(
+                    flag_name="top_k", flag_value=self.top_k
+                )
             if (
                 self.epsilon_cutoff is not None
                 and self.epsilon_cutoff != 0.0
@@ -780,7 +855,9 @@ class GenerationConfig(PushToHubMixin):
                 and _should_warn("num_beams", "early_stopping", user_set_attributes)
             ):
                 minor_issues["early_stopping"] = single_beam_wrong_parameter_msg.format(
-                    num_beams=self.num_beams, flag_name="early_stopping", flag_value=self.early_stopping
+                    num_beams=self.num_beams,
+                    flag_name="early_stopping",
+                    flag_value=self.early_stopping,
                 )
             if (
                 self.length_penalty is not None
@@ -788,7 +865,9 @@ class GenerationConfig(PushToHubMixin):
                 and _should_warn("num_beams", "length_penalty", user_set_attributes)
             ):
                 minor_issues["length_penalty"] = single_beam_wrong_parameter_msg.format(
-                    num_beams=self.num_beams, flag_name="length_penalty", flag_value=self.length_penalty
+                    num_beams=self.num_beams,
+                    flag_name="length_penalty",
+                    flag_value=self.length_penalty,
                 )
 
         # 2.4. check `num_return_sequences`
@@ -867,11 +946,11 @@ class GenerationConfig(PushToHubMixin):
                 raise ValueError("GenerationConfig is invalid: \n" + info_message)
             else:
                 attributes_with_issues = list(minor_issues.keys())
-                warning_message = (
-                    f"The following generation flags are not valid and may be ignored: {attributes_with_issues}."
-                )
+                warning_message = f"The following generation flags are not valid and may be ignored: {attributes_with_issues}."
                 if logging.get_verbosity() >= logging.WARNING:
-                    warning_message += " Set `TRANSFORMERS_VERBOSITY=info` for more details."
+                    warning_message += (
+                        " Set `TRANSFORMERS_VERBOSITY=info` for more details."
+                    )
                 logger.warning_once(warning_message)
                 logger.info_once(info_message)
 
@@ -905,12 +984,18 @@ class GenerationConfig(PushToHubMixin):
         try:
             self.validate(strict=True)
         except ValueError as exc:
-            raise ValueError(str(exc) + "\n\nFix these issues to save the configuration.")
+            raise ValueError(
+                str(exc) + "\n\nFix these issues to save the configuration."
+            )
 
-        config_file_name = config_file_name if config_file_name is not None else GENERATION_CONFIG_NAME
+        config_file_name = (
+            config_file_name if config_file_name is not None else GENERATION_CONFIG_NAME
+        )
 
         if os.path.isfile(save_directory):
-            raise AssertionError(f"Provided path ({save_directory}) should be a directory, not a file")
+            raise AssertionError(
+                f"Provided path ({save_directory}) should be a directory, not a file"
+            )
 
         os.makedirs(save_directory, exist_ok=True)
 
@@ -922,7 +1007,9 @@ class GenerationConfig(PushToHubMixin):
 
         output_config_file = os.path.join(save_directory, config_file_name)
 
-        self.to_json_file(output_config_file, use_diff=True, keys_to_pop=["compile_config"])
+        self.to_json_file(
+            output_config_file, use_diff=True, keys_to_pop=["compile_config"]
+        )
         logger.info(f"Configuration saved in {output_config_file}")
 
         if push_to_hub:
@@ -1026,7 +1113,9 @@ class GenerationConfig(PushToHubMixin):
         >>> unused_kwargs
         {'foo': False}
         ```"""
-        config_file_name = config_file_name if config_file_name is not None else GENERATION_CONFIG_NAME
+        config_file_name = (
+            config_file_name if config_file_name is not None else GENERATION_CONFIG_NAME
+        )
 
         proxies = kwargs.pop("proxies", None)
         subfolder = kwargs.pop("subfolder", "")
@@ -1082,22 +1171,30 @@ class GenerationConfig(PushToHubMixin):
             config_dict = cls._dict_from_json_file(resolved_config_file)
             config_dict["_commit_hash"] = commit_hash
         except (json.JSONDecodeError, UnicodeDecodeError):
-            raise OSError(f"It looks like the config file at '{resolved_config_file}' is not a valid JSON file.")
+            raise OSError(
+                f"It looks like the config file at '{resolved_config_file}' is not a valid JSON file."
+            )
 
         if is_local:
             logger.info(f"loading configuration file {resolved_config_file}")
         else:
-            logger.info(f"loading configuration file {configuration_file} from cache at {resolved_config_file}")
+            logger.info(
+                f"loading configuration file {configuration_file} from cache at {resolved_config_file}"
+            )
 
         if kwargs.get("_from_model_config", False):
             return cls.from_model_config(config_dict)
         elif kwargs.get("return_unused_kwargs") is True:
             config, unused_kwargs = cls.from_dict(config_dict, **kwargs)
-            config._original_object_hash = hash(config)  # Hash to detect whether the instance was modified
+            config._original_object_hash = hash(
+                config
+            )  # Hash to detect whether the instance was modified
             return config, unused_kwargs
         else:
             config = cls.from_dict(config_dict, **kwargs)
-            config._original_object_hash = hash(config)  # Hash to detect whether the instance was modified
+            config._original_object_hash = hash(
+                config
+            )  # Hash to detect whether the instance was modified
             return config
 
     @classmethod
@@ -1169,7 +1266,11 @@ class GenerationConfig(PushToHubMixin):
 
         # only serialize values that differ from the default config
         for key, value in config_dict.items():
-            if key not in default_config_dict or key == "transformers_version" or value != default_config_dict[key]:
+            if (
+                key not in default_config_dict
+                or key == "transformers_version"
+                or value != default_config_dict[key]
+            ):
                 serializable_config_dict[key] = value
 
         self.dict_dtype_to_str(serializable_config_dict)
@@ -1197,7 +1298,10 @@ class GenerationConfig(PushToHubMixin):
         return output
 
     def to_json_string(
-        self, use_diff: bool = True, ignore_metadata: bool = False, keys_to_pop: list[str] | None = None
+        self,
+        use_diff: bool = True,
+        ignore_metadata: bool = False,
+        keys_to_pop: list[str] | None = None,
     ) -> str:
         """
         Serializes this instance to a JSON string.
@@ -1229,7 +1333,10 @@ class GenerationConfig(PushToHubMixin):
 
         def convert_keys_to_string(obj):
             if isinstance(obj, dict):
-                return {str(key): convert_keys_to_string(value) for key, value in obj.items()}
+                return {
+                    str(key): convert_keys_to_string(value)
+                    for key, value in obj.items()
+                }
             elif isinstance(obj, list):
                 return [convert_keys_to_string(item) for item in obj]
             else:
@@ -1237,7 +1344,9 @@ class GenerationConfig(PushToHubMixin):
 
         def convert_dataclass_to_dict(obj):
             if isinstance(obj, dict):
-                return {key: convert_dataclass_to_dict(value) for key, value in obj.items()}
+                return {
+                    key: convert_dataclass_to_dict(value) for key, value in obj.items()
+                }
             elif is_dataclass(obj):
                 # Some of our dataclasses have a custom `to_dict()` method, and we prefer it
                 if hasattr(obj, "to_dict"):
@@ -1251,7 +1360,10 @@ class GenerationConfig(PushToHubMixin):
         return json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
 
     def to_json_file(
-        self, json_file_path: str | os.PathLike, use_diff: bool = True, keys_to_pop: list[str] | None = None
+        self,
+        json_file_path: str | os.PathLike,
+        use_diff: bool = True,
+        keys_to_pop: list[str] | None = None,
     ) -> None:
         """
         Save this instance to a JSON file.
@@ -1266,10 +1378,14 @@ class GenerationConfig(PushToHubMixin):
                 Keys to pop from the config dictionary before serializing
         """
         with open(json_file_path, "w", encoding="utf-8") as writer:
-            writer.write(self.to_json_string(use_diff=use_diff, keys_to_pop=keys_to_pop))
+            writer.write(
+                self.to_json_string(use_diff=use_diff, keys_to_pop=keys_to_pop)
+            )
 
     @classmethod
-    def from_model_config(cls, model_config: Union["PreTrainedConfig", dict]) -> "GenerationConfig":
+    def from_model_config(
+        cls, model_config: Union["PreTrainedConfig", dict]
+    ) -> "GenerationConfig":
         """
         Instantiates a [`GenerationConfig`] from a [`PreTrainedConfig`]. This function is useful to convert legacy
         [`PreTrainedConfig`] objects, which may contain generation parameters, into a stand-alone [`GenerationConfig`].
@@ -1281,12 +1397,20 @@ class GenerationConfig(PushToHubMixin):
         Returns:
             [`GenerationConfig`]: The configuration object instantiated from those parameters.
         """
-        config_dict = model_config.to_dict() if not isinstance(model_config, dict) else model_config
+        config_dict = (
+            model_config.to_dict()
+            if not isinstance(model_config, dict)
+            else model_config
+        )
         config_dict.pop("_from_model_config", None)
 
         # Removes all `None` from the model config dict -- this lets the generation config defaults to take hold
-        config_dict = {key: value for key, value in config_dict.items() if value is not None}
-        generation_config = cls.from_dict(config_dict, return_unused_kwargs=False, _from_model_config=True)
+        config_dict = {
+            key: value for key, value in config_dict.items() if value is not None
+        }
+        generation_config = cls.from_dict(
+            config_dict, return_unused_kwargs=False, _from_model_config=True
+        )
 
         # Special case: some models have generation attributes set in the decoder. Use them if still unset in the
         # generation config (which in turn is defined from the outer attributes of model config).
@@ -1302,7 +1426,9 @@ class GenerationConfig(PushToHubMixin):
 
         default_generation_config = GenerationConfig()
         for attr in generation_config.to_dict():
-            is_unset = getattr(generation_config, attr) == getattr(default_generation_config, attr)
+            is_unset = getattr(generation_config, attr) == getattr(
+                default_generation_config, attr
+            )
             if attr in model_config and is_unset:
                 setattr(generation_config, attr, model_config[attr])
 
@@ -1351,7 +1477,9 @@ class GenerationConfig(PushToHubMixin):
         self.validate(user_set_attributes=set(to_remove))
 
         # Remove all the attributes that were updated, without modifying the input dict
-        unused_kwargs = {key: value for key, value in kwargs.items() if key not in to_remove}
+        unused_kwargs = {
+            key: value for key, value in kwargs.items() if key not in to_remove
+        }
         return unused_kwargs
 
 
@@ -1503,7 +1631,9 @@ class WatermarkingConfig(BaseWatermarkingConfig):
                 ),
             )
 
-    def construct_processor(self, vocab_size: int, device) -> "WatermarkLogitsProcessor":
+    def construct_processor(
+        self, vocab_size: int, device
+    ) -> "WatermarkLogitsProcessor":
         return WatermarkLogitsProcessor(
             vocab_size=vocab_size,
             device=device,
@@ -1592,7 +1722,9 @@ class SynthIDTextWatermarkingConfig(BaseWatermarkingConfig):
                 ),
             )
 
-    def construct_processor(self, vocab_size: int, device) -> "WatermarkLogitsProcessor":
+    def construct_processor(
+        self, vocab_size: int, device
+    ) -> "WatermarkLogitsProcessor":
         return SynthIDTextWatermarkLogitsProcessor(
             ngram_len=self.ngram_len,
             keys=self.keys,
@@ -1654,7 +1786,13 @@ class CompileConfig:
 
     def to_dict(self) -> dict[str, Any]:
         """Serializes this instance to a Python dictionary."""
-        return copy.deepcopy({key: value for key, value in self.__dict__.items() if key != "_compile_all_devices"})
+        return copy.deepcopy(
+            {
+                key: value
+                for key, value in self.__dict__.items()
+                if key != "_compile_all_devices"
+            }
+        )
 
 
 # TODO: add the @strict decorator to prevent attributes passed as args rather than kwargs

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -258,6 +258,17 @@ class GenerationConfigTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 GenerationConfig(assistant_ensemble_weight=invalid).validate()
 
+    def test_validate_negative_bounds(self):
+        """`min_length`, `min_new_tokens` and `temperature` must be non-negative."""
+        GenerationConfig(min_length=0, min_new_tokens=0, temperature=0.0).validate()
+        with self.assertRaises(ValueError):
+            GenerationConfig(min_length=-1).validate()
+        with self.assertRaises(ValueError):
+            GenerationConfig(min_new_tokens=-1).validate()
+        with self.assertRaises(ValueError):
+            GenerationConfig(temperature=-0.5).validate()
+
+
     def test_assistant_ensemble_weight_default_and_round_trip(self):
         """Default is `None`; values round-trip through `to_dict`/`from_dict`."""
         self.assertIsNone(GenerationConfig().assistant_ensemble_weight)

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -22,7 +22,12 @@ import warnings
 from huggingface_hub import create_pull_request
 from parameterized import parameterized
 
-from transformers import AutoConfig, GenerationConfig, WatermarkingConfig, is_torch_available
+from transformers import (
+    AutoConfig,
+    GenerationConfig,
+    WatermarkingConfig,
+    is_torch_available,
+)
 from transformers import logging as transformers_logging
 
 
@@ -77,7 +82,9 @@ class GenerationConfigTest(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmp_dir:
             config.save_pretrained(tmp_dir, config_name=config_name)
-            loaded_config = GenerationConfig.from_pretrained(tmp_dir, config_name=config_name)
+            loaded_config = GenerationConfig.from_pretrained(
+                tmp_dir, config_name=config_name
+            )
 
         # Checks parameters that were specified
         self.assertEqual(loaded_config.do_sample, True)
@@ -99,8 +106,13 @@ class GenerationConfigTest(unittest.TestCase):
         self.assertNotEqual(generation_config_from_model, default_generation_config)
 
         # One of those parameters is eos_token_id -- check if it matches
-        self.assertNotEqual(generation_config_from_model.eos_token_id, default_generation_config.eos_token_id)
-        self.assertEqual(generation_config_from_model.eos_token_id, model_config.eos_token_id)
+        self.assertNotEqual(
+            generation_config_from_model.eos_token_id,
+            default_generation_config.eos_token_id,
+        )
+        self.assertEqual(
+            generation_config_from_model.eos_token_id, model_config.eos_token_id
+        )
 
     def test_update(self):
         generation_config = GenerationConfig()
@@ -149,7 +161,9 @@ class GenerationConfigTest(unittest.TestCase):
         """
         Tests that the `validate` method is working as expected. Note that `validate` is called at initialization time
         """
-        logger = transformers_logging.get_logger("transformers.generation.configuration_utils")
+        logger = transformers_logging.get_logger(
+            "transformers.generation.configuration_utils"
+        )
 
         # A correct configuration will not throw any warning
         logger.warning_once.cache_clear()
@@ -167,14 +181,18 @@ class GenerationConfigTest(unittest.TestCase):
         # Explicitly setting a sampling flag alongside `do_sample=False` still warns: this is a user-level mistake.
         logger.warning_once.cache_clear()
         with CaptureLogger(logger) as captured_logs:
-            generation_config_bad_temperature = GenerationConfig(do_sample=False, temperature=0.5)  # store for later
+            generation_config_bad_temperature = GenerationConfig(
+                do_sample=False, temperature=0.5
+            )  # store for later
         self.assertNotEqual(len(captured_logs.out), 0)
 
         # But a value inherited from a model's default config (i.e. not in this update's kwargs) does NOT warn: in
         # the real world, `generate(do_sample=False)` on a model whose `generation_config.json` has `temperature=0.6`
         # would otherwise log a useless warning.
         logger.warning_once.cache_clear()
-        base_config = GenerationConfig(do_sample=True, temperature=0.6)  # mimics a model's default config
+        base_config = GenerationConfig(
+            do_sample=True, temperature=0.6
+        )  # mimics a model's default config
         with CaptureLogger(logger) as captured_logs:
             base_config.update(do_sample=False)
         self.assertEqual(len(captured_logs.out), 0)
@@ -182,7 +200,9 @@ class GenerationConfigTest(unittest.TestCase):
         # Inverse provenance case: `do_sample=False` inherited from a model's config (so not user-set this call), user only
         # sets a sampling flag. The conflict SHOULD produce noise because the user may think that it's non-greedy by default
         logger.warning_once.cache_clear()
-        greedy_hub_config = GenerationConfig(do_sample=False)  # mimics a model's default config forcing greedy
+        greedy_hub_config = GenerationConfig(
+            do_sample=False
+        )  # mimics a model's default config forcing greedy
         with CaptureLogger(logger) as captured_logs:
             greedy_hub_config.update(top_p=0.8)
         self.assertNotEqual(len(captured_logs.out), 0)
@@ -227,7 +247,9 @@ class GenerationConfigTest(unittest.TestCase):
                 GenerationConfig(do_sample=False, temperature=0.5)
         self.assertNotIn("0.5", captured_logs.out)
         self.assertTrue(len(captured_logs.out) < 150)  # short log
-        self.assertIn("Set `TRANSFORMERS_VERBOSITY=info` for more details", captured_logs.out)
+        self.assertIn(
+            "Set `TRANSFORMERS_VERBOSITY=info` for more details", captured_logs.out
+        )
 
         # INFO level: we share the full deets
         logger.warning_once.cache_clear()
@@ -237,7 +259,9 @@ class GenerationConfigTest(unittest.TestCase):
                 GenerationConfig(do_sample=False, temperature=0.5)
         self.assertIn("0.5", captured_logs.out)
         self.assertTrue(len(captured_logs.out) > 400)  # long log
-        self.assertNotIn("Set `TRANSFORMERS_VERBOSITY=info` for more details", captured_logs.out)
+        self.assertNotIn(
+            "Set `TRANSFORMERS_VERBOSITY=info` for more details", captured_logs.out
+        )
 
         # Finally, we can set `strict=True` to raise an exception on what would otherwise be a warning.
         generation_config = GenerationConfig()
@@ -268,7 +292,6 @@ class GenerationConfigTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             GenerationConfig(temperature=-0.5).validate()
 
-
     def test_assistant_ensemble_weight_default_and_round_trip(self):
         """Default is `None`; values round-trip through `to_dict`/`from_dict`."""
         self.assertIsNone(GenerationConfig().assistant_ensemble_weight)
@@ -277,7 +300,9 @@ class GenerationConfigTest(unittest.TestCase):
         self.assertEqual(config.assistant_ensemble_weight, 0.7)
         config_dict = config.to_dict()
         self.assertEqual(config_dict["assistant_ensemble_weight"], 0.7)
-        self.assertEqual(GenerationConfig.from_dict(config_dict).assistant_ensemble_weight, 0.7)
+        self.assertEqual(
+            GenerationConfig.from_dict(config_dict).assistant_ensemble_weight, 0.7
+        )
 
     def test_validate_sampling_flag_provenance(self):
         """
@@ -286,7 +311,9 @@ class GenerationConfigTest(unittest.TestCase):
         were explicitly provided by the caller in the same context, or none of the 2 were directly provided, or only
         the sampling flag is provided along do_sample=False already existing.
         """
-        logger = transformers_logging.get_logger("transformers.generation.configuration_utils")
+        logger = transformers_logging.get_logger(
+            "transformers.generation.configuration_utils"
+        )
 
         def _warn_count(fn):
             logger.warning_once.cache_clear()
@@ -298,13 +325,17 @@ class GenerationConfigTest(unittest.TestCase):
         #    (Emulates: model whose `generation_config.json` carries `do_sample=True, temperature=0.6`, user
         #    explicitly asks for greedy decoding.)
         def case_hub_temp_user_do_sample_only():
-            cfg = GenerationConfig(do_sample=True, temperature=0.6)  # stands in for the hub default
+            cfg = GenerationConfig(
+                do_sample=True, temperature=0.6
+            )  # stands in for the hub default
             cfg.update(do_sample=False)
 
         self.assertEqual(_warn_count(case_hub_temp_user_do_sample_only), 0)
 
         # 2. User explicitly sets BOTH `do_sample=False` and `top_p=0.8` in the same call -> WARN.
-        self.assertNotEqual(_warn_count(lambda: GenerationConfig(do_sample=False, top_p=0.8)), 0)
+        self.assertNotEqual(
+            _warn_count(lambda: GenerationConfig(do_sample=False, top_p=0.8)), 0
+        )
 
         # 3. User explicitly sets only `do_sample=False` (no sampling flag) -> NO warning, even though
         #    attribute defaults (like `top_k=50`) may be present.
@@ -328,13 +359,17 @@ class GenerationConfigTest(unittest.TestCase):
         # 6. Same idea for beam flags: user only asks for `num_beams=1`, hub default has `length_penalty=0.8`
         #    -> NO warning.
         def case_hub_length_penalty_user_num_beams_only():
-            cfg = GenerationConfig(num_beams=4, length_penalty=0.8)  # stands in for the hub default
+            cfg = GenerationConfig(
+                num_beams=4, length_penalty=0.8
+            )  # stands in for the hub default
             cfg.update(num_beams=1)
 
         self.assertEqual(_warn_count(case_hub_length_penalty_user_num_beams_only), 0)
 
         # 7. User sets BOTH `num_beams=1` and `length_penalty=0.8` explicitly -> WARN.
-        self.assertNotEqual(_warn_count(lambda: GenerationConfig(num_beams=1, length_penalty=0.8)), 0)
+        self.assertNotEqual(
+            _warn_count(lambda: GenerationConfig(num_beams=1, length_penalty=0.8)), 0
+        )
 
     def test_refuse_to_save(self):
         """Tests that we refuse to save a generation config that fails validation."""
@@ -346,7 +381,9 @@ class GenerationConfigTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self.assertRaises(ValueError) as exc:
                 config.save_pretrained(tmp_dir)
-            self.assertTrue("Fix these issues to save the configuration." in str(exc.exception))
+            self.assertTrue(
+                "Fix these issues to save the configuration." in str(exc.exception)
+            )
             self.assertTrue("`temperature` is set to `0.5`" in str(exc.exception))
             self.assertTrue(len(os.listdir(tmp_dir)) == 0)
 
@@ -357,7 +394,9 @@ class GenerationConfigTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self.assertRaises(ValueError) as exc:
                 config.save_pretrained(tmp_dir)
-            self.assertTrue("Fix these issues to save the configuration." in str(exc.exception))
+            self.assertTrue(
+                "Fix these issues to save the configuration." in str(exc.exception)
+            )
             self.assertTrue(
                 "Greedy methods (do_sample != True) without beam search do not support `num_return_sequences` different than 1"
                 in str(exc.exception)
@@ -371,7 +410,9 @@ class GenerationConfigTest(unittest.TestCase):
             with warnings.catch_warnings(record=True) as captured_warnings:
                 # Catch logs (up to WARNING level, the default level)
                 with LoggingLevel(logging.WARNING):
-                    logger = transformers_logging.get_logger("transformers.generation.configuration_utils")
+                    logger = transformers_logging.get_logger(
+                        "transformers.generation.configuration_utils"
+                    )
                     with CaptureLogger(logger) as captured_logs:
                         config.save_pretrained(tmp_dir)
             self.assertEqual(len(captured_warnings), 0)
@@ -391,10 +432,15 @@ class GenerationConfigTest(unittest.TestCase):
 
         # TODO joao, manuel: remove this in v4.62.0
         config = GenerationConfig(top_k=10, do_sample=False, penalty_alpha=0.6)
-        self.assertEqual(config.get_generation_mode(), GenerationMode.CONTRASTIVE_SEARCH)
+        self.assertEqual(
+            config.get_generation_mode(), GenerationMode.CONTRASTIVE_SEARCH
+        )
 
         config = GenerationConfig()
-        self.assertEqual(config.get_generation_mode(assistant_model="foo"), GenerationMode.ASSISTED_GENERATION)
+        self.assertEqual(
+            config.get_generation_mode(assistant_model="foo"),
+            GenerationMode.ASSISTED_GENERATION,
+        )
 
     def test_static_cache_without_cache_config(self):
         """Regression test for #35026 -- static cache should work without a cache config."""
@@ -416,14 +462,18 @@ class GenerationConfigSerializationTest(unittest.TestCase):
 
         expected_sequence_bias = {(45, 67): -0.6, (89,): 1.2}
         bias_logits_processor = SequenceBiasLogitsProcessor(new_config.sequence_bias)
-        self.assertDictEqual(bias_logits_processor.sequence_bias, expected_sequence_bias)
+        self.assertDictEqual(
+            bias_logits_processor.sequence_bias, expected_sequence_bias
+        )
 
     def test_serialize_generation_min_length_eos_token(self):
         """Tests that GenerationConfig is serialized and MinLengthLogitsProcessor is initialized with min_length and eos_token_id"""
         eos_token_id = 0
         min_length = 10
 
-        generation_config = GenerationConfig(min_length=min_length, eos_token_id=eos_token_id)
+        generation_config = GenerationConfig(
+            min_length=min_length, eos_token_id=eos_token_id
+        )
         with tempfile.TemporaryDirectory("test-generation-config") as tmp_dir:
             generation_config.save_pretrained(tmp_dir)
             new_config = GenerationConfig.from_pretrained(tmp_dir)
@@ -465,7 +515,9 @@ class GenerationConfigSerializationTest(unittest.TestCase):
             new_config = GenerationConfig.from_pretrained(tmp_dir)
         self.assertEqual(new_config.temperature, temperature)
 
-        temperature_logits_warper = TemperatureLogitsWarper(temperature=new_config.temperature)
+        temperature_logits_warper = TemperatureLogitsWarper(
+            temperature=new_config.temperature
+        )
         self.assertEqual(temperature_logits_warper.temperature, temperature)
 
     def test_serialize_generation_repetition_penalty(self):
@@ -478,13 +530,17 @@ class GenerationConfigSerializationTest(unittest.TestCase):
             new_config = GenerationConfig.from_pretrained(tmp_dir)
         self.assertEqual(new_config.repetition_penalty, penalty)
 
-        rep_penalty_proc = RepetitionPenaltyLogitsProcessor(penalty=new_config.repetition_penalty)
+        rep_penalty_proc = RepetitionPenaltyLogitsProcessor(
+            penalty=new_config.repetition_penalty
+        )
         self.assertEqual(rep_penalty_proc.penalty, penalty)
 
     def test_serialize_generation_encoder_repetition_penalty(self):
         """Tests that GenerationConfig is serialized and EncoderRepetitionPenaltyLogitsProcessor is initialized with penalty and input_ids"""
         penalty = 2.0
-        input_ids = torch.tensor([[0, 1], [5, 0]], device=torch_device, dtype=torch.long)
+        input_ids = torch.tensor(
+            [[0, 1], [5, 0]], device=torch_device, dtype=torch.long
+        )
 
         generation_config = GenerationConfig(encoder_repetition_penalty=penalty)
         with tempfile.TemporaryDirectory("test-generation-config") as tmp_dir:
@@ -580,28 +636,37 @@ class GenerationConfigSerializationTest(unittest.TestCase):
         """Tests that GenerationConfig is serialized and NoRepeatNGramLogitsProcessor is initialized with ngram_size"""
         ngram_size = 2
 
-        generation_config = GenerationConfig(no_repeat_ngram_size=ngram_size, do_sample=True)
+        generation_config = GenerationConfig(
+            no_repeat_ngram_size=ngram_size, do_sample=True
+        )
         with tempfile.TemporaryDirectory("test-generation-config") as tmp_dir:
             generation_config.save_pretrained(tmp_dir)
             new_config = GenerationConfig.from_pretrained(tmp_dir)
         self.assertEqual(new_config.no_repeat_ngram_size, ngram_size)
 
-        no_repeat_ngram_proc = NoRepeatNGramLogitsProcessor(ngram_size=new_config.no_repeat_ngram_size)
+        no_repeat_ngram_proc = NoRepeatNGramLogitsProcessor(
+            ngram_size=new_config.no_repeat_ngram_size
+        )
         self.assertEqual(no_repeat_ngram_proc.ngram_size, ngram_size)
 
     def test_serialize_generation_encoder_ngram_size(self):
         """Tests that GenerationConfig is serialized and EncoderNoRepeatNGramLogitsProcessor is initialized with ngram_size"""
         ngram_size = 2
-        input_ids = torch.tensor([[0, 1], [5, 0]], device=torch_device, dtype=torch.long)
+        input_ids = torch.tensor(
+            [[0, 1], [5, 0]], device=torch_device, dtype=torch.long
+        )
 
-        generation_config = GenerationConfig(encoder_no_repeat_ngram_size=ngram_size, do_sample=True)
+        generation_config = GenerationConfig(
+            encoder_no_repeat_ngram_size=ngram_size, do_sample=True
+        )
         with tempfile.TemporaryDirectory("test-generation-config") as tmp_dir:
             generation_config.save_pretrained(tmp_dir)
             new_config = GenerationConfig.from_pretrained(tmp_dir)
         self.assertEqual(new_config.encoder_no_repeat_ngram_size, ngram_size)
 
         encoder_no_repeat_ngram_proc = EncoderNoRepeatNGramLogitsProcessor(
-            encoder_ngram_size=new_config.encoder_no_repeat_ngram_size, encoder_input_ids=input_ids
+            encoder_ngram_size=new_config.encoder_no_repeat_ngram_size,
+            encoder_input_ids=input_ids,
         )
         self.assertEqual(encoder_no_repeat_ngram_proc.ngram_size, ngram_size)
 
@@ -615,7 +680,9 @@ class GenerationConfigSerializationTest(unittest.TestCase):
             new_config = GenerationConfig.from_pretrained(tmp_dir)
         self.assertSequenceEqual(new_config.bad_words_ids, bad_word_tokens)
 
-        no_bad_words_dist_proc = NoBadWordsLogitsProcessor(bad_words_ids=new_config.bad_words_ids)
+        no_bad_words_dist_proc = NoBadWordsLogitsProcessor(
+            bad_words_ids=new_config.bad_words_ids
+        )
         self.assertSequenceEqual(no_bad_words_dist_proc.bad_word_ids, bad_word_tokens)
 
     def test_serialize_generation_num_beams(self):
@@ -646,7 +713,9 @@ class GenerationConfigSerializationTest(unittest.TestCase):
             new_config = GenerationConfig.from_pretrained(tmp_dir)
         self.assertEqual(new_config.bos_token_id, bos_token_id)
 
-        logits_processor = ForcedBOSTokenLogitsProcessor(bos_token_id=new_config.bos_token_id)
+        logits_processor = ForcedBOSTokenLogitsProcessor(
+            bos_token_id=new_config.bos_token_id
+        )
         self.assertEqual(logits_processor.bos_token_id, bos_token_id)
 
     def test_serialize_generation_eos_token_id(self):
@@ -661,7 +730,9 @@ class GenerationConfigSerializationTest(unittest.TestCase):
         self.assertEqual(new_config.eos_token_id, eos_token_id)
 
         logits_processor = ForcedEOSTokenLogitsProcessor(
-            max_length=max_length, eos_token_id=new_config.eos_token_id, device=torch_device
+            max_length=max_length,
+            eos_token_id=new_config.eos_token_id,
+            device=torch_device,
         )
         self.assertEqual(logits_processor.eos_token_id, eos_token_id)
 
@@ -673,11 +744,15 @@ class GenerationConfigSerializationTest(unittest.TestCase):
         input_ids_seq_length = 10
         exponential_decay_length_penalty = (penalty_start, penalty_factor)
 
-        generation_config = GenerationConfig(exponential_decay_length_penalty=exponential_decay_length_penalty)
+        generation_config = GenerationConfig(
+            exponential_decay_length_penalty=exponential_decay_length_penalty
+        )
         with tempfile.TemporaryDirectory("test-generation-config") as tmp_dir:
             generation_config.save_pretrained(tmp_dir)
             new_config = GenerationConfig.from_pretrained(tmp_dir)
-        self.assertEqual(new_config.exponential_decay_length_penalty, [penalty_start, penalty_factor])
+        self.assertEqual(
+            new_config.exponential_decay_length_penalty, [penalty_start, penalty_factor]
+        )
 
         exponential_decay_processor = ExponentialDecayLengthPenalty(
             exponential_decay_length_penalty=new_config.exponential_decay_length_penalty,
@@ -685,25 +760,36 @@ class GenerationConfigSerializationTest(unittest.TestCase):
             input_ids_seq_length=input_ids_seq_length,
         )
         self.assertEqual(
-            exponential_decay_processor.regulation_start, exponential_decay_length_penalty[0] + input_ids_seq_length
+            exponential_decay_processor.regulation_start,
+            exponential_decay_length_penalty[0] + input_ids_seq_length,
         )
-        self.assertEqual(exponential_decay_processor.regulation_factor, exponential_decay_length_penalty[1])
+        self.assertEqual(
+            exponential_decay_processor.regulation_factor,
+            exponential_decay_length_penalty[1],
+        )
 
     def test_serialize_generation_begin_suppress_tokens(self):
         """Tests that GenerationConfig is serialized and SuppressTokensAtBeginLogitsProcessor is initialized with begin_suppress_token and begin_index"""
 
         begin_suppress_tokens = [220, 50256]
         begin_index = 0
-        generation_config = GenerationConfig(begin_suppress_tokens=begin_suppress_tokens)
+        generation_config = GenerationConfig(
+            begin_suppress_tokens=begin_suppress_tokens
+        )
         with tempfile.TemporaryDirectory("test-generation-config") as tmp_dir:
             generation_config.save_pretrained(tmp_dir)
             new_config = GenerationConfig.from_pretrained(tmp_dir)
-        self.assertSequenceEqual(new_config.begin_suppress_tokens, begin_suppress_tokens)
+        self.assertSequenceEqual(
+            new_config.begin_suppress_tokens, begin_suppress_tokens
+        )
 
         suppress_processor = SuppressTokensAtBeginLogitsProcessor(
-            begin_suppress_tokens=new_config.begin_suppress_tokens, begin_index=begin_index
+            begin_suppress_tokens=new_config.begin_suppress_tokens,
+            begin_index=begin_index,
         )
-        self.assertSequenceEqual(suppress_processor.begin_suppress_tokens, begin_suppress_tokens)
+        self.assertSequenceEqual(
+            suppress_processor.begin_suppress_tokens, begin_suppress_tokens
+        )
         self.assertEqual(suppress_processor.begin_index, begin_index)
 
     def test_serialize_generation_suppress_tokens(self):
@@ -716,7 +802,9 @@ class GenerationConfigSerializationTest(unittest.TestCase):
             new_config = GenerationConfig.from_pretrained(tmp_dir)
         self.assertSequenceEqual(new_config.suppress_tokens, suppress_tokens)
 
-        suppress_processor = SuppressTokensLogitsProcessor(suppress_tokens=new_config.suppress_tokens)
+        suppress_processor = SuppressTokensLogitsProcessor(
+            suppress_tokens=new_config.suppress_tokens
+        )
         self.assertSequenceEqual(suppress_processor.suppress_tokens, suppress_tokens)
 
     def test_serialize_generation_guidance_scale(self):
@@ -728,7 +816,9 @@ class GenerationConfigSerializationTest(unittest.TestCase):
             new_config = GenerationConfig.from_pretrained(tmp_dir)
         self.assertEqual(new_config.guidance_scale, guidance_scale)
 
-        classifier_processor = ClassifierFreeGuidanceLogitsProcessor(guidance_scale=new_config.guidance_scale)
+        classifier_processor = ClassifierFreeGuidanceLogitsProcessor(
+            guidance_scale=new_config.guidance_scale
+        )
         self.assertEqual(classifier_processor.guidance_scale, guidance_scale)
 
     def test_serialize_generation_guidance_scale_unbatched(self):
@@ -743,7 +833,9 @@ class GenerationConfigSerializationTest(unittest.TestCase):
             new_config = GenerationConfig.from_pretrained(tmp_dir)
         self.assertEqual(new_config.guidance_scale, guidance_scale)
 
-        cfg = UnbatchedClassifierFreeGuidanceLogitsProcessor(new_config.guidance_scale, {}, input_ids)
+        cfg = UnbatchedClassifierFreeGuidanceLogitsProcessor(
+            new_config.guidance_scale, {}, input_ids
+        )
         self.assertEqual(cfg.guidance_scale, guidance_scale)
 
     def test_serialize_generation_watermarking_config(self):
@@ -768,7 +860,9 @@ class GenerationConfigSerializationTest(unittest.TestCase):
             generation_config.save_pretrained(tmp_dir)
             new_config = GenerationConfig.from_pretrained(tmp_dir)
         self.assertEqual(new_config.watermarking_config.bias, bias)
-        self.assertEqual(new_config.watermarking_config.greenlist_ratio, greenlist_ratio)
+        self.assertEqual(
+            new_config.watermarking_config.greenlist_ratio, greenlist_ratio
+        )
         self.assertEqual(new_config.watermarking_config.hashing_key, hashing_key)
         self.assertEqual(new_config.watermarking_config.seeding_scheme, seeding_scheme)
         self.assertEqual(new_config.watermarking_config.context_width, context_width)
@@ -818,7 +912,12 @@ class ConfigPushToHubTester(unittest.TestCase):
             )
             # Push to hub via save_pretrained
             with tempfile.TemporaryDirectory() as tmp_dir:
-                config.save_pretrained(tmp_dir, repo_id=tmp_repo.repo_id, push_to_hub=True, token=self._token)
+                config.save_pretrained(
+                    tmp_dir,
+                    repo_id=tmp_repo.repo_id,
+                    push_to_hub=True,
+                    token=self._token,
+                )
 
             new_config = GenerationConfig.from_pretrained(tmp_repo.repo_id)
             for k, v in config.to_dict().items():
@@ -848,7 +947,12 @@ class ConfigPushToHubTester(unittest.TestCase):
             )
             # Push to hub via save_pretrained
             with tempfile.TemporaryDirectory() as tmp_dir:
-                config.save_pretrained(tmp_dir, repo_id=tmp_repo.repo_id, push_to_hub=True, token=self._token)
+                config.save_pretrained(
+                    tmp_dir,
+                    repo_id=tmp_repo.repo_id,
+                    push_to_hub=True,
+                    token=self._token,
+                )
 
             new_config = GenerationConfig.from_pretrained(tmp_repo.repo_id)
             for k, v in config.to_dict().items():
@@ -858,7 +962,9 @@ class ConfigPushToHubTester(unittest.TestCase):
     def test_push_to_hub_on_pr_revision(self):
         with TemporaryHubRepo(token=self._token) as tmp_repo:
             # create a PR
-            pr = create_pull_request(repo_id=tmp_repo.repo_id, title="Test PR", token=self._token)
+            pr = create_pull_request(
+                repo_id=tmp_repo.repo_id, title="Test PR", token=self._token
+            )
             revision = f"refs/pr/{pr.num}"
 
             # push to PR ref
@@ -870,7 +976,9 @@ class ConfigPushToHubTester(unittest.TestCase):
             config.push_to_hub(tmp_repo.repo_id, token=self._token, revision=revision)
 
             # load from PR ref
-            new_config = GenerationConfig.from_pretrained(tmp_repo.repo_id, revision=revision)
+            new_config = GenerationConfig.from_pretrained(
+                tmp_repo.repo_id, revision=revision
+            )
             for k, v in config.to_dict().items():
                 if k != "transformers_version":
                     self.assertEqual(v, getattr(new_config, k))


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48214&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48214) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48214&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48214)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Adds early validation in `GenerationConfig.validate()` for negative parameter bounds:
- Validates that `min_length >= 0`, `min_new_tokens >= 0`, and `temperature >= 0.0` (when set).
- Prevents downstream runtime failures inside logits processors and generation loops with unhelpful indexing or division errors.
- Added unit test `test_validate_negative_bounds` in `tests/generation/test_configuration_utils.py`.

## Before submitting

- [x] This PR fixes a bug or adds a feature and conforms to the coding standards.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?