### PR TITLE
Fix sliding window cache when assistant model calls generate

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -252,10 +252,16 @@ class DynamicSlidingWindowLayer(DynamicLayer):
         if not self.record_past:
             self.keys = full_key_states[:, :, -self.sliding_window + 1 :, :]
             self.values = full_value_states[:, :, -self.sliding_window + 1 :, :]
-        # If we record the past, we keep them all for now, and they'll be restricted to the window size in `crop`
+        # If we record the past, we keep all states so that `crop` can roll back later, but we can only ever attend to
+        # what `get_mask_sizes` advertises: return the last `sliding_window - 1 + query_length` states
         else:
             self.keys = full_key_states
             self.values = full_value_states
+            num_visible = self.sliding_window - 1 + key_states.shape[-2]
+            return (
+                full_key_states[:, :, -num_visible:, :],
+                full_value_states[:, :, -num_visible:, :],
+            )
 
         # Return the full states
         return full_key_states, full_value_states

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -78,6 +78,8 @@ if is_torch_available():
         GPT2LMHeadModel,
         GPT2Tokenizer,
         ImageGPTForCausalImageModeling,
+        LlamaConfig,
+        LlamaForCausalLM,
         SpeechEncoderDecoderModel,
     )
     from transformers.cache_utils import (
@@ -3949,6 +3951,68 @@ class GenerationIntegrationTests(unittest.TestCase):
             max_new_tokens=7,
         )
         self.assertTrue(out.shape[-1] <= (input_length + 7))
+
+    def test_assisted_decoding_sliding_window_matches_greedy_search(self):
+        # The prompt is longer than the sliding window, so the sliding window cache fills up during prefill and the
+        # assistant drafts several tokens between two crops: assisted decoding must not attend beyond-window states
+        config = LlamaConfig(
+            vocab_size=64,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=4,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=8,
+            max_position_embeddings=512,
+            sliding_window=6,
+        )
+        set_seed(1)
+        model = LlamaForCausalLM(config).eval()
+        input_ids = torch.randint(1, 60, (1, 12))
+        attention_mask = torch.ones_like(input_ids)
+
+        reference = model.generate(
+            do_sample=False, max_new_tokens=8, input_ids=input_ids, attention_mask=attention_mask
+        )
+        assisted = model.generate(
+            do_sample=False,
+            max_new_tokens=8,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            assistant_model=model,
+            num_assistant_tokens=5,
+            assistant_confidence_threshold=0.0,
+        )
+        self.assertTrue(torch.equal(reference, assisted))
+
+    def test_assisted_decoding_sliding_window_multi_token_draft(self):
+        # A low draft-confidence gate lets the assistant draft several tokens in one burst, so the sliding window
+        # cache is updated several times between two crops. Eager attention materializes the mask advertised by
+        # `get_mask_sizes`, so returning more states than that from `update` must hard-crash here rather than pass.
+        config = LlamaConfig(
+            vocab_size=64,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=4,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=8,
+            max_position_embeddings=512,
+            sliding_window=6,
+        )
+        set_seed(1)
+        model = LlamaForCausalLM._from_config(config, attn_implementation="eager").eval()
+        # The caller-level `assistant_confidence_threshold` is overridden by the assistant's own generation config
+        model.generation_config.assistant_confidence_threshold = 0.0
+        input_ids = torch.randint(1, 60, (1, 12))
+        _ = model.generate(
+            do_sample=False,
+            max_new_tokens=8,
+            input_ids=input_ids,
+            attention_mask=torch.ones_like(input_ids),
+            assistant_model=model,
+            num_assistant_tokens=12,
+        )
 
     @require_torch_multi_accelerator
     def test_mtp_use_correct_device_when_drafting(self):

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -1651,3 +1651,50 @@ class CacheCroppingTests(unittest.TestCase):
             if hasattr(layer, "indexer_keys"):
                 self.assertEqual(layer.indexer_keys.shape[-2], self.seq_len - 3)
                 self.assertTrue((layer.indexer_keys == indexer_states[..., :-3, :]).all())
+
+    def test_update_with_recording_returns_advertised_kv_width(self):
+        """Test that with past recording activated, `update` returns exactly the states advertised by `get_mask_sizes`"""
+        sliding_window = 4
+
+        # Several consecutive single-token updates without an intervening `crop`, as during assisted decoding drafting:
+        # `get_mask_sizes` is queried before the update adds the new states, and `update` must return what it advertises
+        layer = DynamicSlidingWindowLayer(sliding_window=sliding_window)
+        layer.activate_past_recording()
+        for step in range(sliding_window + 2):
+            new_states = torch.full((1, 1, 1, 2), float(step))
+            kv_length, _ = layer.get_mask_sizes(new_states.shape[-2])
+            returned_keys, returned_values = layer.update(new_states, new_states)
+
+            self.assertEqual(returned_keys.shape[-2], kv_length)
+            self.assertEqual(returned_values.shape[-2], kv_length)
+            expected_window = torch.arange(float(step + 1))[-kv_length:]
+            self.assertTrue((returned_keys[0, 0, :, 0] == expected_window).all())
+            self.assertTrue((returned_values[0, 0, :, 0] == expected_window).all())
+            # All states stay recorded for `crop` to roll back, even beyond the sliding window
+            self.assertEqual(layer.keys.shape[-2], step + 1)
+            self.assertEqual(layer.values.shape[-2], step + 1)
+
+        # The same must hold for a multi-token update crossing the window size mid-draft
+        layer = DynamicSlidingWindowLayer(sliding_window=sliding_window)
+        layer.activate_past_recording()
+        for step in range(2):
+            new_states = torch.full((1, 1, 1, 2), float(step))
+            kv_length, _ = layer.get_mask_sizes(new_states.shape[-2])
+            returned_keys, _ = layer.update(new_states, new_states)
+            self.assertEqual(returned_keys.shape[-2], kv_length)
+
+        crossing_states = torch.arange(2.0, 5.0).view(1, 1, 3, 1).expand(1, 1, 3, 2)
+        kv_length, _ = layer.get_mask_sizes(crossing_states.shape[-2])
+        returned_keys, returned_values = layer.update(crossing_states, crossing_states)
+        self.assertEqual(returned_keys.shape[-2], kv_length)
+        self.assertEqual(returned_values.shape[-2], kv_length)
+        self.assertEqual(returned_keys[0, 0, :, 0].tolist(), [0.0, 1.0, 2.0, 3.0, 4.0])
+        self.assertEqual(layer.keys.shape[-2], 5)
+
+        # And once the buffer is larger than what is advertised, only its trailing window is returned
+        final_states = torch.full((1, 1, 1, 2), 5.0)
+        kv_length, _ = layer.get_mask_sizes(final_states.shape[-2])
+        returned_keys, _ = layer.update(final_states, final_states)
+        self.assertEqual(kv_length, sliding_window - 1 + 1)
+        self.assertEqual(returned_keys.shape[-2], kv_length)
+        self.assertEqual(returned_keys[0, 0, :, 0].tolist(), [2.0, 3.0, 4.0, 5.0])


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48280&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48280) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48280&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48280)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Assisted and speculative decoding crash or silently corrupt output for any model with a sliding-window attention layer whose sequence reaches the sliding window. The regression came from #47447, which let assisted decoding run on real `DynamicSlidingWindowLayer` caches instead of forcing a full cache: while past-recording is active, `update()` stored AND returned the unbounded key/value concatenation, but `get_mask_sizes()` kept advertising only `sliding_window - 1 + query_length` columns for the attention mask. Draft bursts call `update()` once per drafted token with no crop in between, so from the second token of a burst onward attention received more key/value columns than the mask has:

- eager attention fails hard: `RuntimeError: The size of tensor a (13) must match the size of tensor b (6) at non-singleton dimension 3`, deterministically reproducible;
- SDPA skips the mask at query length 1 and silently attends beyond-window states, so assisted output diverges from greedy decoding (7/8 seeds in my probing).

Minimal reproducer (CPU, tiny model):

```python
import torch
from transformers import LlamaConfig, LlamaForCausalLM
cfg = LlamaConfig(vocab_size=64, hidden_size=16, intermediate_size=32, num_hidden_layers=4,
                  num_attention_heads=2, num_key_value_heads=2, head_dim=8,
                  max_position_embeddings=512, sliding_window=6)
model = LlamaForCausalLM._from_config(cfg, attn_implementation="eager").eval()
model.generation_config.assistant_confidence_threshold = 0.0
input_ids = torch.randint(1, 60, (1, 12))   # prompt longer than the 6-token window
model.generate(input_ids=input_ids, attention_mask=torch.ones_like(input_ids), do_sample=False,
               max_new_tokens=8, assistant_model=model, num_assistant_tokens=12)
# before: RuntimeError size mismatch inside the assistant forward
```

The default confidence gate (0.4) collapses most draft bursts to a single token, which is why the mismatch hides in casual use; any confident drafting model or a lower threshold exposes it.

The fix keeps the unbounded buffer stored internally for `crop` rollback but returns only the trailing advertised window while recording. Paths without recording are bit-identical; `get_mask_sizes`, masking, and crop semantics are untouched. After the fix every probed configuration shows zero width mismatches, no crashes on eager, and greedy-equal results where the model is fully windowed.

One honest caveat: assisted-vs-greedy divergence can still occur when the MAIN model has a bare sliding window, because multi-token verify forwards give later query positions extra context through plain causal masks. That is a separate pre-existing mask-content trait this PR deliberately does not touch.

No upstream issue exists for this to my knowledge; I searched open issues mentioning dflash/sliding-window assisted crashes before preparing this.

## Code Agent Policy

This PR was prepared with the help of a code agent and is disclosed here per the Agentic contributions section of CONTRIBUTING.md; I reviewed every changed line and re-ran all verification locally. The first-time-contributor confirmation above stays unticked because it would be false. No existing issue or PR covers this fix, so there is no coordination link or competing work to differentiate from.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@zucchini-nlp (generation) @CyrilVallez (generate/caches)

## Test plan

```
python -m pytest tests/utils/test_cache_utils.py -k "recording_returns_advertised" -q --no-header
fail-before (fix reverted): 1 failed, AssertionError: 5 != 4   (returned KV wider than advertised)
pass-after: 1 passed

python -m pytest tests/generation/test_utils.py -k "multi_token_draft" -q --no-header
fail-before: 1 failed, RuntimeError "The size of tensor a (13) must match the size of tensor b (6)"
pass-after: 1 passed (stable across repeated runs)

python -m pytest tests/generation/test_utils.py -k "sliding_window_matches" -q --no-header
1 passed

python -m pytest tests/utils/test_cache_utils.py::CacheCroppingTests tests/generation/test_utils.py -k "assisted" ...
CacheCroppingTests 5 passed; assisted sweep: 22 passed, 3 skipped
```