### PR TITLE
Fix `BayesianDetectorModel.from_pretrained()` by calling `post_init()`

### DIFF
--- a/src/transformers/generation/watermarking.py
+++ b/src/transformers/generation/watermarking.py
@@ -386,6 +386,8 @@ class BayesianDetectorModel(PreTrainedModel):
         )
         self.prior = torch.nn.Parameter(torch.tensor([self.base_rate]))
 
+        self.post_init()
+
     @torch.no_grad()
     def _init_weights(self, module):
         """Initialize the weights."""


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48254&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48254) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48254&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48254)
<!-- ci-dashboard-badge:end -->

Fixes #48253

### What

`BayesianDetectorModel` (the trained SynthID-Text detector) can be saved but not
loaded. `save_pretrained()` succeeds; `from_pretrained()` always raises:

```
AttributeError: 'BayesianDetectorModel' object has no attribute 'all_tied_weights_keys'
```

### Why

`all_tied_weights_keys` is assigned in `PreTrainedModel.tie_weights()`
(`modeling_utils.py:1388`), reached via `post_init()`.

`BayesianDetectorModel.__init__` never calls `self.post_init()` — it ends at
`self.prior = torch.nn.Parameter(...)`. The attribute is therefore never created,
and `_move_missing_keys_from_meta_to_device` dereferences it unconditionally.

The class still declares the older `_tied_weights_keys`, which suggests it was
missed when `all_tied_weights_keys` was introduced.

### Reproduction (no weights or network)

```python
import tempfile
from transformers import BayesianDetectorConfig, BayesianDetectorModel

with tempfile.TemporaryDirectory() as d:
    BayesianDetectorModel(BayesianDetectorConfig(watermarking_depth=30)).save_pretrained(d)
    BayesianDetectorModel.from_pretrained(d)   # AttributeError before this patch
```

Verified: passes with this change, fails without it.

### Impact

Training and detection are normally separate processes, so in practice a trained
SynthID detector could not be used at all. This is likely why it went unnoticed —
the affected path only runs if you train your own detector, and `transformers`
ships no training routine for one.

### Note for reviewers

I could not find a test covering `BayesianDetectorModel` round-tripping. Happy to
add one if you would like it — a save/load assertion in
`tests/generation/test_watermarking.py` would have caught this.