### PR TITLE
Warm the page cache before sharded loading (opt-in via `HF_SHARD_PREFETCH`)

### DIFF
--- a/src/transformers/distributed/utils.py
+++ b/src/transformers/distributed/utils.py
@@ -59,6 +59,39 @@ def _get_torch_distributed_world_size() -> int:
     return torch.distributed.get_world_size()
 
 
+def prefetch_checkpoint_shards(checkpoint_files: list[str]) -> None:
+    """Warm the page cache for the checkpoint shards before the per-tensor loading pass, opt-in via
+    `HF_SHARD_PREFETCH=<read threads per rank>`.
+
+    The per-tensor read pattern of sharded loading reads a network filesystem at well under 1 GiB/s
+    while large sequential reads sustain many times that; warming the page cache first makes the
+    actual load run at memory speed. Local ranks split the shard list between them (every node needs
+    the full checkpoint cached, since every rank slices tensors from all shards).
+    """
+    prefetch_threads = int(os.environ.get("HF_SHARD_PREFETCH", "0"))
+    if not checkpoint_files or not prefetch_threads:
+        return
+    import time
+    from concurrent.futures import ThreadPoolExecutor
+
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    local_world = int(os.environ.get("LOCAL_WORLD_SIZE", "1"))
+
+    def _warm(path, bufsize=16 * 2**20):
+        with open(path, "rb", buffering=0) as f:
+            while f.read(bufsize):
+                pass
+
+    prefetch_start = time.time()
+    with ThreadPoolExecutor(max_workers=prefetch_threads) as pool:
+        list(pool.map(_warm, checkpoint_files[local_rank::local_world]))
+    if _is_torch_distributed_initialized():
+        torch.distributed.barrier()
+    logger.warning_once(
+        f"Prefetched {len(checkpoint_files)} checkpoint shards in {time.time() - prefetch_start:.0f}s"
+    )
+
+
 def is_local_dist_rank_0() -> bool:
     return _is_torch_distributed_initialized() and int(os.environ.get("LOCAL_RANK", "-1")) == 0
 

--- a/src/transformers/distributed/utils.py
+++ b/src/transformers/distributed/utils.py
@@ -87,9 +87,7 @@ def prefetch_checkpoint_shards(checkpoint_files: list[str]) -> None:
         list(pool.map(_warm, checkpoint_files[local_rank::local_world]))
     if _is_torch_distributed_initialized():
         torch.distributed.barrier()
-    logger.warning_once(
-        f"Prefetched {len(checkpoint_files)} checkpoint shards in {time.time() - prefetch_start:.0f}s"
-    )
+    logger.warning_once(f"Prefetched {len(checkpoint_files)} checkpoint shards in {time.time() - prefetch_start:.0f}s")
 
 
 def is_local_dist_rank_0() -> bool:

--- a/src/transformers/distributed/utils.py
+++ b/src/transformers/distributed/utils.py
@@ -85,8 +85,7 @@ def prefetch_checkpoint_shards(checkpoint_files: list[str]) -> None:
     prefetch_start = time.time()
     with ThreadPoolExecutor(max_workers=prefetch_threads) as pool:
         list(pool.map(_warm, checkpoint_files[local_rank::local_world]))
-    if _is_torch_distributed_initialized():
-        torch.distributed.barrier()
+    _distributed_barrier()
     logger.warning_once(f"Prefetched {len(checkpoint_files)} checkpoint shards in {time.time() - prefetch_start:.0f}s")
 
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4393,7 +4393,9 @@ class PreTrainedModel(
                 list(pool.map(_warm, checkpoint_files[local_rank::local_world]))
             if torch.distributed.is_available() and torch.distributed.is_initialized():
                 torch.distributed.barrier()
-            logger.warning_once(f"Prefetched {len(checkpoint_files)} checkpoint shards in {time.time() - prefetch_start:.0f}s")
+            logger.warning_once(
+                f"Prefetched {len(checkpoint_files)} checkpoint shards in {time.time() - prefetch_start:.0f}s"
+            )
 
         if logger.level >= logging.WARNING:
             verify_tp_plan(expected_keys, getattr(model, "_tp_plan", None))

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -43,7 +43,7 @@ from torch.autograd.graph import save_on_cpu
 from torch.distributions import constraints
 from torch.utils.checkpoint import checkpoint
 
-from transformers.distributed.utils import is_dtensor
+from transformers.distributed.utils import is_dtensor, prefetch_checkpoint_shards
 
 from . import initialization as init
 from .configuration_utils import PreTrainedConfig
@@ -4372,30 +4372,7 @@ class PreTrainedModel(
         # Model's definition arriving here is final (TP hooks added, quantized layers replaces)
         expected_keys = list(model.state_dict().keys()) if expected_keys is None else expected_keys
 
-        if checkpoint_files and (prefetch_threads := int(os.environ.get("HF_SHARD_PREFETCH", "0"))):
-            # The per-tensor read pattern below reads a network filesystem at well under 1 GiB/s while
-            # large sequential reads sustain many times that; warming the page cache first makes the
-            # actual load run at memory speed. Local ranks split the shard list between them (every
-            # node needs the full checkpoint cached, since every rank slices tensors from all shards).
-            import time
-            from concurrent.futures import ThreadPoolExecutor
-
-            local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-            local_world = int(os.environ.get("LOCAL_WORLD_SIZE", "1"))
-
-            def _warm(path, bufsize=16 * 2**20):
-                with open(path, "rb", buffering=0) as f:
-                    while f.read(bufsize):
-                        pass
-
-            prefetch_start = time.time()
-            with ThreadPoolExecutor(max_workers=prefetch_threads) as pool:
-                list(pool.map(_warm, checkpoint_files[local_rank::local_world]))
-            if torch.distributed.is_available() and torch.distributed.is_initialized():
-                torch.distributed.barrier()
-            logger.warning_once(
-                f"Prefetched {len(checkpoint_files)} checkpoint shards in {time.time() - prefetch_start:.0f}s"
-            )
+        prefetch_checkpoint_shards(checkpoint_files)
 
         if logger.level >= logging.WARNING:
             verify_tp_plan(expected_keys, getattr(model, "_tp_plan", None))

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4372,6 +4372,29 @@ class PreTrainedModel(
         # Model's definition arriving here is final (TP hooks added, quantized layers replaces)
         expected_keys = list(model.state_dict().keys()) if expected_keys is None else expected_keys
 
+        if checkpoint_files and (prefetch_threads := int(os.environ.get("HF_SHARD_PREFETCH", "0"))):
+            # The per-tensor read pattern below reads a network filesystem at well under 1 GiB/s while
+            # large sequential reads sustain many times that; warming the page cache first makes the
+            # actual load run at memory speed. Local ranks split the shard list between them (every
+            # node needs the full checkpoint cached, since every rank slices tensors from all shards).
+            import time
+            from concurrent.futures import ThreadPoolExecutor
+
+            local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+            local_world = int(os.environ.get("LOCAL_WORLD_SIZE", "1"))
+
+            def _warm(path, bufsize=16 * 2**20):
+                with open(path, "rb", buffering=0) as f:
+                    while f.read(bufsize):
+                        pass
+
+            prefetch_start = time.time()
+            with ThreadPoolExecutor(max_workers=prefetch_threads) as pool:
+                list(pool.map(_warm, checkpoint_files[local_rank::local_world]))
+            if torch.distributed.is_available() and torch.distributed.is_initialized():
+                torch.distributed.barrier()
+            logger.warning_once(f"Prefetched {len(checkpoint_files)} checkpoint shards in {time.time() - prefetch_start:.0f}s")
+
         if logger.level >= logging.WARNING:
             verify_tp_plan(expected_keys, getattr(model, "_tp_plan", None))
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48227&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48227) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48227&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48227)
<!-- ci-dashboard-badge:end -->

Adds an opt-in page-cache prefetch to sharded model loading: with `HF_SHARD_PREFETCH=<threads>`, the local ranks split the checkpoint's shard list between them and stream it into the page cache with large sequential reads before loading begins. The load itself then runs at memory speed.

## Why

The loader's per-tensor read pattern (mmap + slicing) reads a network filesystem far below what the hardware sustains. Measured on Lustre (H100 nodes, fadvise-evicted so genuinely cold):

- raw sequential reads: 2.0 GiB/s for 1 stream, 8.5 GiB/s for 32 streams per node
- the loader, cold: 0.26–0.7 GiB/s effective
- the loader, warm page cache: 10–20 GiB/s

So the entire gap is read scheduling, not conversion compute.

## Measured

| Load | Baseline (cold) | With `HF_SHARD_PREFETCH=4` |
|---|---|---|
| GLM-4.5-Air, 206 GiB, 1 node / 8 ranks | 60 s | 23 s + 10 s load = 33 s |
| GLM-4.5-Air, 206 GiB, 8 nodes / 64 ranks | 791 s | 152 s + 32 s = 184 s |
| GLM-4.6, 665 GiB, 8 nodes / 64 ranks | 1042–3110 s | 465 s + 63 s = 528 s |

<img width="1280" height="672" alt="image" src="https://github.com/user-attachments/assets/dcfe5bc3-dcf8-4af4-b061-397843e20207" />


Multi-node totals are bounded by the filesystem's aggregate bandwidth shared across nodes (~10 GiB/s measured here): every node needs the full checkpoint cached, because with `distributed_config` every rank slices tensors from every shard. That is also why the env is opt-in: it requires node RAM ≥ checkpoint size.

With the cache warm, the fixed 4-thread IO pool becomes the next bottleneck; raising it (already possible) halves the load again (Air: 39 s → 19 s across 8 ranks, skew < 3 s), and the usual raise-workers OOM hazard is gone because post-prefetch reads are cheap.

A note on the environments: the multi-node rows above come from remote nodes with ~15 ms of extra latency to the filesystem, which amplifies the loader's many-small-reads pattern; the single-node rows are low-latency nodes. Prefetch helps in both because large sequential reads are latency-tolerant.

## Minimal repro

Runs on one node with 2+ GPUs and any sharded checkpoint (below: Qwen3-30B-A3B, 57 GiB, measured on 8×H100 with a Lustre-backed cache, 23 s cold baseline vs 13 s with prefetch):

```python
# torchrun --nproc_per_node 2 repro.py Qwen/Qwen3-30B-A3B
# run once as-is, once with HF_SHARD_PREFETCH=4
import glob, os, sys, time
from datetime import timedelta
import torch
from huggingface_hub import snapshot_download
from transformers import AutoModelForCausalLM
from transformers.distributed import DistributedConfig

model_id = sys.argv[1]
torch.distributed.init_process_group(backend="nccl", timeout=timedelta(hours=1))
torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))

if int(os.environ["RANK"]) == 0:  # evict the checkpoint from the page cache: genuinely cold, no root needed
    for f in glob.glob(os.path.join(snapshot_download(model_id, allow_patterns=["*.safetensors"]), "*.safetensors")):
        fd = os.open(f, os.O_RDONLY)
        os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
        os.close(fd)
torch.distributed.barrier()

t0 = time.time()
AutoModelForCausalLM.from_pretrained(
    model_id, dtype=torch.bfloat16,
    distributed_config=DistributedConfig(tp_size=int(os.environ["WORLD_SIZE"]), enable_expert_parallel=True),
)
torch.distributed.barrier()
if int(os.environ["RANK"]) == 0:
    print(f"loaded in {time.time() - t0:.0f}s (HF_SHARD_PREFETCH={os.environ.get('HF_SHARD_PREFETCH', 'unset')})")
```

Usage:

```bash
HF_SHARD_PREFETCH=4 torchrun --nproc_per_node 8 train.py  # any from_pretrained with checkpoint files
```

Found while fine-tuning 100B–753B MoEs with FSDP2 × EP (#48204).


Part of the loading-performance work tracked in #48239.
