### PR TITLE
fix(mluke): resolve ent ids via vocab not positional index

### DIFF
--- a/src/transformers/models/mluke/tokenization_mluke.py
+++ b/src/transformers/models/mluke/tokenization_mluke.py
@@ -1012,12 +1012,9 @@ class MLukeTokenizer(TokenizersBackend):
 
             # add special tokens to input ids
             entity_token_start, entity_token_end = first_entity_token_spans[0]
-            first_ids = (
-                first_ids[:entity_token_end] + [self.extra_special_tokens_ids[0]] + first_ids[entity_token_end:]
-            )
-            first_ids = (
-                first_ids[:entity_token_start] + [self.extra_special_tokens_ids[0]] + first_ids[entity_token_start:]
-            )
+            ent_id = self.convert_tokens_to_ids("<ent>")
+            first_ids = first_ids[:entity_token_end] + [ent_id] + first_ids[entity_token_end:]
+            first_ids = first_ids[:entity_token_start] + [ent_id] + first_ids[entity_token_start:]
             first_entity_token_spans = [(entity_token_start, entity_token_end + 2)]
 
         elif self.task == "entity_pair_classification":
@@ -1037,9 +1034,11 @@ class MLukeTokenizer(TokenizersBackend):
             first_ids, first_entity_token_spans = get_input_ids_and_entity_token_spans(text, entity_spans)
 
             head_token_span, tail_token_span = first_entity_token_spans
+            ent_id = self.convert_tokens_to_ids("<ent>")
+            ent2_id = self.convert_tokens_to_ids("<ent2>")
             token_span_with_special_token_ids = [
-                (head_token_span, self.extra_special_tokens_ids[0]),
-                (tail_token_span, self.extra_special_tokens_ids[1]),
+                (head_token_span, ent_id),
+                (tail_token_span, ent2_id),
             ]
             if head_token_span[0] < tail_token_span[0]:
                 first_entity_token_spans[0] = (head_token_span[0], head_token_span[1] + 2)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48316&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48316) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48316&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48316)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes entity marker id resolution in `MLukeTokenizer`.

`MLukeTokenizer` emits `<s>` instead of `<ent>` on all entity tasks. The code at `tokenization_mluke.py:1016,1019,1041,1042` used the positional indices `self.extra_special_tokens_ids[0]` and `[1]`, which resolve to `<s>` (id 0) rather than the intended entity markers when token ordering varies.

The fix resolves the marker ids by vocab lookup with `convert_tokens_to_ids`. The four positional sites now use `ent_id = self.convert_tokens_to_ids("<ent>")` and `ent2_id = self.convert_tokens_to_ids("<ent2>")`.

Verified red to green. Before the fix, decoded entity classification output showed `<s>` markers. After the fix it shows `<ent>` and `<ent2>`. The change touches 1 file (7 insertions, 8 deletions) and `ruff check` passes.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

Tokenizers: @ArthurZucker @itazap
