### PR TITLE
Warn when the RoPE rotary dimension is odd

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -840,12 +840,62 @@ class RotaryEmbeddingConfigMixin:
             validation_fn = getattr(self, f"_validate_{rope_type}_rope_parameters", None)
             rope_parameters["rope_type"] = rope_type
 
+            self._validate_rotary_dim_is_even(rope_parameters)
+
             if validation_fn is not None:
                 validation_fn(rope_parameters, ignore_keys=self.ignore_keys_at_rope_validation)
             else:
                 logger.warning(
                     f"Missing validation function in 'RotaryEmbeddingConfigMixin' for 'rope_type'='{rope_type}'"
                 )
+
+    def _validate_rotary_dim_is_even(self, rope_parameters: dict):
+        """
+        RoPE pairs up consecutive dimensions and rotates each pair. For *full* RoPE (no partial rotary factor,
+        the common case -- Llama, Qwen2, Mixtral, etc.), an odd `head_dim` has no valid pairing for its last
+        component: the cos/sin cache ends up one dimension larger than `head_dim` (rounded up to the nearest
+        even number), and `apply_rotary_pos_emb` applies it to the full, un-sliced query/key tensors, so the
+        shapes never match and it fails deep in the forward pass with a cryptic tensor-size error instead of at
+        config creation time.
+
+        This intentionally only checks the full-rotation case (`partial_rotary_factor` unset or `>= 1.0`).
+        Genuinely partial-RoPE models (e.g. GLM-4(V) MoE, which default to `partial_rotary_factor=0.5`) compute
+        `apply_rotary_pos_emb`'s rotary slice from the cos/sin cache's own (rounded-up, even) size rather than
+        from `head_dim` directly, so an odd `head_dim * partial_rotary_factor` there is silently rounded up and
+        works fine -- flagging it would be a false positive.
+
+        This only runs when `hidden_size`/`num_attention_heads` (or an explicit `head_dim`) are actually present on
+        the config, so it's a no-op for configs that merely inherit this mixin without describing an attention head
+        shape (e.g. some composite/parent configs).
+
+        NOTE: this warns rather than raises. `PreTrainedConfig.to_diff_dict()` (used by `__repr__`,
+        `to_json_string()`, and therefore ordinary printing/logging/saving of a config) instantiates a bare
+        `self.__class__()` purely to diff field values against class defaults. If any registered config class
+        has broken bare defaults (one already does, independent of this check), raising here would make merely
+        *printing* an otherwise-valid config of that class crash -- a hard error is too heavy a hammer for what
+        `to_diff_dict()` needs to be a safe, side-effect-free operation.
+        """
+        partial_rotary_factor = rope_parameters.get("partial_rotary_factor") or 1.0
+        if partial_rotary_factor < 1.0:
+            return
+
+        head_dim = getattr(self, "head_dim", None)
+        if head_dim is None:
+            hidden_size = getattr(self, "hidden_size", None)
+            num_attention_heads = getattr(self, "num_attention_heads", None)
+            if not hidden_size or not num_attention_heads:
+                return
+            head_dim = hidden_size // num_attention_heads
+
+        rotary_dim = int(head_dim * partial_rotary_factor)
+        if rotary_dim % 2 != 0:
+            logger.warning(
+                f"The rotary embedding dimension is odd ({rotary_dim}, from head_dim={head_dim} and "
+                f"partial_rotary_factor={partial_rotary_factor}). RoPE rotates consecutive dimensions in pairs, so "
+                "an odd rotary dimension has no valid pairing for its last component and this will very likely "
+                "fail with a tensor-size mismatch during the forward pass. Adjust `hidden_size`/`num_attention_heads` "
+                "(or set `head_dim` explicitly) so that head_dim * partial_rotary_factor is even."
+            )
 
     def _validate_default_rope_parameters(self, rope_parameters: dict, ignore_keys: set | None = None):
         required_keys = {"rope_type"}

--- a/tests/utils/test_modeling_rope_utils.py
+++ b/tests/utils/test_modeling_rope_utils.py
@@ -137,6 +137,37 @@ class RopeTest(unittest.TestCase):
             if same_rope_per_layer:
                 self.assertIn("mrope_sections", logs.output[1])
 
+    def test_odd_rotary_dim_warns(self):
+        # RoPE rotates dimensions in pairs. Full RoPE (the default -- no `partial_rotary_factor`, e.g. Llama,
+        # Qwen2, Mixtral) applies the rotation to the whole, un-sliced `head_dim`, so an odd `head_dim` has no
+        # valid pairing for its last component and fails deep in `apply_rotary_pos_emb` with a cryptic
+        # tensor-size mismatch. This should be surfaced as a clear warning at config-creation time instead.
+        with self.assertLogs("transformers.modeling_rope_utils", level="WARNING") as logs:
+            LlamaConfig(hidden_size=520, num_attention_heads=8, num_hidden_layers=1)  # head_dim = 65 (odd)
+        self.assertTrue(any("rotary embedding dimension is odd" in line for line in logs.output))
+
+        # An explicitly-set odd `head_dim` triggers the same check, regardless of hidden_size/num_attention_heads.
+        with self.assertLogs("transformers.modeling_rope_utils", level="WARNING") as logs:
+            config = LlamaConfig(hidden_size=512, num_attention_heads=8, num_hidden_layers=1)
+            config.head_dim = 65
+            config.validate_rope()
+        self.assertTrue(any("rotary embedding dimension is odd" in line for line in logs.output))
+
+        # A config whose head_dim is even should never warn.
+        config = LlamaConfig(hidden_size=512, num_attention_heads=8, num_hidden_layers=1)  # head_dim = 64 (even)
+        with self.assertNoLogs("transformers.modeling_rope_utils", level="WARNING"):
+            config.validate_rope()
+
+        # Genuinely partial RoPE (`partial_rotary_factor` < 1.0) must NOT warn, even if `head_dim *
+        # partial_rotary_factor` happens to be odd: `apply_rotary_pos_emb` for these models derives its rotary
+        # slice from the (rounded-up, even) cos/sin cache size rather than from this exact value, so it's not
+        # actually broken. This mirrors GLM-4(V) MoE's real-world default of `head_dim=42,
+        # partial_rotary_factor=0.5` (dim=21, odd, and it works fine) -- flagging it would be a false positive.
+        config = LlamaConfig(hidden_size=336, num_attention_heads=8, num_hidden_layers=1)  # head_dim = 42
+        config.rope_parameters["partial_rotary_factor"] = 0.5  # int(42 * 0.5) = 21 (odd)
+        with self.assertNoLogs("transformers.modeling_rope_utils", level="WARNING"):
+            config.validate_rope()
+
     @parameterized.expand(
         [
             (True, True),


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48217&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48217) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48217&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48217)
<!-- ci-dashboard-badge:end -->

Part of #48101.

## The bug

RoPE rotates dimensions in pairs. For full RoPE (the common case — no `partial_rotary_factor`, e.g. Llama,
Qwen2, Mixtral), the rotation is applied to the whole, un-sliced `head_dim`. If `head_dim` (usually
`hidden_size // num_attention_heads`) is odd, there's no valid pairing for its last component. Config
validation currently passes anyway, and the model builds fine — it only fails on the *first forward pass*,
deep inside `apply_rotary_pos_emb`, with a cryptic shape error:

```python
import torch
from transformers import LlamaConfig, LlamaForCausalLM

config = LlamaConfig(
    hidden_size=520, num_attention_heads=8, num_key_value_heads=2,  # head_dim = 65 (odd)
    intermediate_size=256, num_hidden_layers=1, max_position_embeddings=64, vocab_size=128,
)
model = LlamaForCausalLM(config).eval()
with torch.no_grad():
    model(input_ids=torch.randint(0, 128, (1, 8)))
```
```
RuntimeError: The size of tensor a (65) must match the size of tensor b (66) at non-singleton dimension 3
```

Root cause: `torch.arange(0, dim, 2)` rounds the frequency count up when `dim` is odd, so the cos/sin cache
ends up one dimension larger than `head_dim`. Models whose `apply_rotary_pos_emb` applies the rotation to the
full q/k tensors (rather than slicing to the cache's own size) then hit a hard shape mismatch. Same bug is
reproducible with Qwen2 and Mixtral configs, and reportedly others.

## The fix

Added `_validate_rotary_dim_is_even` to `RotaryEmbeddingConfigMixin.validate_rope()` in
`src/transformers/modeling_rope_utils.py` — the single shared validation entry point that essentially every
RoPE-using config (`PreTrainedConfig` itself inherits this mixin) already runs through via `@strict`
class-validation on `__init__`. This means the check automatically covers every current and future
RoPE-based model without a per-model change, the same shape as the shared-choke-point approach in #48207.

**Why this warns instead of raising**, which I'd initially tried: `PreTrainedConfig.to_diff_dict()` — used by
`__repr__`, `to_json_string()`, and therefore ordinary printing/logging/saving of *any* config — instantiates
a bare `self.__class__()` purely to diff field values against class defaults. While testing a hard-raise
version of this fix, `pytest tests/models/qwen3_omni_moe` went from a clean pass to 125 failures, entirely
because `Qwen3OmniMoeTextConfig`'s own class defaults (`hidden_size=2048`, `num_attention_heads=28` → `head_dim
= 73`, odd) already hit this — and `to_diff_dict()`'s internal bare-default construction hit it too, breaking
`repr()` for *any* instance of that class, not just literal bare construction. A hard error is too heavy a
hammer for what needs to be a safe, side-effect-free operation, so this raises to a `logger.warning` instead —
matching the existing house style in this exact file (every other `_validate_*_rope_parameters` method here
warns rather than raises for non-structural issues).

Aside: that also means `Qwen3OmniMoeTextConfig`'s bare defaults are themselves currently broken (crash on
first forward pass, same as the reported bug) — out of scope here since fixing a specific model's shipped
architecture defaults needs domain knowledge I don't have, but flagging it for whoever owns that model.

**Scope**: the check only fires for full rotation (`partial_rotary_factor` unset or `>= 1.0`). I initially
had it fire unconditionally, and a repo-wide scan of every registered config class's bare defaults caught two
false positives: GLM-4 MoE and GLM-4V MoE both default to `partial_rotary_factor=0.5`, giving an odd computed
rotary dim (`head_dim=42 * 0.5 = 21`) — but their `apply_rotary_pos_emb` derives the rotary slice from the
cos/sin cache's own (rounded-up, even) size rather than from this value directly, so it's silently rounded up
and works fine. Restricting the check to the full-rotation case removed both false positives while keeping
the real catch (confirmed: `Qwen3OmniMoeTextConfig`'s defaults, which are *not* partial-rotary, still flag
correctly).

## Test

Added `test_odd_rotary_dim_warns` to `tests/utils/test_modeling_rope_utils.py`, covering: an odd computed
`head_dim` warns; an explicitly-set odd `head_dim` warns; an even `head_dim` does not warn; and — the
false-positive guard — a genuinely partial-RoPE config with an odd *computed* rotary dim (mirroring GLM-4
MoE's real defaults) does not warn.

## Verification

- Repro above now emits a clear warning at config-creation time before the same forward-pass crash (the crash
  itself is unchanged/out of scope — see "what this doesn't fix" below).
- Scanned all 444 currently-bare-instantiable registered config classes: 0 newly affected after narrowing the
  scope to full rotation (before narrowing, 3 were affected: 2 real false positives now excluded, 1 genuine
  latent bug in `Qwen3OmniMoeTextConfig` still correctly caught).
- Full non-slow suites for `llama`, `qwen2`, `mixtral`, `glm4_moe`, and `glm`: no new failures. Each of these
  models has a handful of pre-existing failures in this environment (`test_causal_lm_can_accept_training_kwargs`,
  `test_fsdp2_*`, `test_tp_*`, `test_generate_compile_model_forward_fullgraph`) — confirmed via `git stash`
  that these fail identically on `main`, unrelated to this change (distributed/compile features unavailable
  in a single-process sandbox).
- `ruff check` / `ruff format --check` clean on both changed files.

## What this doesn't fix

This PR only adds a warning. it doesn't make the odd-`head_dim` case actually work, and it doesn't reject
such configs at construction time (see the `to_diff_dict()` note above for why). The forward-pass crash from
the original issue still happens; the difference is that there's now a clear, actionable message pointing at
the cause before it does. Making full-rotation `apply_rotary_pos_emb` implementations tolerate odd `head_dim`
(by padding or slicing, like the partial-rotary models already do) would be a larger, more architecturally
invasive change I'd want maintainer input on before attempting.

---