### PR TITLE
fix(trainer): pass best_model_checkpoint to sort_checkpoints in rotate_checkpoints

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -366,7 +366,9 @@ def rotate_checkpoints(
     if save_total_limit is None or save_total_limit <= 0:
         return
 
-    checkpoints = sort_checkpoints(output_dir, checkpoint_prefix, use_mtime)
+    checkpoints = sort_checkpoints(
+        output_dir, checkpoint_prefix, use_mtime, best_model_checkpoint=best_model_checkpoint
+    )
     if len(checkpoints) <= save_total_limit:
         return
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -111,15 +111,16 @@ def validate_quantization_for_training(model):
     Args:
         model: The model to validate.
     """
-    _is_quantized_and_base_model = getattr(model, "is_quantized", False) and not getattr(
-        model, "_hf_peft_config_loaded", False
-    )
+    _is_quantized_and_base_model = getattr(
+        model, "is_quantized", False
+    ) and not getattr(model, "_hf_peft_config_loaded", False)
     _quantization_method_supports_training = (
-        getattr(model, "hf_quantizer", None) is not None and model.hf_quantizer.is_trainable
+        getattr(model, "hf_quantizer", None) is not None
+        and model.hf_quantizer.is_trainable
     )
-    _is_model_quantized_and_qat_trainable = getattr(model, "hf_quantizer", None) is not None and getattr(
-        model.hf_quantizer, "is_qat_trainable", False
-    )
+    _is_model_quantized_and_qat_trainable = getattr(
+        model, "hf_quantizer", None
+    ) is not None and getattr(model.hf_quantizer, "is_qat_trainable", False)
 
     # Filter out quantized + compiled models
     if _is_quantized_and_base_model and hasattr(model, "_orig_mod"):
@@ -128,7 +129,11 @@ def validate_quantization_for_training(model):
         )
 
     # At this stage the model is already loaded
-    if _is_quantized_and_base_model and not _is_peft_model(model) and not _is_model_quantized_and_qat_trainable:
+    if (
+        _is_quantized_and_base_model
+        and not _is_peft_model(model)
+        and not _is_model_quantized_and_qat_trainable
+    ):
         raise ValueError(
             "You cannot perform fine-tuning on purely quantized models. Please attach trainable adapters on top of"
             " the quantized model to correctly perform fine-tuning. Please see: https://huggingface.co/docs/transformers/peft"
@@ -272,11 +277,15 @@ def get_last_checkpoint(folder):
     checkpoints = [
         path
         for path in content
-        if _re_checkpoint.search(path) is not None and os.path.isdir(os.path.join(folder, path))
+        if _re_checkpoint.search(path) is not None
+        and os.path.isdir(os.path.join(folder, path))
     ]
     if len(checkpoints) == 0:
         return
-    return os.path.join(folder, max(checkpoints, key=lambda x: int(_re_checkpoint.search(x).groups()[0])))
+    return os.path.join(
+        folder,
+        max(checkpoints, key=lambda x: int(_re_checkpoint.search(x).groups()[0])),
+    )
 
 
 def sort_checkpoints(
@@ -302,7 +311,11 @@ def sort_checkpoints(
     Returns:
         `list[str]`: Sorted list of checkpoint directory paths (oldest first).
     """
-    glob_checkpoints = [str(x) for x in Path(output_dir).glob(f"{checkpoint_prefix}-*") if os.path.isdir(x)]
+    glob_checkpoints = [
+        str(x)
+        for x in Path(output_dir).glob(f"{checkpoint_prefix}-*")
+        if os.path.isdir(x)
+    ]
 
     ordering_and_checkpoint_path = []
     for path in glob_checkpoints:
@@ -311,7 +324,9 @@ def sort_checkpoints(
         else:
             regex_match = re.match(f".*{checkpoint_prefix}-([0-9]+)", path)
             if regex_match is not None and regex_match.groups() is not None:
-                ordering_and_checkpoint_path.append((int(regex_match.groups()[0]), path))
+                ordering_and_checkpoint_path.append(
+                    (int(regex_match.groups()[0]), path)
+                )
 
     checkpoints_sorted = sorted(ordering_and_checkpoint_path)
 
@@ -320,9 +335,14 @@ def sort_checkpoints(
     if use_mtime and len(checkpoints_sorted) > 1:
         mtime_diff = checkpoints_sorted[-1][0] - checkpoints_sorted[0][0]
         if mtime_diff < 1.0:
-            logger.warning_once("mtime may not be reliable on this filesystem, falling back to numerical ordering")
+            logger.warning_once(
+                "mtime may not be reliable on this filesystem, falling back to numerical ordering"
+            )
             return sort_checkpoints(
-                output_dir, checkpoint_prefix, use_mtime=False, best_model_checkpoint=best_model_checkpoint
+                output_dir,
+                checkpoint_prefix,
+                use_mtime=False,
+                best_model_checkpoint=best_model_checkpoint,
             )
 
     checkpoints_sorted = [path for _, path in checkpoints_sorted]
@@ -331,9 +351,16 @@ def sort_checkpoints(
     # while keeping the most recent checkpoint at the end for resuming training.
     if best_model_checkpoint is not None:
         best_model_checkpoint = str(Path(best_model_checkpoint))
-        if best_model_checkpoint in checkpoints_sorted and checkpoints_sorted[-1] != best_model_checkpoint:
+        if (
+            best_model_checkpoint in checkpoints_sorted
+            and checkpoints_sorted[-1] != best_model_checkpoint
+        ):
             most_recent = checkpoints_sorted[-1]
-            checkpoints_sorted = [c for c in checkpoints_sorted if c not in {best_model_checkpoint, most_recent}]
+            checkpoints_sorted = [
+                c
+                for c in checkpoints_sorted
+                if c not in {best_model_checkpoint, most_recent}
+            ]
             checkpoints_sorted += [best_model_checkpoint, most_recent]
 
     return checkpoints_sorted
@@ -367,7 +394,10 @@ def rotate_checkpoints(
         return
 
     checkpoints = sort_checkpoints(
-        output_dir, checkpoint_prefix, use_mtime, best_model_checkpoint=best_model_checkpoint
+        output_dir,
+        checkpoint_prefix,
+        use_mtime,
+        best_model_checkpoint=best_model_checkpoint,
     )
     if len(checkpoints) <= save_total_limit:
         return
@@ -445,7 +475,9 @@ def default_compute_objective(metrics: dict[str, float]) -> float:
     loss = metrics.pop("eval_loss", None)
     _ = metrics.pop("epoch", None)
     # Remove speed metrics
-    speed_metrics = [m for m in metrics if m.endswith("_runtime") or m.endswith("_per_second")]
+    speed_metrics = [
+        m for m in metrics if m.endswith("_runtime") or m.endswith("_per_second")
+    ]
     for sm in speed_metrics:
         _ = metrics.pop(sm, None)
     return loss if len(metrics) == 0 else sum(metrics.values())
@@ -460,7 +492,9 @@ def default_hp_space_optuna(trial) -> dict[str, float]:
         "learning_rate": trial.suggest_float("learning_rate", 1e-6, 1e-4, log=True),
         "num_train_epochs": trial.suggest_int("num_train_epochs", 1, 5),
         "seed": trial.suggest_int("seed", 1, 40),
-        "per_device_train_batch_size": trial.suggest_categorical("per_device_train_batch_size", [4, 8, 16, 32, 64]),
+        "per_device_train_batch_size": trial.suggest_categorical(
+            "per_device_train_batch_size", [4, 8, 16, 32, 64]
+        ),
     }
 
 
@@ -636,7 +670,11 @@ class TrainerMemoryTracker:
 
         import psutil
 
-        if is_torch_cuda_available() or is_torch_mlu_available() or is_torch_musa_available():
+        if (
+            is_torch_cuda_available()
+            or is_torch_mlu_available()
+            or is_torch_musa_available()
+        ):
             import torch
 
             self.torch = torch
@@ -828,7 +866,9 @@ class TrainerMemoryTracker:
                 "alloc": (self.gpu_mem_used_now - self.gpu_mem_used_at_start),
             }
             if self.gpu_mem_used_peak is not None:
-                self.gpu[self.cur_stage]["peaked"] = max(0, self.gpu_mem_used_peak - self.gpu_mem_used_now)
+                self.gpu[self.cur_stage]["peaked"] = max(
+                    0, self.gpu_mem_used_peak - self.gpu_mem_used_now
+                )
             else:
                 self.gpu[self.cur_stage]["peaked"] = "Not available"
 
@@ -863,7 +903,11 @@ class TrainerMemoryTracker:
             for t in ["alloc", "peaked"]:
                 if stage in self.cpu and t in self.cpu[stage]:
                     metrics[f"{stage}_mem_cpu_{t}_delta"] = self.cpu[stage][t]
-                if self.torch is not None and stage in self.gpu and t in self.gpu[stage]:
+                if (
+                    self.torch is not None
+                    and stage in self.gpu
+                    and t in self.gpu[stage]
+                ):
                     metrics[f"{stage}_mem_gpu_{t}_delta"] = self.gpu[stage][t]
             # if we need additional debug info, enable the following
             # for t in ["begin", "end"]:
@@ -922,7 +966,11 @@ def denumpify_detensorize(metrics):
         return type(metrics)({k: denumpify_detensorize(v) for k, v in metrics.items()})
     elif isinstance(metrics, np.generic):
         return metrics.item()
-    elif is_torch_available() and isinstance(metrics, torch.Tensor) and metrics.numel() == 1:
+    elif (
+        is_torch_available()
+        and isinstance(metrics, torch.Tensor)
+        and metrics.numel() == 1
+    ):
         return metrics.item()
     return metrics
 
@@ -938,7 +986,9 @@ def number_of_arguments(func):
 
 
 def find_executable_batch_size(
-    function: Callable | None = None, starting_batch_size: int = 128, auto_find_batch_size: bool = False
+    function: Callable | None = None,
+    starting_batch_size: int = 128,
+    auto_find_batch_size: bool = False,
 ):
     """
     Args:
@@ -961,9 +1011,13 @@ def find_executable_batch_size(
 
     if auto_find_batch_size:
         requires_backends(find_executable_batch_size, "accelerate")
-        from accelerate.utils import find_executable_batch_size as accelerate_find_executable_batch_size
+        from accelerate.utils import (
+            find_executable_batch_size as accelerate_find_executable_batch_size,
+        )
 
-        return accelerate_find_executable_batch_size(function=function, starting_batch_size=starting_batch_size)
+        return accelerate_find_executable_batch_size(
+            function=function, starting_batch_size=starting_batch_size
+        )
 
     return functools.partial(function, batch_size=starting_batch_size)
 
@@ -1002,7 +1056,9 @@ class RemoveColumnsCollator:
         if not self.message_logged and self.logger and self.model_name:
             ignored_columns = list(set(feature.keys()) - set(self.signature_columns))
             if len(ignored_columns) > 0:
-                dset_description = "" if self.description is None else f"in the {self.description} set"
+                dset_description = (
+                    "" if self.description is None else f"in the {self.description} set"
+                )
                 self.logger.info(
                     f"The following columns {dset_description} don't have a corresponding argument in "
                     f"`{self.model_name}.forward` and have been ignored: {', '.join(ignored_columns)}."
@@ -1017,7 +1073,9 @@ class RemoveColumnsCollator:
         return self.data_collator(features)
 
 
-def check_target_module_exists(optim_target_modules, key: str, return_is_regex: bool = False):
+def check_target_module_exists(
+    optim_target_modules, key: str, return_is_regex: bool = False
+):
     """A helper method to check if the passed module's key name matches any of the target modules in the optim_target_modules.
 
     Args:
@@ -1041,12 +1099,17 @@ def check_target_module_exists(optim_target_modules, key: str, return_is_regex: 
     if isinstance(optim_target_modules, str):
         target_module_found = bool(re.fullmatch(optim_target_modules, key))
         is_regex = optim_target_modules != key
-    elif key in optim_target_modules:  # from here, target_module_found must be a list of str
+    elif (
+        key in optim_target_modules
+    ):  # from here, target_module_found must be a list of str
         # this module is specified directly in target_modules
         target_module_found = True
     elif any(target_key in key for target_key in optim_target_modules):
         target_module_found = True
-    elif any(bool(re.fullmatch(optim_target_module, key)) for optim_target_module in optim_target_modules):
+    elif any(
+        bool(re.fullmatch(optim_target_module, key))
+        for optim_target_module in optim_target_modules
+    ):
         target_module_found = True
         is_regex = True
 
@@ -1088,7 +1151,9 @@ def load_sharded_checkpoint(model, folder, strict=True, prefer_safe=True):
 
     if not index_present and not safe_index_present:
         filenames = (WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_INDEX_NAME)
-        raise ValueError(f"Can't find a checkpoint index ({' or '.join(filenames)}) in {folder}.")
+        raise ValueError(
+            f"Can't find a checkpoint index ({' or '.join(filenames)}) in {folder}."
+        )
 
     load_safe = safe_index_present and (prefer_safe or not index_present)
     load_index = safe_index_file if load_safe else index_file
@@ -1155,7 +1220,11 @@ def compare_trainer_and_checkpoint_args(training_args, trainer_state):
         arg_value = getattr(training_args, arg_attr, None)
         state_value = getattr(trainer_state, state_attr, None)
 
-        if arg_value is not None and state_value is not None and arg_value != state_value:
+        if (
+            arg_value is not None
+            and state_value is not None
+            and arg_value != state_value
+        ):
             warning_str += f"\n\t{arg_attr}: {arg_value} (from args) != {state_value} (from trainer_state.json)"
             has_warning = True
 
@@ -1187,22 +1256,32 @@ def align_special_tokens(model, processing_class):
         tokenizer: PreTrainedTokenizerBase = processing_class.tokenizer
     else:
         tokenizer = processing_class
-    model_has_generation_config = hasattr(model, "generation_config") and model.generation_config is not None
+    model_has_generation_config = (
+        hasattr(model, "generation_config") and model.generation_config is not None
+    )
     updated_tokens = {}
 
     # 1 - Align EOS token. EOS is more complex than the others, as `generation_config` may hold more than one EOS
     # token.
-    tokenizer_has_new_eos = tokenizer.eos_token_id != getattr(model.config, "eos_token_id", None)
+    tokenizer_has_new_eos = tokenizer.eos_token_id != getattr(
+        model.config, "eos_token_id", None
+    )
     if model_has_generation_config:
         # `generation_config.eos_token_id` is None: direct comparison
         if model.generation_config.eos_token_id is None:
-            tokenizer_has_new_eos |= tokenizer.eos_token_id != model.generation_config.eos_token_id
+            tokenizer_has_new_eos |= (
+                tokenizer.eos_token_id != model.generation_config.eos_token_id
+            )
         else:
             # `generation_config.eos_token_id` is an `int`: convert it to list (and continue below)
             if isinstance(model.generation_config.eos_token_id, int):
-                model.generation_config.eos_token_id = [model.generation_config.eos_token_id]
+                model.generation_config.eos_token_id = [
+                    model.generation_config.eos_token_id
+                ]
             # `generation_config.eos_token_id` is a `list`: check if the tokenizer's EOS token is in the list
-            tokenizer_has_new_eos |= tokenizer.eos_token_id not in model.generation_config.eos_token_id
+            tokenizer_has_new_eos |= (
+                tokenizer.eos_token_id not in model.generation_config.eos_token_id
+            )
 
     if tokenizer_has_new_eos:
         updated_tokens["eos_token_id"] = tokenizer.eos_token_id
@@ -1213,12 +1292,18 @@ def align_special_tokens(model, processing_class):
             all_eos_tokens = [tokenizer.eos_token_id]
             if model.generation_config.eos_token_id is not None:
                 all_eos_tokens += list(model.generation_config.eos_token_id)
-            model.generation_config.eos_token_id = [token for token in all_eos_tokens if token is not None]
+            model.generation_config.eos_token_id = [
+                token for token in all_eos_tokens if token is not None
+            ]
 
     # 2 - Align BOS
-    tokenizer_has_new_bos = tokenizer.bos_token_id != getattr(model.config, "bos_token_id", None)
+    tokenizer_has_new_bos = tokenizer.bos_token_id != getattr(
+        model.config, "bos_token_id", None
+    )
     if model_has_generation_config:
-        tokenizer_has_new_bos |= tokenizer.bos_token_id != model.generation_config.bos_token_id
+        tokenizer_has_new_bos |= (
+            tokenizer.bos_token_id != model.generation_config.bos_token_id
+        )
 
     if tokenizer_has_new_bos:
         updated_tokens["bos_token_id"] = tokenizer.bos_token_id
@@ -1227,9 +1312,13 @@ def align_special_tokens(model, processing_class):
             model.generation_config.bos_token_id = tokenizer.bos_token_id
 
     # 3 - Align PAD
-    tokenizer_has_new_pad = tokenizer.pad_token_id != getattr(model.config, "pad_token_id", None)
+    tokenizer_has_new_pad = tokenizer.pad_token_id != getattr(
+        model.config, "pad_token_id", None
+    )
     if model_has_generation_config:
-        tokenizer_has_new_pad |= tokenizer.pad_token_id != model.generation_config.pad_token_id
+        tokenizer_has_new_pad |= (
+            tokenizer.pad_token_id != model.generation_config.pad_token_id
+        )
 
     if tokenizer_has_new_pad:
         updated_tokens["pad_token_id"] = tokenizer.pad_token_id

--- a/tests/trainer/test_trainer_checkpointing.py
+++ b/tests/trainer/test_trainer_checkpointing.py
@@ -102,7 +102,10 @@ from .trainer_test_utils import (
 
 
 if is_torch_available():
-    from transformers.trainer_jit_checkpoint import CheckpointManager, JITCheckpointCallback
+    from transformers.trainer_jit_checkpoint import (
+        CheckpointManager,
+        JITCheckpointCallback,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -122,13 +125,19 @@ class TrainerCheckpointSaveTest(TestCasePlus, TrainerIntegrationCommon):
         tmp_dir = self.get_auto_remove_tmp_dir()
         trainer = get_regression_trainer(output_dir=tmp_dir, save_steps=5)
         trainer.train()
-        self.check_saved_checkpoints(tmp_dir, 5, int(self.n_epochs * 64 / self.batch_size))
+        self.check_saved_checkpoints(
+            tmp_dir, 5, int(self.n_epochs * 64 / self.batch_size)
+        )
 
         # With a regular model that is not a PreTrainedModel
         tmp_dir = self.get_auto_remove_tmp_dir()
-        trainer = get_regression_trainer(output_dir=tmp_dir, save_steps=5, pretrained=False)
+        trainer = get_regression_trainer(
+            output_dir=tmp_dir, save_steps=5, pretrained=False
+        )
         trainer.train()
-        self.check_saved_checkpoints(tmp_dir, 5, int(self.n_epochs * 64 / self.batch_size), False)
+        self.check_saved_checkpoints(
+            tmp_dir, 5, int(self.n_epochs * 64 / self.batch_size), False
+        )
 
     def test_save_collator_tokenizer_by_default(self):
         class FakeCollator:
@@ -136,15 +145,23 @@ class TrainerCheckpointSaveTest(TestCasePlus, TrainerIntegrationCommon):
                 self.tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
                 self.tokenizer.add_tokens(["<NEW_TOKEN1>", "<NEW_TOKEN2>"])
 
-            def __call__(self, features: list[Any], return_tensors="pt") -> dict[str, Any]:
+            def __call__(
+                self, features: list[Any], return_tensors="pt"
+            ) -> dict[str, Any]:
                 return default_data_collator(features, return_tensors)
 
         data_collator = FakeCollator()
         tmp_dir = self.get_auto_remove_tmp_dir()
-        trainer = get_regression_trainer(output_dir=tmp_dir, save_steps=5, data_collator=data_collator)
+        trainer = get_regression_trainer(
+            output_dir=tmp_dir, save_steps=5, data_collator=data_collator
+        )
         trainer.train()
-        loaded_tokenizer = AutoTokenizer.from_pretrained(os.path.join(tmp_dir, os.listdir(tmp_dir)[0]))
-        assert len(loaded_tokenizer) == len(trainer.data_collator.tokenizer), "Failed to load updated tokenizer"
+        loaded_tokenizer = AutoTokenizer.from_pretrained(
+            os.path.join(tmp_dir, os.listdir(tmp_dir)[0])
+        )
+        assert len(loaded_tokenizer) == len(trainer.data_collator.tokenizer), (
+            "Failed to load updated tokenizer"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -258,7 +275,9 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
         trainer = get_regression_trainer(output_dir=tmp_dir)
         with self.assertRaises(Exception) as context:
             trainer.train(resume_from_checkpoint=True)
-        self.assertTrue("No valid checkpoint found in output directory" in str(context.exception))
+        self.assertTrue(
+            "No valid checkpoint found in output directory" in str(context.exception)
+        )
 
     # require_torch_non_multi_accelerator is necessary because this worker blocks runs when using multiple GPUs, making
     # the test slower.
@@ -287,7 +306,9 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
             trainer = get_language_model_trainer(**kwargs)
             trainer.train(resume_from_checkpoint=False)
             # Get the parameter length of the model
-            model_params = torch.cat([p.cpu().flatten() for p in trainer.model.parameters()])
+            model_params = torch.cat(
+                [p.cpu().flatten() for p in trainer.model.parameters()]
+            )
             model_param_len = len(model_params)
             # Sample uniform indexes and save the values of the parameters (considering an unrolled vector with
             # all of them)
@@ -298,13 +319,21 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
             # Delete the reference
             del model_params, trainer
             # Checks if all checkpoints are there, +1 is necessary because range is 1-indexed
-            self.check_saved_checkpoints(tmpdir, freq=1, total=training_steps + 1, is_pretrained=True, use_scaler=True)
+            self.check_saved_checkpoints(
+                tmpdir,
+                freq=1,
+                total=training_steps + 1,
+                is_pretrained=True,
+                use_scaler=True,
+            )
 
             # Checkpoint at intermediate step
             checkpoint = os.path.join(tmpdir, f"checkpoint-{resume_from_step + 1}")
             trainer = get_language_model_trainer(**kwargs)
             trainer.train(resume_from_checkpoint=checkpoint)
-            model_params = torch.cat([p.cpu().flatten() for p in trainer.model.parameters()])
+            model_params = torch.cat(
+                [p.cpu().flatten() for p in trainer.model.parameters()]
+            )
 
             # Check that the parameters are the same
             self.assertTrue(torch.allclose(model_params[indices], model_params_sample))
@@ -319,7 +348,9 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
         # For more than 1 GPUs, since the randomness is introduced in the model and with DataParallel (which is used
         # in this test for more than 2 GPUs), the calls to the torch RNG will happen in a random order (sometimes
         # GPU 0 will call first and sometimes GPU 1).
-        random_torch = not torch.cuda.is_available() or backend_device_count(torch_device) <= 1
+        random_torch = (
+            not torch.cuda.is_available() or backend_device_count(torch_device) <= 1
+        )
 
         if torch.cuda.is_available():
             torch.backends.cudnn.deterministic = True
@@ -332,13 +363,17 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
 
             tmp_dir = self.get_auto_remove_tmp_dir()
             args = RegressionTrainingArguments(tmp_dir, save_steps=5, learning_rate=0.1)
-            trainer = Trainer(model, args, train_dataset=train_dataset, eval_dataset=eval_dataset)
+            trainer = Trainer(
+                model, args, train_dataset=train_dataset, eval_dataset=eval_dataset
+            )
 
             trainer.train()
             (a, b) = trainer.model.a.item(), trainer.model.b.item()
 
             model = RegressionRandomPreTrainedModel(config)
-            trainer = Trainer(model, args, train_dataset=train_dataset, eval_dataset=eval_dataset)
+            trainer = Trainer(
+                model, args, train_dataset=train_dataset, eval_dataset=eval_dataset
+            )
             trainer.train(resume_from_checkpoint=os.path.join(tmp_dir, "checkpoint-15"))
             (a1, b1) = trainer.model.a.item(), trainer.model.b.item()
 
@@ -350,19 +385,29 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
             model = RegressionRandomPreTrainedModel(config)
 
             tmp_dir = self.get_auto_remove_tmp_dir()
-            args = RegressionTrainingArguments(tmp_dir, save_strategy="epoch", learning_rate=0.1)
-            trainer = Trainer(model, args, train_dataset=train_dataset, eval_dataset=eval_dataset)
+            args = RegressionTrainingArguments(
+                tmp_dir, save_strategy="epoch", learning_rate=0.1
+            )
+            trainer = Trainer(
+                model, args, train_dataset=train_dataset, eval_dataset=eval_dataset
+            )
 
             trainer.train()
             (a, b) = trainer.model.a.item(), trainer.model.b.item()
 
             model = RegressionRandomPreTrainedModel(config)
-            trainer = Trainer(model, args, train_dataset=train_dataset, eval_dataset=eval_dataset)
+            trainer = Trainer(
+                model, args, train_dataset=train_dataset, eval_dataset=eval_dataset
+            )
 
-            checkpoints = [d for d in os.listdir(tmp_dir) if d.startswith("checkpoint-")]
+            checkpoints = [
+                d for d in os.listdir(tmp_dir) if d.startswith("checkpoint-")
+            ]
             # There should be one checkpoint per epoch.
             self.assertEqual(len(checkpoints), 3)
-            checkpoint_dir = min(checkpoints, key=lambda x: int(x.replace("checkpoint-", "")))
+            checkpoint_dir = min(
+                checkpoints, key=lambda x: int(x.replace("checkpoint-", ""))
+            )
 
             trainer.train(resume_from_checkpoint=os.path.join(tmp_dir, checkpoint_dir))
             (a1, b1) = trainer.model.a.item(), trainer.model.b.item()
@@ -394,7 +439,9 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
 
         # Verify the checkpoint saved with the effective batch size (per_device * n_gpu)
         checkpoint = os.path.join(tmp_dir, "checkpoint-1")
-        state = TrainerState.load_from_json(os.path.join(checkpoint, "trainer_state.json"))
+        state = TrainerState.load_from_json(
+            os.path.join(checkpoint, "trainer_state.json")
+        )
         self.assertEqual(state.train_batch_size, args.train_batch_size)
 
         # Resume with a different batch_size=4 (without auto_find_batch_size)
@@ -423,7 +470,9 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
 
         tmp_dir = self.get_auto_remove_tmp_dir()
         args = RegressionTrainingArguments(tmp_dir, save_steps=5, learning_rate=0.1)
-        trainer = Trainer(model, args, train_dataset=train_dataset, eval_dataset=eval_dataset)
+        trainer = Trainer(
+            model, args, train_dataset=train_dataset, eval_dataset=eval_dataset
+        )
 
         trainer.train(resume_from_checkpoint=False)
 
@@ -434,7 +483,9 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
         # won't be the same since the training dataloader is shuffled).
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            trainer = get_regression_trainer(output_dir=tmpdir, train_len=128, save_steps=5, learning_rate=0.1)
+            trainer = get_regression_trainer(
+                output_dir=tmpdir, train_len=128, save_steps=5, learning_rate=0.1
+            )
             trainer.train()
             (a, b) = trainer.model.a.item(), trainer.model.b.item()
             state = dataclasses.asdict(trainer.state)
@@ -443,7 +494,9 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
             self.convert_to_sharded_checkpoint(checkpoint)
 
             # Reinitialize trainer
-            trainer = get_regression_trainer(output_dir=tmpdir, train_len=128, save_steps=5, learning_rate=0.1)
+            trainer = get_regression_trainer(
+                output_dir=tmpdir, train_len=128, save_steps=5, learning_rate=0.1
+            )
 
             trainer.train(resume_from_checkpoint=checkpoint)
             (a1, b1) = trainer.model.a.item(), trainer.model.b.item()
@@ -473,7 +526,9 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
             self.convert_to_sharded_checkpoint(checkpoint)
 
             # Reinitialize trainer
-            trainer = get_regression_trainer(output_dir=tmpdir, train_len=128, save_steps=5, learning_rate=0.1)
+            trainer = get_regression_trainer(
+                output_dir=tmpdir, train_len=128, save_steps=5, learning_rate=0.1
+            )
 
             trainer.train(resume_from_checkpoint=checkpoint)
             (a1, b1) = trainer.model.a.item(), trainer.model.b.item()
@@ -594,14 +649,18 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
             max_steps=10,
             use_cpu=True,
         )
-        trainer = Trainer(tiny_model, args, processing_class=tokenizer, train_dataset=train_dataset)
+        trainer = Trainer(
+            tiny_model, args, processing_class=tokenizer, train_dataset=train_dataset
+        )
 
         trainer.train()
         parameters = dict(tiny_model.named_parameters())
         state = dataclasses.asdict(trainer.state)
 
         # Reinitialize trainer
-        trainer = Trainer(tiny_model, args, processing_class=tokenizer, train_dataset=train_dataset)
+        trainer = Trainer(
+            tiny_model, args, processing_class=tokenizer, train_dataset=train_dataset
+        )
 
         checkpoint = os.path.join(tmp_dir, "checkpoint-5")
 
@@ -634,7 +693,14 @@ class TrainerAutoBatchSizeTest(TestCasePlus, TrainerIntegrationCommon):
             torch.backends.cudnn.deterministic = True
 
         SRC_DIR = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "..", "..", "examples", "pytorch", "text-classification")
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "..",
+                "examples",
+                "pytorch",
+                "text-classification",
+            )
         )
         sys.path.append(SRC_DIR)
         import run_glue
@@ -689,7 +755,9 @@ class TrainerAutoBatchSizeTest(TestCasePlus, TrainerIntegrationCommon):
             auto_find_batch_size=True,
             deepspeed=deepspeed,
         )
-        trainer = Trainer(model, args, train_dataset=train_dataset, callbacks=[MockCudaOOMCallback()])
+        trainer = Trainer(
+            model, args, train_dataset=train_dataset, callbacks=[MockCudaOOMCallback()]
+        )
         trainer.train()
         self.assertEqual(trainer._train_batch_size, 14)
 
@@ -709,7 +777,9 @@ class TrainerAutoBatchSizeTest(TestCasePlus, TrainerIntegrationCommon):
             per_device_train_batch_size=16,
             auto_find_batch_size=True,
         )
-        trainer = Trainer(model, args, train_dataset=train_dataset, callbacks=[MockCudaOOMCallback()])
+        trainer = Trainer(
+            model, args, train_dataset=train_dataset, callbacks=[MockCudaOOMCallback()]
+        )
         trainer.train()
         previous_batch_size = trainer._train_batch_size
         # Depends on the number of gpus so it is easier to just check that the batch_size decreased as expected
@@ -745,32 +815,48 @@ class TrainerCheckpointRotationTest(TestCasePlus, TrainerIntegrationCommon):
 
             # Test sorting by step number (oldest first)
             sorted_cps = sort_checkpoints(tmp_dir)
-            values = [int(re.match(f".*{PREFIX_CHECKPOINT_DIR}-([0-9]+)", d).groups()[0]) for d in sorted_cps]
+            values = [
+                int(re.match(f".*{PREFIX_CHECKPOINT_DIR}-([0-9]+)", d).groups()[0])
+                for d in sorted_cps
+            ]
             self.assertEqual(values, [5, 10, 15, 20, 25])
 
             # Test with best_model_checkpoint - moved to second-to-last to protect from deletion
             best = os.path.join(tmp_dir, f"{PREFIX_CHECKPOINT_DIR}-5")
             sorted_cps = sort_checkpoints(tmp_dir, best_model_checkpoint=best)
-            values = [int(re.match(f".*{PREFIX_CHECKPOINT_DIR}-([0-9]+)", d).groups()[0]) for d in sorted_cps]
+            values = [
+                int(re.match(f".*{PREFIX_CHECKPOINT_DIR}-([0-9]+)", d).groups()[0])
+                for d in sorted_cps
+            ]
             self.assertEqual(values, [10, 15, 20, 5, 25])
 
             # Test with best_model_checkpoint already at end (stays at end)
             best = os.path.join(tmp_dir, f"{PREFIX_CHECKPOINT_DIR}-25")
             sorted_cps = sort_checkpoints(tmp_dir, best_model_checkpoint=best)
-            values = [int(re.match(f".*{PREFIX_CHECKPOINT_DIR}-([0-9]+)", d).groups()[0]) for d in sorted_cps]
+            values = [
+                int(re.match(f".*{PREFIX_CHECKPOINT_DIR}-([0-9]+)", d).groups()[0])
+                for d in sorted_cps
+            ]
             self.assertEqual(values, [5, 10, 15, 20, 25])
 
     def check_checkpoint_deletion(self, trainer, output_dir, expected):
         # Make fake checkpoints
         for n in [5, 10, 15, 20, 25]:
-            os.makedirs(os.path.join(output_dir, f"{PREFIX_CHECKPOINT_DIR}-{n}"), exist_ok=True)
+            os.makedirs(
+                os.path.join(output_dir, f"{PREFIX_CHECKPOINT_DIR}-{n}"), exist_ok=True
+            )
         rotate_checkpoints(
             output_dir=output_dir,
             save_total_limit=trainer.args.save_total_limit,
             best_model_checkpoint=trainer.state.best_model_checkpoint,
         )
-        glob_checkpoints = [str(x) for x in Path(output_dir).glob(f"{PREFIX_CHECKPOINT_DIR}-*")]
-        values = [int(re.match(f".*{PREFIX_CHECKPOINT_DIR}-([0-9]+)", d).groups()[0]) for d in glob_checkpoints]
+        glob_checkpoints = [
+            str(x) for x in Path(output_dir).glob(f"{PREFIX_CHECKPOINT_DIR}-*")
+        ]
+        values = [
+            int(re.match(f".*{PREFIX_CHECKPOINT_DIR}-([0-9]+)", d).groups()[0])
+            for d in glob_checkpoints
+        ]
         self.assertSetEqual(set(values), set(expected))
 
     def test_checkpoint_rotation(self):
@@ -781,7 +867,10 @@ class TrainerCheckpointRotationTest(TestCasePlus, TrainerIntegrationCommon):
 
             # With best model at end
             trainer = get_regression_trainer(
-                output_dir=tmp_dir, eval_strategy="steps", load_best_model_at_end=True, save_total_limit=2
+                output_dir=tmp_dir,
+                eval_strategy="steps",
+                load_best_model_at_end=True,
+                save_total_limit=2,
             )
             trainer.state.best_model_checkpoint = os.path.join(tmp_dir, "checkpoint-5")
             self.check_checkpoint_deletion(trainer, tmp_dir, [5, 25])
@@ -789,7 +878,10 @@ class TrainerCheckpointRotationTest(TestCasePlus, TrainerIntegrationCommon):
             # Edge case: we don't always honor save_total_limit=1 if load_best_model_at_end=True to be able to resume
             # from checkpoint
             trainer = get_regression_trainer(
-                output_dir=tmp_dir, eval_strategy="steps", load_best_model_at_end=True, save_total_limit=1
+                output_dir=tmp_dir,
+                eval_strategy="steps",
+                load_best_model_at_end=True,
+                save_total_limit=1,
             )
             trainer.state.best_model_checkpoint = os.path.join(tmp_dir, "checkpoint-25")
             self.check_checkpoint_deletion(trainer, tmp_dir, [25])
@@ -824,7 +916,9 @@ class TrainerCheckpointRotationTest(TestCasePlus, TrainerIntegrationCommon):
             )
             checkpoint_trainer.train(resume_from_checkpoint=checkpoint)
 
-        self.assertIn("save_steps: 10 (from args) != 5 (from trainer_state.json)", cl.out)
+        self.assertIn(
+            "save_steps: 10 (from args) != 5 (from trainer_state.json)", cl.out
+        )
 
         self.assertIn(
             "per_device_train_batch_size: 8 (from args) != 4 (from trainer_state.json)",
@@ -918,7 +1012,10 @@ class TrainerInterruptedTrainingTest(TestCasePlus, TrainerIntegrationCommon):
 
         # 3. Verify that a checkpoint was created before the "interruption"
         checkpoint_path = os.path.join(output_dir_initial, "checkpoint-2")
-        self.assertTrue(os.path.exists(checkpoint_path), f"Checkpoint not found at {checkpoint_path}")
+        self.assertTrue(
+            os.path.exists(checkpoint_path),
+            f"Checkpoint not found at {checkpoint_path}",
+        )
 
         # 4. Second training phase (resuming from the checkpoint)
         output_dir_resumed = self.get_auto_remove_tmp_dir()
@@ -944,18 +1041,26 @@ class TrainerInterruptedTrainingTest(TestCasePlus, TrainerIntegrationCommon):
         # 5. Assertions: Check if the training completed and the final model was saved
         # Total steps per epoch = ceil(num_samples / (train_batch_size * grad_accum))
         steps_per_epoch = math.ceil(
-            100 / (training_args_resumed.train_batch_size * training_args_resumed.gradient_accumulation_steps)
+            100
+            / (
+                training_args_resumed.train_batch_size
+                * training_args_resumed.gradient_accumulation_steps
+            )
         )
         self.assertEqual(trainer_resumed.state.global_step, steps_per_epoch)
 
         # Check that a checkpoint for the final step exists.
-        final_checkpoint_path = os.path.join(output_dir_resumed, f"checkpoint-{steps_per_epoch}")
+        final_checkpoint_path = os.path.join(
+            output_dir_resumed, f"checkpoint-{steps_per_epoch}"
+        )
         self.assertTrue(os.path.exists(final_checkpoint_path))
 
         # Check if the model weights file exists in the final checkpoint directory.
         # Trainer saves non-PreTrainedModel models as `model.safetensors` by default if safetensors is available.
         final_model_path = os.path.join(final_checkpoint_path, SAFE_WEIGHTS_NAME)
-        self.assertTrue(os.path.exists(final_model_path), "Final model checkpoint was not saved!")
+        self.assertTrue(
+            os.path.exists(final_model_path), "Final model checkpoint was not saved!"
+        )
 
     @require_torch_non_multi_accelerator
     def test_resume_batch_order(self):
@@ -989,7 +1094,10 @@ class TrainerInterruptedTrainingTest(TestCasePlus, TrainerIntegrationCommon):
                 # Handle data_order buffer size mismatch during checkpoint loading
                 if "data_order" in state_dict:
                     saved_data_order = state_dict["data_order"]
-                    if hasattr(self, "data_order") and self.data_order.shape != saved_data_order.shape:
+                    if (
+                        hasattr(self, "data_order")
+                        and self.data_order.shape != saved_data_order.shape
+                    ):
                         # Resize the buffer to match the saved state
                         self.data_order = saved_data_order.clone()
 
@@ -1004,7 +1112,9 @@ class TrainerInterruptedTrainingTest(TestCasePlus, TrainerIntegrationCommon):
 
                 # Log the data order for verification
                 data_indices = input_ids[:, 0].int()
-                self.data_order = torch.cat([self.data_order, data_indices.detach().clone()])
+                self.data_order = torch.cat(
+                    [self.data_order, data_indices.detach().clone()]
+                )
 
                 return {"loss": loss, "logits": logits}
 
@@ -1039,10 +1149,14 @@ class TrainerInterruptedTrainingTest(TestCasePlus, TrainerIntegrationCommon):
 
         # 1.2 Get the data order from the last saved checkpoint for the full run
         last_checkpoint_path = get_last_checkpoint(exp_dir_baseline)
-        last_ckpt_num = int(os.path.basename(last_checkpoint_path).split("-")[1])  # Must be 15
+        last_ckpt_num = int(
+            os.path.basename(last_checkpoint_path).split("-")[1]
+        )  # Must be 15
 
         baseline_state_dict = safetensors.torch.load_file(
-            os.path.join(exp_dir_baseline, f"checkpoint-{last_ckpt_num}", "model.safetensors")
+            os.path.join(
+                exp_dir_baseline, f"checkpoint-{last_ckpt_num}", "model.safetensors"
+            )
         )
         baseline_data_order = baseline_state_dict["data_order"]
 
@@ -1050,7 +1164,9 @@ class TrainerInterruptedTrainingTest(TestCasePlus, TrainerIntegrationCommon):
         # 2.1 Resume training from the second batch of epoch 1 (target_ckpt_num = 7)
         # 1 epoch consists of 10 points, so 5 steps with batch size 2
         target_ckpt_num = 7
-        checkpoint_path = os.path.join(exp_dir_baseline, f"checkpoint-{target_ckpt_num - 1}")
+        checkpoint_path = os.path.join(
+            exp_dir_baseline, f"checkpoint-{target_ckpt_num - 1}"
+        )
 
         set_seed(42)
         model_resume = DummyModel(size=10)
@@ -1080,7 +1196,9 @@ class TrainerInterruptedTrainingTest(TestCasePlus, TrainerIntegrationCommon):
 
         # 2.2 Get the data order from the last saved checkpoint for the resumed run
         resumed_state_dict = safetensors.torch.load_file(
-            os.path.join(exp_dir_resume, f"checkpoint-{last_ckpt_num}", "model.safetensors")
+            os.path.join(
+                exp_dir_resume, f"checkpoint-{last_ckpt_num}", "model.safetensors"
+            )
         )
         resumed_data_order = resumed_state_dict["data_order"]
 
@@ -1240,7 +1358,9 @@ class JITCheckpointTest(unittest.TestCase):
 
         # Verify sentinel file was removed (should be in checkpoint-42 folder)
         checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-42"
-        sentinel_file = os.path.join(self.test_dir, checkpoint_folder, "checkpoint-is-incomplete.txt")
+        sentinel_file = os.path.join(
+            self.test_dir, checkpoint_folder, "checkpoint-is-incomplete.txt"
+        )
         self.assertFalse(os.path.exists(sentinel_file))
 
     def test_execute_jit_checkpoint_sentinel_file_cleanup(self):
@@ -1255,7 +1375,9 @@ class JITCheckpointTest(unittest.TestCase):
         trainer.state.global_step = 42
 
         checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-42"
-        sentinel_file = os.path.join(self.test_dir, checkpoint_folder, "checkpoint-is-incomplete.txt")
+        sentinel_file = os.path.join(
+            self.test_dir, checkpoint_folder, "checkpoint-is-incomplete.txt"
+        )
 
         # Execute checkpoint
         manager.execute_jit_checkpoint()
@@ -1322,7 +1444,9 @@ class JITCheckpointTest(unittest.TestCase):
         control.should_training_stop = False
 
         # Mock execute method
-        with patch.object(callback.jit_manager, "execute_jit_checkpoint") as mock_execute:
+        with patch.object(
+            callback.jit_manager, "execute_jit_checkpoint"
+        ) as mock_execute:
             # Test when checkpoint not requested
             callback.jit_manager.is_checkpoint_requested = False
             callback.on_pre_optimizer_step(trainer.args, trainer.state, control)
@@ -1346,7 +1470,9 @@ class JITCheckpointTest(unittest.TestCase):
         control.should_training_stop = False
 
         # Mock execute method
-        with patch.object(callback.jit_manager, "execute_jit_checkpoint") as mock_execute:
+        with patch.object(
+            callback.jit_manager, "execute_jit_checkpoint"
+        ) as mock_execute:
             # Test when checkpoint not requested
             callback.jit_manager.is_checkpoint_requested = False
             callback.on_step_begin(trainer.args, trainer.state, control)
@@ -1371,7 +1497,9 @@ class JITCheckpointTest(unittest.TestCase):
         control.should_save = True
 
         # Mock execute method
-        with patch.object(callback.jit_manager, "execute_jit_checkpoint") as mock_execute:
+        with patch.object(
+            callback.jit_manager, "execute_jit_checkpoint"
+        ) as mock_execute:
             # Test when checkpoint not requested
             callback.jit_manager.is_checkpoint_requested = False
             callback.on_step_end(trainer.args, trainer.state, control)
@@ -1400,7 +1528,9 @@ class JITCheckpointTest(unittest.TestCase):
         control.should_training_stop = False
 
         # Mock execute method
-        with patch.object(callback.jit_manager, "execute_jit_checkpoint") as mock_execute:
+        with patch.object(
+            callback.jit_manager, "execute_jit_checkpoint"
+        ) as mock_execute:
             # Test when checkpoint not requested
             callback.jit_manager.is_checkpoint_requested = False
             callback.on_epoch_end(trainer.args, trainer.state, control)
@@ -1442,7 +1572,9 @@ class JITCheckpointTest(unittest.TestCase):
 
             # Verify signal handler was restored
             current_handler = signal.signal(signal.SIGTERM, signal.SIG_DFL)
-            self.assertEqual(current_handler, callback.jit_manager._original_sigterm_handler)
+            self.assertEqual(
+                current_handler, callback.jit_manager._original_sigterm_handler
+            )
 
         finally:
             # Restore original handler for cleanup
@@ -1468,7 +1600,11 @@ class JITCheckpointTest(unittest.TestCase):
         trainer = self.get_trainer(enable_jit=True)
 
         # Check that JIT callback was added
-        jit_callbacks = [cb for cb in trainer.callback_handler.callbacks if isinstance(cb, JITCheckpointCallback)]
+        jit_callbacks = [
+            cb
+            for cb in trainer.callback_handler.callbacks
+            if isinstance(cb, JITCheckpointCallback)
+        ]
         self.assertEqual(len(jit_callbacks), 1)
 
         jit_callback = jit_callbacks[0]
@@ -1528,7 +1664,9 @@ class TrainerSavingTest(TestCasePlus, TrainerIntegrationCommon):
             trainer.save_model()
             reloaded_image_processor = AutoImageProcessor.from_pretrained(tmp_dir)
 
-        self.assertDictEqual(image_processor.to_dict(), reloaded_image_processor.to_dict())
+        self.assertDictEqual(
+            image_processor.to_dict(), reloaded_image_processor.to_dict()
+        )
 
     def test_trainer_saves_feature_extractor(self):
         MODEL_ID = "facebook/wav2vec2-base-960h"
@@ -1545,7 +1683,9 @@ class TrainerSavingTest(TestCasePlus, TrainerIntegrationCommon):
 
             reloaded_feature_extractor = AutoFeatureExtractor.from_pretrained(tmp_dir)
 
-        self.assertDictEqual(feature_extractor.to_dict(), reloaded_feature_extractor.to_dict())
+        self.assertDictEqual(
+            feature_extractor.to_dict(), reloaded_feature_extractor.to_dict()
+        )
 
     @require_vision
     @require_torchvision
@@ -1638,11 +1778,13 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
         )
         trainer.train()
         # Check that we have the last known step:
-        assert os.path.exists(os.path.join(tmp_dir, f"checkpoint-{trainer.state.max_steps}")), (
-            f"Could not find checkpoint-{trainer.state.max_steps}"
-        )
+        assert os.path.exists(
+            os.path.join(tmp_dir, f"checkpoint-{trainer.state.max_steps}")
+        ), f"Could not find checkpoint-{trainer.state.max_steps}"
         # And then check the last step
-        assert os.path.exists(os.path.join(tmp_dir, "checkpoint-9")), "Could not find checkpoint-9"
+        assert os.path.exists(os.path.join(tmp_dir, "checkpoint-9")), (
+            "Could not find checkpoint-9"
+        )
 
         # Now test that using a limit works
         # Should result in:
@@ -1661,18 +1803,26 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
         )
         trainer.train()
         # Check that we have the last known step:
-        assert os.path.exists(os.path.join(tmp_dir, "checkpoint-11")), "Could not find checkpoint-11"
+        assert os.path.exists(os.path.join(tmp_dir, "checkpoint-11")), (
+            "Could not find checkpoint-11"
+        )
         # And then check the last multiple
-        assert os.path.exists(os.path.join(tmp_dir, "checkpoint-10")), "Could not find checkpoint-10"
+        assert os.path.exists(os.path.join(tmp_dir, "checkpoint-10")), (
+            "Could not find checkpoint-10"
+        )
         # Finally check that we don't have an old one
-        assert not os.path.exists(os.path.join(tmp_dir, "checkpoint-5")), "Found checkpoint-5, limit not respected"
+        assert not os.path.exists(os.path.join(tmp_dir, "checkpoint-5")), (
+            "Found checkpoint-5, limit not respected"
+        )
 
         # Finally check that the right model was loaded in - it should be the checkpoint
         # with the best eval metric. With eval at steps 5, 10, 11, the best could be any of them.
         model_state = trainer.model.state_dict()
         # Find which checkpoint has the best metric
         best_checkpoint_dir = trainer.state.best_model_checkpoint
-        final_model_weights = safetensors.torch.load_file(os.path.join(best_checkpoint_dir, "model.safetensors"))
+        final_model_weights = safetensors.torch.load_file(
+            os.path.join(best_checkpoint_dir, "model.safetensors")
+        )
         for k, v in model_state.items():
             assert torch.allclose(v, final_model_weights[k]), f"{k} is not the same"
 
@@ -1758,7 +1908,9 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
                     save_strategy="best",
                     compute_metrics=AlmostAccuracy(),
                 )
-            self.assertIn("`args.metric_for_best_model` must be provided", str(context.exception))
+            self.assertIn(
+                "`args.metric_for_best_model` must be provided", str(context.exception)
+            )
 
         # Case 2: Metric name not provided when `load_best_model_at_end == True`.
         # `metric_for_best_model` should be set to `"loss"` by default.
@@ -1848,7 +2000,9 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
             assert trainer.state.best_metric == 0.59
             assert trainer.state.best_global_step == steps_per_epoch
 
-            best_ckpt = os.path.join(tmpdir, f"{PREFIX_CHECKPOINT_DIR}-{trainer.state.best_global_step}")
+            best_ckpt = os.path.join(
+                tmpdir, f"{PREFIX_CHECKPOINT_DIR}-{trainer.state.best_global_step}"
+            )
             assert trainer.state.best_model_checkpoint == best_ckpt
 
             assert len(os.listdir(tmpdir)) == trainer.state.num_train_epochs
@@ -1884,7 +2038,9 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
             assert trainer.state.best_metric == 0.59
             assert trainer.state.best_global_step == steps_per_epoch
 
-            best_ckpt = os.path.join(tmpdir, f"{PREFIX_CHECKPOINT_DIR}-{trainer.state.best_global_step}")
+            best_ckpt = os.path.join(
+                tmpdir, f"{PREFIX_CHECKPOINT_DIR}-{trainer.state.best_global_step}"
+            )
             assert trainer.state.best_model_checkpoint == best_ckpt
 
             assert len(os.listdir(tmpdir)) == trainer.state.global_step
@@ -1920,7 +2076,9 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
             assert trainer.state.best_metric == 0.90
             assert trainer.state.best_global_step == 1
 
-            best_ckpt = os.path.join(tmpdir, f"{PREFIX_CHECKPOINT_DIR}-{trainer.state.best_global_step}")
+            best_ckpt = os.path.join(
+                tmpdir, f"{PREFIX_CHECKPOINT_DIR}-{trainer.state.best_global_step}"
+            )
             assert trainer.state.best_model_checkpoint == best_ckpt
 
             assert len(os.listdir(tmpdir)) == 1
@@ -1975,7 +2133,9 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
             self.assertFalse(trainer.args.greater_is_better)
             trainer.train()
             self.check_saved_checkpoints(tmpdir, 5, total)
-            self.check_best_model_has_been_loaded(tmpdir, 5, total, trainer, "eval_loss")
+            self.check_best_model_has_been_loaded(
+                tmpdir, 5, total, trainer, "eval_loss"
+            )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             trainer = get_regression_trainer(
@@ -1993,7 +2153,9 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
             self.assertTrue(trainer.args.greater_is_better)
             trainer.train()
             self.check_saved_checkpoints(tmpdir, 5, total)
-            self.check_best_model_has_been_loaded(tmpdir, 5, total, trainer, "eval_accuracy", greater_is_better=True)
+            self.check_best_model_has_been_loaded(
+                tmpdir, 5, total, trainer, "eval_accuracy", greater_is_better=True
+            )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             trainer = get_regression_trainer(
@@ -2011,7 +2173,12 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
             trainer.train()
             self.check_saved_checkpoints(tmpdir, 64 // self.batch_size, total)
             self.check_best_model_has_been_loaded(
-                tmpdir, 64 // self.batch_size, total, trainer, "eval_accuracy", greater_is_better=True
+                tmpdir,
+                64 // self.batch_size,
+                total,
+                trainer,
+                "eval_accuracy",
+                greater_is_better=True,
             )
 
         # Test this works with a non PreTrainedModel
@@ -2028,7 +2195,9 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
             self.assertFalse(trainer.args.greater_is_better)
             trainer.train()
             self.check_saved_checkpoints(tmpdir, 5, total, is_pretrained=False)
-            self.check_best_model_has_been_loaded(tmpdir, 5, total, trainer, "eval_loss", is_pretrained=False)
+            self.check_best_model_has_been_loaded(
+                tmpdir, 5, total, trainer, "eval_loss", is_pretrained=False
+            )
 
     def test_load_best_model_from_safetensors(self):
         total = int(self.n_epochs * 64 / self.batch_size)
@@ -2048,7 +2217,9 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
                 self.assertFalse(trainer.args.greater_is_better)
                 trainer.train()
                 self.check_saved_checkpoints(tmpdir, 5, total, is_pretrained=pretrained)
-                self.check_best_model_has_been_loaded(tmpdir, 5, total, trainer, "eval_loss", is_pretrained=pretrained)
+                self.check_best_model_has_been_loaded(
+                    tmpdir, 5, total, trainer, "eval_loss", is_pretrained=pretrained
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -2105,7 +2276,9 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
             repo_name = re_search.groups()[0]
             self.assertEqual(repo_name, f"valid_org/{output_dir_name}")
 
-            model = RegressionPreTrainedModel.from_pretrained(f"valid_org/{output_dir_name}")
+            model = RegressionPreTrainedModel.from_pretrained(
+                f"valid_org/{output_dir_name}"
+            )
             self.assertEqual(model.a.item(), trainer.model.a.item())
             self.assertEqual(model.b.item(), trainer.model.b.item())
 
@@ -2143,7 +2316,12 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
             self.assertIn("Training in progress, epoch 1", commits)
             self.assertIn("Training in progress, epoch 2", commits)
             # Epochs 3 and 4 are not guaranteed to be present (empty commits)
-            self.assertTrue(any("Skipping to prevent empty commit." in record.message for record in logs.records))
+            self.assertTrue(
+                any(
+                    "Skipping to prevent empty commit." in record.message
+                    for record in logs.records
+                )
+            )
 
     def test_push_to_hub_with_saves_each_n_steps(self):
         num_gpus = max(1, backend_device_count(torch_device))
@@ -2172,16 +2350,26 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
             # Some commits are skipped if nothing has changed
             # We expect 1 commit per 5 epochs + 1 commit at the end
             nb_empty_commits = len(
-                [record for record in logs.records if "Skipping to prevent empty commit." in record.message]
+                [
+                    record
+                    for record in logs.records
+                    if "Skipping to prevent empty commit." in record.message
+                ]
             )
-            nb_epoch_commits = len([commit for commit in commits if "Training in progress, step" in commit])
+            nb_epoch_commits = len(
+                [commit for commit in commits if "Training in progress, step" in commit]
+            )
 
             # max_steps depend on the number of available GPUs
-            max_steps = math.ceil(trainer.args.num_train_epochs * len(trainer.get_train_dataloader()))
+            max_steps = math.ceil(
+                trainer.args.num_train_epochs * len(trainer.get_train_dataloader())
+            )
             nb_expected_commits = len(range(5, max_steps, 5))
 
             # '>=' since final commit might be an empty commit as well (not deterministic)
-            self.assertGreaterEqual(nb_empty_commits + nb_epoch_commits, nb_expected_commits)
+            self.assertGreaterEqual(
+                nb_empty_commits + nb_epoch_commits, nb_expected_commits
+            )
 
     @require_tensorboard
     def test_push_to_hub_with_tensorboard_logs(self):
@@ -2244,10 +2432,17 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
                     hub_token=self._token,
                 )
                 branch = "v1.0"
-                create_branch(repo_id=trainer.hub_model_id, branch=branch, token=self._token, exist_ok=True)
+                create_branch(
+                    repo_id=trainer.hub_model_id,
+                    branch=branch,
+                    token=self._token,
+                    exist_ok=True,
+                )
                 push_commit = trainer.push_to_hub(revision=branch)
 
-            commits = list_repo_commits(repo_id=trainer.hub_model_id, revision=branch, token=self._token)
+            commits = list_repo_commits(
+                repo_id=trainer.hub_model_id, revision=branch, token=self._token
+            )
             self.assertEqual(commits[0].commit_id, push_commit.oid)
 
     def test_rotate_checkpoints_preserves_best_model(self):
@@ -2270,4 +2465,3 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
             self.assertIn("checkpoint-20", remaining)
             self.assertNotIn("checkpoint-10", remaining)
             self.assertNotIn("checkpoint-15", remaining)
-

--- a/tests/trainer/test_trainer_checkpointing.py
+++ b/tests/trainer/test_trainer_checkpointing.py
@@ -2249,3 +2249,25 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
 
             commits = list_repo_commits(repo_id=trainer.hub_model_id, revision=branch, token=self._token)
             self.assertEqual(commits[0].commit_id, push_commit.oid)
+
+    def test_rotate_checkpoints_preserves_best_model(self):
+        from transformers.trainer_utils import rotate_checkpoints
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            for step in (5, 10, 15, 20):
+                os.makedirs(os.path.join(tmp_dir, f"checkpoint-{step}"))
+
+            best_cp = os.path.join(tmp_dir, "checkpoint-5")
+            rotate_checkpoints(
+                output_dir=tmp_dir,
+                save_total_limit=2,
+                best_model_checkpoint=best_cp,
+            )
+
+            remaining = set(os.listdir(tmp_dir))
+            # Best model (checkpoint-5) and latest (checkpoint-20) must be preserved
+            self.assertIn("checkpoint-5", remaining)
+            self.assertIn("checkpoint-20", remaining)
+            self.assertNotIn("checkpoint-10", remaining)
+            self.assertNotIn("checkpoint-15", remaining)
+


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48216&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48216) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48216&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48216)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Passes `best_model_checkpoint=best_model_checkpoint` to `sort_checkpoints` inside `rotate_checkpoints`:
- `sort_checkpoints` supports protecting `best_model_checkpoint` by moving it to the second-to-last position before rotation.
- However, `rotate_checkpoints` called `sort_checkpoints(output_dir, checkpoint_prefix, use_mtime)` without forwarding `best_model_checkpoint`, preventing the protection order from being applied.
- Forwarding `best_model_checkpoint` ensures the best model checkpoint is correctly preserved when rotating checkpoints.
- Added unit test `test_rotate_checkpoints_preserves_best_model` in `tests/trainer/test_trainer_checkpointing.py`.

## Before submitting

- [x] This PR fixes a bug or adds a feature and conforms to the coding standards.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?