### PR TITLE
Fix flaky test_training_gradient_checkpointing for BigBirdPegasus (fp noise filter)

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1733,8 +1733,7 @@ class ModelTesterMixin(ExportTesterMixin):
                     # Observed flakiness (see #48332): a parameter's gradient is exactly 0.0 in one
                     # run and a tiny value (≤1e-6, orders of magnitude below real gradients) in the
                     # other. Either side can be the near-zero one. Treat such pairs as not a mismatch.
-                    # fmt: off
-                    _fp_noise = 1e-6  # see #48332
+                    _fp_noise = 1e-6
                     only_in_normal = {
                         n
                         for n in only_in_normal
@@ -1745,8 +1744,6 @@ class ModelTesterMixin(ExportTesterMixin):
                         for n in only_in_gradcp
                         if not (normal_grad_sums[n] == 0.0 and gradcp_grad_sums[n] <= _fp_noise)
                     }
-                    # fmt: on
-
                     self.assertEqual(
                         # set union
                         only_in_gradcp | only_in_normal,

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1697,7 +1697,8 @@ class ModelTesterMixin(ExportTesterMixin):
                 loss = model(**inputs).loss
                 loss.backward()
                 grad_expected_params = [(n, p) for n, p in model.named_parameters() if p.grad is not None]
-                non_zero_grads_normal = {n for n, p in grad_expected_params if p.grad.abs().sum() > 0}
+                normal_grad_sums = {n: p.grad.abs().sum().item() for n, p in grad_expected_params}
+                non_zero_grads_normal = {n for n, s in normal_grad_sums.items() if s > 0}
 
                 # reset all gradients to zero for the comparison with the gradient checkpointing run
                 optimizer.zero_grad()
@@ -1722,8 +1723,36 @@ class ModelTesterMixin(ExportTesterMixin):
 
                 # check that all the parameters that had non-zero gradients before, have non-zero grads with gradient
                 # checkpointing. divergence indicates a different forward-pass environment that needs special handling.
-                non_zero_grads_gradcp = {n for n, p in grad_expected_params if p.grad.abs().sum() > 0}
-                self.assertEqual(non_zero_grads_gradcp, non_zero_grads_normal)
+                gradcp_grad_sums = {n: p.grad.abs().sum().item() for n, p in grad_expected_params}
+                non_zero_grads_gradcp = {n for n, s in gradcp_grad_sums.items() if s > 0}
+
+                if non_zero_grads_gradcp != non_zero_grads_normal:
+                    only_in_normal = non_zero_grads_normal - non_zero_grads_gradcp
+                    only_in_gradcp = non_zero_grads_gradcp - non_zero_grads_normal
+
+                    # Observed flakiness (see #48332): a parameter's gradient is exactly 0.0 in one
+                    # run and a tiny value (≤1e-6, orders of magnitude below real gradients) in the
+                    # other. Either side can be the near-zero one. Treat such pairs as not a mismatch.
+                    # fmt: off
+                    _fp_noise = 1e-6  # see #48332
+                    only_in_normal = {
+                        n
+                        for n in only_in_normal
+                        if not (gradcp_grad_sums[n] == 0.0 and normal_grad_sums[n] <= _fp_noise)
+                    }
+                    only_in_gradcp = {
+                        n
+                        for n in only_in_gradcp
+                        if not (normal_grad_sums[n] == 0.0 and gradcp_grad_sums[n] <= _fp_noise)
+                    }
+                    # fmt: on
+
+                    self.assertEqual(
+                        # set union
+                        only_in_gradcp | only_in_normal,
+                        set(),
+                        f"non_zero_grads mismatch after filtering fp noise: only_in_normal={only_in_normal}, only_in_gradcp={only_in_gradcp}",
+                    )
 
                 if self.test_all_params_have_gradient:
                     for k, v in model.named_parameters():


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48332&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48332) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48332&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48332)
<!-- ci-dashboard-badge:end -->

## Summary

`test_training_gradient_checkpointing` (and `_use_reentrant_false`) was flaky for BigBirdPegasus on CI: `non_zero_grads_gradcp != non_zero_grads_normal` ~3% of runs.

**Root cause**: `qa_outputs.bias` has a theoretically-zero gradient (cross-entropy bias gradient sums to zero). In some runs it appears as exactly `0.0` in one mode and a tiny value in the other — mostly in the 1e-8 range, occasionally 1e-7 — orders of magnitude below real gradients (~10–30). Either side can be the near-zero one. This is fp noise, not a real correctness issue. The issue appears to be CPU-specific: 10000 iterations on GPU showed no failures.

**Fix** (in `tests/test_modeling_common.py`): after computing the mismatch sets, filter out parameter pairs where one side is exactly `0.0` and the other is ≤1e-6. Assert the remaining union is empty.

Removes the BigBirdPegasus `check_training_gradient_checkpointing` debug override and the two `@unittest.skip` workarounds that were masking the flakiness.