### PR TITLE
Byte-level tokenizer.json + Hub tokenizer_class LlamaTokenizer/Fast

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -668,10 +668,9 @@ def _tokenizer_json_has_byte_level(
     )
     if resolved_file is None:
         return False
+
     with open(resolved_file, encoding="utf-8") as reader:
-        tokenizer_json = json.load(reader)
-    pipeline = (tokenizer_json.get("pre_tokenizer"), tokenizer_json.get("decoder"))
-    return "ByteLevel" in str(pipeline)
+        return '"ByteLevel"' in reader.read()
 
 
 class AutoTokenizer:
@@ -821,6 +820,8 @@ class AutoTokenizer:
         tokenizer_config = get_tokenizer_config(pretrained_model_name_or_path, **kwargs)
         tokenizer_config_class = tokenizer_config.get("tokenizer_class", None)
 
+        kwargs["_commit_hash"] = tokenizer_config.get("_commit_hash", kwargs.get("_commit_hash"))
+
         # Check for auto_map early to handle dynamic tokenizers properly
         tokenizer_auto_map = None
         if "auto_map" in tokenizer_config:
@@ -911,9 +912,6 @@ class AutoTokenizer:
                 f"Tokenizer class '{_hub_class}' specified in the tokenizer config was not found. "
                 f"The tokenizer may need to be converted or re-saved."
             )
-
-        if "_commit_hash" in tokenizer_config:
-            kwargs["_commit_hash"] = tokenizer_config["_commit_hash"]
 
         if tokenizer_config_class and tokenizer_config_class.endswith("Fast"):
             tokenizer_config_class = tokenizer_config_class[:-4]

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -841,7 +841,7 @@ class AutoTokenizer:
         ):
             return TokenizersBackend.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
 
-        # Hub repos that declare this but ship ByteLevel (Llama3 style) must use TokenizersBackend 
+        # Hub repos that declare this but ship ByteLevel (Llama3 style) must use TokenizersBackend
         # because LlamaTokenizer hardcodes Metaspace.
         _hub_declared_class = tokenizer_config_class or getattr(config, "tokenizer_class", None)
         if (

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -843,13 +843,15 @@ class AutoTokenizer:
             return TokenizersBackend.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
 
         # Hub repos that declare this but ship ByteLevel (Llama3 style) must use TokenizersBackend
-        # because LlamaTokenizer hardcodes Metaspace.
+        # because LlamaTokenizer hardcodes Metaspace. Skip Mistral checkpoints (also ByteLevel) so
+        # they still go through the tekken-first MistralCommonBackend check below.
         _hub_declared_class = tokenizer_config_class or getattr(config, "tokenizer_class", None)
         if (
             tokenizer_auto_map is None
             and TokenizersBackend is not None
             and _hub_declared_class is not None
             and _hub_declared_class.removesuffix("Fast") == "LlamaTokenizer"
+            and (TOKENIZER_MAPPING_NAMES.get(config_model_type) or "").removesuffix("Fast") != "MistralCommonBackend"
             and _tokenizer_json_has_byte_level(pretrained_model_name_or_path, **kwargs)
         ):
             logger.warning_once(

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -26,7 +26,7 @@ from transformers.utils.import_utils import is_mistral_common_available
 from ...configuration_utils import PreTrainedConfig
 from ...dynamic_module_utils import get_class_from_dynamic_module, resolve_trust_remote_code
 from ...modeling_gguf_pytorch_utils import load_gguf_checkpoint
-from ...tokenization_utils_base import TOKENIZER_CONFIG_FILE
+from ...tokenization_utils_base import FULL_TOKENIZER_FILE, TOKENIZER_CONFIG_FILE
 from ...utils import (
     extract_commit_hash,
     is_g2p_en_available,
@@ -635,6 +635,45 @@ def get_tokenizer_config(
     return result
 
 
+def _tokenizer_json_has_byte_level(
+    pretrained_model_name_or_path: str | os.PathLike[str],
+    cache_dir: str | os.PathLike[str] | None = None,
+    force_download: bool = False,
+    proxies: dict[str, str] | None = None,
+    token: bool | str | None = None,
+    revision: str | None = None,
+    local_files_only: bool = False,
+    subfolder: str = "",
+    **kwargs,
+) -> bool:
+    """Return whether `tokenizer.json` declares a ByteLevel pre_tokenizer or decoder.
+
+    Used when Hub `tokenizer_class` is `LlamaTokenizer` but the serialized tokenizer is
+    byte-level, so AutoTokenizer can load `TokenizersBackend` instead.
+    """
+    resolved_file = cached_file(
+        pretrained_model_name_or_path,
+        FULL_TOKENIZER_FILE,
+        cache_dir=cache_dir,
+        force_download=force_download,
+        proxies=proxies,
+        token=token,
+        revision=revision,
+        local_files_only=local_files_only,
+        subfolder=subfolder,
+        _raise_exceptions_for_gated_repo=False,
+        _raise_exceptions_for_missing_entries=False,
+        _raise_exceptions_for_connection_errors=False,
+        _commit_hash=kwargs.get("_commit_hash"),
+    )
+    if resolved_file is None:
+        return False
+    with open(resolved_file, encoding="utf-8") as reader:
+        tokenizer_json = json.load(reader)
+    pipeline = (tokenizer_json.get("pre_tokenizer"), tokenizer_json.get("decoder"))
+    return "ByteLevel" in str(pipeline)
+
+
 class AutoTokenizer:
     r"""
     This is a generic tokenizer class that will be instantiated as one of the tokenizer classes of the library when
@@ -800,6 +839,23 @@ class AutoTokenizer:
             and TokenizersBackend is not None
             and any(fnmatch.fnmatch(_config_name_or_path, p) for p in MODEL_IDS_TO_TOKENIZERS_BACKEND)
         ):
+            return TokenizersBackend.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
+
+        # Hub repos that declare this but ship ByteLevel (Llama3 style) must use TokenizersBackend 
+        # because LlamaTokenizer hardcodes Metaspace.
+        _hub_declared_class = tokenizer_config_class or getattr(config, "tokenizer_class", None)
+        if (
+            tokenizer_auto_map is None
+            and TokenizersBackend is not None
+            and _hub_declared_class is not None
+            and _hub_declared_class.removesuffix("Fast") == "LlamaTokenizer"
+            and _tokenizer_json_has_byte_level(pretrained_model_name_or_path, **kwargs)
+        ):
+            logger.warning_once(
+                f"`tokenizer_class` is `{_hub_declared_class}` but `tokenizer.json` is ByteLevel; "
+                "loading `TokenizersBackend`. Set `tokenizer_class` to `TokenizersBackend` in "
+                "`tokenizer_config.json`."
+            )
             return TokenizersBackend.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
 
         # if there is a config, we can check that the tokenizer class != than model class.

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -87,6 +87,26 @@ class AutoTokenizerTest(unittest.TestCase):
     def setUp(self):
         transformers.dynamic_module_utils.TIME_OUT_REMOTE_CODE = 0
 
+    # Byte-level tokenizer.json + Hub tokenizer_class LlamaTokenizer/Fast
+    BYTE_LEVEL_LLAMA_TOKENIZER_CLASS_CHECKPOINTS = [
+        "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+        "deepseek-ai/deepseek-llm-7b-base",
+        "Salesforce/xLAM-1b-fc-r",
+        "microsoft/wavecoder-ultra-6.7b",
+        "LSX-UniWue/LLaMmlein_1B_prerelease",
+        "AI-MO/NuminaMath-7B-TIR",
+    ]
+
+    @slow
+    @require_tokenizers
+    @parameterized.expand(BYTE_LEVEL_LLAMA_TOKENIZER_CLASS_CHECKPOINTS)
+    def test_byte_level_llama_tokenizer_class_uses_tokenizers_backend(self, repo_id):
+        text = "Hello world. I'm an AI."
+        tokenizer = AutoTokenizer.from_pretrained(repo_id)
+        # exact type: LlamaTokenizer subclasses TokenizersBackend
+        self.assertIs(type(tokenizer), TokenizersBackend)
+        self.assertEqual(tokenizer.decode(tokenizer.encode(text, add_special_tokens=False)), text)
+
     @slow
     def test_tokenizer_from_pretrained(self):
         for model_name in ("google-bert/bert-base-uncased", "google-bert/bert-base-cased"):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48317&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48317) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48317&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48317)
<!-- ci-dashboard-badge:end -->

we need to open tokenizer.json to find if its byte level , yet we have llamatokenizer in config. for llama / deepseek models

fixes:  https://github.com/huggingface/transformers/pull/48219