### PR TITLE
Fix T5 tied weights order for lm_head

### DIFF
--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -900,9 +900,9 @@ class T5ForConditionalGeneration(T5PreTrainedModel, GenerationMixin):
         "decoder.block.0.layer.1.EncDecAttention.relative_attention_bias.weight",
     ]
     _tied_weights_keys = {
-        "lm_head.weight": "shared.weight",
         "encoder.embed_tokens.weight": "shared.weight",
         "decoder.embed_tokens.weight": "shared.weight",
+        "lm_head.weight": "shared.weight",
     }
 
     def __init__(self, config: T5Config):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48238&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48238) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48238&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48238)
<!-- ci-dashboard-badge:end -->

Reorders the keys in \_tied_weights_keys\ so that \lm_head.weight\ is last. This prevents checkpoints like \madlad400-3b-mt\ that have separate \lm_head\ weights from tying \encoder.embed_tokens.weight\ incorrectly when \shared.weight\ is absent. Fixes #48154