### PR TITLE
Fix nested optional kernel silent fallback

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -111,11 +111,24 @@ def resolve_internal_import(module: ModuleType | None, chained_path: str) -> Cal
     if not module:
         return None
 
-    if final_module := getattr(module, chained_path.split(".")[-1], None):
+    parts = chained_path.split(".")
+    
+    if final_module := getattr(module, parts[-1], None):
         return final_module
 
+    if len(parts) > 1:
+        module_name = module.__name__
+        try:
+            import importlib
+            submodule_name = f"{module_name}.{'.'.join(parts[:-1])}"
+            submodule = importlib.import_module(submodule_name)
+            if final_module := getattr(submodule, parts[-1], None):
+                return final_module
+        except Exception:
+            pass
+
     final_module = module
-    for path in chained_path.split("."):
+    for path in parts:
         final_module = getattr(final_module, path, None)
         if not final_module:
             return None


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48220&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48220) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48220&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48220)
<!-- ci-dashboard-badge:end -->

Fixes a bug in resolve_internal_import where dynamically nested optional flash attention kernels (like fla) failed to load, falling back silently to slower Torch implementations.