### PR TITLE
[Fix] Avoid duplicating tests in CI

### DIFF
--- a/.github/workflows/self-scheduled-intel-gaudi.yml
+++ b/.github/workflows/self-scheduled-intel-gaudi.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   setup:
-    if: contains(fromJSON('["run_models_gpu", "run_trainer_and_fsdp_gpu"]'), inputs.job)
+    if: contains(fromJSON('["run_models_gpu", "run_trainer_and_fsdp_gpu", "run_quantization_torch_gpu"]'), inputs.job)
     name: Setup
     runs-on: ubuntu-latest
     outputs:
@@ -325,6 +325,92 @@ jobs:
           name: ${{ env.machine_type }}_run_torch_cuda_extensions_gpu_test_reports
           path: reports/${{ env.machine_type }}_run_torch_cuda_extensions_gpu_test_reports
 
+  run_quantization_torch_gpu:
+    if: ${{ inputs.job == 'run_quantization_torch_gpu' }}
+    name: " "
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        folders: ${{ fromJson(needs.setup.outputs.quantization_matrix) }}
+        machine_type: [1gaudi, 2gaudi]
+    runs-on:
+      group: ${{ inputs.runner_scale_set }}-${{ matrix.machine_type }}
+    container:
+      image: vault.habana.ai/gaudi-docker/1.21.1/ubuntu22.04/habanalabs/pytorch-installer-2.6.0:latest
+      options: --runtime=habana
+        -v /mnt/cache/.cache/huggingface:/mnt/cache/.cache/huggingface
+        --env OMPI_MCA_btl_vader_single_copy_mechanism=none
+        --env HABANA_VISIBLE_DEVICES
+        --env HABANA_VISIBLE_MODULES
+        --cap-add=sys_nice
+        --shm-size=64G
+    steps:
+      - name: Echo folder ${{ matrix.folders }}
+        shell: bash
+        # For a folder like `quantization/gptq`, set `matrix_folders` to `quantization_gptq`, which is what the
+        # report and artifact names below use (artifact names cannot contain `/`).
+        env:
+          matrix_folders_raw: ${{ matrix.folders }}
+        run: |
+          echo "$matrix_folders_raw"
+          matrix_folders="${matrix_folders_raw/'quantization/'/'quantization_'}"
+          echo "$matrix_folders"
+          echo "matrix_folders=$matrix_folders" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: |
+          pip install -e .[testing,torch] "numpy<2.0.0" scipy scikit-learn librosa soundfile
+
+      - name: HL-SMI
+        run: |
+          hl-smi
+          echo "HABANA_VISIBLE_DEVICES=${HABANA_VISIBLE_DEVICES}"
+          echo "HABANA_VISIBLE_MODULES=${HABANA_VISIBLE_MODULES}"
+
+      - name: Environment
+        run: python3 utils/print_env.py
+
+      - name: Show installed libraries and their versions
+        run: pip freeze
+
+      - name: Set `machine_type` for report and artifact names
+        shell: bash
+        run: |
+          if [ "${{ matrix.machine_type }}" = "1gaudi" ]; then
+            machine_type=single-gpu
+          elif [ "${{ matrix.machine_type }}" = "2gaudi" ]; then
+            machine_type=multi-gpu
+          else
+            machine_type=${{ matrix.machine_type }}
+          fi
+          echo "machine_type=$machine_type" >> $GITHUB_ENV
+
+      - name: Run quantization tests on Intel Gaudi
+        env:
+          folders: ${{ matrix.folders }}
+        run: |
+          python3 -m pytest -v --make-reports="${machine_type}_run_quantization_torch_gpu_${matrix_folders}_test_reports" "tests/${folders}" -m "not not_device_test"
+
+      - name: Failure short reports
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          cat "reports/${machine_type}_run_quantization_torch_gpu_${matrix_folders}_test_reports/failures_short.txt"
+
+      - name: "Test suite reports artifacts: ${{ env.machine_type }}_run_quantization_torch_gpu_${{ env.matrix_folders }}_test_reports"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.machine_type }}_run_quantization_torch_gpu_${{ env.matrix_folders }}_test_reports
+          path: reports/${{ env.machine_type }}_run_quantization_torch_gpu_${{ env.matrix_folders }}_test_reports
+
   send_results:
     name: Slack Report
     needs:
@@ -335,6 +421,7 @@ jobs:
         run_torch_cuda_extensions_gpu,
         run_pipelines_torch_gpu,
         run_trainer_and_fsdp_gpu,
+        run_quantization_torch_gpu,
       ]
     if: ${{ always() }}
     uses: ./.github/workflows/slack-report.yml

--- a/.github/workflows/self-scheduled-intel-gaudi.yml
+++ b/.github/workflows/self-scheduled-intel-gaudi.yml
@@ -39,7 +39,7 @@ jobs:
     outputs:
       slice_ids: ${{ steps.set-matrix.outputs.slice_ids }}
       folder_slices: ${{ steps.set-matrix.outputs.folder_slices }}
-      quantization_matrix: ${{ steps.set-matrix.outputs.quantization_matrix }}
+      quantization_matrix: ${{ steps.set-matrix-quantization.outputs.quantization_matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/self-scheduled-intel-gaudi3-caller.yml
+++ b/.github/workflows/self-scheduled-intel-gaudi3-caller.yml
@@ -68,3 +68,14 @@ jobs:
       slack_report_channel: "#transformers-ci-daily-intel-gaudi3"
       report_repo_id: optimum-intel/transformers_daily_ci_intel_gaudi3
     secrets: inherit
+
+  quantization-ci:
+    name: Quantization CI
+    uses: ./.github/workflows/self-scheduled-intel-gaudi.yml
+    with:
+      job: run_quantization_torch_gpu
+      ci_event: Scheduled CI (Intel) - Gaudi3
+      runner_scale_set: itac-bm-emr-gaudi3-dell
+      slack_report_channel: "#transformers-ci-daily-intel-gaudi3"
+      report_repo_id: optimum-intel/transformers_daily_ci_intel_gaudi3
+    secrets: inherit

--- a/tests/repo_utils/test_split_model_tests.py
+++ b/tests/repo_utils/test_split_model_tests.py
@@ -1,0 +1,66 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+git_repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+sys.path.append(os.path.join(git_repo_path, "utils"))
+
+from split_model_tests import COVERED_BY_DEDICATED_JOB, NO_TEST_FILES  # noqa: E402
+
+
+SCRIPT = Path(git_repo_path) / "utils" / "split_model_tests.py"
+TESTS_DIR = Path(git_repo_path) / "tests"
+
+
+class SplitModelTestsTester(unittest.TestCase):
+    def test_default_run_skips_the_duplicated_directories(self):
+        """
+        The default run is what every CI caller uses, so it is the one that must drop the directories a dedicated job
+        already covers. An inverted flag or a moved filter shows up here instead of as a silently doubled daily CI.
+        """
+        command = [sys.executable, str(SCRIPT), "--num_splits", "1"]
+        stdout = subprocess.run(command, cwd=TESTS_DIR, capture_output=True, check=True, text=True).stdout
+        folders = [folder for split in ast.literal_eval(stdout.strip()) for folder in split]
+
+        for folder in [*COVERED_BY_DEDICATED_JOB, *NO_TEST_FILES]:
+            self.assertNotIn(folder, folders, f"`tests/{folder}` should not be in the auto-discovered folder list")
+        # `models/<model>` entries are never filtered, whatever a model is called.
+        self.assertIn("models/bert", folders)
+
+    def test_no_test_files_dirs_really_hold_no_test_file(self):
+        """`NO_TEST_FILES` claims a directory collects nothing. Prove it, so the list cannot silently diverge."""
+        for folder in NO_TEST_FILES:
+            path = TESTS_DIR / folder
+            self.assertTrue(path.is_dir(), f"`NO_TEST_FILES` names `{folder}`, which is not a directory under `tests`")
+            offenders = sorted(str(p.relative_to(TESTS_DIR)) for p in path.rglob("test_*.py"))
+            self.assertEqual(
+                offenders,
+                [],
+                f"`tests/{folder}` is in `NO_TEST_FILES` but holds test files: {offenders}. Those tests never run.",
+            )
+
+    def test_covered_dirs_exist_under_tests(self):
+        """A typo here skips nothing, so the duplicate run it was meant to remove keeps happening unnoticed."""
+        for folder in COVERED_BY_DEDICATED_JOB:
+            self.assertTrue(
+                (TESTS_DIR / folder).is_dir(),
+                f"`COVERED_BY_DEDICATED_JOB` names `{folder}`, which is not a directory under `tests`",
+            )

--- a/utils/split_model_tests.py
+++ b/utils/split_model_tests.py
@@ -42,11 +42,8 @@ import ast
 import os
 
 
-# Directories under `tests` (other than `models`) that a dedicated daily CI job already covers in full:
-#   - `pipelines`:    `run_pipelines_torch_gpu` runs `tests/pipelines` on both machine types.
-#   - `quantization`: `run_quantization_torch_gpu` runs every `tests/quantization/<method>`
-# Any workflow calling this script must define both jobs, or they loses that coverage entirely.
-COVERED_BY_DEDICATED_JOB = ["pipelines", "quantization"]
+# Directories under `tests` (other than `models`) that a dedicated daily CI job already covers in full
+COVERED_BY_DEDICATED_JOB = ["pipelines", "quantization", "trainer"]
 
 # Directories under `tests` holding no test file at all, so a job for them collects nothing.
 NO_TEST_FILES = ["fixtures"]

--- a/utils/split_model_tests.py
+++ b/utils/split_model_tests.py
@@ -18,9 +18,10 @@ The main use case is a GitHub Actions workflow file calling this script to get t
 to split the list of jobs to run into multiple slices each containing a smaller number of jobs. This way, we can bypass
 the maximum of 256 jobs in a matrix.
 
-The other directories under `tests` are appended to the list too, except for the ones a dedicated job in the same
-workflow already runs in full (see `COVERED_BY_DEDICATED_JOB`) and the ones holding no test file at all (see
-`NO_TEST_FILES`): a folder in both lists would have its tests run twice per CI run, on every machine type.
+The other directories under `tests` are appended to the list too, except for two groups. The ones holding no test file
+at all (see `NO_TEST_FILES`) are dropped because a job for them would collect nothing. The ones a dedicated job runs in
+full (see `COVERED_BY_DEDICATED_JOB`) are dropped because keeping them here would run their tests twice per CI run, on
+every machine type.
 
 See the `setup` and `run_models_gpu` jobs defined in the reusable workflow file
 `.github/workflows/daily-ci_reusable.yml` in the `huggingface/transformers-ci` repository (called from
@@ -42,7 +43,8 @@ import ast
 import os
 
 
-# Directories under `tests` (other than `models`) that a dedicated daily CI job already covers in full
+# Directories under `tests` (other than `models`) that a dedicated daily CI job already covers in full, skipped to avoid
+# running the same tests twice per CI run, on every machine type. Opt-out of the skip with --no-skip-dedicated-jobs.
 COVERED_BY_DEDICATED_JOB = ["pipelines", "quantization", "trainer"]
 
 # Directories under `tests` holding no test file at all, so a job for them collects nothing.
@@ -63,6 +65,11 @@ if __name__ == "__main__":
         default=1,
         help="the number of splits into which the (flat) list of folders will be split.",
     )
+    parser.add_argument(
+        "--no-skip-dedicated-jobs",
+        action="store_true",
+        help="do not skip the directories a dedicated job already covers.",
+    )
     args = parser.parse_args()
 
     tests = os.getcwd()
@@ -71,7 +78,7 @@ if __name__ == "__main__":
     d2 = sorted(filter(os.path.isdir, [f"models/{x}" for x in model_tests]))
     d1.remove("models")
     # Only for the auto-discovered directories: an explicit `--subdirs` request below is honored as-is.
-    skipped = set(COVERED_BY_DEDICATED_JOB) | set(NO_TEST_FILES)
+    skipped = set(NO_TEST_FILES) | (set() if args.no_skip_dedicated_jobs else set(COVERED_BY_DEDICATED_JOB))
     d1 = [x for x in d1 if x not in skipped]
     d = d2 + d1
 

--- a/utils/split_model_tests.py
+++ b/utils/split_model_tests.py
@@ -18,6 +18,10 @@ The main use case is a GitHub Actions workflow file calling this script to get t
 to split the list of jobs to run into multiple slices each containing a smaller number of jobs. This way, we can bypass
 the maximum of 256 jobs in a matrix.
 
+The other directories under `tests` are appended to the list too, except for the ones a dedicated job in the same
+workflow already runs in full (see `COVERED_BY_DEDICATED_JOB`) and the ones holding no test file at all (see
+`NO_TEST_FILES`): a folder in both lists would have its tests run twice per CI run, on every machine type.
+
 See the `setup` and `run_models_gpu` jobs defined in the reusable workflow file
 `.github/workflows/daily-ci_reusable.yml` in the `huggingface/transformers-ci` repository (called from
 `.github/workflows/self-scheduled-caller.yml` here) for more details.
@@ -36,6 +40,16 @@ python ../utils/split_model_tests.py --num_splits 64
 import argparse
 import ast
 import os
+
+
+# Directories under `tests` (other than `models`) that a dedicated daily CI job already covers in full:
+#   - `pipelines`:    `run_pipelines_torch_gpu` runs `tests/pipelines` on both machine types.
+#   - `quantization`: `run_quantization_torch_gpu` runs every `tests/quantization/<method>`
+# Any workflow calling this script must define both jobs, or they loses that coverage entirely.
+COVERED_BY_DEDICATED_JOB = ["pipelines", "quantization"]
+
+# Directories under `tests` holding no test file at all, so a job for them collects nothing.
+NO_TEST_FILES = ["fixtures"]
 
 
 if __name__ == "__main__":
@@ -59,6 +73,9 @@ if __name__ == "__main__":
     d1 = sorted(filter(os.path.isdir, os.listdir(tests)))
     d2 = sorted(filter(os.path.isdir, [f"models/{x}" for x in model_tests]))
     d1.remove("models")
+    # Only for the auto-discovered directories: an explicit `--subdirs` request below is honored as-is.
+    skipped = set(COVERED_BY_DEDICATED_JOB) | set(NO_TEST_FILES)
+    d1 = [x for x in d1 if x not in skipped]
     d = d2 + d1
 
     if args.subdirs != "":


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48287&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48287) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48287&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48287)
<!-- ci-dashboard-badge:end -->

This PR fixes a bug in the daily CI, where some tests directories are being collected and run twice. 

This is because for the models_ci, we collect tests from directories that are covered in their own workflows, namely "pipelines", "quantization", "trainer". By default, those dirs are now skipped. One dir (fixture) is also skipped because it contains no test files. There is a flag to opt out of this.  A test was also added to make sure the skipped dirs actually exist, along with a few tests to make sure the harcoded constants don't drift from reality.
Also, to keep the test coverage even, this PR adds a `quantization` workflow for gaudi, which was missing, but the test were run as part of the models CI. This can be removed if gaudi needs no coverage for that.