### PR TITLE
Disable daily nightly CI

### DIFF
--- a/.github/workflows/self-nightly-caller.yml
+++ b/.github/workflows/self-nightly-caller.yml
@@ -2,12 +2,12 @@ name: Nvidia CI with nightly torch
 
 on:
   repository_dispatch:
-  # triggered when the daily scheduled Nvidia CI is completed.
-  # This way, we can compare the results more easily.
-  workflow_run:
-    workflows: ["Nvidia CI"]
-    branches: ["main"]
-    types: [completed]
+  # The daily run is disabled. It used to be triggered when the daily scheduled Nvidia CI completed, so that the
+  # results could be compared more easily. Re-enable by uncommenting the `workflow_run` trigger below.
+  # workflow_run:
+  #   workflows: ["Nvidia CI"]
+  #   branches: ["main"]
+  #   types: [completed]
   push:
     branches:
       - run_ci_with_nightly_torch*


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48292&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48292) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48292&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48292)
<!-- ci-dashboard-badge:end -->

As per title: since we don't use the results of this CI in a daily way, disable its daily run.