### PR TITLE
ignore mlinter ci file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ tags
 # checkers cache
 utils/.checkers_cache.json
 utils/.checkers_requirements.json
+mlinter-findings.json
 
 # modular conversion
 *.modular_backup


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48267&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48267) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48267&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48267)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`mlinter-findings.json` is created by the CI to provide developers feedback, we should ignore it in Git