### PR TITLE
[xcodec2] Fix flex attention and flash dispatch tests

### DIFF
--- a/tests/models/xcodec2/test_modeling_xcodec2.py
+++ b/tests/models/xcodec2/test_modeling_xcodec2.py
@@ -202,6 +202,23 @@ class Xcodec2ModelTest(ModelTesterMixin, unittest.TestCase):
     def test_hidden_states_output(self):
         pass
 
+    @unittest.skip(
+        reason="The Wav2Vec2Bert semantic encoder uses relative position embeddings that produce a dense attention bias incompatible with Flash Attention"
+    )
+    def test_sdpa_can_dispatch_on_flash(self):
+        pass
+
+    @staticmethod
+    def _prepare_config_headdim(config, requested_dim):
+        """
+        Override to keep `quantization_dim` in sync with the encoder outputs. The quantizer consumes the
+        concatenation of the acoustic and semantic encoder outputs, i.e. `hidden_size +
+        semantic_model_config.hidden_size`, and both hidden sizes are scaled when adjusting the head dim.
+        """
+        config = ModelTesterMixin._prepare_config_headdim(config, requested_dim)
+        config.quantization_dim = config.hidden_size + config.semantic_model_config.hidden_size
+        return config
+
 
 @slow
 @require_torch


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48244&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48244) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48244&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48244)
<!-- ci-dashboard-badge:end -->

Fixes the two xcodec2 failures bisected to #46196
([comment](https://github.com/huggingface/transformers/pull/46196#issuecomment-5372446844)).

Both were silently skipped until #46196 turned on `_supports_sdpa` / `_supports_flex_attn`
for `Wav2Vec2BertPreTrainedModel`, which xcodec2 uses as its semantic encoder. The modeling
code is fine, both fixes are in the test file.

**`test_sdpa_can_dispatch_on_flash`** — wav2vec2-bert's `relative_key` position bias is a
dense additive mask, which the flash backend rejects. Skipped, same reason as the identical
skip in the wav2vec2-bert tests.

**`test_flex_attention_with_grads`** — `_prepare_config_headdim` scales `hidden_size` on the
config and every sub-config, breaking the tester's
`quantization_dim == hidden_size + semantic_model_config.hidden_size` invariant. Restored in
an override, like janus/blip_2/instructblip do for theirs.

## Tests

```
tests/models/xcodec2/  ->  105 passed, 56 skipped, 7784 subtests passed
```

Remaining failures in the full run are environment-only here (`torchaudio` missing, ABI
mismatch in the prebuilt `kernels-community/rotary` binary) and also fail on `main`.

cc @IlyasMoutawwakil @YangKai0616