### PR TITLE
[conftest] Use get_cpu_ram_total_gib for psutil patch (cgroup-aware)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,6 +18,7 @@
 import doctest
 import errno
 import functools
+import math
 import os
 import re
 import sys
@@ -32,7 +33,7 @@ import pytest
 from transformers.testing_utils import (
     HfDoctestModule,
     HfDocTestParser,
-    get_ci_cpu_memory_budget_gib,
+    get_cpu_ram_total_gib,
     is_torch_available,
     patch_psutil_cpu_memory,
     patch_testing_methods_to_collect_info,
@@ -157,12 +158,12 @@ def _with_tmpdir_cache_fallback(fn):
 
 # In K8S instance-sharing CI, each runner sees the full machine's CPU RAM (~750 GB) even though it only
 # owns a fraction. This causes `device_map="auto"` to overfill GPU+CPU with nothing offloaded to disk,
-# leading to GPU OOM at runtime. When CI_CPU_MEMORY_LIMIT_GB is set, cap psutil.virtual_memory so the
-# entire test session sees a realistic per-runner memory budget. `get_ci_cpu_memory_budget_gib` owns the
-# per-accelerator arithmetic, and is also what the `require_large_cpu_ram` guard reads.
-_cpu_memory_budget_gib = get_ci_cpu_memory_budget_gib()
-if _cpu_memory_budget_gib is not None:
-    patch_psutil_cpu_memory(int(_cpu_memory_budget_gib * 1024**3))
+# leading to GPU OOM at runtime. Cap psutil.virtual_memory to the actual per-runner limit so the entire
+# test session sees a realistic budget. `get_cpu_ram_total_gib` prefers the cgroup limit (accurate inside
+# a pod) and the machine's physical RAM, falling back to the CI budget only when neither is available.
+_cpu_ram_total_gib = get_cpu_ram_total_gib()
+if not math.isinf(_cpu_ram_total_gib):
+    patch_psutil_cpu_memory(int(_cpu_ram_total_gib * 1024**3))
 
 
 NOT_DEVICE_TESTS = {

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3714,6 +3714,26 @@ def patch_psutil_cpu_memory(limit_bytes: int):
     psutil.virtual_memory = _capped_virtual_memory
 
 
+@contextlib.contextmanager
+def cap_psutil_cpu_memory(limit_bytes: int):
+    """
+    Context manager that temporarily caps `psutil.virtual_memory` to `limit_bytes`, then restores the
+    previous value on exit.
+
+    Use this inside individual tests that need a tighter CPU memory budget than the session-wide cap set
+    by conftest (e.g. to force `device_map="auto"` to use disk offload during `from_pretrained`), without
+    affecting the rest of the test session.
+    """
+    import psutil
+
+    prev = psutil.virtual_memory
+    patch_psutil_cpu_memory(limit_bytes)
+    try:
+        yield
+    finally:
+        psutil.virtual_memory = prev
+
+
 def _get_test_info():
     """
     Collect some information about the current test.

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3693,10 +3693,14 @@ def patch_psutil_cpu_memory(limit_bytes: int):
 
     import psutil
 
-    _original_virtual_memory = psutil.virtual_memory
-    # Keep the honest reader reachable: the cap above is a `device_map="auto"` planning budget, but a guard that
-    # asks "will this OOM-kill the container?" needs the machine's real RAM. See `get_physical_cpu_ram_gib`.
-    if _UNPATCHED_VIRTUAL_MEMORY is None:
+    # Keep the honest reader reachable: the cap described in the docstring is a `device_map="auto"` planning budget,
+    # but a guard that asks "will this OOM-kill the container?" needs the machine's real RAM.
+    # See `get_physical_cpu_ram_gib`.
+    # If already patched, always use the stored original so a second call doesn't chain patches on top of each other.
+    if _UNPATCHED_VIRTUAL_MEMORY is not None:
+        _original_virtual_memory = _UNPATCHED_VIRTUAL_MEMORY
+    else:
+        _original_virtual_memory = psutil.virtual_memory
         _UNPATCHED_VIRTUAL_MEMORY = _original_virtual_memory
 
     def _capped_virtual_memory():

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -122,20 +122,8 @@ class PhimoeIntegrationTest(unittest.TestCase):
     def get_model(cls):
         if cls.model is None:
             cls.offload_dir = tempfile.TemporaryDirectory()
-            # Cap CPU memory to 60 GiB × num_accelerators during loading so device_map="auto" is
-            # forced to offload some layers to disk. Without the cap, on K8S runners where psutil
-            # reports the full node RAM (~83 GiB after the session-wide patch), device_map may assign
-            # too many layers to GPU+CPU with nothing on disk, leading to GPU OOM at inference time.
-            # Scaling by num_accelerators keeps the GPU-to-CPU memory ratio constant across single-
-            # and multi-GPU runners, so device_map distributes layers consistently.
-            #
-            # We use cap_psutil_cpu_memory rather than passing max_memory={"cpu": "60GiB"} to
-            # from_pretrained: without also specifying GPU memory, device_map="auto" skips the GPU
-            # entirely, which is undesirable since integration tests should use the GPU whenever
-            # possible. Correctly specifying GPU memory alongside CPU (e.g. {0: get_gpu_memory()})
-            # would be fragile. Patching psutil gives device_map the correct overall memory view
-            # (GPU + capped CPU), so it distributes layers across GPU, CPU, and disk as intended.
-            # The cap is restored to the session-wide value after from_pretrained returns.
+            # Cap psutil CPU memory to 60 GiB × num_accelerators so device_map="auto" offloads some
+            # layers to disk, preventing GPU OOM at inference time. See #48290 for full rationale.
             num_accelerators = max(1, backend_device_count(torch_device)) if torch_device is not None else 1
             with cap_psutil_cpu_memory(int(60 * num_accelerators * 1024**3)):
                 cls.model = PhimoeForCausalLM.from_pretrained(

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -14,27 +14,21 @@
 
 """Testing suite for the PyTorch PhiMoE model."""
 
-import logging
 import tempfile
 import unittest
 
-import psutil
+from parameterized import parameterized
 
 from transformers import StaticCache, is_torch_available
 from transformers.testing_utils import (
+    cap_psutil_cpu_memory,
     cleanup,
     require_torch,
     slow,
     torch_device,
 )
 
-logger = logging.getLogger(__name__)
-
-
-
-
-
-
+from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
 
 
 if is_torch_available():
@@ -43,6 +37,7 @@ if is_torch_available():
     from transformers import (
         AutoTokenizer,
         PhimoeForCausalLM,
+        PhimoeModel,
     )
 
     end_of_text_token = 32000
@@ -90,6 +85,32 @@ if is_torch_available():
             return response_tokens
 
 
+class PhimoeModelTester(CausalLMModelTester):
+    if is_torch_available():
+        base_model_class = PhimoeModel
+
+
+@require_torch
+class PhimoeModelTest(CausalLMModelTest, unittest.TestCase):
+    test_all_params_have_gradient = False
+    model_tester_class = PhimoeModelTester
+
+    # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79292/workflows/fa2ba644-8953-44a6-8f67-ccd69ca6a476/jobs/1012905
+    def is_pipeline_test_to_skip(
+        self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
+    ):
+        return True
+
+    @unittest.skip("PhiMoE's RoPE has custom parameterization")
+    def test_model_rope_scaling_frequencies(self):
+        pass
+
+    @parameterized.expand([("linear",), ("dynamic",), ("yarn",)])
+    @unittest.skip("PhiMoE's RoPE has custom parameterization")
+    def test_model_rope_scaling_from_config(self, scaling_type):
+        pass
+
+
 @slow
 @require_torch
 class PhimoeIntegrationTest(unittest.TestCase):
@@ -100,21 +121,26 @@ class PhimoeIntegrationTest(unittest.TestCase):
     def get_model(cls):
         if cls.model is None:
             cls.offload_dir = tempfile.TemporaryDirectory()
-            mem = psutil.virtual_memory()
-            logger.warning(
-                "psutil.virtual_memory() before from_pretrained: total=%.2f GiB, available=%.2f GiB",
-                mem.total / 1024**3,
-                mem.available / 1024**3,
-            )
-            cls.model = PhimoeForCausalLM.from_pretrained(
-                "microsoft/Phi-3.5-MoE-instruct",
-                experts_implementation="eager",
-                dtype="auto",
-                device_map="auto",
-                offload_folder=cls.offload_dir.name,
-                max_memory={"cpu": "60GiB"},
-            )
-            logger.warning("device_map=%s", cls.model.hf_device_map)
+            # Cap CPU memory to 60 GiB during loading so device_map="auto" is forced to offload
+            # some layers to disk. Without the cap, on K8S runners where psutil reports the full
+            # node RAM (~83 GiB after the session-wide patch), device_map may assign too many
+            # layers to GPU+CPU with nothing on disk, leading to GPU OOM at inference time.
+            #
+            # We use cap_psutil_cpu_memory rather than passing max_memory={"cpu": "60GiB"} to
+            # from_pretrained: the latter only caps CPU in the planning budget but leaves GPU
+            # unspecified, causing device_map="auto" to skip the GPU entirely and place all
+            # layers on CPU/disk, which produces wrong numerical results.
+            # Patching psutil gives device_map the correct overall memory view (GPU + capped CPU),
+            # so it distributes layers across GPU, CPU, and disk as intended.
+            # The cap is restored to the session-wide value after from_pretrained returns.
+            with cap_psutil_cpu_memory(60 * 1024**3):
+                cls.model = PhimoeForCausalLM.from_pretrained(
+                    "microsoft/Phi-3.5-MoE-instruct",
+                    experts_implementation="eager",
+                    dtype="auto",
+                    device_map="auto",
+                    offload_folder=cls.offload_dir.name,
+                )
         return cls.model
 
     @classmethod
@@ -148,3 +174,47 @@ class PhimoeIntegrationTest(unittest.TestCase):
         ).to(device=torch_device, dtype=output.dtype)  # fmt: skip
 
         torch.testing.assert_close(output[0, :2, :10], EXPECTED_OUTPUT, rtol=1e-4, atol=1e-4)
+
+    def test_phimoe_instruct_generation(self):
+        model = self.get_model()
+        tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3.5-MoE-instruct")
+
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.",
+            },
+            {"role": "user", "content": "Can you provide ways to eat combinations of bananas and dragonfruits?"},
+        ]
+        inputs = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_tensors="pt")
+
+        outputs = model.generate(**inputs, max_new_tokens=30)
+        output_text = tokenizer.batch_decode(outputs)
+
+        EXPECTED_OUTPUT = [
+            "<|system|> You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.<|end|><|user|> Can you provide ways to eat combinations of bananas and dragonfruits?<|end|><|assistant|> Certainly! Bananas and dragonfruits are both delicious and nutritious fruits that can be combined in various ways to create",
+        ]
+        self.assertListEqual(output_text, EXPECTED_OUTPUT)
+
+    def test_phimoe_instruct_with_static_cache(self):
+        model = self.get_model()
+        tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3.5-MoE-instruct")
+
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.",
+            },
+            {"role": "user", "content": "Can you provide ways to eat combinations of bananas and dragonfruits?"},
+        ]
+        inputs = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_tensors="pt").to(
+            torch_device
+        )
+
+        response_tokens = PhimoeMiniWithStaticCache.generate(model, inputs["input_ids"], max_seq_len=30)
+        output_text = tokenizer.batch_decode(torch.tensor([response_tokens], dtype=torch.long, device=torch_device))
+
+        EXPECTED_OUTPUT = [
+            "<|system|> You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.<|end|><|user|> Can you provide ways to eat combinations of bananas and dragonfruits?<|end|><|assistant|> C"
+        ]
+        self.assertListEqual(output_text, EXPECTED_OUTPUT)

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -21,6 +21,7 @@ from parameterized import parameterized
 
 from transformers import StaticCache, is_torch_available
 from transformers.testing_utils import (
+    backend_device_count,
     cap_psutil_cpu_memory,
     cleanup,
     require_torch,
@@ -121,10 +122,12 @@ class PhimoeIntegrationTest(unittest.TestCase):
     def get_model(cls):
         if cls.model is None:
             cls.offload_dir = tempfile.TemporaryDirectory()
-            # Cap CPU memory to 60 GiB during loading so device_map="auto" is forced to offload
-            # some layers to disk. Without the cap, on K8S runners where psutil reports the full
-            # node RAM (~83 GiB after the session-wide patch), device_map may assign too many
-            # layers to GPU+CPU with nothing on disk, leading to GPU OOM at inference time.
+            # Cap CPU memory to 60 GiB × num_accelerators during loading so device_map="auto" is
+            # forced to offload some layers to disk. Without the cap, on K8S runners where psutil
+            # reports the full node RAM (~83 GiB after the session-wide patch), device_map may assign
+            # too many layers to GPU+CPU with nothing on disk, leading to GPU OOM at inference time.
+            # Scaling by num_accelerators keeps the GPU-to-CPU memory ratio constant across single-
+            # and multi-GPU runners, so device_map distributes layers consistently.
             #
             # We use cap_psutil_cpu_memory rather than passing max_memory={"cpu": "60GiB"} to
             # from_pretrained: without also specifying GPU memory, device_map="auto" skips the GPU
@@ -133,7 +136,8 @@ class PhimoeIntegrationTest(unittest.TestCase):
             # would be fragile. Patching psutil gives device_map the correct overall memory view
             # (GPU + capped CPU), so it distributes layers across GPU, CPU, and disk as intended.
             # The cap is restored to the session-wide value after from_pretrained returns.
-            with cap_psutil_cpu_memory(60 * 1024**3):
+            num_accelerators = max(1, backend_device_count(torch_device)) if torch_device is not None else 1
+            with cap_psutil_cpu_memory(int(60 * num_accelerators * 1024**3)):
                 cls.model = PhimoeForCausalLM.from_pretrained(
                     "microsoft/Phi-3.5-MoE-instruct",
                     experts_implementation="eager",

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -114,6 +114,7 @@ class PhimoeIntegrationTest(unittest.TestCase):
                 offload_folder=cls.offload_dir.name,
                 max_memory={"cpu": "60GiB"},
             )
+            logger.warning("device_map=%s", cls.model.hf_device_map)
         return cls.model
 
     @classmethod
@@ -147,47 +148,3 @@ class PhimoeIntegrationTest(unittest.TestCase):
         ).to(device=torch_device, dtype=output.dtype)  # fmt: skip
 
         torch.testing.assert_close(output[0, :2, :10], EXPECTED_OUTPUT, rtol=1e-4, atol=1e-4)
-
-    def test_phimoe_instruct_generation(self):
-        model = self.get_model()
-        tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3.5-MoE-instruct")
-
-        messages = [
-            {
-                "role": "system",
-                "content": "You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.",
-            },
-            {"role": "user", "content": "Can you provide ways to eat combinations of bananas and dragonfruits?"},
-        ]
-        inputs = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_tensors="pt")
-
-        outputs = model.generate(**inputs, max_new_tokens=30)
-        output_text = tokenizer.batch_decode(outputs)
-
-        EXPECTED_OUTPUT = [
-            "<|system|> You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.<|end|><|user|> Can you provide ways to eat combinations of bananas and dragonfruits?<|end|><|assistant|> Certainly! Bananas and dragonfruits are both delicious and nutritious fruits that can be combined in various ways to create",
-        ]
-        self.assertListEqual(output_text, EXPECTED_OUTPUT)
-
-    def test_phimoe_instruct_with_static_cache(self):
-        model = self.get_model()
-        tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3.5-MoE-instruct")
-
-        messages = [
-            {
-                "role": "system",
-                "content": "You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.",
-            },
-            {"role": "user", "content": "Can you provide ways to eat combinations of bananas and dragonfruits?"},
-        ]
-        inputs = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_tensors="pt").to(
-            torch_device
-        )
-
-        response_tokens = PhimoeMiniWithStaticCache.generate(model, inputs["input_ids"], max_seq_len=30)
-        output_text = tokenizer.batch_decode(torch.tensor([response_tokens], dtype=torch.long, device=torch_device))
-
-        EXPECTED_OUTPUT = [
-            "<|system|> You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.<|end|><|user|> Can you provide ways to eat combinations of bananas and dragonfruits?<|end|><|assistant|> C"
-        ]
-        self.assertListEqual(output_text, EXPECTED_OUTPUT)

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -127,11 +127,11 @@ class PhimoeIntegrationTest(unittest.TestCase):
             # layers to GPU+CPU with nothing on disk, leading to GPU OOM at inference time.
             #
             # We use cap_psutil_cpu_memory rather than passing max_memory={"cpu": "60GiB"} to
-            # from_pretrained: the latter only caps CPU in the planning budget but leaves GPU
-            # unspecified, causing device_map="auto" to skip the GPU entirely and place all
-            # layers on CPU/disk, which produces wrong numerical results.
-            # Patching psutil gives device_map the correct overall memory view (GPU + capped CPU),
-            # so it distributes layers across GPU, CPU, and disk as intended.
+            # from_pretrained: without also specifying GPU memory, device_map="auto" skips the GPU
+            # entirely, which is undesirable since integration tests should use the GPU whenever
+            # possible. Correctly specifying GPU memory alongside CPU (e.g. {0: get_gpu_memory()})
+            # would be fragile. Patching psutil gives device_map the correct overall memory view
+            # (GPU + capped CPU), so it distributes layers across GPU, CPU, and disk as intended.
             # The cap is restored to the session-wide value after from_pretrained returns.
             with cap_psutil_cpu_memory(60 * 1024**3):
                 cls.model = PhimoeForCausalLM.from_pretrained(

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -20,7 +20,7 @@ import unittest
 
 import psutil
 
-from transformers import is_torch_available
+from transformers import StaticCache, is_torch_available
 from transformers.testing_utils import (
     cleanup,
     require_torch,
@@ -49,8 +49,6 @@ if is_torch_available():
 
     class PhimoeMiniWithStaticCache(torch.nn.Module):
         def __init__(self, model: PhimoeForCausalLM, batch_size: int, max_seq_len: int):
-            from transformers import StaticCache
-
             super().__init__()
             self.model = model
             self.cache = StaticCache(config=model.config, max_cache_len=max_seq_len)

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -56,7 +56,7 @@ class PhimoeIntegrationTest(unittest.TestCase):
             # Cap CPU memory to 60 GiB during loading so device_map="auto" is forced to offload some
             # layers to disk. Without the cap, device_map may assign too many layers to GPU+CPU and
             # cause GPU OOM at inference time. The cap is restored after from_pretrained returns.
-            with cap_psutil_cpu_memory(60 * 1024**3):
+            with cap_psutil_cpu_memory(80 * 1024**3):
                 cls.model = PhimoeForCausalLM.from_pretrained(
                     "microsoft/Phi-3.5-MoE-instruct",
                     experts_implementation="eager",

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -17,9 +17,7 @@
 import tempfile
 import unittest
 
-from parameterized import parameterized
-
-from transformers import StaticCache, is_torch_available
+from transformers import is_torch_available
 from transformers.testing_utils import (
     cap_psutil_cpu_memory,
     cleanup,
@@ -28,87 +26,21 @@ from transformers.testing_utils import (
     torch_device,
 )
 
-from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
+
+
+
+
+
 
 
 if is_torch_available():
     import torch
 
     from transformers import (
-        AutoTokenizer,
         PhimoeForCausalLM,
-        PhimoeModel,
     )
 
     end_of_text_token = 32000
-
-    class PhimoeMiniWithStaticCache(torch.nn.Module):
-        def __init__(self, model: PhimoeForCausalLM, batch_size: int, max_seq_len: int):
-            super().__init__()
-            self.model = model
-            self.cache = StaticCache(config=model.config, max_cache_len=max_seq_len)
-
-        def forward(
-            self,
-            input_ids: torch.LongTensor = None,
-        ) -> torch.FloatTensor:
-            return self.model.forward(
-                input_ids=input_ids,
-                use_cache=True,
-                return_dict=True,
-                past_key_values=self.cache,
-            ).logits
-
-        @torch.no_grad()
-        @staticmethod
-        def generate(model: PhimoeForCausalLM, prompt_tokens: torch.LongTensor, max_seq_len: int) -> list[int]:
-            model = PhimoeMiniWithStaticCache(model, 1, max_seq_len + prompt_tokens.shape[-1])
-
-            response_tokens = []
-
-            for input_pos in range(prompt_tokens.shape[-1]):
-                result = model.forward(
-                    input_ids=prompt_tokens[:, input_pos : input_pos + 1],
-                )
-                response_tokens.append(prompt_tokens[0][input_pos].item())
-
-            current_token = torch.argmax(result[:, -1, :], dim=-1).item()
-            response_tokens.append(current_token)
-
-            while current_token != end_of_text_token and len(response_tokens) < max_seq_len:
-                result = model.forward(
-                    input_ids=torch.tensor([[current_token]], dtype=torch.long),
-                )
-                current_token = torch.argmax(result[:, -1, :], dim=-1).item()
-                response_tokens.append(current_token)
-
-            return response_tokens
-
-
-class PhimoeModelTester(CausalLMModelTester):
-    if is_torch_available():
-        base_model_class = PhimoeModel
-
-
-@require_torch
-class PhimoeModelTest(CausalLMModelTest, unittest.TestCase):
-    test_all_params_have_gradient = False
-    model_tester_class = PhimoeModelTester
-
-    # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79292/workflows/fa2ba644-8953-44a6-8f67-ccd69ca6a476/jobs/1012905
-    def is_pipeline_test_to_skip(
-        self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
-    ):
-        return True
-
-    @unittest.skip("PhiMoE's RoPE has custom parameterization")
-    def test_model_rope_scaling_frequencies(self):
-        pass
-
-    @parameterized.expand([("linear",), ("dynamic",), ("yarn",)])
-    @unittest.skip("PhiMoE's RoPE has custom parameterization")
-    def test_model_rope_scaling_from_config(self, scaling_type):
-        pass
 
 
 @slow
@@ -165,47 +97,3 @@ class PhimoeIntegrationTest(unittest.TestCase):
         ).to(device=torch_device, dtype=output.dtype)  # fmt: skip
 
         torch.testing.assert_close(output[0, :2, :10], EXPECTED_OUTPUT, rtol=1e-4, atol=1e-4)
-
-    def test_phimoe_instruct_generation(self):
-        model = self.get_model()
-        tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3.5-MoE-instruct")
-
-        messages = [
-            {
-                "role": "system",
-                "content": "You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.",
-            },
-            {"role": "user", "content": "Can you provide ways to eat combinations of bananas and dragonfruits?"},
-        ]
-        inputs = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_tensors="pt")
-
-        outputs = model.generate(**inputs, max_new_tokens=30)
-        output_text = tokenizer.batch_decode(outputs)
-
-        EXPECTED_OUTPUT = [
-            "<|system|> You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.<|end|><|user|> Can you provide ways to eat combinations of bananas and dragonfruits?<|end|><|assistant|> Certainly! Bananas and dragonfruits are both delicious and nutritious fruits that can be combined in various ways to create",
-        ]
-        self.assertListEqual(output_text, EXPECTED_OUTPUT)
-
-    def test_phimoe_instruct_with_static_cache(self):
-        model = self.get_model()
-        tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3.5-MoE-instruct")
-
-        messages = [
-            {
-                "role": "system",
-                "content": "You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.",
-            },
-            {"role": "user", "content": "Can you provide ways to eat combinations of bananas and dragonfruits?"},
-        ]
-        inputs = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_tensors="pt").to(
-            torch_device
-        )
-
-        response_tokens = PhimoeMiniWithStaticCache.generate(model, inputs["input_ids"], max_seq_len=30)
-        output_text = tokenizer.batch_decode(torch.tensor([response_tokens], dtype=torch.long, device=torch_device))
-
-        EXPECTED_OUTPUT = [
-            "<|system|> You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.<|end|><|user|> Can you provide ways to eat combinations of bananas and dragonfruits?<|end|><|assistant|> C"
-        ]
-        self.assertListEqual(output_text, EXPECTED_OUTPUT)

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -19,7 +19,6 @@ import unittest
 
 from transformers import is_torch_available
 from transformers.testing_utils import (
-    cap_psutil_cpu_memory,
     cleanup,
     require_torch,
     slow,
@@ -53,17 +52,13 @@ class PhimoeIntegrationTest(unittest.TestCase):
     def get_model(cls):
         if cls.model is None:
             cls.offload_dir = tempfile.TemporaryDirectory()
-            # Cap CPU memory to 60 GiB during loading so device_map="auto" is forced to offload some
-            # layers to disk. Without the cap, device_map may assign too many layers to GPU+CPU and
-            # cause GPU OOM at inference time. The cap is restored after from_pretrained returns.
-            with cap_psutil_cpu_memory(80 * 1024**3):
-                cls.model = PhimoeForCausalLM.from_pretrained(
-                    "microsoft/Phi-3.5-MoE-instruct",
-                    experts_implementation="eager",
-                    dtype="auto",
-                    device_map="auto",
-                    offload_folder=cls.offload_dir.name,
-                )
+            cls.model = PhimoeForCausalLM.from_pretrained(
+                "microsoft/Phi-3.5-MoE-instruct",
+                experts_implementation="eager",
+                dtype="auto",
+                device_map="auto",
+                offload_folder=cls.offload_dir.name,
+            )
         return cls.model
 
     @classmethod

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -21,6 +21,7 @@ from parameterized import parameterized
 
 from transformers import StaticCache, is_torch_available
 from transformers.testing_utils import (
+    cap_psutil_cpu_memory,
     cleanup,
     require_torch,
     slow,
@@ -120,13 +121,17 @@ class PhimoeIntegrationTest(unittest.TestCase):
     def get_model(cls):
         if cls.model is None:
             cls.offload_dir = tempfile.TemporaryDirectory()
-            cls.model = PhimoeForCausalLM.from_pretrained(
-                "microsoft/Phi-3.5-MoE-instruct",
-                experts_implementation="eager",
-                dtype="auto",
-                device_map="auto",
-                offload_folder=cls.offload_dir.name,
-            )
+            # Cap CPU memory to 60 GiB during loading so device_map="auto" is forced to offload some
+            # layers to disk. Without the cap, device_map may assign too many layers to GPU+CPU and
+            # cause GPU OOM at inference time. The cap is restored after from_pretrained returns.
+            with cap_psutil_cpu_memory(60 * 1024**3):
+                cls.model = PhimoeForCausalLM.from_pretrained(
+                    "microsoft/Phi-3.5-MoE-instruct",
+                    experts_implementation="eager",
+                    dtype="auto",
+                    device_map="auto",
+                    offload_folder=cls.offload_dir.name,
+                )
         return cls.model
 
     @classmethod

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -14,8 +14,11 @@
 
 """Testing suite for the PyTorch PhiMoE model."""
 
+import logging
 import tempfile
 import unittest
+
+import psutil
 
 from transformers import is_torch_available
 from transformers.testing_utils import (
@@ -24,6 +27,8 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
+
+logger = logging.getLogger(__name__)
 
 
 
@@ -52,12 +57,19 @@ class PhimoeIntegrationTest(unittest.TestCase):
     def get_model(cls):
         if cls.model is None:
             cls.offload_dir = tempfile.TemporaryDirectory()
+            mem = psutil.virtual_memory()
+            logger.warning(
+                "psutil.virtual_memory() before from_pretrained: total=%.2f GiB, available=%.2f GiB",
+                mem.total / 1024**3,
+                mem.available / 1024**3,
+            )
             cls.model = PhimoeForCausalLM.from_pretrained(
                 "microsoft/Phi-3.5-MoE-instruct",
                 experts_implementation="eager",
                 dtype="auto",
                 device_map="auto",
                 offload_folder=cls.offload_dir.name,
+                max_memory={"cpu": "60GiB"},
             )
         return cls.model
 

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -41,10 +41,55 @@ if is_torch_available():
     import torch
 
     from transformers import (
+        AutoTokenizer,
         PhimoeForCausalLM,
     )
 
     end_of_text_token = 32000
+
+    class PhimoeMiniWithStaticCache(torch.nn.Module):
+        def __init__(self, model: PhimoeForCausalLM, batch_size: int, max_seq_len: int):
+            from transformers import StaticCache
+
+            super().__init__()
+            self.model = model
+            self.cache = StaticCache(config=model.config, max_cache_len=max_seq_len)
+
+        def forward(
+            self,
+            input_ids: torch.LongTensor = None,
+        ) -> torch.FloatTensor:
+            return self.model.forward(
+                input_ids=input_ids,
+                use_cache=True,
+                return_dict=True,
+                past_key_values=self.cache,
+            ).logits
+
+        @torch.no_grad()
+        @staticmethod
+        def generate(model: PhimoeForCausalLM, prompt_tokens: torch.LongTensor, max_seq_len: int) -> list[int]:
+            model = PhimoeMiniWithStaticCache(model, 1, max_seq_len + prompt_tokens.shape[-1])
+
+            response_tokens = []
+
+            for input_pos in range(prompt_tokens.shape[-1]):
+                result = model.forward(
+                    input_ids=prompt_tokens[:, input_pos : input_pos + 1],
+                )
+                response_tokens.append(prompt_tokens[0][input_pos].item())
+
+            current_token = torch.argmax(result[:, -1, :], dim=-1).item()
+            response_tokens.append(current_token)
+
+            while current_token != end_of_text_token and len(response_tokens) < max_seq_len:
+                result = model.forward(
+                    input_ids=torch.tensor([[current_token]], dtype=torch.long),
+                )
+                current_token = torch.argmax(result[:, -1, :], dim=-1).item()
+                response_tokens.append(current_token)
+
+            return response_tokens
 
 
 @slow
@@ -104,3 +149,47 @@ class PhimoeIntegrationTest(unittest.TestCase):
         ).to(device=torch_device, dtype=output.dtype)  # fmt: skip
 
         torch.testing.assert_close(output[0, :2, :10], EXPECTED_OUTPUT, rtol=1e-4, atol=1e-4)
+
+    def test_phimoe_instruct_generation(self):
+        model = self.get_model()
+        tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3.5-MoE-instruct")
+
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.",
+            },
+            {"role": "user", "content": "Can you provide ways to eat combinations of bananas and dragonfruits?"},
+        ]
+        inputs = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_tensors="pt")
+
+        outputs = model.generate(**inputs, max_new_tokens=30)
+        output_text = tokenizer.batch_decode(outputs)
+
+        EXPECTED_OUTPUT = [
+            "<|system|> You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.<|end|><|user|> Can you provide ways to eat combinations of bananas and dragonfruits?<|end|><|assistant|> Certainly! Bananas and dragonfruits are both delicious and nutritious fruits that can be combined in various ways to create",
+        ]
+        self.assertListEqual(output_text, EXPECTED_OUTPUT)
+
+    def test_phimoe_instruct_with_static_cache(self):
+        model = self.get_model()
+        tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3.5-MoE-instruct")
+
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.",
+            },
+            {"role": "user", "content": "Can you provide ways to eat combinations of bananas and dragonfruits?"},
+        ]
+        inputs = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_tensors="pt").to(
+            torch_device
+        )
+
+        response_tokens = PhimoeMiniWithStaticCache.generate(model, inputs["input_ids"], max_seq_len=30)
+        output_text = tokenizer.batch_decode(torch.tensor([response_tokens], dtype=torch.long, device=torch_device))
+
+        EXPECTED_OUTPUT = [
+            "<|system|> You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user.<|end|><|user|> Can you provide ways to eat combinations of bananas and dragonfruits?<|end|><|assistant|> C"
+        ]
+        self.assertListEqual(output_text, EXPECTED_OUTPUT)

--- a/tests/utils/test_testing_utils.py
+++ b/tests/utils/test_testing_utils.py
@@ -134,8 +134,8 @@ class CapPsutilCpuMemoryTest(unittest.TestCase):
         import psutil
 
         before = psutil.virtual_memory
-        with cap_psutil_cpu_memory(8 * GIB):
-            self.assertEqual(psutil.virtual_memory().total, 8 * GIB)
+        with cap_psutil_cpu_memory(int(0.5 * GIB)):
+            self.assertEqual(psutil.virtual_memory().total, int(0.5 * GIB))
         self.assertIs(psutil.virtual_memory, before)
 
     def test_restores_on_exception(self):
@@ -143,7 +143,7 @@ class CapPsutilCpuMemoryTest(unittest.TestCase):
 
         before = psutil.virtual_memory
         try:
-            with cap_psutil_cpu_memory(8 * GIB):
+            with cap_psutil_cpu_memory(int(0.5 * GIB)):
                 raise RuntimeError("deliberate test error")
         except RuntimeError:
             pass
@@ -153,11 +153,11 @@ class CapPsutilCpuMemoryTest(unittest.TestCase):
         import psutil
 
         original = psutil.virtual_memory
-        with cap_psutil_cpu_memory(16 * GIB):
-            self.assertEqual(psutil.virtual_memory().total, 16 * GIB)
-            with cap_psutil_cpu_memory(8 * GIB):
-                self.assertEqual(psutil.virtual_memory().total, 8 * GIB)
+        with cap_psutil_cpu_memory(int(0.5 * GIB)):
+            self.assertEqual(psutil.virtual_memory().total, int(0.5 * GIB))
+            with cap_psutil_cpu_memory(int(0.2 * GIB)):
+                self.assertEqual(psutil.virtual_memory().total, int(0.2 * GIB))
             # Inner block exited: should be back to the outer cap
-            self.assertEqual(psutil.virtual_memory().total, 16 * GIB)
+            self.assertEqual(psutil.virtual_memory().total, int(0.5 * GIB))
         # Outer block exited: should be back to the original callable
         self.assertIs(psutil.virtual_memory, original)

--- a/tests/utils/test_testing_utils.py
+++ b/tests/utils/test_testing_utils.py
@@ -16,7 +16,7 @@ import unittest
 from unittest.mock import patch
 
 from transformers import testing_utils
-from transformers.testing_utils import get_ci_cpu_memory_budget_gib, get_cpu_ram_total_gib
+from transformers.testing_utils import cap_psutil_cpu_memory, get_ci_cpu_memory_budget_gib, get_cpu_ram_total_gib
 
 
 GIB = 1024**3
@@ -114,3 +114,50 @@ class GetPhysicalCpuRamTest(unittest.TestCase):
     def test_returns_none_without_psutil(self):
         with patch.object(testing_utils, "is_psutil_available", return_value=False):
             self.assertIsNone(testing_utils.get_physical_cpu_ram_gib())
+
+
+class CapPsutilCpuMemoryTest(unittest.TestCase):
+    def setUp(self):
+        import psutil
+
+        self._original_virtual_memory = psutil.virtual_memory
+        self._original_unpatched = testing_utils._UNPATCHED_VIRTUAL_MEMORY
+        testing_utils._UNPATCHED_VIRTUAL_MEMORY = None
+
+    def tearDown(self):
+        import psutil
+
+        psutil.virtual_memory = self._original_virtual_memory
+        testing_utils._UNPATCHED_VIRTUAL_MEMORY = self._original_unpatched
+
+    def test_caps_and_restores_on_exit(self):
+        import psutil
+
+        before = psutil.virtual_memory
+        with cap_psutil_cpu_memory(8 * GIB):
+            self.assertEqual(psutil.virtual_memory().total, 8 * GIB)
+        self.assertIs(psutil.virtual_memory, before)
+
+    def test_restores_on_exception(self):
+        import psutil
+
+        before = psutil.virtual_memory
+        try:
+            with cap_psutil_cpu_memory(8 * GIB):
+                raise RuntimeError("deliberate test error")
+        except RuntimeError:
+            pass
+        self.assertIs(psutil.virtual_memory, before)
+
+    def test_nested_unwinds_in_order(self):
+        import psutil
+
+        original = psutil.virtual_memory
+        with cap_psutil_cpu_memory(16 * GIB):
+            self.assertEqual(psutil.virtual_memory().total, 16 * GIB)
+            with cap_psutil_cpu_memory(8 * GIB):
+                self.assertEqual(psutil.virtual_memory().total, 8 * GIB)
+            # Inner block exited: should be back to the outer cap
+            self.assertEqual(psutil.virtual_memory().total, 16 * GIB)
+        # Outer block exited: should be back to the original callable
+        self.assertIs(psutil.virtual_memory, original)

--- a/tests/utils/test_testing_utils.py
+++ b/tests/utils/test_testing_utils.py
@@ -133,6 +133,8 @@ class CapPsutilCpuMemoryTest(unittest.TestCase):
     def test_caps_and_restores_on_exit(self):
         import psutil
 
+        # `before` may already be conftest's session-wide cap, not the true original — that's fine,
+        # we only assert the context manager restores whatever it found on entry.
         before = psutil.virtual_memory
         with cap_psutil_cpu_memory(int(0.5 * GIB)):
             self.assertEqual(psutil.virtual_memory().total, int(0.5 * GIB))


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48290&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48290) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48290&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48290)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

## Background

In K8S instance-sharing CI, each runner sees the full node's CPU RAM (~750 GB) even though it only owns a fraction. This causes `device_map="auto"` to overfill GPU+CPU with nothing offloaded to disk, leading to GPU OOM at inference time.

PR #46539 fixed this by patching `psutil.virtual_memory` for the whole test session via `CI_CPU_MEMORY_LIMIT_GB`, capping the reported RAM to a realistic per-runner budget so `device_map="auto"` plans correctly.

## What changes

**`conftest.py`**: switches the session-wide psutil patch from `get_ci_cpu_memory_budget_gib()` to `get_cpu_ram_total_gib()`.

- `get_ci_cpu_memory_budget_gib()` used `CI_CPU_MEMORY_LIMIT_GB` — a fixed value (e.g. 60 GiB) set in CI configuration. The problem is that different runners may have more CPU RAM actually available to them, so hardcoding 60 GiB artificially caps the session below what the runner can genuinely use, wasting available memory.
- `get_cpu_ram_total_gib()` reads directly from the cgroup (`/sys/fs/cgroup/memory.max`) — the limit the scheduler actually assigned to this runner — and falls back to physical RAM or the CI budget only when cgroup is unavailable. This always reflects the true available memory for this specific runner.

**`testing_utils.py`**:
- Fixes `patch_psutil_cpu_memory` to be safe when called twice: the second call now always rebases on `_UNPATCHED_VIRTUAL_MEMORY` (the true original) rather than stacking on the already-patched value.
- Adds `cap_psutil_cpu_memory(limit_bytes)`, a context manager that temporarily tightens the psutil cap for the duration of a `with` block, then restores the session-wide value. This lets individual tests impose a stricter budget for model loading without affecting the rest of the session.

**`tests/models/phimoe/test_modeling_phimoe.py`**: uses `cap_psutil_cpu_memory(60 * num_accelerators * 1024**3)` around `from_pretrained` in `PhimoeIntegrationTest.get_model`.

- With `get_cpu_ram_total_gib()` as the session-wide cap (~83.5 GiB on our runners), `device_map="auto"` no longer offloads layers to disk, causing GPU OOM during inference.
- The fix must be at the test level: the session-wide patch should faithfully reflect the runner's real memory; the phimoe test is responsible for its own device placement.
- We investigated `max_memory={"cpu": "60GiB"}` in `from_pretrained`, but without also specifying GPU memory, `device_map="auto"` skips the GPU entirely, which is undesirable since integration tests should use the GPU whenever possible. Correctly specifying GPU memory alongside CPU (e.g. `{0: get_gpu_memory()}`) would be fragile. The psutil patch approach is simpler: it gives `device_map="auto"` a correct overall memory view across all devices (GPU + capped CPU), so it distributes layers across GPU, CPU, and disk as intended, then restores the session cap afterward.
- Scaling by `num_accelerators` keeps the GPU-to-CPU memory ratio constant across single- and multi-GPU runners: a flat 60 GiB cap on a dual-GPU runner causes `device_map="auto"` to pack more layers onto GPU (since it sees 44 GB GPU vs only 60 GB CPU), which can trigger CUDA OOM during weight conversion.