### PR TITLE
Fix video-llama modular conversion

### DIFF
--- a/src/transformers/models/video_llama_3/modular_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/modular_video_llama_3.py
@@ -1166,7 +1166,7 @@ class VideoLlama3VideoProcessor(Qwen2VLVideoProcessor):
     # This processor's resize already spreads `size.longest_edge` across the sampled frames, so
     # Qwen2VL's opt-in cap does not apply here.
     cap_pixels_per_frame = AttributeError()
-    video_total_seq_len = AttributeError()
+    max_video_tokens = AttributeError()
     valid_kwargs = VideoLlama3VideoProcessorInitKwargs
     model_input_names = ["pixel_values_videos", "video_grid_thw", "video_merge_sizes", "video_compression_mask"]
 

--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -267,7 +267,7 @@ if __name__ == "__main__":
                         is_changed_flags.append(result)
                     except Exception as individual_error:
                         console.print(f"[bold red]Failed to convert {file_path}: {individual_error}[/bold red]")
-                        is_changed_flags.append(0)  # Mark as no change to continue processing
+                        is_changed_flags.append(1)  # Mark as changed to let it raise a proper Error
 
             # Collect changed files and their original paths
             for is_changed, file_path in zip(is_changed_flags, files_to_check):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48336&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48336) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48336&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48336)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

I merged a PR and now modular conversion for video-llama-3 is raising an error. CI didnt raise an error because all exceptions in modular check were being skipped, I fixed that as well

Found the workflow where it says `Error: 'video_total_seq_len'; Failed to convert src/transformers/models/video_llama_3/modular_video_llama_3.py: ` but still turns green, letting us merge - https://github.com/huggingface/transformers/actions/runs/32945165588/job/98104299345