### PR TITLE
Fix Zamba2 construction for num_mem_blocks > 1 checkpoints

### DIFF
--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -1217,6 +1217,7 @@ class Zamba2Model(Zamba2PreTrainedModel):
         self._tied_weights_keys = {}
         self.first_transformer_layer_id = 0
         unique_hybrid_blocks = []
+        hybrid_layer_count = 0
 
         for layer_id, layer_type in enumerate(self.layers_block_type):
             mamba_layer = Zamba2MambaDecoderLayer(self.config, layer_idx=layer_id)
@@ -1238,7 +1239,11 @@ class Zamba2Model(Zamba2PreTrainedModel):
                     # Store source patterns to which the subsequent modules will be tied
                     unique_hybrid_blocks.append(prefix_pattern)
 
-                block_id = layer_id % self.config.num_mem_blocks
+                # `block_id` must count hybrid layers, not all layers: the tie cycle above and the
+                # adapter slots inside each block (`i % num_mem_blocks == block_id`, with `i` running
+                # over hybrid layers) both follow hybrid-layer order, as do the published checkpoints.
+                block_id = hybrid_layer_count % self.config.num_mem_blocks
+                hybrid_layer_count += 1
                 attn_block = Zamba2AttentionDecoderLayer(self.config, block_id=block_id)
                 linear_layer = nn.Linear(self.config.hidden_size, self.config.hidden_size, bias=False)
                 layers.append(Zamba2HybridLayer(attn_block, linear_layer, mamba_layer))

--- a/src/transformers/models/zamba2/modular_zamba2.py
+++ b/src/transformers/models/zamba2/modular_zamba2.py
@@ -465,6 +465,7 @@ class Zamba2Model(ZambaModel, Zamba2PreTrainedModel):
         self._tied_weights_keys = {}
         self.first_transformer_layer_id = 0
         unique_hybrid_blocks = []
+        hybrid_layer_count = 0
 
         for layer_id, layer_type in enumerate(self.layers_block_type):
             mamba_layer = Zamba2MambaDecoderLayer(self.config, layer_idx=layer_id)
@@ -486,7 +487,11 @@ class Zamba2Model(ZambaModel, Zamba2PreTrainedModel):
                     # Store source patterns to which the subsequent modules will be tied
                     unique_hybrid_blocks.append(prefix_pattern)
 
-                block_id = layer_id % self.config.num_mem_blocks
+                # `block_id` must count hybrid layers, not all layers: the tie cycle above and the
+                # adapter slots inside each block (`i % num_mem_blocks == block_id`, with `i` running
+                # over hybrid layers) both follow hybrid-layer order, as do the published checkpoints.
+                block_id = hybrid_layer_count % self.config.num_mem_blocks
+                hybrid_layer_count += 1
                 attn_block = Zamba2AttentionDecoderLayer(self.config, block_id=block_id)
                 linear_layer = nn.Linear(self.config.hidden_size, self.config.hidden_size, bias=False)
                 layers.append(Zamba2HybridLayer(attn_block, linear_layer, mamba_layer))

--- a/tests/models/zamba2/test_modeling_zamba2.py
+++ b/tests/models/zamba2/test_modeling_zamba2.py
@@ -400,60 +400,6 @@ class Zamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_sequence_classification(*config_and_inputs)
 
-    def test_num_mem_blocks_mixed_residue_hybrid_layout(self):
-        # Regression test for #47994: `block_id` was derived from the global layer index while the
-        # weight-tie cycle and the adapter slots follow hybrid-layer order, so every config whose
-        # hybrid layer indices are not all congruent modulo `num_mem_blocks` (all published
-        # `num_mem_blocks=2` checkpoints, e.g. Zamba2-2.7B with hybrid layers `[6, 12, ..., 47, 51]`)
-        # raised at construction. An evenly spaced hybrid layout does not trigger the bug, so this
-        # test must keep a mixed-residue layout: hybrid layers `[2, 4, 7]` have residues `[0, 0, 1]`
-        # modulo 2 while the tie cycle assigns blocks `[0, 1, 0]`.
-        config = Zamba2Config(
-            vocab_size=99,
-            hidden_size=16,
-            num_hidden_layers=8,
-            layers_block_type=["mamba", "mamba", "hybrid", "mamba", "hybrid", "mamba", "mamba", "hybrid"],
-            num_mem_blocks=2,
-            use_shared_attention_adapter=True,
-            adapter_rank=2,
-            num_attention_heads=2,
-            n_mamba_heads=8,
-            mamba_ngroups=8,
-            mamba_d_state=2,
-            chunk_size=8,
-            intermediate_size=4,
-            max_position_embeddings=512,
-            is_decoder=True,
-            use_mamba_kernels=False,
-        )
-        model = Zamba2ForCausalLM(config).eval()
-
-        # The third hybrid layer ties to the first (both block 0), skipping the second (block 1).
-        first_block = model.model.layers[2].shared_transformer
-        second_block = model.model.layers[4].shared_transformer
-        third_block = model.model.layers[7].shared_transformer
-        self.assertIs(third_block.feed_forward.gate_up_proj.weight, first_block.feed_forward.gate_up_proj.weight)
-        self.assertIsNot(third_block.feed_forward.gate_up_proj.weight, second_block.feed_forward.gate_up_proj.weight)
-
-        # Each block holds real (parametrized) adapters exactly at the slots of the hybrid layers
-        # assigned to it, which is the layout the published checkpoints store.
-        def real_adapter_slots(block):
-            return [len(list(adapter.parameters())) > 0 for adapter in block.feed_forward.gate_up_proj_adapter_list]
-
-        self.assertEqual(real_adapter_slots(first_block), [True, False, True])
-        self.assertEqual(real_adapter_slots(second_block), [False, True, False])
-
-        # The full save -> load round trip resolves all ties.
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            model.save_pretrained(tmp_dir)
-            _, loading_info = Zamba2ForCausalLM.from_pretrained(tmp_dir, output_loading_info=True)
-        self.assertSetEqual(set(loading_info["missing_keys"]), set())
-        self.assertSetEqual(set(loading_info["unexpected_keys"]), set())
-
-        with torch.no_grad():
-            logits = model(input_ids=ids_tensor([1, 6], config.vocab_size)).logits
-        self.assertTrue(torch.isfinite(logits).all())
-
     def test_mamba2_chunked_prefill_cpu(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_zamba2_chunked_prefill(*config_and_inputs, device="cpu")
@@ -720,17 +666,29 @@ class Zamba2ModelIntegrationTest(unittest.TestCase):
     def test_num_mem_blocks_2_official_checkpoint(self):
         # Regression test for #47994: every published `num_mem_blocks=2` checkpoint (the Zamba2-2.7B
         # and Zamba2-7B families) raised at construction, before any weight was read, because
-        # `block_id` followed the global layer index while the weight-tie cycle follows
-        # hybrid-layer order.
+        # `block_id` followed the global layer index while the weight-tie cycle follows hybrid-layer
+        # order. The layout is what makes this checkpoint the right one to test: its hybrid layers
+        # `[6, 12, 18, 24, 30, 36, 42, 47, 51]` are not all congruent modulo `num_mem_blocks`, and an
+        # evenly spaced layout constructs fine even without the fix.
         model_id = "Zyphra/Zamba2-2.7B-instruct"
         model, loading_info = Zamba2ForCausalLM.from_pretrained(
             model_id, dtype=torch.bfloat16, output_loading_info=True
         )
         self.assertSetEqual(set(loading_info["missing_keys"]), set())
         self.assertSetEqual(set(loading_info["unexpected_keys"]), set())
+        model.to(torch_device)
 
         tokenizer = AutoTokenizer.from_pretrained(model_id)
-        input_ids = tokenizer("Hey how are you doing?", return_tensors="pt")["input_ids"]
-        with torch.no_grad():
-            logits = model(input_ids=input_ids).logits
-        self.assertTrue(torch.isfinite(logits.float()).all())
+        messages = [{"role": "user", "content": "Hey how are you doing on this lovely evening?"}]
+        inputs = tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, return_tensors="pt", return_dict=True
+        ).to(torch_device)
+        out = model.generate(**inputs, do_sample=False, max_new_tokens=20)
+        output_sentence = tokenizer.decode(out[0, :])
+
+        EXPECTED_TEXTS = Expectations(
+            {
+                (None, None): "<|im_start|> user\nHey how are you doing on this lovely evening?<|im_end|> \n<|im_start|> assistant\nHello! I'm just a computer program, so I don't have feelings or experiences,",
+            }
+        )  # fmt: skip
+        self.assertEqual(output_sentence, EXPECTED_TEXTS.get_expectation())

--- a/tests/models/zamba2/test_modeling_zamba2.py
+++ b/tests/models/zamba2/test_modeling_zamba2.py
@@ -400,6 +400,60 @@ class Zamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_sequence_classification(*config_and_inputs)
 
+    def test_num_mem_blocks_mixed_residue_hybrid_layout(self):
+        # Regression test for #47994: `block_id` was derived from the global layer index while the
+        # weight-tie cycle and the adapter slots follow hybrid-layer order, so every config whose
+        # hybrid layer indices are not all congruent modulo `num_mem_blocks` (all published
+        # `num_mem_blocks=2` checkpoints, e.g. Zamba2-2.7B with hybrid layers `[6, 12, ..., 47, 51]`)
+        # raised at construction. An evenly spaced hybrid layout does not trigger the bug, so this
+        # test must keep a mixed-residue layout: hybrid layers `[2, 4, 7]` have residues `[0, 0, 1]`
+        # modulo 2 while the tie cycle assigns blocks `[0, 1, 0]`.
+        config = Zamba2Config(
+            vocab_size=99,
+            hidden_size=16,
+            num_hidden_layers=8,
+            layers_block_type=["mamba", "mamba", "hybrid", "mamba", "hybrid", "mamba", "mamba", "hybrid"],
+            num_mem_blocks=2,
+            use_shared_attention_adapter=True,
+            adapter_rank=2,
+            num_attention_heads=2,
+            n_mamba_heads=8,
+            mamba_ngroups=8,
+            mamba_d_state=2,
+            chunk_size=8,
+            intermediate_size=4,
+            max_position_embeddings=512,
+            is_decoder=True,
+            use_mamba_kernels=False,
+        )
+        model = Zamba2ForCausalLM(config).eval()
+
+        # The third hybrid layer ties to the first (both block 0), skipping the second (block 1).
+        first_block = model.model.layers[2].shared_transformer
+        second_block = model.model.layers[4].shared_transformer
+        third_block = model.model.layers[7].shared_transformer
+        self.assertIs(third_block.feed_forward.gate_up_proj.weight, first_block.feed_forward.gate_up_proj.weight)
+        self.assertIsNot(third_block.feed_forward.gate_up_proj.weight, second_block.feed_forward.gate_up_proj.weight)
+
+        # Each block holds real (parametrized) adapters exactly at the slots of the hybrid layers
+        # assigned to it, which is the layout the published checkpoints store.
+        def real_adapter_slots(block):
+            return [len(list(adapter.parameters())) > 0 for adapter in block.feed_forward.gate_up_proj_adapter_list]
+
+        self.assertEqual(real_adapter_slots(first_block), [True, False, True])
+        self.assertEqual(real_adapter_slots(second_block), [False, True, False])
+
+        # The full save -> load round trip resolves all ties.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model.save_pretrained(tmp_dir)
+            _, loading_info = Zamba2ForCausalLM.from_pretrained(tmp_dir, output_loading_info=True)
+        self.assertSetEqual(set(loading_info["missing_keys"]), set())
+        self.assertSetEqual(set(loading_info["unexpected_keys"]), set())
+
+        with torch.no_grad():
+            logits = model(input_ids=ids_tensor([1, 6], config.vocab_size)).logits
+        self.assertTrue(torch.isfinite(logits).all())
+
     def test_mamba2_chunked_prefill_cpu(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_zamba2_chunked_prefill(*config_and_inputs, device="cpu")
@@ -661,3 +715,22 @@ class Zamba2ModelIntegrationTest(unittest.TestCase):
             rtol=1e-3,
             atol=6e-3 if device == "cpu" else 1e-3,
         )
+
+    @slow
+    def test_num_mem_blocks_2_official_checkpoint(self):
+        # Regression test for #47994: every published `num_mem_blocks=2` checkpoint (the Zamba2-2.7B
+        # and Zamba2-7B families) raised at construction, before any weight was read, because
+        # `block_id` followed the global layer index while the weight-tie cycle follows
+        # hybrid-layer order.
+        model_id = "Zyphra/Zamba2-2.7B-instruct"
+        model, loading_info = Zamba2ForCausalLM.from_pretrained(
+            model_id, dtype=torch.bfloat16, output_loading_info=True
+        )
+        self.assertSetEqual(set(loading_info["missing_keys"]), set())
+        self.assertSetEqual(set(loading_info["unexpected_keys"]), set())
+
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        input_ids = tokenizer("Hey how are you doing?", return_tensors="pt")["input_ids"]
+        with torch.no_grad():
+            logits = model(input_ids=input_ids).logits
+        self.assertTrue(torch.isfinite(logits.float()).all())


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48325&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48325) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48325&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48325)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #47994, as requested there — thanks for the bisect and for pointing at the missing adapter handling.

Every published `num_mem_blocks=2` checkpoint (the Zamba2-2.7B and Zamba2-7B families, five Hub repos) raises at construction, before any weight is read:

```python
import torch
from transformers import AutoConfig, Zamba2ForCausalLM

config = AutoConfig.from_pretrained("Zyphra/Zamba2-2.7B-instruct")
with torch.device("meta"):
    Zamba2ForCausalLM(config)  # ValueError: ... `tie_weights_keys` ... layers.12 <-> layers.47
```

## Root cause

In `Zamba2Model.get_layers`, `block_id = layer_id % num_mem_blocks` follows the global layer index, while the weight-tie cycle right above advances once per hybrid layer — and the adapter slots inside each shared block follow hybrid-layer order too (`i % num_mem_blocks == block_id`, with `i` running over hybrid layers). On the 2.7B layout (hybrid layers `[6, 12, 18, 24, 30, 36, 42, 47, 51]`) the global rule assigns blocks `[0, 0, 0, 0, 0, 0, 0, 1, 1]` where the tie cycle expects `[0, 1, 0, 1, 0, 1, 0, 1, 0]`, so tie validation ends up pairing structurally different blocks (`layers.47` into `layers.12`, with disjoint adapter sets) and raises.

The fix derives `block_id` from a hybrid-layer counter. About the adapter handling the old code had ([L1465-L1472](https://github.com/huggingface/transformers/blob/113424bcd53b92600f77d82f48add0a60fb41556/src/transformers/models/zamba2/modeling_zamba2.py#L1465-L1472)): with this fix no separate adapter bookkeeping is needed — the per-layer prefix pattern (`layers.{N}.shared_transformer`) ties the adapter lists together with the trunk, and hybrid-order `block_id` is exactly what makes the tied blocks structurally identical. `num_mem_blocks == 1` (the Zamba2-1.2B family, and the config default) is unaffected: both rules give every hybrid layer block 0.

## Verification against the Hub (config + safetensors metadata only)

- The five failing repos (`Zamba2-2.7B`, `-2.7B-instruct`, `-2.7B-Instruct-v2`, `-7B-Instruct`, `-7B-Instruct-v2`) all construct on the meta device, and the built parameter names match the checkpoint tensor names exactly: 531/531 for the 2.7B family, 786/786 for the 7B family.
- The three `Zamba2-1.2B` repos build an identical parameter set under the old and the new rule — the fix is a no-op for every published checkpoint that constructs today.
- Exact BC bound: a `num_mem_blocks > 1` config whose hybrid layers are evenly spaced (all indices congruent mod `num_mem_blocks`) constructs on `main` too, and this fix moves its adapter slot names. No Hub checkpoint has that shape.

## Tests

- `test_num_mem_blocks_mixed_residue_hybrid_layout` (fast, no Hub access): tiny config, hybrid layers `[2, 4, 7]`, `num_mem_blocks=2`. The mixed-residue layout is load-bearing: an evenly spaced one constructs even without the fix and would catch nothing. Asserts construction, tie sharing, per-block adapter slots, and a save→load round trip. Fails on `main` with the issue's `ValueError`.
- `test_num_mem_blocks_2_official_checkpoint` (slow): `Zyphra/Zamba2-2.7B-instruct` — one of the official checkpoints failing today, as requested — loads with no missing or unexpected keys and returns finite logits.

## Who can review?

@zucchini-nlp @Rocketknight1