### PR TITLE
[CB] Fail faster

### DIFF
--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -844,7 +844,7 @@ class CBGenerateManager(BaseGenerateManager):
 
     def is_alive(self) -> bool:
         """Whether the CB worker is healthy. ``True`` before ``init_cb()`` is called."""
-        return self._cb is None or self._cb.fatal_error is None
+        return self._cb is None or self._cb.background_thread_status.fatal_error is None
 
     def _check_alive(self, request_id: str) -> None:
         """Raise :class:`CBWorkerDeadError` if the CB worker has died.
@@ -852,10 +852,10 @@ class CBGenerateManager(BaseGenerateManager):
         Called at request entry to fail fast — submitting to a dead worker would otherwise
         enqueue the request into a void where it never gets processed.
         """
-        if self._cb is not None and self._cb.fatal_error is not None:
-            raise CBWorkerDeadError(
-                f"CB worker is dead and cannot accept request {request_id}: {self._cb.fatal_error}"
-            )
+        if self._cb is not None:
+            fatal_error = self._cb.background_thread_status.fatal_error
+            if fatal_error is not None:
+                raise CBWorkerDeadError(f"CB worker is dead and cannot accept request {request_id}: {fatal_error}")
 
     def generate_streaming(
         self,
@@ -955,7 +955,7 @@ class CBGenerateManager(BaseGenerateManager):
         # as requests submitted post-crash; otherwise it's a per-request failure (e.g. unsupported
         # logit-processor kwarg) and a plain RuntimeError -> 500 is appropriate.
         if result.error is not None:
-            if cb.fatal_error is not None:
+            if cb.background_thread_status.fatal_error is not None:
                 raise CBWorkerDeadError(f"CB worker died during request {request_id}: {result.error}")
             raise RuntimeError(f"CB generation failed for {request_id}: {result.error}")
         generated_ids = result.generated_tokens

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -1325,13 +1325,18 @@ class ContinuousMixin:
 
         # Re-order requests to match the order of the inputs
         reordered_results = {}
-        missing_keys = []
+        missing_keys, failed_keys = [], []
         for req_id in request_ids:
             result = results.get(req_id)
             if result is not None:
                 reordered_results[req_id] = result
+                if result.error is not None:
+                    failed_keys.append(req_id)
             else:
                 missing_keys.append(req_id)
+
         if missing_keys:
             logger.error(f"Requests {missing_keys} not found in results.")
+        if failed_keys:
+            logger.error(f"Requests {failed_keys} failed during generation.")
         return reordered_results

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -179,6 +179,15 @@ class BackgroundThreadStatus:
         with self._local_status_lock:
             self._local_status = max(self._local_status, tp_status)
 
+    def can_accept_new_requests(self) -> bool:
+        """Whether the background thread can accept new requests. Raises an error if the background thread already died
+        with a fatal error."""
+        if self.fatal_error is not None:
+            raise RuntimeError(
+                "The continuous batching background thread died with a fatal error."
+            ) from self.fatal_error
+        return self.local_status == self.DONT_STOP
+
     @property
     def local_status(self) -> int:
         """The locally requested status, possibly ahead of the value agreed upon by the TP group."""
@@ -789,8 +798,8 @@ class ContinuousBatchingManager:
         # If this process is not a TP driver, request submission is a no-op
         if not self.is_tp_driver:
             return None
-        # If the manager is not accepting new requests, throw a warning and return None
-        if self.background_thread_status.local_status >= BackgroundThreadStatus.FLUSH_AND_STOP:
+        # If the manager is not accepting new requests, stop here. This also checks for a fatal error in the BG thread.
+        if not self.background_thread_status.can_accept_new_requests():
             preview = f"{input_ids[:3]}"[:-1] + ", ..., " + f"{input_ids[-3:]}"[1:]
             logger.warning(f"Background thread is stopping. Request with ids {preview} will be dropped.")
             return None

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -874,7 +874,7 @@ class ContinuousBatchingManager:
             self.cancel_queue.put(request_id)
             self._has_new_requests.set()
 
-    # TODO:handle benchmarking properly when updating / fixing the requeue logic
+    # TODO (remi-or) : handle benchmarking properly when updating / fixing the requeue logic
     # TODO (remi-or) : this NEEDS to get fixed in a future PR -- it's quite wasteful
     def get_result(self, request_id: str | None = None, timeout: float | None = None) -> GenerationOutput | None:
         """Retrieve one result from the output queue. If an ID is provided, returns the first matching request. If a

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -158,18 +158,23 @@ class BackgroundThreadStatus:
             self._local_status = self.DONT_STOP
         self.fatal_error = None
 
-    def request_stop(self, status: int, global_rank: int, error: Exception | None = None) -> None:
+    def request_stop(self, status: int, global_rank: int) -> None:
         """Request the background thread to stop. This does not take effect immediately, only after the TP group has
-        communicated. If no error has been recorded yet, the provided error will be recorded."""
+        communicated."""
         if status not in [self.FLUSH_AND_STOP, self.HARD_STOP]:
             raise ValueError(f"Invalid stop status {status} from rank {global_rank}")
         with self._local_status_lock:
             self._local_status = max(status, self._local_status, self._tp_status)
-        if self.fatal_error is None:
-            self.fatal_error = error
         logger.info(
             f"Rank {global_rank} requested background thread to stop with {status = }. Now {self._local_status = }"
         )
+
+    def record_fatal_error(self, error: Exception) -> None:
+        """Record a fatal error if none has been recorded yet."""
+        if self.fatal_error is not None:
+            logger.error(f"A fatal error was already recorded, ignoring later error: {error}")
+        else:
+            self.fatal_error = error
 
     def mark_as_stopped(self) -> None:
         """Mark the background thread as stopped. This should be called by the main thread when the generation loop
@@ -186,18 +191,13 @@ class BackgroundThreadStatus:
         with self._local_status_lock:
             self._local_status = max(self._local_status, tp_status)
 
-    def check_for_fatal_error(self) -> None:
-        """Raises an error if the background thread already died with a fatal error."""
+    def can_accept_new_requests(self) -> str | None:
+        """If the background thread cannot accept new requests, return the reason why. Otherwise, returns None."""
         if self.fatal_error is not None:
-            raise RuntimeError(
-                "The continuous batching background thread died with a fatal error."
-            ) from self.fatal_error
-
-    def can_accept_new_requests(self) -> bool:
-        """Whether the background thread can accept new requests. Raises an error if the background thread already died
-        with a fatal error."""
-        self.check_for_fatal_error()
-        return self.local_status == self.DONT_STOP
+            return "The background thread died with a fatal error."
+        if self.local_status != self.DONT_STOP:
+            return "The background thread is stopping."
+        return None
 
     @property
     def local_status(self) -> int:
@@ -806,10 +806,11 @@ class ContinuousBatchingManager:
         # If this process is not a TP driver, request submission is a no-op
         if not self.is_tp_driver:
             return None
-        # If the manager is not accepting new requests, stop here. This also checks for a fatal error in the BG thread.
-        if not self.background_thread_status.can_accept_new_requests():
+        # If the manager is not accepting new requests, stop here.
+        denial_msg = self.background_thread_status.can_accept_new_requests()
+        if denial_msg is not None:
             preview = f"{input_ids[:3]}"[:-1] + ", ..., " + f"{input_ids[-3:]}"[1:]
-            logger.warning(f"Background thread is stopping. Request with ids {preview} will be dropped.")
+            logger.warning(f"{denial_msg}. Request with ids {preview} will be dropped.")
             return None
 
         if request_id is None:
@@ -885,8 +886,7 @@ class ContinuousBatchingManager:
         timeout is provided, returns None after the timeout (in seconds)."""
         # Stop if the output queue is empty and the bg thread is not going to produce new results (crashed or stopped)
         if self.output_router.output_queue.empty():
-            self.background_thread_status.check_for_fatal_error()
-            if self._generation_thread is None:
+            if self._generation_thread is None or self.background_thread_status.fatal_error is not None:
                 return None
         # Otherwise, wait for a result from the output queue
         try:
@@ -1078,13 +1078,15 @@ class ContinuousBatchingManager:
         """Handle critical errors that terminate the generation loop."""
         # Request a hard stop
         self.background_thread_status.request_stop(
-            status=BackgroundThreadStatus.HARD_STOP, global_rank=self.distributed_helper.global_rank, error=error
+            status=BackgroundThreadStatus.HARD_STOP, global_rank=self.distributed_helper.global_rank
         )
         # Communicate to other processes in the TP group that the group is stopping (they could have not crashed)
         # Since the other processes need to reach the collective, it may take a few seconds to complete.
         self.distributed_helper.tp_all_reduce_state(0, BackgroundThreadStatus.HARD_STOP)
         # Fail all remaining requests
         self._fail_all_remaining_requests(error, batch_processor)
+        # After failing the remaining requests (and so retrieving their partial outputs), record the fatal error
+        self.background_thread_status.record_fatal_error(error)
 
     def _fail_all_remaining_requests(self, error: Exception, batch_processor: ContinuousBatchProcessor | None) -> None:
         """Fail all remaining requests in the input queue and active requests."""
@@ -1298,6 +1300,7 @@ class ContinuousMixin:
         # Main loop
         results = {}
         finished_count = 0
+        request_ids = []  # if the manager fails before add_requests returns, request_ids should not be unbounded
         with manager_cm as manager, logging_cm, pbar_cm as pbar:
             try:
                 request_ids = manager.add_requests(

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -179,13 +179,17 @@ class BackgroundThreadStatus:
         with self._local_status_lock:
             self._local_status = max(self._local_status, tp_status)
 
-    def can_accept_new_requests(self) -> bool:
-        """Whether the background thread can accept new requests. Raises an error if the background thread already died
-        with a fatal error."""
+    def check_for_fatal_error(self) -> None:
+        """Raises an error if the background thread already died with a fatal error."""
         if self.fatal_error is not None:
             raise RuntimeError(
                 "The continuous batching background thread died with a fatal error."
             ) from self.fatal_error
+
+    def can_accept_new_requests(self) -> bool:
+        """Whether the background thread can accept new requests. Raises an error if the background thread already died
+        with a fatal error."""
+        self.check_for_fatal_error()
         return self.local_status == self.DONT_STOP
 
     @property
@@ -875,8 +879,12 @@ class ContinuousBatchingManager:
     def get_result(self, request_id: str | None = None, timeout: float | None = None) -> GenerationOutput | None:
         """Retrieve one result from the output queue. If an ID is provided, returns the first matching request. If a
         timeout is provided, returns None after the timeout (in seconds)."""
-        if self._generation_thread is None and self.output_router.output_queue.empty():
-            return None
+        # Stop if the output queue is empty and the bg thread is not going to produce new results (crashed or stopped)
+        if self.output_router.output_queue.empty():
+            self.background_thread_status.check_for_fatal_error()
+            if self._generation_thread is None:
+                return None
+        # Otherwise, wait for a result from the output queue
         try:
             result = self.output_router.output_queue.get(block=True, timeout=timeout)
             if request_id is not None and result.request_id != request_id:

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -127,6 +127,13 @@ class OutputRouter:
 
             loop.call_soon_threadsafe(_run_batch)
 
+    def fail_and_deliver(self, state: RequestState, error: Exception) -> None:
+        """Fail the request and deliver the output to the output router. This is made from the OutputRouter so that it
+        can be called even when a batch processor could not be created."""
+        state.status = RequestStatus.FAILED
+        state.error = str(error)
+        self.deliver(state.to_generation_output())
+
 
 class BackgroundThreadStatus:
     """Tracks the status of the background thread locally and in its TP group. The status is an int that can only
@@ -363,16 +370,13 @@ class ContinuousBatchProcessor:
 
     def _handle_request_error(self, error: Exception, state: RequestState) -> None:
         """Handle general request processing error."""
-        state.status = RequestStatus.FAILED
-        state.error = str(error)
-
         # Include any generated tokens if this is an active request
         if isinstance(state.request_id, str):
             state.generated_tokens = self.scheduler.get_active_request_static_outputs(state.request_id)
         else:
             state.generated_tokens = []
-
-        self.output_router.deliver(state.to_generation_output())
+        # Actual failing of the request
+        self.output_router.fail_and_deliver(state, error)
 
     def prepare_next_batch(self) -> bool:
         """Prepare tensors and metadata for the next model forward pass. Returns True if there are requests to process,
@@ -1090,6 +1094,8 @@ class ContinuousBatchingManager:
                 req_data = self.input_queue.get_nowait()
                 if batch_processor is not None:
                     batch_processor._handle_request_error(error, req_data)
+                else:
+                    self.output_router.fail_and_deliver(req_data, error)
         except queue.Empty:
             pass
         # Fail active and waiting requests

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -141,6 +141,7 @@ class BackgroundThreadStatus:
         self._local_status_lock = threading.Lock()
         self._local_status = self.DONT_STOP
         self._tp_status = self.DONT_STOP
+        self.fatal_error = None
 
     def clear(self) -> None:
         """Clear the local and TP statuses. This method should ONLY be called by the main thread itself BEFORE starting
@@ -148,14 +149,17 @@ class BackgroundThreadStatus:
         self._tp_status = self.DONT_STOP
         with self._local_status_lock:
             self._local_status = self.DONT_STOP
+        self.fatal_error = None
 
-    def request_stop(self, status: int, global_rank: int) -> None:
+    def request_stop(self, status: int, global_rank: int, error: Exception | None = None) -> None:
         """Request the background thread to stop. This does not take effect immediately, only after the TP group has
-        communicated."""
+        communicated. If no error has been recorded yet, the provided error will be recorded."""
         if status not in [self.FLUSH_AND_STOP, self.HARD_STOP]:
             raise ValueError(f"Invalid stop status {status} from rank {global_rank}")
         with self._local_status_lock:
             self._local_status = max(status, self._local_status, self._tp_status)
+        if self.fatal_error is None:
+            self.fatal_error = error
         logger.info(
             f"Rank {global_rank} requested background thread to stop with {status = }. Now {self._local_status = }"
         )
@@ -588,7 +592,6 @@ class ContinuousBatchingManager:
         self._generation_thread = None
 
         # Control flow attributes
-        self.fatal_error: Exception | None = None
         self.warmed_up = False  # Set to True after warmup is completed. Useful for persistent managers.
 
         # Model-related attributes
@@ -682,7 +685,6 @@ class ContinuousBatchingManager:
             logger.warning("Manager thread is already running.")
             return None
         self.background_thread_status.clear()
-        self.fatal_error = None
         self._generation_thread = threading.Thread(target=self._run_generation_loop)
         self._generation_thread.start()
 
@@ -1053,11 +1055,9 @@ class ContinuousBatchingManager:
 
     def _handle_critical_error(self, error: Exception, batch_processor: ContinuousBatchProcessor | None) -> None:
         """Handle critical errors that terminate the generation loop."""
-        # Record the error so callers (e.g. the serving layer) can fail fast on subsequent requests
-        self.fatal_error = error
         # Request a hard stop
         self.background_thread_status.request_stop(
-            status=BackgroundThreadStatus.HARD_STOP, global_rank=self.distributed_helper.global_rank
+            status=BackgroundThreadStatus.HARD_STOP, global_rank=self.distributed_helper.global_rank, error=error
         )
         # Communicate to other processes in the TP group that the group is stopping (they could have not crashed)
         # Since the other processes need to reach the collective, it may take a few seconds to complete.

--- a/src/transformers/generation/continuous_batching/requests.py
+++ b/src/transformers/generation/continuous_batching/requests.py
@@ -116,7 +116,8 @@ class GenerationOutput:
     timestamps: list[float] | None = None  # Timestamps of the generated tokens
 
     def is_finished(self) -> bool:
-        return self.status == RequestStatus.FINISHED
+        """Whether the request reached a terminal state, either because it finished generating or because it failed."""
+        return self.status >= RequestStatus.FINISHED
 
 
 @dataclass
@@ -204,9 +205,11 @@ class RequestState:
 
     @status.setter
     def status(self, value: RequestStatus):
+        # Leaving the pending state means the request started: we stamp the start of its lifespan
         if self._status == RequestStatus.PENDING:
             self.lifespan = (time.perf_counter(), -1)
-        elif value == RequestStatus.FINISHED:
+        # Reaching a terminal state means the request is over: we stamp the end of its lifespan
+        if value >= RequestStatus.FINISHED:
             self.lifespan = (self.lifespan[0], time.perf_counter())
             if logger.isEnabledFor(logging.DEBUG):
                 self.log_end_of_request()

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -1941,7 +1941,7 @@ class TestCBWorkerDeadServerIntegration(unittest.TestCase):
         # Manager whose underlying CB has a fatal_error set -> is_alive() returns False.
         mgr = CBGenerateManager()
         mgr._cb = MagicMock()
-        mgr._cb.fatal_error = RuntimeError("CUDA illegal memory access")
+        mgr._cb.background_thread_status.fatal_error = RuntimeError("CUDA illegal memory access")
         state._cb_manager = mgr
 
         resp = TestClient(self._build_app(state)).get("/health")

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -1239,6 +1239,7 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             def on_result(output):
                 token_counts.append(len(output.generated_tokens))
                 if output.is_finished():
+                    self.assertEqual(output.status, RequestStatus.FINISHED)  # fail if the request failed
                     future.set_result(True)
 
             request_id = manager.add_request(inputs, max_new_tokens=max_new_tokens, streaming=True)
@@ -1394,6 +1395,7 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             while requests_left:
                 result = manager.get_result(timeout=1)
                 if result and result.is_finished():
+                    self.assertEqual(result.status, RequestStatus.FINISHED)  # fail if the request failed
                     results.append(result)
                     requests_left -= 1
                 else:
@@ -1573,6 +1575,7 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             while len(results) < 2:
                 result = manager.get_result(timeout=1)
                 if result is not None and result.is_finished():
+                    self.assertEqual(result.status, RequestStatus.FINISHED)  # fail if the request failed
                     results[result.request_id] = result
                 elif not manager.is_running():
                     break


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48334&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48334) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48334&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48334)
<!-- ci-dashboard-badge:end -->

This PR fixes #48303 and makes error handling more redundant in CB:
- the `fatal_error` attribute lived awkwardly next to `background_thread_status`, an object meant to keep track of the bg thread status (shockingly). Since `fatal_error` is there for consumers to check if the thread is still running, and if not why, it is now an attribute of the `background_thread_status` object
- `add_request` now returns ealry when you try to add a request after a fatal error. It does not fail, because the current API is not built that way, but we can change that downstream.
- `get_output`also returns early if the manager had a `fatal_error`
- unlike in #48301, `get_output` timeout stayed similar but the way `pending_requests` are failed now ensures that even if the processor is not created when the manager fail, there will be an output delivered for pending request. This eliminates the need for a more granular timeout
- changed the behavior of `is_finished` because it's mostly used as `is_finished_or_failed`, there might be a name change down the road but out of scope here

It supersedes #48301.

Tests run well. This script no finishes fast:
```
import traceback
from time import perf_counter

import torch

from transformers import AutoModelForImageTextToText, AutoTokenizer


model_id = "Qwen/Qwen3-VL-4B-Instruct"  # any ForConditionalGeneration model
tokenizer = AutoTokenizer.from_pretrained(model_id)
model = AutoModelForImageTextToText.from_pretrained(model_id, dtype=torch.bfloat16, device_map="cuda:0")

prompt = tokenizer.apply_chat_template([{"role": "user", "content": "Hi!"}], add_generation_prompt=True)["input_ids"]

with model.continuous_batching_context_manager(warmup=False) as cb:
    start = perf_counter()
    try:
        request_id = cb.add_request(prompt)
        print(f"[{perf_counter() - start:.2f}s] add_request returned {request_id = }")
        result = cb.get_result(request_id, timeout=100)
        print(f"[{perf_counter() - start:.2f}s] get_result returned {result = }  <-- BUG: silent timeout")
    except Exception:
        print(f"[{perf_counter() - start:.2f}s] failed fast with:")
        traceback.print_exc()
```