### PR TITLE
Ignore a stale best checkpoint recorded in a resumed trainer state

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1575,6 +1575,12 @@ class Trainer:
             os.path.join(resume_from_checkpoint, TRAINER_STATE_NAME)
         ):
             self.state = TrainerState.load_from_json(os.path.join(resume_from_checkpoint, TRAINER_STATE_NAME))
+            if self.state.best_model_checkpoint is not None and not os.path.isdir(self.state.best_model_checkpoint):
+                logger.warning(
+                    f"The best checkpoint {self.state.best_model_checkpoint} recorded in the resumed state does not "
+                    "exist anymore. Ignoring it for this run."
+                )
+                self.state.best_model_checkpoint = None
             compare_trainer_and_checkpoint_args(self.args, self.state)
             self._load_callback_state()
             epochs_trained = int(self.state.global_step // num_update_steps_per_epoch)

--- a/tests/trainer/test_trainer_checkpointing.py
+++ b/tests/trainer/test_trainer_checkpointing.py
@@ -24,6 +24,7 @@ import dataclasses
 import math
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
@@ -2049,6 +2050,67 @@ class TrainerBestModelTest(TestCasePlus, TrainerIntegrationCommon):
                 trainer.train()
                 self.check_saved_checkpoints(tmpdir, 5, total, is_pretrained=pretrained)
                 self.check_best_model_has_been_loaded(tmpdir, 5, total, trainer, "eval_loss", is_pretrained=pretrained)
+
+    def test_resume_from_checkpoint_with_stale_best_model_checkpoint(self):
+        def constant_metrics(_):
+            return {"accuracy": 0.5}
+
+        with (
+            tempfile.TemporaryDirectory() as tmp_dir_a,
+            tempfile.TemporaryDirectory() as tmp_dir_moved,
+            tempfile.TemporaryDirectory() as tmp_dir_b,
+        ):
+            trainer = get_regression_trainer(
+                output_dir=tmp_dir_a,
+                learning_rate=0.1,
+                eval_strategy="steps",
+                eval_steps=2,
+                save_steps=2,
+                save_total_limit=1,
+                load_best_model_at_end=True,
+                metric_for_best_model="accuracy",
+                greater_is_better=True,
+                compute_metrics=constant_metrics,
+                max_steps=4,
+            )
+            trainer.train()
+
+            stale_best = trainer.state.best_model_checkpoint
+            self.assertIsNotNone(stale_best)
+            # With save_total_limit=1 only the best checkpoint survived the first run
+            checkpoints_a = [os.path.basename(str(p)) for p in Path(tmp_dir_a).glob(f"{PREFIX_CHECKPOINT_DIR}-*")]
+            self.assertEqual(checkpoints_a, [os.path.basename(stale_best)])
+
+            # Simulate the original run being deleted and its checkpoints moved elsewhere
+            moved_checkpoint = os.path.join(tmp_dir_moved, os.path.basename(stale_best))
+            shutil.move(stale_best, moved_checkpoint)
+
+            trainer = get_regression_trainer(
+                output_dir=tmp_dir_b,
+                learning_rate=0.1,
+                eval_strategy="steps",
+                eval_steps=2,
+                save_steps=2,
+                save_total_limit=1,
+                load_best_model_at_end=True,
+                metric_for_best_model="accuracy",
+                greater_is_better=True,
+                compute_metrics=constant_metrics,
+                max_steps=6,
+            )
+            with CaptureLogger(logging.get_logger()) as cl:
+                output = trainer.train(resume_from_checkpoint=moved_checkpoint)
+
+            self.assertEqual(output.global_step, 6)
+            self.assertIn("does not exist", cl.out)
+            self.assertTrue(
+                trainer.state.best_model_checkpoint is None
+                or trainer.state.best_model_checkpoint.startswith(tmp_dir_b + os.sep)
+            )
+            checkpoints_b = sorted(
+                os.path.basename(str(p)) for p in Path(tmp_dir_b).glob(f"{PREFIX_CHECKPOINT_DIR}-*")
+            )
+            self.assertEqual(checkpoints_b, [f"{PREFIX_CHECKPOINT_DIR}-6"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48319&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48319) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48319&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48319)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48315

Resuming a run from a checkpoint whose `trainer_state.json` records a `best_model_checkpoint` directory that no longer exists on disk (checkpoints moved to another machine, original run dir deleted) kept the dead path for the whole resumed run. With `load_best_model_at_end=True` and `save_total_limit=1`, training ran to completion and then crashed in `_finalize_training` on `os.path.samefile` (`FileNotFoundError`), and the ghost path also kept one extra checkpoint beyond `save_total_limit` all run long via `rotate_checkpoints`.

#35885 already added a writer-side guard (`_save_checkpoint` only records the path when the folder exists), so states written after that fix are clean. This PR covers the reader side: during resume, `_init_training_state` validates the restored path once - if it is missing it logs a warning and clears `best_model_checkpoint`, so every consumer treats the run as having no best checkpoint yet. All consumers of the field were audited: each one guards on `is not None`, so clearing is safe.

What this deliberately does not do: touch the writer logic from #35885, or repair/delete anything on disk.

## Code Agent Policy

Per [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md)'s disclosure requirement for AI-assisted contributions: this change was prepared with coding tools under my supervision. I reviewed every changed line, validated the behavior end to end with the standalone repro from #48315, and ran the tests below myself.

- Coordination: issue #48315 (opened by me, includes the repro script and root-cause analysis) precedes this PR.
- Difference from existing PRs/issues: #35885 fixed the writer side only and closed #35609 as completed; this is the complementary reader-side validation for state files written before that fix (or produced outside this code path). No open or closed PR implements the reader-side check.
- Commit messages contain no tool attribution per repo rules; the disclosure lives here in the description only.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. -> #48315
- [x] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)? -> no docs change needed: internal robustness fix plus a warning log line, no public API or documented behavior change
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@SunMarc (trainer)

### Test plan

New regression test `test_resume_from_checkpoint_with_stale_best_model_checkpoint`
(tests/trainer/test_trainer_checkpointing.py): trains once with `load_best_model_at_end=True`,
moves the surviving checkpoint elsewhere to simulate relocation, then resumes into a fresh
output dir. Before the fix it dies after training completes:

```
File ".../trainer.py", line 1878, in _finalize_training
    if not os.path.samefile(checkpoint, self.state.best_model_checkpoint):
FileNotFoundError: [WinError 2] The system cannot find the file specified: '...checkpoint-1'
```

After the fix (current HEAD):

```
python -m pytest tests/trainer/test_trainer_checkpointing.py -k "stale" -q --no-header -p no:cacheprovider
================= 1 passed, 55 deselected, 1 warning in 9.48s ==================

python -m pytest tests/trainer/test_trainer_checkpointing.py -q --no-header -p no:cacheprovider
============ 45 passed, 11 skipped, 1 warning in 72.79s (0:01:12) =============
```

(skips are staging/hub-gated tests unrelated to this change)