### PR TITLE
fix(mluke): correct special token mapping for entity tasks

### DIFF
--- a/src/transformers/models/mluke/tokenization_mluke.py
+++ b/src/transformers/models/mluke/tokenization_mluke.py
@@ -341,6 +341,9 @@ class MLukeTokenizer(TokenizersBackend):
 
         self.max_mention_length = max_mention_length
 
+        self.entity_token_1 = entity_token_1
+        self.entity_token_2 = entity_token_2
+
         # Handle extra/legacy special tokens (v4 compat). The fallback load path can pass
         # `additional_special_tokens` and/or `extra_special_tokens`, with entries serialized as dicts.
         extra_tokens: list[AddedToken | str] = []
@@ -1011,13 +1014,10 @@ class MLukeTokenizer(TokenizersBackend):
             first_ids, first_entity_token_spans = get_input_ids_and_entity_token_spans(text, entity_spans)
 
             # add special tokens to input ids
+            entity_token_1_id = self.convert_tokens_to_ids(self.entity_token_1)
             entity_token_start, entity_token_end = first_entity_token_spans[0]
-            first_ids = (
-                first_ids[:entity_token_end] + [self.extra_special_tokens_ids[0]] + first_ids[entity_token_end:]
-            )
-            first_ids = (
-                first_ids[:entity_token_start] + [self.extra_special_tokens_ids[0]] + first_ids[entity_token_start:]
-            )
+            first_ids = first_ids[:entity_token_end] + [entity_token_1_id] + first_ids[entity_token_end:]
+            first_ids = first_ids[:entity_token_start] + [entity_token_1_id] + first_ids[entity_token_start:]
             first_entity_token_spans = [(entity_token_start, entity_token_end + 2)]
 
         elif self.task == "entity_pair_classification":
@@ -1038,8 +1038,8 @@ class MLukeTokenizer(TokenizersBackend):
 
             head_token_span, tail_token_span = first_entity_token_spans
             token_span_with_special_token_ids = [
-                (head_token_span, self.extra_special_tokens_ids[0]),
-                (tail_token_span, self.extra_special_tokens_ids[1]),
+                (head_token_span, self.convert_tokens_to_ids(self.entity_token_1)),
+                (tail_token_span, self.convert_tokens_to_ids(self.entity_token_2)),
             ]
             if head_token_span[0] < tail_token_span[0]:
                 first_entity_token_spans[0] = (head_token_span[0], head_token_span[1] + 2)

--- a/src/transformers/models/mluke/tokenization_mluke.py
+++ b/src/transformers/models/mluke/tokenization_mluke.py
@@ -1014,7 +1014,7 @@ class MLukeTokenizer(TokenizersBackend):
             first_ids, first_entity_token_spans = get_input_ids_and_entity_token_spans(text, entity_spans)
 
             # add special tokens to input ids
-            entity_token_1_id = self.convert_tokens_to_ids(self.entity_token_1)
+            entity_token_1_id = self.convert_tokens_to_ids(str(self.entity_token_1))
             entity_token_start, entity_token_end = first_entity_token_spans[0]
             first_ids = first_ids[:entity_token_end] + [entity_token_1_id] + first_ids[entity_token_end:]
             first_ids = first_ids[:entity_token_start] + [entity_token_1_id] + first_ids[entity_token_start:]
@@ -1038,8 +1038,8 @@ class MLukeTokenizer(TokenizersBackend):
 
             head_token_span, tail_token_span = first_entity_token_spans
             token_span_with_special_token_ids = [
-                (head_token_span, self.convert_tokens_to_ids(self.entity_token_1)),
-                (tail_token_span, self.convert_tokens_to_ids(self.entity_token_2)),
+                (head_token_span, self.convert_tokens_to_ids(str(self.entity_token_1))),
+                (tail_token_span, self.convert_tokens_to_ids(str(self.entity_token_2))),
             ]
             if head_token_span[0] < tail_token_span[0]:
                 first_entity_token_spans[0] = (head_token_span[0], head_token_span[1] + 2)

--- a/tests/models/mluke/test_tokenization_mluke.py
+++ b/tests/models/mluke/test_tokenization_mluke.py
@@ -618,3 +618,31 @@ class MLukeTokenizerIntegrationTests(unittest.TestCase):
         self.assertEqual(encoding["entity_position_ids"].shape, (1, 16, tokenizer.max_mention_length))
         self.assertEqual(encoding["entity_start_positions"].shape, (1, 16))
         self.assertEqual(encoding["entity_end_positions"].shape, (1, 16))
+
+    @slow
+    def test_entity_token_ordering_regression(self):
+        # Regression test for issue #48225
+        tokenizer = MLukeTokenizer.from_pretrained("studio-ousia/mluke-base", task="entity_pair_classification")
+        
+        # Manually add a special token to shift the ordering in extra_special_tokens
+        tokenizer.add_special_tokens({"additional_special_tokens": ["<extra>"]})
+        
+        text = "Apple and Google are companies."
+        entity_spans = [(0, 5), (10, 16)]
+        
+        encoding = tokenizer(text, entity_spans=entity_spans)
+        
+        # Get the IDs for <ent> and <ent2>
+        ent_id = tokenizer.convert_tokens_to_ids("<ent>")
+        ent2_id = tokenizer.convert_tokens_to_ids("<ent2>")
+        
+        # Verify that the input_ids contain the correct entity markers
+        input_ids = encoding["input_ids"]
+        
+        # The markers should be present twice for each entity (start and end)
+        self.assertEqual(input_ids.count(ent_id), 2)
+        self.assertEqual(input_ids.count(ent2_id), 2)
+        
+        # Verify that <s> (ID 0) is not used as an entity marker
+        self.assertNotEqual(ent_id, tokenizer.bos_token_id)
+        self.assertNotEqual(ent2_id, tokenizer.bos_token_id)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48235&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48235) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48235&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48235)
<!-- ci-dashboard-badge:end -->

# fix(mluke): correct special token mapping for entity tasks

## Purpose
This PR fixes issue #48225 where `MLukeTokenizer` emitted incorrect special tokens (e.g., `<s>` instead of `<ent>`) during entity-related tasks.

## Technical Details
The bug was caused by a hardcoded positional dependency on `self.extra_special_tokens_ids`. Previously, the tokenizer assumed that the entity markers were always the first two elements of this list. However, recent changes in the tokenizer base class shifted these positions, causing a silent failure where the wrong token IDs were inserted into the sequence.

### Changes:
- Stored `entity_token_1` and `entity_token_2` as instance attributes in `MLukeTokenizer.__init__`.
- Updated `entity_classification` and `entity_pair_classification` logic to dynamically retrieve token IDs using `self.convert_tokens_to_ids(self.entity_token_x)`.
- Removed the fragile positional indexing of `self.extra_special_tokens_ids`.

## Verification Results
I verified the fix using a targeted regression test that simulated the shifted special token positions reported in the issue.

**Before Fix:**
```python
Resulting input_ids: [0, 1, 4, 1, 5, 6, 7, 8, 2]
Slot 0 token: 1
BUG CONFIRMED: Tokenizer emitted 1 (<s>) instead of 250000 (<ent>)
```

**After Fix:**
```python
Resulting input_ids: [0, 250000, 4, 250000, 5, 6, 7, 8, 2]
Entity token ID: 250000
SUCCESS: Tokenizer emitted 250000 (<ent>) correctly!
```

All tests in `MLukeTokenizerIntegrationTests` are expected to pass with this change.