### PR TITLE
Fix GlmConfig GQA head-count validation

### DIFF
--- a/src/transformers/models/glm/configuration_glm.py
+++ b/src/transformers/models/glm/configuration_glm.py
@@ -79,5 +79,16 @@ class GlmConfig(PreTrainedConfig):
             self.eos_token_id = [151329, 151336, 151338]
         super().__post_init__(**kwargs)
 
+    def validate_architecture(self):
+        """Part of ``@strict``-powered validation."""
+        super().validate_architecture()
+        if (
+            self.num_key_value_heads is not None
+            and self.num_attention_heads % self.num_key_value_heads != 0
+        ):
+            raise ValueError(
+                "`num_attention_heads` must be divisible by `num_key_value_heads` for grouped-query attention."
+            )
+
 
 __all__ = ["GlmConfig"]

--- a/tests/models/glm/test_modeling_glm.py
+++ b/tests/models/glm/test_modeling_glm.py
@@ -15,6 +15,7 @@
 
 import unittest
 
+import huggingface_hub
 import pytest
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, is_torch_available
@@ -34,8 +35,59 @@ if is_torch_available():
     import torch
 
     from transformers import (
+        GlmConfig,
+        GlmForCausalLM,
         GlmModel,
     )
+
+
+def _tiny_gqa_config(num_attention_heads=8, num_key_value_heads=2):
+    return GlmConfig(
+        vocab_size=128,
+        hidden_size=256,
+        intermediate_size=512,
+        num_hidden_layers=1,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=num_key_value_heads,
+        head_dim=32,
+        max_position_embeddings=64,
+        pad_token_id=0,
+        eos_token_id=1,
+    )
+
+
+@require_torch
+class GlmConfigTest(unittest.TestCase):
+    def test_default_gqa_config_is_valid(self):
+        config = GlmConfig()
+        config.validate_architecture()
+
+    def test_valid_gqa_config_forward(self):
+        config = _tiny_gqa_config(num_attention_heads=8, num_key_value_heads=2)
+        config.validate_architecture()
+
+        model = GlmForCausalLM(config).eval()
+        input_ids = torch.randint(2, config.vocab_size, (1, 8))
+        with torch.no_grad():
+            output = model(input_ids=input_ids)
+
+        self.assertEqual(output.logits.shape, (1, 8, config.vocab_size))
+
+    def test_invalid_gqa_config_raises_on_validate_architecture(self):
+        config = _tiny_gqa_config(num_attention_heads=8, num_key_value_heads=2)
+        config.num_attention_heads = 7
+
+        with self.assertRaises(ValueError) as context:
+            config.validate_architecture()
+
+        self.assertIn("divisible", str(context.exception))
+
+    def test_invalid_gqa_config_raises_on_construction(self):
+        with self.assertRaisesRegex(
+            huggingface_hub.errors.StrictDataclassClassValidationError,
+            "divisible",
+        ):
+            _tiny_gqa_config(num_attention_heads=7, num_key_value_heads=2)
 
 
 @require_torch


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48265&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48265) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48265&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48265)
<!-- ci-dashboard-badge:end -->

## Summary
Catch invalid GQA head counts in GlmConfig before forward pass.

Adds validate_architecture() to reject configs where num_attention_heads % num_key_value_heads != 0, plus tests for the happy path and the failure cases.

Fixes #48169

## Why
Configs like 7 query heads / 2 KV heads used to build fine, then die in SDPA with an unhelpful runtime error. Now they fail at config time with a clear message.

## Test plan
 Ran GlmConfigTest locally
 Style checks via CI (make style not run locally)