### PR TITLE
fix(zamba):  add use_associative_scan config flag to avoid torch.compile slowdown

### DIFF
--- a/src/transformers/models/zamba/configuration_zamba.py
+++ b/src/transformers/models/zamba/configuration_zamba.py
@@ -47,6 +47,10 @@ class ZambaConfig(PreTrainedConfig):
         Flag indicating whether or not to use the fast mamba kernels. These are available only if `mamba-ssm` and
         `causal-conv1d` are installed, and the mamba modules are running on a CUDA device. Raises ValueError if
         `True` and kernels are not available
+    use_associative_scan (`bool`, *optional*, defaults to `True`):
+        Whether to use PyTorch's `torch._higher_order_ops.associative_scan` for the
+        parallel scan instead of the naive sequential implementation.
+        Set to `False` to fall back to the sequential loop.
     mamba_dt_rank (`Union[int,str]`, *optional*, defaults to `"auto"`):
         Rank of the mamba discretization projection matrix. `"auto"` means that it will default to `math.ceil(self.hidden_size / 16)`
     layers_block_type (`str`, *optional*):
@@ -85,6 +89,7 @@ class ZambaConfig(PreTrainedConfig):
     mamba_d_conv: int = 4
     mamba_expand: int = 2
     mamba_dt_rank: str | int = "auto"
+    use_associative_scan: bool = True
     time_step_min: float = 0.001
     time_step_max: float = 0.1
     time_step_floor: float = 1e-4

--- a/src/transformers/models/zamba/modeling_zamba.py
+++ b/src/transformers/models/zamba/modeling_zamba.py
@@ -430,6 +430,7 @@ class ZambaMambaMixer(nn.Module):
         self.act = ACT2FN[config.hidden_mamba_act]
 
         self.use_fast_kernels = config.use_mamba_kernels
+        self.use_associative_scan = config.use_associative_scan
 
         # projection of the input hidden states
         self.in_proj = nn.Linear(self.hidden_size, self.intermediate_size * 2, bias=self.use_bias)
@@ -580,7 +581,7 @@ class ZambaMambaMixer(nn.Module):
                     return_last_state=output_final_state,
                     # Old model: only when user request it explicitly
                     use_mambapy=False,
-                    use_associative_scan=False,
+                    use_associative_scan=self.use_associative_scan,
                 )
 
                 if output_final_state:

--- a/tests/models/zamba/test_modeling_zamba.py
+++ b/tests/models/zamba/test_modeling_zamba.py
@@ -16,9 +16,12 @@
 import math
 import unittest
 
+import pytest
+
 from transformers import AutoTokenizer, ZambaConfig, is_torch_available
 from transformers.testing_utils import (
     require_torch,
+    require_torch_greater_or_equal,
     slow,
     torch_device,
 )
@@ -516,3 +519,36 @@ class ZambaModelIntegrationTest(unittest.TestCase):
 
         torch.testing.assert_close(logits[0, -1, :40].cpu(), EXPECTED_LOGITS_NO_GRAD_0, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(logits[1, -1, :40].cpu(), EXPECTED_LOGITS_NO_GRAD_1, rtol=1e-3, atol=1e-3)
+
+    @require_torch_greater_or_equal("2.9.0")
+    @pytest.mark.torch_compile_test
+    @slow
+    def test_associative_scan_matches_sequential(self):
+        """Compiled generate with use_associative_scan=False vs =True produces the same text."""
+        if torch_device == "cpu":
+            self.skipTest("Associative scan compile test requires a torch accelerator.")
+
+        input_ids = self.tokenizer("Hey how are you doing?", return_tensors="pt")["input_ids"].to(torch_device)
+
+        # Opt-out: use_associative_scan=False → compiled sequential loop
+        model = ZambaForCausalLM.from_pretrained(
+            "Zyphra/Zamba-7B-v1", dtype=torch.bfloat16, use_associative_scan=False
+        ).to(torch_device)
+        model.eval()
+        model.forward = torch.compile(model.forward)
+        output = model.generate(input_ids, do_sample=False, use_cache=False, max_new_tokens=10)
+        expected_text = self.tokenizer.decode(output[0].tolist())
+
+        del model
+        torch._dynamo.reset()
+
+        # Opt-in: use_associative_scan=True → compiled associative scan
+        model = ZambaForCausalLM.from_pretrained(
+            "Zyphra/Zamba-7B-v1", dtype=torch.bfloat16, use_associative_scan=True
+        ).to(torch_device)
+        model.eval()
+        model.forward = torch.compile(model.forward)
+        output = model.generate(input_ids, do_sample=False, use_cache=False, max_new_tokens=10)
+        output_text = self.tokenizer.decode(output[0].tolist())
+
+        self.assertEqual(output_text, expected_text)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48331&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48331) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48331&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48331)
<!-- ci-dashboard-badge:end -->

ZambaMambaMixer.forward() passes use_associative_scan=False directly to mamba_selective_scan, which falls back to a sequential Python loop that makes torch.compile slow.

The other Mamba-family models (mamba, jamba, falcon_mamba) instead read this setting from their config and forward it to the scan function. This PR adds the same plumbing to ZambaConfig and ZambaMambaMixer.

Changes:
1. configuration_zamba.py: add use_associative_scan: bool = True field
2. modeling_zamba.py: read config.use_associative_scan in __init__ and pass it in forward() instead of the hardcoded False

@vasqu