### PR TITLE
[mLUKE] Un-skip MLukeTokenizerTest

### DIFF
--- a/tests/models/mluke/test_tokenization_mluke.py
+++ b/tests/models/mluke/test_tokenization_mluke.py
@@ -26,18 +26,15 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
 SAMPLE_ENTITY_VOCAB = get_tests_dir("fixtures/test_entity_vocab.json")
 
 
-# TODO: (Ita / Arthur) FIXME
-@unittest.skip("Skip for now as this fails after #40936")
 class MLukeTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
-    from_pretrained_id = "studio-ousia/mluke-base"
+    # -lite shares mluke-base's sentencepiece vocab; mluke-base's 438MB entity_vocab.json OOMs CI under -n 4
+    from_pretrained_id = "studio-ousia/mluke-base-lite"
     tokenizer_class = MLukeTokenizer
     from_pretrained_kwargs = {"cls_token": "<s>"}
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.from_pretrained_id = "studio-ousia/mluke-base"
-        cls.tokenizer_class = MLukeTokenizer
 
         cls.special_tokens_map = {"entity_token_1": "<ent>", "entity_token_2": "<ent2>"}
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48226&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48226) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48226&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48226)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`MLukeTokenizerTest` was skipped "temporarily" in #42520, for memory rather than for a logic
failure. Since #40936, `TokenizerTesterMixin.setUpClass` loads and re-serialises each class's
checkpoint, and mLUKE's is `studio-ousia/mluke-base`, whose `entity_vocab.json` is 438,520,875
bytes: 6.0 GB RSS for one worker and 15.5 GB for the class under `pytest -n 4`, against a
tokenization job that runs `-n 4` on `resource_class: large`
(`.circleci/create_circleci_config.py:258,338`).

Under an 8 GB cgroup cap the class is OOM-killed 14 s in — kernel
`oom-kill:constraint=CONSTRAINT_MEMCG ... task=python`, exit 143, no pytest summary. The original
CI log is no longer retrievable, so this reproduces the mechanism, not the incident.

Pointing `from_pretrained_id` at `studio-ousia/mluke-base-lite` — same authors, byte-identical
5,069,051-byte `sentencepiece.bpe.model`, 51-byte `entity_vocab.json` — runs the same 51 tests in
8.6 s and 3.7 GB across 4 workers instead of 84 s and 15.5 GB, and under the same 8 GB cap reports
`51 passed, 7 skipped in 8.75s`. The set of `tokenization_mluke.py` lines the class
executes is identical under either checkpoint — 753 lines, recorded with `sys.settrace` — so the
smaller entity vocab costs no coverage. Same approach as #47115.

It also drops the two `setUpClass` assignments added by #40936, which re-assign
`from_pretrained_id` after `super().setUpClass()` has converted it to a list, so tests reading it
iterate the string's characters instead of the model id.

`run-slow: mluke` will show 3 failures in `MLukeTokenizerIntegrationTests`. That class was never
skipped, the failures are red on `main` too, and none of them is caused by this diff. #48225
covers one of the three.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline and the Pull Request checks?
- [ ] Was this discussed/approved via a Github issue or the forum? (no issue tracks the
      skip itself — it came from #42520, which describes it as temporary)
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? (no new tests — this re-enables 51 existing ones)

## Who can review?

@ydshieh, since #42520 is yours and this is the CI-memory side of it.

---

AI assistance disclosure, per `CONTRIBUTING.md`:

- Coordination: no open issue maps to this change; #42520 is the maintainer PR that added the
  skip and calls it temporary. #48225 is mine and documents one of the pre-existing slow-test
  failures this PR surfaces, not the skip.
- Differentiation: I searched open PRs for `mluke` and `tokenization_mluke` and found none
  overlapping; #48143 is a different mLUKE `save_pretrained` problem.
- Tests run:
  - `pytest tests/models/mluke/test_tokenization_mluke.py` — 51 passed, 19 skipped
  - `RUN_SLOW=1 pytest tests/models/mluke/test_tokenization_mluke.py` — 3 failed, 63 passed,
    4 skipped; identical to `main`
  - the fast tier also under `HF_HUB_OFFLINE=1` and `--random-order` — 51 passed, 19 skipped both
  - `make style` — clean
- I reviewed every changed line and ran the commands above myself.