### PR TITLE
Fix Mllama vision/cross-attention being treated as causal under SDPA

### DIFF
--- a/src/transformers/models/blt/modeling_blt.py
+++ b/src/transformers/models/blt/modeling_blt.py
@@ -358,6 +358,7 @@ class BltCrossAttention(nn.Module):
         self.layer_idx = layer_idx
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         self.scaling = self.head_dim**-0.5
+        self.is_causal = False
 
         self.q_proj = nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=False)
         self.k_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=False)
@@ -365,7 +366,6 @@ class BltCrossAttention(nn.Module):
         self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=False)
         self.q_norm = BltRMSNorm(self.hidden_size, eps=config.rms_norm_eps)
         self.k_norm = BltRMSNorm(self.hidden_size, eps=config.rms_norm_eps)
-        self.is_causal = False
 
     def forward(
         self,

--- a/src/transformers/models/hunyuan_vl/modeling_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modeling_hunyuan_vl.py
@@ -330,11 +330,11 @@ class HunYuanVLVisionAttention(nn.Module):
         self.head_dim = getattr(config, "head_dim", self.embed_dim // self.num_heads)
         self.scaling = self.head_dim**-0.5
         self.num_key_value_groups = 1
+        self.is_causal = False
         self.q_proj = nn.Linear(self.embed_dim, self.num_heads * self.head_dim, bias=True)
         self.k_proj = nn.Linear(self.embed_dim, self.num_heads * self.head_dim, bias=True)
         self.v_proj = nn.Linear(self.embed_dim, self.num_heads * self.head_dim, bias=True)
         self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.embed_dim, bias=True)
-        self.is_causal = False
 
     @deprecate_kwarg("hidden_state", new_name="hidden_states", version="v5.20")
     def forward(

--- a/src/transformers/models/mllama/modeling_mllama.py
+++ b/src/transformers/models/mllama/modeling_mllama.py
@@ -224,6 +224,7 @@ class MllamaVisionAttention(nn.Module):
         self.head_dim = config.hidden_size // config.attention_heads
         self.scaling = self.head_dim**-0.5
         self.num_key_value_groups = 1
+        self.is_causal = False
 
         self.q_proj = nn.Linear(self.embed_dim, self.num_heads * self.head_dim, bias=False)
         self.k_proj = nn.Linear(self.embed_dim, self.num_heads * self.head_dim, bias=False)
@@ -399,6 +400,7 @@ class MllamaTextCrossAttention(nn.Module):
         self.layer_idx = layer_idx
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         self.scaling = self.head_dim**-0.5
+        self.is_causal = False
 
         self.q_proj = nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=False)
         self.k_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=False)

--- a/tests/models/mllama/test_modeling_mllama.py
+++ b/tests/models/mllama/test_modeling_mllama.py
@@ -291,6 +291,42 @@ class MllamaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTester
     def test_config(self):
         self.config_tester.run_common_tests()
 
+    def test_vision_and_cross_attention_are_not_causal(self):
+        # sdpa_attention defaults getattr(module, "is_causal", True). Vision and cross-attn
+        # must opt out so they are not treated as decoder self-attention (#48172).
+        from transformers.models.mllama.configuration_mllama import MllamaVisionConfig
+        from transformers.models.mllama.modeling_mllama import (
+            MllamaTextCrossAttention,
+            MllamaTextSelfAttention,
+            MllamaVisionAttention,
+        )
+
+        vision_config = MllamaVisionConfig(
+            hidden_size=16,
+            attention_heads=4,
+            num_hidden_layers=1,
+            num_global_layers=1,
+            intermediate_size=32,
+            vision_output_dim=32,
+            image_size=16,
+            patch_size=2,
+            intermediate_layers_indices=[0],
+        )
+        text_config = MllamaTextConfig(
+            hidden_size=32,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            num_hidden_layers=2,
+            intermediate_size=37,
+            cross_attention_layers=[1],
+        )
+        vision_attn = MllamaVisionAttention(vision_config)
+        cross_attn = MllamaTextCrossAttention(text_config, layer_idx=1)
+        self_attn = MllamaTextSelfAttention(text_config, layer_idx=0)
+        self.assertIs(vision_attn.is_causal, False)
+        self.assertIs(cross_attn.is_causal, False)
+        self.assertIs(self_attn.is_causal, True)
+
     def test_resize_embeddings_results_in_successful_loss(self):
         # resizing embeddings should result in successful loss computation
         config, inputs = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48218&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48218) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48218&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48218)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48172.

sdpa_attention resolves causality as getattr(module, "is_causal", True). MllamaTextSelfAttention sets is_causal = True, but MllamaVisionAttention and MllamaTextCrossAttention never set the flag. With no 4-D mask (typical for text cross-attention when cross_attention_mask is omitted), SDPA therefore applies a causal mask to encoder/cross-attention.

This is the same class of miss as Qwen2.5-VL (#39231 / #39121). The FlashAttention path reads module.is_causal as a required attribute, so those two modules can also raise AttributeError under FA2.

Change: set self.is_causal = False on both modules, matching CLIP / SigLIP / Qwen2-VL vision attention. Added a unit test that instantiates the three attention classes and checks the flag.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline and the Pull Request checks?
- [x] Was this discussed/approved via a Github issue or the forum? https://github.com/huggingface/transformers/issues/48172
- [ ] Did you make sure to update the documentation with your changes according to the guidelines?
- [x] Did you write any new necessary tests?

## Who can review?

@zucchini-nlp