### PR TITLE
fix(pipelines): handle empty container inputs and validate batch_size in Pipeline.__call__

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1234,7 +1234,7 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
             container_types = (list, tuple)
             if is_torch_available():
                 container_types = (*container_types, KeyDataset)
-            if isinstance(inputs, container_types):
+            if isinstance(inputs, container_types) and len(inputs) > 0:
                 if is_valid_message(inputs[0]):
                     inputs = Chat(inputs)
                 elif isinstance(inputs[0], (list, tuple)) and all(
@@ -1252,6 +1252,9 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
                 batch_size = 1
             else:
                 batch_size = self._batch_size
+
+        if batch_size <= 0:
+            raise ValueError(f"`batch_size` must be a positive integer, got {batch_size}")
 
         preprocess_params, forward_params, postprocess_params = self._sanitize_parameters(**kwargs)
 

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -108,7 +108,11 @@ def _pad(items, key, padding_value, padding_side):
             # we can consistently pad since the size should be matching
             return torch.cat([item[key] for item in items], dim=0)
         else:
-            tensor = torch.full([batch_size, max_length] + list(shape[2:]), fill_value=padding_value, dtype=dtype)
+            tensor = torch.full(
+                [batch_size, max_length] + list(shape[2:]),
+                fill_value=padding_value,
+                dtype=dtype,
+            )
 
         for i, item in enumerate(items):
             if padding_side == "left":
@@ -127,7 +131,9 @@ def pad_collate_fn(tokenizer, feature_extractor):
     # Feature extractor
     f_padding_side = None
     if tokenizer is None and feature_extractor is None:
-        raise ValueError("Pipeline without tokenizer or feature_extractor cannot do batching")
+        raise ValueError(
+            "Pipeline without tokenizer or feature_extractor cannot do batching"
+        )
     if tokenizer is not None:
         if tokenizer.pad_token_id is None:
             raise ValueError(
@@ -142,7 +148,11 @@ def pad_collate_fn(tokenizer, feature_extractor):
         f_padding_value = getattr(feature_extractor, "padding_value", None)
         f_padding_side = getattr(feature_extractor, "padding_side", None)
 
-    if t_padding_side is not None and f_padding_side is not None and t_padding_side != f_padding_side:
+    if (
+        t_padding_side is not None
+        and f_padding_side is not None
+        and t_padding_side != f_padding_side
+    ):
         raise ValueError(
             f"The feature extractor, and tokenizer don't agree on padding side {t_padding_side} != {f_padding_side}"
         )
@@ -215,7 +225,9 @@ def load_model(
         The model.
     """
     if not is_torch_available():
-        raise RuntimeError("PyTorch should be installed. Please follow the instructions at https://pytorch.org/.")
+        raise RuntimeError(
+            "PyTorch should be installed. Please follow the instructions at https://pytorch.org/."
+        )
 
     if isinstance(model, str):
         model_kwargs["_from_pipeline"] = task
@@ -230,7 +242,9 @@ def load_model(
             class_tuple = class_tuple + tuple(classes)
 
         if len(class_tuple) == 0:
-            raise ValueError(f"Pipeline cannot infer suitable model classes from {model}")
+            raise ValueError(
+                f"Pipeline cannot infer suitable model classes from {model}"
+            )
 
         all_traceback = {}
         for model_class in class_tuple:
@@ -272,7 +286,9 @@ def load_model(
         if isinstance(model, str):
             error = ""
             for class_name, trace in all_traceback.items():
-                error += f"while loading with {class_name}, an error is thrown:\n{trace}\n"
+                error += (
+                    f"while loading with {class_name}, an error is thrown:\n{trace}\n"
+                )
             raise ValueError(
                 f"Could not load model {model} with any of the following classes: {class_tuple}. See the original errors:\n\n{error}\n"
             )
@@ -280,7 +296,9 @@ def load_model(
     return model
 
 
-def get_default_model_and_revision(targeted_task: dict, task_options: Any | None) -> tuple[str, str]:
+def get_default_model_and_revision(
+    targeted_task: dict, task_options: Any | None
+) -> tuple[str, str]:
     """
     Select a default model to use for a given task.
 
@@ -300,7 +318,9 @@ def get_default_model_and_revision(targeted_task: dict, task_options: Any | None
     defaults = targeted_task["default"]
     if task_options:
         if task_options not in defaults:
-            raise ValueError(f"The task does not provide any default models for options {task_options}")
+            raise ValueError(
+                f"The task does not provide any default models for options {task_options}"
+            )
         default_models = defaults[task_options]["model"]
     elif "model" in defaults:
         default_models = targeted_task["default"]["model"]
@@ -336,7 +356,9 @@ def load_assistant_model(
     if isinstance(assistant_model, str):
         assistant_config = AutoConfig.from_pretrained(assistant_model)
         loaded_assistant_model = load_model(assistant_model, config=assistant_config)
-        loaded_assistant_model = loaded_assistant_model.to(device=model.device, dtype=model.dtype)
+        loaded_assistant_model = loaded_assistant_model.to(
+            device=model.device, dtype=model.dtype
+        )
         loaded_assistant_tokenizer = AutoTokenizer.from_pretrained(assistant_model)
     else:
         loaded_assistant_model = assistant_model
@@ -424,7 +446,9 @@ class PipelineDataFormat:
         self.is_multi_columns = len(self.column) > 1
 
         if self.is_multi_columns:
-            self.column = [tuple(c.split("=")) if "=" in c else (c, c) for c in self.column]
+            self.column = [
+                tuple(c.split("=")) if "=" in c else (c, c) for c in self.column
+            ]
 
         if output_path is not None and not overwrite:
             if exists(abspath(self.output_path)):
@@ -493,13 +517,21 @@ class PipelineDataFormat:
             [`~pipelines.PipelineDataFormat`]: The proper data format.
         """
         if format == "json":
-            return JsonPipelineDataFormat(output_path, input_path, column, overwrite=overwrite)
+            return JsonPipelineDataFormat(
+                output_path, input_path, column, overwrite=overwrite
+            )
         elif format == "csv":
-            return CsvPipelineDataFormat(output_path, input_path, column, overwrite=overwrite)
+            return CsvPipelineDataFormat(
+                output_path, input_path, column, overwrite=overwrite
+            )
         elif format == "pipe":
-            return PipedPipelineDataFormat(output_path, input_path, column, overwrite=overwrite)
+            return PipedPipelineDataFormat(
+                output_path, input_path, column, overwrite=overwrite
+            )
         else:
-            raise KeyError(f"Unknown reader {format} (Available reader are json/csv/pipe)")
+            raise KeyError(
+                f"Unknown reader {format} (Available reader are json/csv/pipe)"
+            )
 
 
 class CsvPipelineDataFormat(PipelineDataFormat):
@@ -747,7 +779,10 @@ if is_torch_available():
 
 @add_end_docstrings(
     build_pipeline_init_args(
-        has_tokenizer=True, has_feature_extractor=True, has_image_processor=True, has_processor=True
+        has_tokenizer=True,
+        has_feature_extractor=True,
+        has_image_processor=True,
+        has_processor=True,
     )
 )
 class Pipeline(_ScikitCompat, PushToHubMixin):
@@ -797,7 +832,11 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         **kwargs,
     ):
         # We need to pop them for _sanitize_parameters call later
-        _, _, _ = kwargs.pop("args_parser", None), kwargs.pop("torch_dtype", None), kwargs.pop("dtype", None)
+        _, _, _ = (
+            kwargs.pop("args_parser", None),
+            kwargs.pop("torch_dtype", None),
+            kwargs.pop("dtype", None),
+        )
 
         self.task = task
         self.model = model
@@ -826,17 +865,21 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         if device == -1 and self.model.device is not None:
             device = self.model.device
         if isinstance(device, torch.device):
-            if (device.type == "xpu" and not is_torch_xpu_available(check_device=True)) or (
-                device.type == "hpu" and not is_torch_hpu_available()
-            ):
-                raise ValueError(f'{device} is not available, you should use device="cpu" instead')
+            if (
+                device.type == "xpu" and not is_torch_xpu_available(check_device=True)
+            ) or (device.type == "hpu" and not is_torch_hpu_available()):
+                raise ValueError(
+                    f'{device} is not available, you should use device="cpu" instead'
+                )
 
             self.device = device
         elif isinstance(device, str):
             if ("xpu" in device and not is_torch_xpu_available(check_device=True)) or (
                 "hpu" in device and not is_torch_hpu_available()
             ):
-                raise ValueError(f'{device} is not available, you should use device="cpu" instead')
+                raise ValueError(
+                    f'{device} is not available, you should use device="cpu" instead'
+                )
 
             self.device = torch.device(device)
         elif device < 0:
@@ -878,22 +921,34 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         # 2 - load the assistant model if it is passed.
         if self._pipeline_calls_generate and self.model.can_generate():
             self.assistant_model, self.assistant_tokenizer = load_assistant_model(
-                self.model, kwargs.pop("assistant_model", None), kwargs.pop("assistant_tokenizer", None)
+                self.model,
+                kwargs.pop("assistant_model", None),
+                kwargs.pop("assistant_tokenizer", None),
             )
-            self.prefix = self.model.config.prefix if hasattr(self.model.config, "prefix") else None
+            self.prefix = (
+                self.model.config.prefix
+                if hasattr(self.model.config, "prefix")
+                else None
+            )
             # Priority order: kwargs > user_generation_config > model.generation_config > default_pipeline_generation_config
-            default_pipeline_generation_config = getattr(self, "_default_generation_config", None)
+            default_pipeline_generation_config = getattr(
+                self, "_default_generation_config", None
+            )
             user_generation_config = kwargs.pop("generation_config", None)
             if hasattr(self.model, "_prepare_generation_config"):
-                base_config = user_generation_config or copy.deepcopy(self.model.generation_config)
+                base_config = user_generation_config or copy.deepcopy(
+                    self.model.generation_config
+                )
                 if default_pipeline_generation_config is not None:
                     base_config.update(
                         **default_pipeline_generation_config.to_dict(),
                         defaults_only=True,
                         allow_custom_entries=True,
                     )
-                prepared_generation_config, kwargs = self.model._prepare_generation_config(
-                    generation_config=base_config, **kwargs
+                prepared_generation_config, kwargs = (
+                    self.model._prepare_generation_config(
+                        generation_config=base_config, **kwargs
+                    )
                 )
                 self.generation_config = prepared_generation_config
                 # if the `max_new_tokens` is set to the pipeline default, but `max_length` is set to a non-default
@@ -901,8 +956,10 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
                 # over over the pipeline's length default.
                 if (
                     default_pipeline_generation_config is not None
-                    and default_pipeline_generation_config.max_new_tokens is not None  # there's a pipeline default
-                    and self.generation_config.max_new_tokens == default_pipeline_generation_config.max_new_tokens
+                    and default_pipeline_generation_config.max_new_tokens
+                    is not None  # there's a pipeline default
+                    and self.generation_config.max_new_tokens
+                    == default_pipeline_generation_config.max_new_tokens
                     and self.generation_config.max_length is not None
                     and self.generation_config.max_length != 20  # global default
                 ):
@@ -915,7 +972,9 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
             # Update the generation config with task specific params if they exist.
             # NOTE: 1. `prefix` is pipeline-specific and doesn't exist in the generation config.
             #       2. `task_specific_params` is a legacy feature and should be removed in a future version.
-            task_specific_params = getattr(self.model.config, "task_specific_params", None)
+            task_specific_params = getattr(
+                self.model.config, "task_specific_params", None
+            )
             if task_specific_params is not None and task in task_specific_params:
                 this_task_params = task_specific_params.get(task)
                 if "prefix" in this_task_params:
@@ -932,11 +991,17 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         self.call_count = 0
         self._batch_size = kwargs.pop("batch_size", None)
         self._num_workers = kwargs.pop("num_workers", None)
-        self._preprocess_params, self._forward_params, self._postprocess_params = self._sanitize_parameters(**kwargs)
+        self._preprocess_params, self._forward_params, self._postprocess_params = (
+            self._sanitize_parameters(**kwargs)
+        )
 
         # In processor only mode, we can get the modality processors from the processor
         if self.processor is not None and all(
-            [self.tokenizer is None, self.feature_extractor is None, self.image_processor is None]
+            [
+                self.tokenizer is None,
+                self.feature_extractor is None,
+                self.image_processor is None,
+            ]
         ):
             self.tokenizer = getattr(self.processor, "tokenizer", None)
             self.feature_extractor = getattr(self.processor, "feature_extractor", None)
@@ -971,7 +1036,9 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
                 Additional key word arguments passed along to the [`~utils.PushToHubMixin.push_to_hub`] method.
         """
         if os.path.isfile(save_directory):
-            logger.error(f"Provided path ({save_directory}) should be a directory, not a file")
+            logger.error(
+                f"Provided path ({save_directory}) should be a directory, not a file"
+            )
             return
         os.makedirs(save_directory, exist_ok=True)
 
@@ -1030,7 +1097,9 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         """
         Torch dtype of the model (if it's Pytorch model), `None` otherwise.
         """
-        logger.warning_once("`torch_dtype` attribute is deprecated. Use `dtype` instead!")
+        logger.warning_once(
+            "`torch_dtype` attribute is deprecated. Use `dtype` instead!"
+        )
         return getattr(self.model, "dtype", None)
 
     @contextmanager
@@ -1082,12 +1151,23 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
     def _ensure_tensor_on_device(self, inputs, device):
         if isinstance(inputs, ModelOutput):
             return ModelOutput(
-                {name: self._ensure_tensor_on_device(tensor, device) for name, tensor in inputs.items()}
+                {
+                    name: self._ensure_tensor_on_device(tensor, device)
+                    for name, tensor in inputs.items()
+                }
             )
         elif isinstance(inputs, dict):
-            return {name: self._ensure_tensor_on_device(tensor, device) for name, tensor in inputs.items()}
+            return {
+                name: self._ensure_tensor_on_device(tensor, device)
+                for name, tensor in inputs.items()
+            }
         elif isinstance(inputs, UserDict):
-            return UserDict({name: self._ensure_tensor_on_device(tensor, device) for name, tensor in inputs.items()})
+            return UserDict(
+                {
+                    name: self._ensure_tensor_on_device(tensor, device)
+                    for name, tensor in inputs.items()
+                }
+            )
         elif isinstance(inputs, list):
             return [self._ensure_tensor_on_device(item, device) for item in inputs]
         elif isinstance(inputs, tuple):
@@ -1144,7 +1224,9 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         raise NotImplementedError("_sanitize_parameters not implemented")
 
     @abstractmethod
-    def preprocess(self, input_: Any, **preprocess_parameters: dict) -> dict[str, GenericTensor]:
+    def preprocess(
+        self, input_: Any, **preprocess_parameters: dict
+    ) -> dict[str, GenericTensor]:
         """
         Preprocess will take the `input_` of a specific pipeline and return a dictionary of everything necessary for
         `_forward` to run properly. It should contain at least one tensor, but might have arbitrary other items.
@@ -1152,7 +1234,9 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         raise NotImplementedError("preprocess not implemented")
 
     @abstractmethod
-    def _forward(self, input_tensors: dict[str, GenericTensor], **forward_parameters: dict) -> ModelOutput:
+    def _forward(
+        self, input_tensors: dict[str, GenericTensor], **forward_parameters: dict
+    ) -> ModelOutput:
         """
         _forward will receive the prepared dictionary from `preprocess` and run it on the model. This method might
         involve the GPU or the CPU and should be agnostic to it. Isolating this function is the reason for `preprocess`
@@ -1165,7 +1249,9 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         raise NotImplementedError("_forward not implemented")
 
     @abstractmethod
-    def postprocess(self, model_outputs: ModelOutput, **postprocess_parameters: dict) -> Any:
+    def postprocess(
+        self, model_outputs: ModelOutput, **postprocess_parameters: dict
+    ) -> Any:
         """
         Postprocess will receive the raw outputs of the `_forward` method, generally tensors, and reformat them into
         something more friendly. Generally it will output a list or a dict or results (containing just strings and
@@ -1180,13 +1266,23 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         with self.device_placement():
             inference_context = self.get_inference_context()
             with inference_context():
-                model_inputs = self._ensure_tensor_on_device(model_inputs, device=self.device)
+                model_inputs = self._ensure_tensor_on_device(
+                    model_inputs, device=self.device
+                )
                 model_outputs = self._forward(model_inputs, **forward_params)
-                model_outputs = self._ensure_tensor_on_device(model_outputs, device=torch.device("cpu"))
+                model_outputs = self._ensure_tensor_on_device(
+                    model_outputs, device=torch.device("cpu")
+                )
         return model_outputs
 
     def get_iterator(
-        self, inputs, num_workers: int, batch_size: int, preprocess_params, forward_params, postprocess_params
+        self,
+        inputs,
+        num_workers: int,
+        batch_size: int,
+        preprocess_params,
+        forward_params,
+        postprocess_params,
     ):
         if isinstance(inputs, collections.abc.Sized):
             dataset = PipelineDataset(inputs, self.preprocess, preprocess_params)
@@ -1200,14 +1296,33 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
                 num_workers = 1
             dataset = PipelineIterator(inputs, self.preprocess, preprocess_params)
         if "TOKENIZERS_PARALLELISM" not in os.environ:
-            logger.info("Disabling tokenizer parallelism, we're using DataLoader multithreading already")
+            logger.info(
+                "Disabling tokenizer parallelism, we're using DataLoader multithreading already"
+            )
             os.environ["TOKENIZERS_PARALLELISM"] = "false"
         # TODO hack by collating feature_extractor and image_processor
-        feature_extractor = self.feature_extractor if self.feature_extractor is not None else self.image_processor
-        collate_fn = no_collate_fn if batch_size == 1 else pad_collate_fn(self.tokenizer, feature_extractor)
-        dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=batch_size, collate_fn=collate_fn)
-        model_iterator = PipelineIterator(dataloader, self.forward, forward_params, loader_batch_size=batch_size)
-        final_iterator = PipelineIterator(model_iterator, self.postprocess, postprocess_params)
+        feature_extractor = (
+            self.feature_extractor
+            if self.feature_extractor is not None
+            else self.image_processor
+        )
+        collate_fn = (
+            no_collate_fn
+            if batch_size == 1
+            else pad_collate_fn(self.tokenizer, feature_extractor)
+        )
+        dataloader = DataLoader(
+            dataset,
+            num_workers=num_workers,
+            batch_size=batch_size,
+            collate_fn=collate_fn,
+        )
+        model_iterator = PipelineIterator(
+            dataloader, self.forward, forward_params, loader_batch_size=batch_size
+        )
+        final_iterator = PipelineIterator(
+            model_iterator, self.postprocess, postprocess_params
+        )
         return final_iterator
 
     def __call__(self, inputs, *args, num_workers=None, batch_size=None, **kwargs):
@@ -1225,7 +1340,11 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
             else:
                 if is_valid_message(first):
                     inputs = Chat([first, *inputs])
-                elif isinstance(first, (list, tuple)) and first and is_valid_message(first[0]):
+                elif (
+                    isinstance(first, (list, tuple))
+                    and first
+                    and is_valid_message(first[0])
+                ):
                     # Keep this a generator expression, not a list, so it doesn't materialize everything
                     inputs = (Chat(chat) for chat in _reform_generator(first, inputs))
                 else:
@@ -1254,9 +1373,13 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
                 batch_size = self._batch_size
 
         if batch_size <= 0:
-            raise ValueError(f"`batch_size` must be a positive integer, got {batch_size}")
+            raise ValueError(
+                f"`batch_size` must be a positive integer, got {batch_size}"
+            )
 
-        preprocess_params, forward_params, postprocess_params = self._sanitize_parameters(**kwargs)
+        preprocess_params, forward_params, postprocess_params = (
+            self._sanitize_parameters(**kwargs)
+        )
 
         # Fuse __init__ params and __call__ params without modifying the __init__ ones.
         preprocess_params = {**self._preprocess_params, **preprocess_params}
@@ -1277,25 +1400,42 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         if is_list:
             # A list input is eagerly consumed and returns a list of outputs.
             final_iterator = self.get_iterator(
-                inputs, num_workers, batch_size, preprocess_params, forward_params, postprocess_params
+                inputs,
+                num_workers,
+                batch_size,
+                preprocess_params,
+                forward_params,
+                postprocess_params,
             )
             return list(final_iterator)
         elif is_dataset or is_generator:
             # Datasets and generators stream lazily: return an iterator consumed on demand so the input is
             # never fully materialized.
             return self.get_iterator(
-                inputs, num_workers, batch_size, preprocess_params, forward_params, postprocess_params
+                inputs,
+                num_workers,
+                batch_size,
+                preprocess_params,
+                forward_params,
+                postprocess_params,
             )
         elif isinstance(self, ChunkPipeline):
             return next(
                 iter(
                     self.get_iterator(
-                        [inputs], num_workers, batch_size, preprocess_params, forward_params, postprocess_params
+                        [inputs],
+                        num_workers,
+                        batch_size,
+                        preprocess_params,
+                        forward_params,
+                        postprocess_params,
                     )
                 )
             )
         else:
-            return self.run_single(inputs, preprocess_params, forward_params, postprocess_params)
+            return self.run_single(
+                inputs, preprocess_params, forward_params, postprocess_params
+            )
 
     def run_single(self, inputs, preprocess_params, forward_params, postprocess_params):
         model_inputs = self.preprocess(inputs, **preprocess_params)
@@ -1321,10 +1461,18 @@ class ChunkPipeline(Pipeline):
         return outputs
 
     def get_iterator(
-        self, inputs, num_workers: int, batch_size: int, preprocess_params, forward_params, postprocess_params
+        self,
+        inputs,
+        num_workers: int,
+        batch_size: int,
+        preprocess_params,
+        forward_params,
+        postprocess_params,
     ):
         if "TOKENIZERS_PARALLELISM" not in os.environ:
-            logger.info("Disabling tokenizer parallelism, we're using DataLoader multithreading already")
+            logger.info(
+                "Disabling tokenizer parallelism, we're using DataLoader multithreading already"
+            )
             os.environ["TOKENIZERS_PARALLELISM"] = "false"
         if num_workers > 1:
             logger.warning(
@@ -1335,21 +1483,42 @@ class ChunkPipeline(Pipeline):
         dataset = PipelineChunkIterator(inputs, self.preprocess, preprocess_params)
 
         # TODO hack by collating feature_extractor and image_processor
-        feature_extractor = self.feature_extractor if self.feature_extractor is not None else self.image_processor
-        collate_fn = no_collate_fn if batch_size == 1 else pad_collate_fn(self.tokenizer, feature_extractor)
-        dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=batch_size, collate_fn=collate_fn)
-        model_iterator = PipelinePackIterator(dataloader, self.forward, forward_params, loader_batch_size=batch_size)
-        final_iterator = PipelineIterator(model_iterator, self.postprocess, postprocess_params)
+        feature_extractor = (
+            self.feature_extractor
+            if self.feature_extractor is not None
+            else self.image_processor
+        )
+        collate_fn = (
+            no_collate_fn
+            if batch_size == 1
+            else pad_collate_fn(self.tokenizer, feature_extractor)
+        )
+        dataloader = DataLoader(
+            dataset,
+            num_workers=num_workers,
+            batch_size=batch_size,
+            collate_fn=collate_fn,
+        )
+        model_iterator = PipelinePackIterator(
+            dataloader, self.forward, forward_params, loader_batch_size=batch_size
+        )
+        final_iterator = PipelineIterator(
+            model_iterator, self.postprocess, postprocess_params
+        )
         return final_iterator
 
 
 class PipelineRegistry:
-    def __init__(self, supported_tasks: dict[str, Any], task_aliases: dict[str, str]) -> None:
+    def __init__(
+        self, supported_tasks: dict[str, Any], task_aliases: dict[str, str]
+    ) -> None:
         self.supported_tasks = supported_tasks
         self.task_aliases = task_aliases
 
     def get_supported_tasks(self) -> list[str]:
-        supported_task = list(self.supported_tasks.keys()) + list(self.task_aliases.keys())
+        supported_task = list(self.supported_tasks.keys()) + list(
+            self.task_aliases.keys()
+        )
         supported_task.sort()
         return supported_task
 
@@ -1360,7 +1529,9 @@ class PipelineRegistry:
             targeted_task = self.supported_tasks[task]
             return task, targeted_task, None
 
-        raise KeyError(f"Unknown task {task}, available tasks are {self.get_supported_tasks()}")
+        raise KeyError(
+            f"Unknown task {task}, available tasks are {self.get_supported_tasks()}"
+        )
 
     def register_pipeline(
         self,
@@ -1371,7 +1542,9 @@ class PipelineRegistry:
         type: str | None = None,
     ) -> None:
         if task in self.supported_tasks:
-            logger.warning(f"{task} is already registered. Overwriting pipeline for task {task}...")
+            logger.warning(
+                f"{task} is already registered. Overwriting pipeline for task {task}..."
+            )
 
         if pt_model is None:
             pt_model = ()

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -551,6 +551,30 @@ class PipelineUtilsTest(unittest.TestCase):
         self.assertEqual(outputs, [0, 1, 0, 1, 2])
 
     @require_torch
+    def test_pipeline_call_batch_size_validation(self):
+        from transformers.pipelines.base import Pipeline
+
+        class DummyPipeline(Pipeline):
+            def _sanitize_parameters(self, **kwargs):
+                return {}, {}, {}
+            def preprocess(self, input_):
+                return {"input": input_}
+            def _forward(self, model_inputs):
+                return model_inputs
+            def postprocess(self, model_outputs):
+                return model_outputs
+
+        pipe = DummyPipeline.__new__(DummyPipeline)
+        pipe._batch_size = None
+        pipe._num_workers = None
+        pipe._sanitize_parameters = lambda **kwargs: ({}, {}, {})
+
+        with self.assertRaises(ValueError):
+            pipe(["test"], batch_size=0)
+        with self.assertRaises(ValueError):
+            pipe(["test"], batch_size=-1)
+
+    @require_torch
     def test_pipeline_pack_iterator(self):
         from transformers.pipelines.pt_utils import PipelinePackIterator
 

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -67,7 +67,9 @@ from test_module.custom_pipeline import PairClassificationPipeline  # noqa E402
 logger = logging.getLogger(__name__)
 
 
-PATH_TO_TRANSFORMERS = os.path.join(Path(__file__).parent.parent.parent, "src/transformers")
+PATH_TO_TRANSFORMERS = os.path.join(
+    Path(__file__).parent.parent.parent, "src/transformers"
+)
 
 
 # Dynamically import the Transformers module to grab the attribute classes of the processor form their names.
@@ -104,7 +106,10 @@ class CommonPipelineTest(unittest.TestCase):
             def __getitem__(self, i):
                 return self.data[i]
 
-        text_classifier = pipeline(task="text-classification", model="hf-internal-testing/tiny-random-distilbert")
+        text_classifier = pipeline(
+            task="text-classification",
+            model="hf-internal-testing/tiny-random-distilbert",
+        )
         dataset = MyDataset()
         for output in text_classifier(dataset):
             self.assertEqual(output, {"label": ANY(str), "score": ANY(float)})
@@ -121,7 +126,11 @@ class CommonPipelineTest(unittest.TestCase):
         self.assertEqual(pipe._batch_size, None)
         self.assertEqual(pipe._num_workers, None)
 
-        pipe = pipeline(model="hf-internal-testing/tiny-random-distilbert", batch_size=2, num_workers=1)
+        pipe = pipeline(
+            model="hf-internal-testing/tiny-random-distilbert",
+            batch_size=2,
+            num_workers=1,
+        )
         self.assertEqual(pipe._batch_size, 2)
         self.assertEqual(pipe._num_workers, 1)
 
@@ -139,7 +148,10 @@ class CommonPipelineTest(unittest.TestCase):
         class MyPipeline(TextClassificationPipeline):
             pass
 
-        text_classifier = pipeline(model="hf-internal-testing/tiny-random-distilbert", pipeline_class=MyPipeline)
+        text_classifier = pipeline(
+            model="hf-internal-testing/tiny-random-distilbert",
+            pipeline_class=MyPipeline,
+        )
 
         self.assertIsInstance(text_classifier, MyPipeline)
 
@@ -160,7 +172,9 @@ class CommonPipelineTest(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             # Wrong framework
-            get_task("espnet/siddhana_slurp_entity_asr_train_asr_conformer_raw_en_word_valid.acc.ave_10best")
+            get_task(
+                "espnet/siddhana_slurp_entity_asr_train_asr_conformer_raw_en_word_valid.acc.ave_10best"
+            )
 
     @require_torch
     def test_iterator_data(self):
@@ -264,9 +278,13 @@ class CommonPipelineTest(unittest.TestCase):
     @require_torch
     def test_unbatch_attentions_hidden_states(self):
         model = DistilBertForSequenceClassification.from_pretrained(
-            "hf-internal-testing/tiny-random-distilbert", output_hidden_states=True, output_attentions=True
+            "hf-internal-testing/tiny-random-distilbert",
+            output_hidden_states=True,
+            output_attentions=True,
         )
-        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-distilbert")
+        tokenizer = AutoTokenizer.from_pretrained(
+            "hf-internal-testing/tiny-random-distilbert"
+        )
         text_classifier = TextClassificationPipeline(model=model, tokenizer=tokenizer)
 
         # Used to throw an error because `hidden_states` are a tuple of tensors
@@ -300,10 +318,14 @@ class CommonPipelineTest(unittest.TestCase):
     @require_torch
     def test_auto_model_pipeline_registration_from_local_dir(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            snapshot_download("hf-internal-testing/tiny-random-custom-architecture", local_dir=tmp_dir)
+            snapshot_download(
+                "hf-internal-testing/tiny-random-custom-architecture", local_dir=tmp_dir
+            )
             pipe = pipeline("text-generation", tmp_dir, trust_remote_code=True)
 
-            self.assertIsInstance(pipe, TextGenerationPipeline)  # Assert successful load
+            self.assertIsInstance(
+                pipe, TextGenerationPipeline
+            )  # Assert successful load
 
     @require_peft
     @require_torch
@@ -357,7 +379,10 @@ class PipelineScikitCompatTest(unittest.TestCase):
     def test_pipeline_predict(self):
         data = ["This is a test"]
 
-        text_classifier = pipeline(task="text-classification", model="hf-internal-testing/tiny-random-distilbert")
+        text_classifier = pipeline(
+            task="text-classification",
+            model="hf-internal-testing/tiny-random-distilbert",
+        )
 
         expected_output = [{"label": ANY(str), "score": ANY(float)}]
         actual_output = text_classifier.predict(data)
@@ -366,7 +391,10 @@ class PipelineScikitCompatTest(unittest.TestCase):
     def test_pipeline_transform(self):
         data = ["This is a test"]
 
-        text_classifier = pipeline(task="text-classification", model="hf-internal-testing/tiny-random-distilbert")
+        text_classifier = pipeline(
+            task="text-classification",
+            model="hf-internal-testing/tiny-random-distilbert",
+        )
 
         expected_output = [{"label": ANY(str), "score": ANY(float)}]
         actual_output = text_classifier.transform(data)
@@ -407,7 +435,8 @@ class PipelinePadTest(unittest.TestCase):
         )
         self.assertTrue(
             torch.allclose(
-                _pad(items, "attention_mask", 0, "right"), torch.LongTensor([[0, 1, 1, 0, 0, 0], [0, 1, 1, 1, 1, 0]])
+                _pad(items, "attention_mask", 0, "right"),
+                torch.LongTensor([[0, 1, 1, 0, 0, 0], [0, 1, 1, 1, 1, 0]]),
             )
         )
 
@@ -512,7 +541,9 @@ class PipelineUtilsTest(unittest.TestCase):
         def add(number, extra=0):
             return {"id": [i + extra for i in number["id"]]}
 
-        dataset = PipelineIterator(dummy_dataset, add, {"extra": 2}, loader_batch_size=3)
+        dataset = PipelineIterator(
+            dummy_dataset, add, {"extra": 2}, loader_batch_size=3
+        )
 
         outputs = list(dataset)
         self.assertEqual(outputs, [{"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}])
@@ -523,16 +554,22 @@ class PipelineUtilsTest(unittest.TestCase):
 
         from transformers.pipelines.pt_utils import PipelineIterator
 
-        dummy_dataset = [{"id": torch.LongTensor([[10, 20], [0, 1], [0, 2]])}, {"id": torch.LongTensor([[3]])}]
+        dummy_dataset = [
+            {"id": torch.LongTensor([[10, 20], [0, 1], [0, 2]])},
+            {"id": torch.LongTensor([[3]])},
+        ]
 
         def add(number, extra=0):
             return {"id": number["id"] + extra}
 
-        dataset = PipelineIterator(dummy_dataset, add, {"extra": 2}, loader_batch_size=3)
+        dataset = PipelineIterator(
+            dummy_dataset, add, {"extra": 2}, loader_batch_size=3
+        )
 
         outputs = list(dataset)
         self.assertEqual(
-            nested_simplify(outputs), [{"id": [[12, 22]]}, {"id": [[2, 3]]}, {"id": [[2, 4]]}, {"id": [[5]]}]
+            nested_simplify(outputs),
+            [{"id": [[12, 22]]}, {"id": [[2, 3]]}, {"id": [[2, 4]]}, {"id": [[5]]}],
         )
 
     @require_torch
@@ -544,7 +581,9 @@ class PipelineUtilsTest(unittest.TestCase):
 
         dataset = [2, 3]
 
-        dataset = PipelineChunkIterator(dataset, preprocess_chunk, {}, loader_batch_size=3)
+        dataset = PipelineChunkIterator(
+            dataset, preprocess_chunk, {}, loader_batch_size=3
+        )
 
         outputs = list(dataset)
 
@@ -557,10 +596,13 @@ class PipelineUtilsTest(unittest.TestCase):
         class DummyPipeline(Pipeline):
             def _sanitize_parameters(self, **kwargs):
                 return {}, {}, {}
+
             def preprocess(self, input_):
                 return {"input": input_}
+
             def _forward(self, model_inputs):
                 return model_inputs
+
             def postprocess(self, model_outputs):
                 return model_outputs
 
@@ -611,30 +653,48 @@ class PipelineUtilsTest(unittest.TestCase):
     def test_pipeline_pack_unbatch_iterator(self):
         from transformers.pipelines.pt_utils import PipelinePackIterator
 
-        dummy_dataset = [{"id": [0, 1, 2], "is_last": [False, True, False]}, {"id": [3], "is_last": [True]}]
+        dummy_dataset = [
+            {"id": [0, 1, 2], "is_last": [False, True, False]},
+            {"id": [3], "is_last": [True]},
+        ]
 
         def add(number, extra=0):
-            return {"id": [i + extra for i in number["id"]], "is_last": number["is_last"]}
+            return {
+                "id": [i + extra for i in number["id"]],
+                "is_last": number["is_last"],
+            }
 
-        dataset = PipelinePackIterator(dummy_dataset, add, {"extra": 2}, loader_batch_size=3)
+        dataset = PipelinePackIterator(
+            dummy_dataset, add, {"extra": 2}, loader_batch_size=3
+        )
 
         outputs = list(dataset)
         self.assertEqual(outputs, [[{"id": 2}, {"id": 3}], [{"id": 4}, {"id": 5}]])
 
         # is_false Across batch
-        dummy_dataset = [{"id": [0, 1, 2], "is_last": [False, False, False]}, {"id": [3], "is_last": [True]}]
+        dummy_dataset = [
+            {"id": [0, 1, 2], "is_last": [False, False, False]},
+            {"id": [3], "is_last": [True]},
+        ]
 
         def add(number, extra=0):
-            return {"id": [i + extra for i in number["id"]], "is_last": number["is_last"]}
+            return {
+                "id": [i + extra for i in number["id"]],
+                "is_last": number["is_last"],
+            }
 
-        dataset = PipelinePackIterator(dummy_dataset, add, {"extra": 2}, loader_batch_size=3)
+        dataset = PipelinePackIterator(
+            dummy_dataset, add, {"extra": 2}, loader_batch_size=3
+        )
 
         outputs = list(dataset)
         self.assertEqual(outputs, [[{"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}]])
 
     def test_pipeline_negative_device(self):
         # To avoid regressing, pipeline used to accept device=-1
-        classifier = pipeline("text-generation", "hf-internal-testing/tiny-random-bert", device=-1)
+        classifier = pipeline(
+            "text-generation", "hf-internal-testing/tiny-random-bert", device=-1
+        )
 
         expected_output = [{"generated_text": ANY(str)}]
         actual_output = classifier("Test input.")
@@ -647,27 +707,35 @@ class PipelineUtilsTest(unittest.TestCase):
 
         from transformers import AutoModelForCausalLM
 
-        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-bert")
-        # Case 1: Model is manually moved to device
-        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-bert", dtype=torch.float16).to(
-            torch_device
+        tokenizer = AutoTokenizer.from_pretrained(
+            "hf-internal-testing/tiny-random-bert"
         )
+        # Case 1: Model is manually moved to device
+        model = AutoModelForCausalLM.from_pretrained(
+            "hf-internal-testing/tiny-random-bert", dtype=torch.float16
+        ).to(torch_device)
         model_device = model.device
         pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
         self.assertEqual(pipe.model.device, model_device)
         # Case 2: Model is loaded by accelerate
         model = AutoModelForCausalLM.from_pretrained(
-            "hf-internal-testing/tiny-random-bert", device_map=torch_device, dtype=torch.float16
+            "hf-internal-testing/tiny-random-bert",
+            device_map=torch_device,
+            dtype=torch.float16,
         )
         model_device = model.device
         pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
         self.assertEqual(pipe.model.device, model_device)
         # Case 3: device_map is passed to model and device is passed to pipeline
         model = AutoModelForCausalLM.from_pretrained(
-            "hf-internal-testing/tiny-random-bert", device_map=torch_device, dtype=torch.float16
+            "hf-internal-testing/tiny-random-bert",
+            device_map=torch_device,
+            dtype=torch.float16,
         )
         with self.assertRaises(ValueError):
-            pipe = pipeline("text-generation", model=model, device="cpu", tokenizer=tokenizer)
+            pipe = pipeline(
+                "text-generation", model=model, device="cpu", tokenizer=tokenizer
+            )
 
     @require_torch_multi_accelerator
     def test_pipeline_device_not_equal_model_device(self):
@@ -676,14 +744,18 @@ class PipelineUtilsTest(unittest.TestCase):
 
         from transformers import AutoModelForCausalLM
 
-        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-bert")
-        model_device = f"{torch_device}:1"
-        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-bert", dtype=torch.float16).to(
-            model_device
+        tokenizer = AutoTokenizer.from_pretrained(
+            "hf-internal-testing/tiny-random-bert"
         )
+        model_device = f"{torch_device}:1"
+        model = AutoModelForCausalLM.from_pretrained(
+            "hf-internal-testing/tiny-random-bert", dtype=torch.float16
+        ).to(model_device)
         target_device = f"{torch_device}:0"
         self.assertNotEqual(model_device, target_device)
-        pipe = pipeline("text-generation", model=model, device=target_device, tokenizer=tokenizer)
+        pipe = pipeline(
+            "text-generation", model=model, device=target_device, tokenizer=tokenizer
+        )
         self.assertEqual(pipe.model.device, torch.device(target_device))
 
     @slow
@@ -711,7 +783,9 @@ class PipelineUtilsTest(unittest.TestCase):
         import torch
 
         set_seed_fn = lambda: torch.manual_seed(0)  # noqa: E731
-        self.check_default_pipeline("table-question-answering", set_seed_fn, self.check_models_equal_pt)
+        self.check_default_pipeline(
+            "table-question-answering", set_seed_fn, self.check_models_equal_pt
+        )
 
         # clean-up as much as possible GPU memory occupied by PyTorch
         gc.collect()
@@ -740,12 +814,21 @@ class PipelineUtilsTest(unittest.TestCase):
 
         for task in get_supported_tasks():
             # Check that it works for all dtypes
-            for dtype in ["float16", "bfloat16", "float32", "auto", torch.float16, torch.bfloat16, torch.float32]:
+            for dtype in [
+                "float16",
+                "bfloat16",
+                "float32",
+                "auto",
+                torch.float16,
+                torch.bfloat16,
+                torch.float32,
+            ]:
                 pipe_torch_dtype = pipeline(task, torch_dtype=dtype)
                 pipe_dtype = pipeline(task, dtype=dtype)
                 # Make sure all parameters have the same dtype
                 for (k1, v1), (k2, v2) in zip(
-                    pipe_torch_dtype.model.named_parameters(), pipe_dtype.model.named_parameters()
+                    pipe_torch_dtype.model.named_parameters(),
+                    pipe_dtype.model.named_parameters(),
                 ):
                     self.assertEqual(k1, k2)
                     self.assertEqual(v1.dtype, v2.dtype)
@@ -754,7 +837,8 @@ class PipelineUtilsTest(unittest.TestCase):
                 pipe_dtype = pipeline(task, model_kwargs={"dtype": dtype})
                 # Make sure all parameters have the same dtype
                 for (k1, v1), (k2, v2) in zip(
-                    pipe_torch_dtype.model.named_parameters(), pipe_dtype.model.named_parameters()
+                    pipe_torch_dtype.model.named_parameters(),
+                    pipe_dtype.model.named_parameters(),
                 ):
                     self.assertEqual(k1, k2)
                     self.assertEqual(v1.dtype, v2.dtype)
@@ -852,17 +936,27 @@ class CustomPipelineTest(unittest.TestCase):
         PIPELINE_REGISTRY.register_pipeline(
             "custom-text-classification",
             pipeline_class=PairClassificationPipeline,
-            pt_model=AutoModelForSequenceClassification if is_torch_available() else None,
-            default={"model": ("hf-internal-testing/tiny-random-distilbert", "2ef615d")},
+            pt_model=AutoModelForSequenceClassification
+            if is_torch_available()
+            else None,
+            default={
+                "model": ("hf-internal-testing/tiny-random-distilbert", "2ef615d")
+            },
             type="text",
         )
         assert "custom-text-classification" in PIPELINE_REGISTRY.get_supported_tasks()
 
         _, task_def, _ = PIPELINE_REGISTRY.check_task("custom-text-classification")
-        self.assertEqual(task_def["pt"], (AutoModelForSequenceClassification,) if is_torch_available() else ())
+        self.assertEqual(
+            task_def["pt"],
+            (AutoModelForSequenceClassification,) if is_torch_available() else (),
+        )
         self.assertEqual(task_def["type"], "text")
         self.assertEqual(task_def["impl"], PairClassificationPipeline)
-        self.assertEqual(task_def["default"], {"model": ("hf-internal-testing/tiny-random-distilbert", "2ef615d")})
+        self.assertEqual(
+            task_def["default"],
+            {"model": ("hf-internal-testing/tiny-random-distilbert", "2ef615d")},
+        )
 
         # Clean registry for next tests.
         del PIPELINE_REGISTRY.supported_tasks["custom-text-classification"]
@@ -872,10 +966,14 @@ class CustomPipelineTest(unittest.TestCase):
         PIPELINE_REGISTRY.register_pipeline(
             "pair-classification",
             pipeline_class=PairClassificationPipeline,
-            pt_model=AutoModelForSequenceClassification if is_torch_available() else None,
+            pt_model=AutoModelForSequenceClassification
+            if is_torch_available()
+            else None,
         )
 
-        classifier = pipeline("pair-classification", model="hf-internal-testing/tiny-random-bert")
+        classifier = pipeline(
+            "pair-classification", model="hf-internal-testing/tiny-random-bert"
+        )
 
         # Clean registry as we won't need the pipeline to be in it for the rest to work.
         del PIPELINE_REGISTRY.supported_tasks["pair-classification"]
@@ -888,7 +986,9 @@ class CustomPipelineTest(unittest.TestCase):
                 {
                     "pair-classification": {
                         "impl": "custom_pipeline.PairClassificationPipeline",
-                        "pt": ("AutoModelForSequenceClassification",) if is_torch_available() else (),
+                        "pt": ("AutoModelForSequenceClassification",)
+                        if is_torch_available()
+                        else (),
                     }
                 },
             )
@@ -898,10 +998,14 @@ class CustomPipelineTest(unittest.TestCase):
 
             new_classifier = pipeline(model=tmp_dir, trust_remote_code=True)
             # Using trust_remote_code=False forces the traditional pipeline tag
-            old_classifier = pipeline("text-classification", model=tmp_dir, trust_remote_code=False)
+            old_classifier = pipeline(
+                "text-classification", model=tmp_dir, trust_remote_code=False
+            )
         # Can't make an isinstance check because the new_classifier is from the PairClassificationPipeline class of a
         # dynamic module
-        self.assertEqual(new_classifier.__class__.__name__, "PairClassificationPipeline")
+        self.assertEqual(
+            new_classifier.__class__.__name__, "PairClassificationPipeline"
+        )
         self.assertEqual(new_classifier.task, "pair-classification")
         results = new_classifier("I hate you", second_text="I love you")
         self.assertDictEqual(
@@ -909,7 +1013,9 @@ class CustomPipelineTest(unittest.TestCase):
             {"label": "LABEL_0", "score": 0.505, "logits": [-0.003, -0.024]},
         )
 
-        self.assertEqual(old_classifier.__class__.__name__, "TextClassificationPipeline")
+        self.assertEqual(
+            old_classifier.__class__.__name__, "TextClassificationPipeline"
+        )
         self.assertEqual(old_classifier.task, "text-classification")
         results = old_classifier("I hate you", text_pair="I love you")
         self.assertListEqual(
@@ -920,9 +1026,13 @@ class CustomPipelineTest(unittest.TestCase):
     @require_torch
     def test_cached_pipeline_has_minimum_calls_to_head(self):
         # Make sure we have cached the pipeline.
-        _ = pipeline("text-classification", model="hf-internal-testing/tiny-random-bert")
+        _ = pipeline(
+            "text-classification", model="hf-internal-testing/tiny-random-bert"
+        )
         with RequestCounter() as counter:
-            _ = pipeline("text-classification", model="hf-internal-testing/tiny-random-bert")
+            _ = pipeline(
+                "text-classification", model="hf-internal-testing/tiny-random-bert"
+            )
         self.assertEqual(counter["GET"], 0)
         self.assertEqual(counter["HEAD"], 1)
         self.assertEqual(counter.total_calls, 1)
@@ -931,7 +1041,9 @@ class CustomPipelineTest(unittest.TestCase):
     def test_chunk_pipeline_batching_single_file(self):
         # Make sure we have cached the pipeline.
         pipe = pipeline(model="hf-internal-testing/tiny-random-Wav2Vec2ForCTC")
-        ds = datasets.load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation").sort("id")
+        ds = datasets.load_dataset(
+            "hf-internal-testing/librispeech_asr_dummy", "clean", split="validation"
+        ).sort("id")
         audio = ds[40]["audio"]["array"]
 
         pipe = pipeline(model="hf-internal-testing/tiny-random-Wav2Vec2ForCTC")
@@ -945,7 +1057,13 @@ class CustomPipelineTest(unittest.TestCase):
 
         pipe.model.forward = new_forward
 
-        for out in pipe(audio, return_timestamps="char", chunk_length_s=3, stride_length_s=[1, 1], batch_size=1024):
+        for out in pipe(
+            audio,
+            return_timestamps="char",
+            chunk_length_s=3,
+            stride_length_s=[1, 1],
+            batch_size=1024,
+        ):
             pass
 
         self.assertEqual(self.COUNT, 1)
@@ -962,7 +1080,9 @@ class CustomPipelineTest(unittest.TestCase):
             trust_remote_code=True,
         )
 
-        self.assertIsInstance(text_generator, TextGenerationPipeline)  # Assert successful loading
+        self.assertIsInstance(
+            text_generator, TextGenerationPipeline
+        )  # Assert successful loading
 
     @require_torch
     def test_custom_code_with_string_feature_extractor(self):
@@ -974,7 +1094,9 @@ class CustomPipelineTest(unittest.TestCase):
             trust_remote_code=True,
         )
 
-        self.assertIsInstance(speech_recognizer, AutomaticSpeechRecognitionPipeline)  # Assert successful loading
+        self.assertIsInstance(
+            speech_recognizer, AutomaticSpeechRecognitionPipeline
+        )  # Assert successful loading
 
     @require_torch
     def test_custom_code_with_string_preprocessor(self):
@@ -985,13 +1107,25 @@ class CustomPipelineTest(unittest.TestCase):
             trust_remote_code=True,
         )
 
-        self.assertIsInstance(mask_generator, MaskGenerationPipeline)  # Assert successful loading
+        self.assertIsInstance(
+            mask_generator, MaskGenerationPipeline
+        )  # Assert successful loading
 
 
 @require_torch
 @is_staging_test
 class DynamicPipelineTester(unittest.TestCase):
-    vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]", "I", "love", "hate", "you"]
+    vocab_tokens = [
+        "[UNK]",
+        "[CLS]",
+        "[SEP]",
+        "[PAD]",
+        "[MASK]",
+        "I",
+        "love",
+        "hate",
+        "you",
+    ]
 
     @classmethod
     def setUpClass(cls):
@@ -1006,7 +1140,11 @@ class DynamicPipelineTester(unittest.TestCase):
 
     @unittest.skip("Broken, TODO @Yih-Dar")
     def test_push_to_hub_dynamic_pipeline(self):
-        from transformers import BertConfig, BertForSequenceClassification, BertTokenizer
+        from transformers import (
+            BertConfig,
+            BertForSequenceClassification,
+            BertTokenizer,
+        )
 
         PIPELINE_REGISTRY.register_pipeline(
             "pair-classification",
@@ -1015,7 +1153,11 @@ class DynamicPipelineTester(unittest.TestCase):
         )
 
         config = BertConfig(
-            vocab_size=99, hidden_size=32, num_hidden_layers=5, num_attention_heads=4, intermediate_size=37
+            vocab_size=99,
+            hidden_size=32,
+            num_hidden_layers=5,
+            num_attention_heads=4,
+            intermediate_size=37,
         )
         model = BertForSequenceClassification(config).eval()
 
@@ -1025,7 +1167,9 @@ class DynamicPipelineTester(unittest.TestCase):
                 vocab_writer.write("".join([x + "\n" for x in self.vocab_tokens]))
             tokenizer = BertTokenizer(vocab_file)
 
-            classifier = pipeline("pair-classification", model=model, tokenizer=tokenizer)
+            classifier = pipeline(
+                "pair-classification", model=model, tokenizer=tokenizer
+            )
 
             # Clean registry as we won't need the pipeline to be in it for the rest to work.
             del PIPELINE_REGISTRY.supported_tasks["pair-classification"]
@@ -1048,10 +1192,14 @@ class DynamicPipelineTester(unittest.TestCase):
         with self.assertRaises(ValueError):
             _ = pipeline(model=f"{USER}/test-dynamic-pipeline")
 
-        new_classifier = pipeline(model=f"{USER}/test-dynamic-pipeline", trust_remote_code=True)
+        new_classifier = pipeline(
+            model=f"{USER}/test-dynamic-pipeline", trust_remote_code=True
+        )
         # Can't make an isinstance check because the new_classifier is from the PairClassificationPipeline class of a
         # dynamic module
-        self.assertEqual(new_classifier.__class__.__name__, "PairClassificationPipeline")
+        self.assertEqual(
+            new_classifier.__class__.__name__, "PairClassificationPipeline"
+        )
         # check for tag exitence, tag needs to be added when we are calling a custom pipeline from the hub
         # useful for cases such as finetuning
         self.assertDictEqual(
@@ -1066,9 +1214,13 @@ class DynamicPipelineTester(unittest.TestCase):
         # test if the pipeline still works after the model is finetuned
         # (we are actually testing if the pipeline still works from the final repo)
         # this is where the user/repo--module.class is used for
-        new_classifier.model.push_to_hub(repo_name=f"{USER}/test-pipeline-for-a-finetuned-model", token=self._token)
+        new_classifier.model.push_to_hub(
+            repo_name=f"{USER}/test-pipeline-for-a-finetuned-model", token=self._token
+        )
         del new_classifier  # free up memory
-        new_classifier = pipeline(model=f"{USER}/test-pipeline-for-a-finetuned-model", trust_remote_code=True)
+        new_classifier = pipeline(
+            model=f"{USER}/test-pipeline-for-a-finetuned-model", trust_remote_code=True
+        )
 
         results = classifier("I hate you", second_text="I love you")
         new_results = new_classifier("I hate you", second_text="I love you")
@@ -1076,11 +1228,16 @@ class DynamicPipelineTester(unittest.TestCase):
 
         # Using trust_remote_code=False forces the traditional pipeline tag
         old_classifier = pipeline(
-            "text-classification", model=f"{USER}/test-dynamic-pipeline", trust_remote_code=False
+            "text-classification",
+            model=f"{USER}/test-dynamic-pipeline",
+            trust_remote_code=False,
         )
-        self.assertEqual(old_classifier.__class__.__name__, "TextClassificationPipeline")
+        self.assertEqual(
+            old_classifier.__class__.__name__, "TextClassificationPipeline"
+        )
         self.assertEqual(old_classifier.task, "text-classification")
         new_results = old_classifier("I hate you", text_pair="I love you")
         self.assertListEqual(
-            nested_simplify([{"label": results["label"], "score": results["score"]}]), nested_simplify(new_results)
+            nested_simplify([{"label": results["label"], "score": results["score"]}]),
+            nested_simplify(new_results),
         )


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48215&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48215) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48215&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48215)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Improves input and parameter robustness in `Pipeline.__call__`:
1. Safely checks `len(inputs) > 0` before accessing `inputs[0]` when detecting chat-style formatting, preventing `IndexError: list index out of range` on empty container inputs (`[]`).
2. Validates that `batch_size > 0` (raising a clear `ValueError` on non-positive integers `<= 0` before PyTorch DataLoader initialization).
3. Added unit test `test_pipeline_call_batch_size_validation` in `tests/pipelines/test_pipelines_common.py`.

## Before submitting

- [x] This PR fixes a bug or adds a feature and conforms to the coding standards.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?