### PR TITLE
Fix MiniMaxM2 partial RoPE: map legacy `rotary_dim` to `partial_rotary_factor`

### DIFF
--- a/src/transformers/models/minimax_m2/configuration_minimax_m2.py
+++ b/src/transformers/models/minimax_m2/configuration_minimax_m2.py
@@ -97,5 +97,16 @@ class MiniMaxM2Config(PreTrainedConfig):
     router_jitter_noise: float = 0.0
     rope_parameters: RopeParameters | dict | None = None
 
+    def convert_rope_params_to_dict(self, **kwargs):
+        # Released MiniMax-M2 checkpoints express partial RoPE through a legacy
+        # `rotary_dim` field (e.g. 64 of head_dim 128) instead of
+        # `partial_rotary_factor`; their original remote-code config derived the
+        # factor in `__init__`. Without this mapping the model silently rotates
+        # the full head dimension with the wrong frequency ladder.
+        rotary_dim = kwargs.get("rotary_dim", getattr(self, "rotary_dim", None))
+        if rotary_dim is not None:
+            kwargs.setdefault("partial_rotary_factor", rotary_dim / self.head_dim)
+        return super().convert_rope_params_to_dict(**kwargs)
+
 
 __all__ = ["MiniMaxM2Config"]

--- a/src/transformers/models/minimax_m2/modular_minimax_m2.py
+++ b/src/transformers/models/minimax_m2/modular_minimax_m2.py
@@ -116,6 +116,17 @@ class MiniMaxM2Config(PreTrainedConfig):
     router_jitter_noise: float = 0.0
     rope_parameters: RopeParameters | dict | None = None
 
+    def convert_rope_params_to_dict(self, **kwargs):
+        # Released MiniMax-M2 checkpoints express partial RoPE through a legacy
+        # `rotary_dim` field (e.g. 64 of head_dim 128) instead of
+        # `partial_rotary_factor`; their original remote-code config derived the
+        # factor in `__init__`. Without this mapping the model silently rotates
+        # the full head dimension with the wrong frequency ladder.
+        rotary_dim = kwargs.get("rotary_dim", getattr(self, "rotary_dim", None))
+        if rotary_dim is not None:
+            kwargs.setdefault("partial_rotary_factor", rotary_dim / self.head_dim)
+        return super().convert_rope_params_to_dict(**kwargs)
+
 
 class MiniMaxM2TopKRouter(MixtralTopKRouter):
     def forward(self, hidden_states, e_score_correction_bias):

--- a/tests/models/minimax_m2/test_modeling_minimax_m2.py
+++ b/tests/models/minimax_m2/test_modeling_minimax_m2.py
@@ -31,6 +31,7 @@ if is_torch_available():
     import torch
 
     from transformers import (
+        MiniMaxM2Config,
         MiniMaxM2ForCausalLM,
         MiniMaxM2Model,
     )
@@ -88,6 +89,29 @@ class MiniMaxM2ModelTest(CausalLMModelTest, unittest.TestCase):
 
         # This is to mimic torch.testing.assert_not_close
         self.assertNotAlmostEqual(include_padding_result.aux_loss.item(), result.aux_loss.item())
+
+    def test_legacy_rotary_dim_maps_to_partial_rotary_factor(self):
+        r"""
+        Released MiniMax-M2 checkpoints express partial RoPE through a legacy `rotary_dim`
+        config field (64 of head_dim 128); it must reach `rope_parameters` so the rotary
+        embedding only rotates `rotary_dim` dims instead of the full head dimension.
+        """
+        from transformers.models.minimax_m2.modeling_minimax_m2 import MiniMaxM2RotaryEmbedding
+
+        config = MiniMaxM2Config(rotary_dim=64)
+        self.assertEqual(config.rope_parameters["partial_rotary_factor"], 0.5)
+        # inv_freq holds one frequency per rotated dim pair: rotary_dim // 2.
+        self.assertEqual(MiniMaxM2RotaryEmbedding(config).inv_freq.shape[0], 32)
+
+        # An explicit partial factor still wins over the legacy field.
+        config = MiniMaxM2Config(
+            rotary_dim=64,
+            rope_parameters={"rope_theta": 5_000_000.0, "rope_type": "default", "partial_rotary_factor": 0.25},
+        )
+        self.assertEqual(config.rope_parameters["partial_rotary_factor"], 0.25)
+
+        # Configs without the legacy field keep full-width rotary.
+        self.assertIsNone(MiniMaxM2Config().rope_parameters.get("partial_rotary_factor"))
 
 
 @slow


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48242&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48242) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48242&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48242)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48241.

All released `MiniMaxAI/MiniMax-M2*` checkpoints are trained with partial RoPE (`rotary_dim: 64` of `head_dim: 128`) and express it through a legacy `rotary_dim` config field; their original remote-code config derived `partial_rotary_factor = rotary_dim / head_dim` in `__init__`. The in-tree `MiniMaxM2Config` keeps `rotary_dim` as an opaque extra attribute, so `rope_parameters` never receives a partial factor and `MiniMaxM2RotaryEmbedding` silently rotates the full head dimension with a full-width frequency ladder — wrong frequency spacing *and* wrong rotate-half pairing in every attention layer (measured: mean KL 13.1 / cosine 0.02 vs a faithful reference on MiniMax-M2.7 over 2,048 tokens; details in the issue).

This maps the legacy field in a `convert_rope_params_to_dict` override on `MiniMaxM2Config` (in `modular_minimax_m2.py`, generated file regenerated), following the `GPTNeoXConfig` `rotary_pct` precedent:

- `MiniMaxM2Config(rotary_dim=64)` → `rope_parameters["partial_rotary_factor"] == 0.5`, `inv_freq` length 32;
- an explicit `partial_rotary_factor` in `rope_parameters` still wins;
- configs without `rotary_dim` are unaffected.

## Before submitting
- [ ] This PR fixes a typo or improves the docs
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a Github issue? #48241
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? `test_legacy_rotary_dim_maps_to_partial_rotary_factor` (covers legacy mapping, explicit-factor priority, and the no-legacy-field case; `utils/check_modular_conversion.py` passes)

## Who can review?

@ArthurZucker @Cyrilvallez