### PR TITLE
Fix InternVL NumPy cumsum tensor conversion

### DIFF
--- a/src/transformers/models/internvl/processing_internvl.py
+++ b/src/transformers/models/internvl/processing_internvl.py
@@ -107,7 +107,10 @@ class InternVLProcessor(ProcessorMixin):
 
         # Merge image and video pixel into a single array, as model expects only `pixel_values` as arg
         if images is not None:
-            image_num_patches_indices = np.cumsum(model_inputs.pop("num_patches"))
+            num_patches = model_inputs.pop("num_patches")
+            if hasattr(num_patches, "tolist"):
+                num_patches = num_patches.tolist()
+            image_num_patches_indices = np.cumsum(num_patches)
         if videos is not None:
             video_pixel_values = model_inputs.pop("pixel_values_videos")
             batch_size, num_frames, *_ = video_pixel_values.shape

--- a/tests/models/internvl/test_processing_internvl.py
+++ b/tests/models/internvl/test_processing_internvl.py
@@ -14,7 +14,9 @@
 
 import inspect
 import unittest
+from unittest.mock import patch
 
+import numpy as np
 from parameterized import parameterized
 
 from transformers import InternVLProcessor
@@ -84,6 +86,19 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         self.assertTrue("num_image_patches" in output)
         self.assertEqual(len(output["num_image_patches"]), 3)
+
+    @require_torch
+    def test_image_patch_offsets_do_not_pass_torch_tensor_to_numpy(self):
+        processor = self.get_processor()
+
+        original_cumsum = np.cumsum
+
+        def check_input(values):
+            self.assertIsInstance(values, list)
+            return original_cumsum(values)
+
+        with patch("transformers.models.internvl.processing_internvl.np.cumsum", side_effect=check_input):
+            processor(text=processor.image_token, images=[np.zeros((20, 20, 3), dtype=np.uint8)], return_tensors="pt")
 
     @require_av
     @require_torch


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48231&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48231) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48231&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48231)
<!-- ci-dashboard-badge:end -->

Fixes #48177.\n\nInternVL receives num_patches as a torch tensor when return_tensors is set to pt. Convert it to Python values before calling NumPy cumsum so the processor does not enter NumPy's deprecated tensor wrapping path. The existing list behavior remains unchanged.\n\nAdded a regression test that verifies NumPy receives a list of patch counts.\n\nValidation: python3 -m py_compile passed. The targeted pytest could not be collected locally because the checkout dependencies do not include the transformers package.