### PR TITLE
Normalize HunYuanVL's legacy field aliases via attribute_map

### DIFF
--- a/src/transformers/models/hunyuan_vl/configuration_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/configuration_hunyuan_vl.py
@@ -184,6 +184,8 @@ class HunYuanVLTextConfig(PreTrainedConfig):
     }
 
     attribute_map = {
+        "attention_head_dim": "head_dim",
+        "org_vocab_size": "vocab_size",
         "pad_id": "pad_token_id",
     }
 
@@ -191,8 +193,9 @@ class HunYuanVLTextConfig(PreTrainedConfig):
 
     def __post_init__(self, **kwargs):
         # Legacy aliases (`pad_id`, `attention_head_dim`, `org_vocab_size`) are normalized onto canonical fields by the
-        # base `__setattr__` via `attribute_map`, so no manual translation is needed here. The MoE/MLA hyperparameters
-        # the OCR checkpoints inherited from the Tencent MoE codebase have no counterpart in this dense-only variant.
+        # base `__setattr__` via `attribute_map`, so no manual translation is needed here -- every public Tencent
+        # checkpoint stores them with the same value as the canonical field. The MoE/MLA hyperparameters the OCR
+        # checkpoints inherited from the Tencent MoE codebase have no counterpart at all in this dense-only variant.
         for key in _LEGACY_MOE_MLA_KEYS:
             kwargs.pop(key, None)
         if self.num_key_value_heads is None:
@@ -309,7 +312,12 @@ class HunYuanVLConfig(PreTrainedConfig):
         # nested `text_config` block) we fold the recognized text-side keys into the text config payload. This keeps
         # ``HunYuanVLConfig.from_pretrained(...)`` working with both the upstream nested layout and the existing
         # public OCR checkpoints.
-        text_keys = set(self.sub_configs["text_config"].__dataclass_fields__) | {"rope_scaling", "rope_theta"}
+        text_config_class = self.sub_configs["text_config"]
+        text_keys = (
+            set(text_config_class.__dataclass_fields__)
+            | set(text_config_class.attribute_map)
+            | {"rope_scaling", "rope_theta"}
+        )
         text_kwargs = {key: kwargs.pop(key) for key in list(kwargs) if key in text_keys}
         for key in _LEGACY_MOE_MLA_KEYS:
             kwargs.pop(key, None)
@@ -320,9 +328,9 @@ class HunYuanVLConfig(PreTrainedConfig):
             self.vision_config = self.sub_configs["vision_config"]()
 
         if isinstance(self.text_config, dict):
-            self.text_config = self.sub_configs["text_config"](**{**self.text_config, **text_kwargs})
+            self.text_config = text_config_class(**{**self.text_config, **text_kwargs})
         elif self.text_config is None:
-            self.text_config = self.sub_configs["text_config"](**text_kwargs)
+            self.text_config = text_config_class(**text_kwargs)
 
         # Keep the vision tower in sync with the consuming text backbone size.
         self.vision_config.text_hidden_size = self.text_config.hidden_size

--- a/src/transformers/models/hunyuan_vl/configuration_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/configuration_hunyuan_vl.py
@@ -89,6 +89,37 @@ class HunYuanVLVisionConfig(PreTrainedConfig):
         super().__post_init__(**kwargs)
 
 
+# The public HunYuanOCR checkpoints were exported from the Tencent MoE codebase and still persist its routing and
+# multi-head-latent-attention hyperparameters on disk (e.g. a vestigial `num_experts=1`). This variant is dense-only
+# and models none of them, so they would otherwise be re-attached as untyped attributes by
+# `PreTrainedConfig.__post_init__` and round-trip back out through `save_pretrained`.
+_LEGACY_MOE_MLA_KEYS = (
+    "expert_hidden_dim",
+    "first_k_dense_replace",
+    "group_limited_greedy",
+    "kv_lora_rank",
+    "moe_drop_tokens",
+    "moe_intermediate_size",
+    "moe_layer_num_skipped",
+    "moe_random_routing_dropped_token",
+    "moe_topk",
+    "n_group",
+    "norm_topk_prob",
+    "num_experts",
+    "num_experts_per_tok",
+    "num_shared_expert",
+    "num_shared_experts",
+    "q_lora_rank",
+    "qk_nope_head_dim",
+    "qk_rope_head_dim",
+    "routed_scaling_factor",
+    "topk_group",
+    "use_mixed_mlp_moe",
+    "use_mla",
+    "v_head_dim",
+)
+
+
 @auto_docstring(
     custom_intro="""
     Text backbone configuration for the dense-only, image-text HunYuanVL open-source variant.
@@ -159,6 +190,11 @@ class HunYuanVLTextConfig(PreTrainedConfig):
     sep_token_id: int | None = 4
 
     def __post_init__(self, **kwargs):
+        # Legacy aliases (`pad_id`, `attention_head_dim`, `org_vocab_size`) are normalized onto canonical fields by the
+        # base `__setattr__` via `attribute_map`, so no manual translation is needed here. The MoE/MLA hyperparameters
+        # the OCR checkpoints inherited from the Tencent MoE codebase have no counterpart in this dense-only variant.
+        for key in _LEGACY_MOE_MLA_KEYS:
+            kwargs.pop(key, None)
         if self.num_key_value_heads is None:
             self.num_key_value_heads = self.num_attention_heads
         super().__post_init__(**kwargs)
@@ -275,6 +311,8 @@ class HunYuanVLConfig(PreTrainedConfig):
         # public OCR checkpoints.
         text_keys = set(self.sub_configs["text_config"].__dataclass_fields__) | {"rope_scaling", "rope_theta"}
         text_kwargs = {key: kwargs.pop(key) for key in list(kwargs) if key in text_keys}
+        for key in _LEGACY_MOE_MLA_KEYS:
+            kwargs.pop(key, None)
 
         if isinstance(self.vision_config, dict):
             self.vision_config = self.sub_configs["vision_config"](**self.vision_config)

--- a/src/transformers/models/hunyuan_vl/configuration_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/configuration_hunyuan_vl.py
@@ -89,37 +89,6 @@ class HunYuanVLVisionConfig(PreTrainedConfig):
         super().__post_init__(**kwargs)
 
 
-# The public HunYuanOCR checkpoints were exported from the Tencent MoE codebase and still persist its routing and
-# multi-head-latent-attention hyperparameters on disk (e.g. a vestigial `num_experts=1`). This variant is dense-only
-# and models none of them, so they would otherwise be re-attached as untyped attributes by
-# `PreTrainedConfig.__post_init__` and round-trip back out through `save_pretrained`.
-_LEGACY_MOE_MLA_KEYS = (
-    "expert_hidden_dim",
-    "first_k_dense_replace",
-    "group_limited_greedy",
-    "kv_lora_rank",
-    "moe_drop_tokens",
-    "moe_intermediate_size",
-    "moe_layer_num_skipped",
-    "moe_random_routing_dropped_token",
-    "moe_topk",
-    "n_group",
-    "norm_topk_prob",
-    "num_experts",
-    "num_experts_per_tok",
-    "num_shared_expert",
-    "num_shared_experts",
-    "q_lora_rank",
-    "qk_nope_head_dim",
-    "qk_rope_head_dim",
-    "routed_scaling_factor",
-    "topk_group",
-    "use_mixed_mlp_moe",
-    "use_mla",
-    "v_head_dim",
-)
-
-
 @auto_docstring(
     custom_intro="""
     Text backbone configuration for the dense-only, image-text HunYuanVL open-source variant.
@@ -192,12 +161,6 @@ class HunYuanVLTextConfig(PreTrainedConfig):
     sep_token_id: int | None = 4
 
     def __post_init__(self, **kwargs):
-        # Legacy aliases (`pad_id`, `attention_head_dim`, `org_vocab_size`) are normalized onto canonical fields by the
-        # base `__setattr__` via `attribute_map`, so no manual translation is needed here -- every public Tencent
-        # checkpoint stores them with the same value as the canonical field. The MoE/MLA hyperparameters the OCR
-        # checkpoints inherited from the Tencent MoE codebase have no counterpart at all in this dense-only variant.
-        for key in _LEGACY_MOE_MLA_KEYS:
-            kwargs.pop(key, None)
         if self.num_key_value_heads is None:
             self.num_key_value_heads = self.num_attention_heads
         super().__post_init__(**kwargs)
@@ -319,8 +282,6 @@ class HunYuanVLConfig(PreTrainedConfig):
             | {"rope_scaling", "rope_theta"}
         )
         text_kwargs = {key: kwargs.pop(key) for key in list(kwargs) if key in text_keys}
-        for key in _LEGACY_MOE_MLA_KEYS:
-            kwargs.pop(key, None)
 
         if isinstance(self.vision_config, dict):
             self.vision_config = self.sub_configs["vision_config"](**self.vision_config)

--- a/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
@@ -213,6 +213,8 @@ class HunYuanVLTextConfig(HunYuanDenseV1Config):
     }
 
     attribute_map = {
+        "attention_head_dim": "head_dim",
+        "org_vocab_size": "vocab_size",
         "pad_id": "pad_token_id",
     }
 
@@ -258,8 +260,9 @@ class HunYuanVLTextConfig(HunYuanDenseV1Config):
 
     def __post_init__(self, **kwargs):
         # Legacy aliases (`pad_id`, `attention_head_dim`, `org_vocab_size`) are normalized onto canonical fields by the
-        # base `__setattr__` via `attribute_map`, so no manual translation is needed here. The MoE/MLA hyperparameters
-        # the OCR checkpoints inherited from the Tencent MoE codebase have no counterpart in this dense-only variant.
+        # base `__setattr__` via `attribute_map`, so no manual translation is needed here -- every public Tencent
+        # checkpoint stores them with the same value as the canonical field. The MoE/MLA hyperparameters the OCR
+        # checkpoints inherited from the Tencent MoE codebase have no counterpart at all in this dense-only variant.
         for key in _LEGACY_MOE_MLA_KEYS:
             kwargs.pop(key, None)
         super().__post_init__(**kwargs)
@@ -337,7 +340,12 @@ class HunYuanVLConfig(Qwen2VLConfig):
         # nested `text_config` block) we fold the recognized text-side keys into the text config payload. This keeps
         # ``HunYuanVLConfig.from_pretrained(...)`` working with both the upstream nested layout and the existing
         # public OCR checkpoints.
-        text_keys = set(self.sub_configs["text_config"].__dataclass_fields__) | {"rope_scaling", "rope_theta"}
+        text_config_class = self.sub_configs["text_config"]
+        text_keys = (
+            set(text_config_class.__dataclass_fields__)
+            | set(text_config_class.attribute_map)
+            | {"rope_scaling", "rope_theta"}
+        )
         text_kwargs = {key: kwargs.pop(key) for key in list(kwargs) if key in text_keys}
         for key in _LEGACY_MOE_MLA_KEYS:
             kwargs.pop(key, None)
@@ -348,9 +356,9 @@ class HunYuanVLConfig(Qwen2VLConfig):
             self.vision_config = self.sub_configs["vision_config"]()
 
         if isinstance(self.text_config, dict):
-            self.text_config = self.sub_configs["text_config"](**{**self.text_config, **text_kwargs})
+            self.text_config = text_config_class(**{**self.text_config, **text_kwargs})
         elif self.text_config is None:
-            self.text_config = self.sub_configs["text_config"](**text_kwargs)
+            self.text_config = text_config_class(**text_kwargs)
 
         # Keep the vision tower in sync with the consuming text backbone size.
         self.vision_config.text_hidden_size = self.text_config.hidden_size

--- a/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
@@ -76,37 +76,6 @@ class HunYuanVLModelOutputWithPast(BaseModelOutputWithPast):
     image_hidden_states: torch.FloatTensor | None = None
 
 
-# The public HunYuanOCR checkpoints were exported from the Tencent MoE codebase and still persist its routing and
-# multi-head-latent-attention hyperparameters on disk (e.g. a vestigial `num_experts=1`). This variant is dense-only
-# and models none of them, so they would otherwise be re-attached as untyped attributes by
-# `PreTrainedConfig.__post_init__` and round-trip back out through `save_pretrained`.
-_LEGACY_MOE_MLA_KEYS = (
-    "expert_hidden_dim",
-    "first_k_dense_replace",
-    "group_limited_greedy",
-    "kv_lora_rank",
-    "moe_drop_tokens",
-    "moe_intermediate_size",
-    "moe_layer_num_skipped",
-    "moe_random_routing_dropped_token",
-    "moe_topk",
-    "n_group",
-    "norm_topk_prob",
-    "num_experts",
-    "num_experts_per_tok",
-    "num_shared_expert",
-    "num_shared_experts",
-    "q_lora_rank",
-    "qk_nope_head_dim",
-    "qk_rope_head_dim",
-    "routed_scaling_factor",
-    "topk_group",
-    "use_mixed_mlp_moe",
-    "use_mla",
-    "v_head_dim",
-)
-
-
 @auto_docstring(
     custom_intro="""
     Vision backbone configuration for the dense-only, image-text HunYuanVL open-source variant.
@@ -261,10 +230,7 @@ class HunYuanVLTextConfig(HunYuanDenseV1Config):
     def __post_init__(self, **kwargs):
         # Legacy aliases (`pad_id`, `attention_head_dim`, `org_vocab_size`) are normalized onto canonical fields by the
         # base `__setattr__` via `attribute_map`, so no manual translation is needed here -- every public Tencent
-        # checkpoint stores them with the same value as the canonical field. The MoE/MLA hyperparameters the OCR
-        # checkpoints inherited from the Tencent MoE codebase have no counterpart at all in this dense-only variant.
-        for key in _LEGACY_MOE_MLA_KEYS:
-            kwargs.pop(key, None)
+        # checkpoint stores them with the same value as the canonical field.
         super().__post_init__(**kwargs)
         rope_parameters = getattr(self, "rope_parameters", None)
         head_dim = self.head_dim if self.head_dim is not None else self.hidden_size // self.num_attention_heads
@@ -347,8 +313,6 @@ class HunYuanVLConfig(Qwen2VLConfig):
             | {"rope_scaling", "rope_theta"}
         )
         text_kwargs = {key: kwargs.pop(key) for key in list(kwargs) if key in text_keys}
-        for key in _LEGACY_MOE_MLA_KEYS:
-            kwargs.pop(key, None)
 
         if isinstance(self.vision_config, dict):
             self.vision_config = self.sub_configs["vision_config"](**self.vision_config)

--- a/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
+++ b/src/transformers/models/hunyuan_vl/modular_hunyuan_vl.py
@@ -76,6 +76,37 @@ class HunYuanVLModelOutputWithPast(BaseModelOutputWithPast):
     image_hidden_states: torch.FloatTensor | None = None
 
 
+# The public HunYuanOCR checkpoints were exported from the Tencent MoE codebase and still persist its routing and
+# multi-head-latent-attention hyperparameters on disk (e.g. a vestigial `num_experts=1`). This variant is dense-only
+# and models none of them, so they would otherwise be re-attached as untyped attributes by
+# `PreTrainedConfig.__post_init__` and round-trip back out through `save_pretrained`.
+_LEGACY_MOE_MLA_KEYS = (
+    "expert_hidden_dim",
+    "first_k_dense_replace",
+    "group_limited_greedy",
+    "kv_lora_rank",
+    "moe_drop_tokens",
+    "moe_intermediate_size",
+    "moe_layer_num_skipped",
+    "moe_random_routing_dropped_token",
+    "moe_topk",
+    "n_group",
+    "norm_topk_prob",
+    "num_experts",
+    "num_experts_per_tok",
+    "num_shared_expert",
+    "num_shared_experts",
+    "q_lora_rank",
+    "qk_nope_head_dim",
+    "qk_rope_head_dim",
+    "routed_scaling_factor",
+    "topk_group",
+    "use_mixed_mlp_moe",
+    "use_mla",
+    "v_head_dim",
+)
+
+
 @auto_docstring(
     custom_intro="""
     Vision backbone configuration for the dense-only, image-text HunYuanVL open-source variant.
@@ -227,7 +258,10 @@ class HunYuanVLTextConfig(HunYuanDenseV1Config):
 
     def __post_init__(self, **kwargs):
         # Legacy aliases (`pad_id`, `attention_head_dim`, `org_vocab_size`) are normalized onto canonical fields by the
-        # base `__setattr__` via `attribute_map`, so no manual translation is needed here.
+        # base `__setattr__` via `attribute_map`, so no manual translation is needed here. The MoE/MLA hyperparameters
+        # the OCR checkpoints inherited from the Tencent MoE codebase have no counterpart in this dense-only variant.
+        for key in _LEGACY_MOE_MLA_KEYS:
+            kwargs.pop(key, None)
         super().__post_init__(**kwargs)
         rope_parameters = getattr(self, "rope_parameters", None)
         head_dim = self.head_dim if self.head_dim is not None else self.hidden_size // self.num_attention_heads
@@ -305,6 +339,8 @@ class HunYuanVLConfig(Qwen2VLConfig):
         # public OCR checkpoints.
         text_keys = set(self.sub_configs["text_config"].__dataclass_fields__) | {"rope_scaling", "rope_theta"}
         text_kwargs = {key: kwargs.pop(key) for key in list(kwargs) if key in text_keys}
+        for key in _LEGACY_MOE_MLA_KEYS:
+            kwargs.pop(key, None)
 
         if isinstance(self.vision_config, dict):
             self.vision_config = self.sub_configs["vision_config"](**self.vision_config)

--- a/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
+++ b/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
@@ -246,6 +246,31 @@ class HunYuanVLModelTest(VLMModelTest, unittest.TestCase):
         self.assertEqual(text_config.rope_parameters["mrope_section"], [2, 2, 2, 2])
         self.assertNotIn("xdrope_section", text_config.rope_parameters)
 
+    def test_legacy_moe_keys_are_dropped(self):
+        # The public OCR checkpoints were exported from the Tencent MoE codebase and still carry its routing and MLA
+        # hyperparameters (notably a vestigial `num_experts=1`). This variant is dense-only, so they must not survive
+        # loading, nor be written back out by `save_pretrained`.
+        legacy_kwargs = {
+            "num_experts": 1,
+            "num_experts_per_tok": 1,
+            "moe_topk": 1,
+            "num_shared_experts": 1,
+            "use_mixed_mlp_moe": False,
+            "routed_scaling_factor": 1.0,
+            "use_mla": False,
+            "kv_lora_rank": 512,
+        }
+
+        text_config = HunYuanVLTextConfig(**legacy_kwargs)
+        config = HunYuanVLConfig(**legacy_kwargs, text_config=legacy_kwargs)
+
+        for key in legacy_kwargs:
+            self.assertFalse(hasattr(text_config, key), f"`{key}` should not be set on the text config")
+            self.assertFalse(hasattr(config, key), f"`{key}` should not be set on the config")
+            self.assertFalse(hasattr(config.text_config, key), f"`{key}` should not be set on the text config")
+            self.assertNotIn(key, config.to_dict())
+            self.assertNotIn(key, config.to_dict()["text_config"])
+
     def test_mismatching_num_image_tokens(self):
         config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
         for model_class in self.all_model_classes:

--- a/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
+++ b/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
@@ -271,6 +271,26 @@ class HunYuanVLModelTest(VLMModelTest, unittest.TestCase):
             self.assertNotIn(key, config.to_dict())
             self.assertNotIn(key, config.to_dict()["text_config"])
 
+    def test_legacy_field_aliases_normalize_onto_canonical_fields(self):
+        # `attention_head_dim` / `org_vocab_size` / `pad_id` are the names the Tencent codebase uses for `head_dim` /
+        # `vocab_size` / `pad_token_id`; every public checkpoint stores both spellings with the same value. They must
+        # fold onto the canonical field rather than linger as duplicate attributes.
+        aliases = {"attention_head_dim": "head_dim", "org_vocab_size": "vocab_size", "pad_id": "pad_token_id"}
+        legacy_kwargs = {"attention_head_dim": 16, "org_vocab_size": 99, "pad_id": 7}
+
+        for config in (HunYuanVLTextConfig(**legacy_kwargs), HunYuanVLConfig(**legacy_kwargs).text_config):
+            for alias, canonical in aliases.items():
+                self.assertEqual(getattr(config, canonical), legacy_kwargs[alias])
+                # reading the alias keeps working, but it is not stored (and so not serialized) separately
+                self.assertEqual(getattr(config, alias), legacy_kwargs[alias])
+                self.assertNotIn(alias, config.__dict__)
+                self.assertNotIn(alias, config.to_dict())
+
+        # the top-level config folds them into `text_config` instead of keeping them at the root
+        config = HunYuanVLConfig(**legacy_kwargs)
+        for alias in aliases:
+            self.assertNotIn(alias, config.to_dict())
+
     def test_mismatching_num_image_tokens(self):
         config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
         for model_class in self.all_model_classes:

--- a/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
+++ b/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
@@ -246,31 +246,6 @@ class HunYuanVLModelTest(VLMModelTest, unittest.TestCase):
         self.assertEqual(text_config.rope_parameters["mrope_section"], [2, 2, 2, 2])
         self.assertNotIn("xdrope_section", text_config.rope_parameters)
 
-    def test_legacy_moe_keys_are_dropped(self):
-        # The public OCR checkpoints were exported from the Tencent MoE codebase and still carry its routing and MLA
-        # hyperparameters (notably a vestigial `num_experts=1`). This variant is dense-only, so they must not survive
-        # loading, nor be written back out by `save_pretrained`.
-        legacy_kwargs = {
-            "num_experts": 1,
-            "num_experts_per_tok": 1,
-            "moe_topk": 1,
-            "num_shared_experts": 1,
-            "use_mixed_mlp_moe": False,
-            "routed_scaling_factor": 1.0,
-            "use_mla": False,
-            "kv_lora_rank": 512,
-        }
-
-        text_config = HunYuanVLTextConfig(**legacy_kwargs)
-        config = HunYuanVLConfig(**legacy_kwargs, text_config=legacy_kwargs)
-
-        for key in legacy_kwargs:
-            self.assertFalse(hasattr(text_config, key), f"`{key}` should not be set on the text config")
-            self.assertFalse(hasattr(config, key), f"`{key}` should not be set on the config")
-            self.assertFalse(hasattr(config.text_config, key), f"`{key}` should not be set on the text config")
-            self.assertNotIn(key, config.to_dict())
-            self.assertNotIn(key, config.to_dict()["text_config"])
-
     def test_legacy_field_aliases_normalize_onto_canonical_fields(self):
         # `attention_head_dim` / `org_vocab_size` / `pad_id` are the names the Tencent codebase uses for `head_dim` /
         # `vocab_size` / `pad_token_id`; every public checkpoint stores both spellings with the same value. They must


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48261&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48261) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48261&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48261)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`HunYuanVLTextConfig`'s `__post_init__` carries this comment:

> Legacy aliases (`pad_id`, `attention_head_dim`, `org_vocab_size`) are normalized onto canonical fields by the base `__setattr__` via `attribute_map`, so no manual translation is needed here.

but `attribute_map` only ever listed `pad_id`. So `attention_head_dim` and `org_vocab_size` fell through `PreTrainedConfig.__post_init__`'s catch-all `setattr` loop and were re-attached as untyped attributes, duplicating `head_dim` / `vocab_size` and round-tripping back out through `save_pretrained`.

This PR adds the two missing entries so the code matches what the docstring already claims, and extends the "flat checkpoint" fold in `HunYuanVLConfig.__post_init__` to also recognize alias names, so a top-level `attention_head_dim` lands in `text_config` rather than sticking to the root config.

Every public Tencent checkpoint that persists these aliases (`tencent/HunyuanOCR`, `tencent/Hunyuan-7B-Instruct`, `tencent/Hunyuan-A13B-Instruct`) stores them with the same value as the canonical field, so nothing changes semantically — the alias stays readable via `attribute_map`, it just isn't stored (or serialized) twice.

A test covers the round-trip.

<details>
<summary>Originally this PR also dropped the legacy MoE/MLA keys</summary>

The `tencent/HunyuanOCR` config used to persist the routing and multi-head-latent-attention hyperparameters it inherited from the Tencent MoE codebase — most visibly `num_experts=1`, which made a dense-only OCR model advertise itself as a 1-expert MoE to anything downstream that sniffs the config. The first commit stripped them on load.

Tencent has since [updated the checkpoint](https://huggingface.co/tencent/HunyuanOCR/blob/main/config.json) to remove those fields, so that workaround is no longer needed and has been reverted (thanks @zucchini-nlp for chasing it upstream).

</details>

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Did you write any new necessary tests?

## Who can review?

@zucchini-nlp