### PR TITLE
Fix DFlash sampled candidates losing the batch dimension

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1720,7 +1720,7 @@ class DFlashTokenCandidateGenerator(CandidateGenerator):
             if self.do_sample:
                 probs = nn.functional.softmax(candidate_logits, dim=-1, dtype=torch.float32)
                 # Multinomial only works on 2d matrices, and assisted decoding restrict to batch size == 1 anyway
-                candidate_ids = torch.multinomial(probs.squeeze(0), num_samples=1)
+                candidate_ids = torch.multinomial(probs.squeeze(0), num_samples=1).squeeze(1)[None, :]
             else:
                 candidate_ids = candidate_logits.argmax(dim=-1)
             candidate_ids = torch.cat([input_ids, candidate_ids], dim=-1)

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -21,6 +21,7 @@ import os
 import random
 import re
 import tempfile
+import types
 import unittest
 import warnings
 from pathlib import Path
@@ -4024,6 +4025,65 @@ class GenerationIntegrationTests(unittest.TestCase):
         # Both will live on `input_device` as the main model is there
         self.assertEqual(dflash_candidate_ids.device, input_device)
         self.assertEqual(dflash_candidate_logits.device, input_device)
+
+    def test_dflash_sampling_keeps_batch_dimension(self):
+        """Test that when sampling, dflash keeps the batch dimension on the drafted candidates and their logits"""
+        from transformers import PretrainedConfig
+
+        class MockAssistantConfig(PretrainedConfig):
+            def __init__(self):
+                self.target_layer_ids = [0]
+                self.block_size = 4
+                self.mask_token_id = 0
+                self.hidden_size = 8
+                self.num_hidden_layers = 2
+
+        class MockAssistantOutput:
+            def __init__(self, last_hidden_state):
+                self.last_hidden_state = last_hidden_state
+
+        class MockAssistantModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = MockAssistantConfig()
+
+            @property
+            def device(self):
+                return torch.device("cpu")
+
+            def forward(self, noise_embeds=None, **kwargs):
+                return MockAssistantOutput(torch.randn(noise_embeds.shape[0], noise_embeds.shape[1], 8))
+
+        assistant = MockAssistantModel()
+        dflash_generator = DFlashTokenCandidateGenerator(
+            assistant_model=assistant,
+            main_model_input_embeddings=torch.nn.Embedding(50, 8),
+            main_model_output_embeddings=torch.nn.Linear(8, 50),
+            generation_config=GenerationConfig(max_length=64, do_sample=True),
+        )
+
+        input_ids = torch.tensor([[5, 6, 7]])
+        model_kwargs = {
+            "attention_mask": torch.ones_like(input_ids),
+            "position_ids": torch.arange(input_ids.shape[1]).unsqueeze(0),
+        }
+        model_outputs = types.SimpleNamespace(hidden_states=[None, torch.randn(1, 2, 8), torch.randn(1, 2, 8)])
+
+        with torch.no_grad():
+            candidate_ids, candidate_logits = dflash_generator.get_candidates(
+                input_ids=input_ids,
+                model_kwargs=model_kwargs,
+                model_outputs=model_outputs,
+                is_first_iteration=False,
+                n_last_matches=0,
+            )
+        # Sampling must yield the same shapes as the greedy branch: `(1, input_len + block_size - 1)` for the ids and
+        # `(1, block_size - 1)` for the logits
+        self.assertEqual(candidate_ids.shape[0], 1)
+        self.assertEqual(candidate_ids.shape[1], input_ids.shape[1] + assistant.config.block_size - 1)
+        self.assertEqual(candidate_ids.dtype, input_ids.dtype)
+        self.assertEqual(candidate_logits.shape[0], 1)
+        self.assertEqual(candidate_logits.shape[1], assistant.config.block_size - 1)
 
     def test_model_kwarg_assisted_decoding_decoder_only(self):
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48281&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48281) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48281&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48281)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`DFlashTokenCandidateGenerator` crashes whenever `do_sample=True` and no logits processor is set. The vectorized sampling branch squeezed the `(1, T, V)` probability matrix to `(T, V)`, drew one token per draft position, and never restored the batch dimension, so concatenating the `(T, 1)` result onto the `(1, L)` input ids raised:

```
RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 1 but got size 3 for tensor number 1 in the list.
```

for any `block_size > 2`. Sampled DFlash assisted decoding therefore never worked without a logits processor; the greedy branch returns `(1, T)` from `argmax(dim=-1)` and every downstream consumer expects exactly that shape. Introduced when sampling support landed for these generators (#47867, refined by #48007); no test exercised DFlash with `do_sample`.

The fix squeezes the per-position samples back to `(1, T)`, identical to what the greedy branch produces. No behavior change on any other path (greedy, processors loop, `block_size == 2`).

No upstream issue exists for this to my knowledge; I searched open items mentioning dflash before preparing this.

## Code Agent Policy

This PR was prepared with the help of a code agent and is disclosed here per the Agentic contributions section of CONTRIBUTING.md; I reviewed every changed line and re-ran all verification locally. The first-time-contributor confirmation stays unticked because it would be false. No existing issue or PR covers this fix, so there is no coordination link or competing work to differentiate from.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@zucchini-nlp (generation)

## Test plan

```
python -m pytest tests/generation/test_utils.py -k dflash -q --no-header
fail-before (fix reverted): 1 failed with the RuntimeError above (new CPU-only mock test), 1 skipped
pass-after: 1 passed, 1 skipped

python -m pytest tests/generation/test_utils.py -k "candidate or assistant or prompt_lookup" -q --no-header
19 passed, 2 skipped
```