### PR TITLE
fix(cli): migrate chat.py from requests to httpx to fix transformers env

### DIFF
--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -23,7 +23,6 @@ from typing import Annotated, Any
 from urllib.parse import urljoin, urlparse, urlunparse
 
 import httpx
-import requests
 import typer
 import yaml
 from huggingface_hub import AsyncInferenceClient, ChatCompletionStreamOutput
@@ -216,11 +215,6 @@ class RichInterface:
         self._console.print()
 
     def print_model_load(self, model: str):
-        response = requests.post(
-            urljoin(get_service_root_url(self.base_url) + "/", "load_model"), json={"model": model}, stream=True
-        )
-        response.raise_for_status()
-
         class StatsColumn(ProgressColumn):
             def render(self, task):
                 if not task.total:
@@ -266,32 +260,40 @@ class RichInterface:
         task_id = progress.add_task(_label("processor"), total=None)
         cached = False
 
-        with Live(progress, console=self._console, transient=True):
-            for line in response.iter_lines():
-                if not line or not line.startswith(b"data: "):
-                    continue
-                event = json.loads(line[6:])
-                status = event.get("status")
+        url = urljoin(get_service_root_url(self.base_url) + "/", "load_model")
+        with httpx.stream("POST", url, json={"model": model}) as response:
+            response.raise_for_status()
 
-                if status == "ready":
-                    cached = event.get("cached", False)
-                    break
+            with Live(progress, console=self._console, transient=True):
+                for line in response.iter_lines():
+                    if not line or not line.startswith("data: "):
+                        continue
+                    event = json.loads(line[6:])
+                    status = event.get("status")
 
-                if status == "error":
-                    raise RuntimeError(event.get("message", "Unknown error"))
+                    if status == "ready":
+                        cached = event.get("cached", False)
+                        break
 
-                if status == "loading":
-                    stage = event.get("stage")
-                    prog = event.get("progress")
-                    label = _label(stage)
+                    if status == "error":
+                        raise RuntimeError(event.get("message", "Unknown error"))
 
-                    if prog:
-                        unit = "bytes" if stage == "download" else "items"
-                        progress.update(
-                            task_id, description=label, completed=prog["current"], total=prog.get("total"), unit=unit
-                        )
-                    else:
-                        progress.update(task_id, description=label, completed=0, total=None)
+                    if status == "loading":
+                        stage = event.get("stage")
+                        prog = event.get("progress")
+                        label = _label(stage)
+
+                        if prog:
+                            unit = "bytes" if stage == "download" else "items"
+                            progress.update(
+                                task_id,
+                                description=label,
+                                completed=prog["current"],
+                                total=prog.get("total"),
+                                unit=unit,
+                            )
+                        else:
+                            progress.update(task_id, description=label, completed=0, total=None)
 
         if cached:
             self._console.print(Markdown(f"_*{model} was already loaded.*_"))

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -14,8 +14,10 @@
 import json
 import os
 import tempfile
+from unittest.mock import MagicMock, patch
 
 from transformers.cli.chat import (
+    RichInterface,
     get_service_root_url,
     new_chat_history,
     parse_generate_flags,
@@ -57,3 +59,20 @@ def test_get_service_root_url():
     assert get_service_root_url("http://localhost:8000") == "http://localhost:8000"
     assert get_service_root_url("http://localhost:8000/") == "http://localhost:8000"
     assert get_service_root_url("https://example.com/proxy/v1") == "https://example.com/proxy"
+
+
+def test_print_model_load():
+    mock_resp = MagicMock()
+    mock_resp.iter_lines.return_value = [
+        "data: " + json.dumps({"status": "loading", "stage": "processor"}),
+        "data: " + json.dumps({"status": "ready", "cached": True}),
+    ]
+    mock_stream = MagicMock()
+    mock_stream.__enter__.return_value = mock_resp
+    mock_stream.__exit__.return_value = None
+
+    with patch("httpx.stream", return_value=mock_stream) as stream_mock:
+        client = RichInterface(model_id="dummy-model", user_id="user", base_url="http://localhost:8000/v1")
+        client.print_model_load("dummy-model")
+
+    stream_mock.assert_called_once_with("POST", "http://localhost:8000/load_model", json={"model": "dummy-model"})


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48318&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48318) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48318&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48318)
<!-- ci-dashboard-badge:end -->

### Problem

`transformers.cli.transformers` imports `Chat` from `transformers.cli.chat` at top-level. `chat.py` previously imported `requests` unconditionally at top-level and used it in `print_model_load` for streaming model-load status.

Because `requests` is not a core requirement of `transformers`, running CLI commands such as `transformers env` or `transformers version` in a clean environment failed with:
```
ModuleNotFoundError: No module named 'requests'
```

Fixes #48283

### Solution

- Migrated `RichInterface.print_model_load` in `src/transformers/cli/chat.py` from `requests.post(..., stream=True)` to `httpx.stream("POST", ...)` (which is already used across the CLI and serving modules).
- Removed the top-level `import requests`.
- Added unit test `test_print_model_load` in `tests/cli/test_chat.py` verifying the `httpx.stream` invocation and SSE parsing.