### PR TITLE
[debug] Trace previous CI run selection in get_previous_daily_ci.py

### DIFF
--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -31,7 +31,9 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
     workflow_runs = result["workflow_runs"]
     print(f"[DEBUG get_daily_ci_runs] event=schedule returned {len(workflow_runs)} runs:")
     for r in workflow_runs:
-        print(f"  id={r['id']} status={r['status']} conclusion={r.get('conclusion')} created_at={r['created_at']} event={r['event']}")
+        print(
+            f"  id={r['id']} status={r['status']} conclusion={r.get('conclusion')} created_at={r['created_at']} event={r['event']}"
+        )
     if len(workflow_runs) == 0:
         workflow_run_url = f"{url}&event=workflow_run"
         print(f"[DEBUG get_daily_ci_runs] Falling back to: {workflow_run_url}")
@@ -39,7 +41,9 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
         workflow_runs = result["workflow_runs"]
         print(f"[DEBUG get_daily_ci_runs] event=workflow_run returned {len(workflow_runs)} runs:")
         for r in workflow_runs:
-            print(f"  id={r['id']} status={r['status']} conclusion={r.get('conclusion')} created_at={r['created_at']} event={r['event']}")
+            print(
+                f"  id={r['id']} status={r['status']} conclusion={r.get('conclusion')} created_at={r['created_at']} event={r['event']}"
+            )
 
     return workflow_runs
 
@@ -61,7 +65,9 @@ def get_last_daily_ci_run(token, workflow_run_id=None, workflow_id=None, commit_
     workflow_runs = get_daily_ci_runs(token, workflow_id=workflow_id)
     print(f"[DEBUG get_last_daily_ci_run] Iterating {len(workflow_runs)} runs (commit_sha={commit_sha!r}):")
     for run in workflow_runs:
-        print(f"  checking id={run['id']} status={run['status']} conclusion={run.get('conclusion')} created_at={run['created_at']} head_sha={run['head_sha']}")
+        print(
+            f"  checking id={run['id']} status={run['status']} conclusion={run.get('conclusion')} created_at={run['created_at']} head_sha={run['head_sha']}"
+        )
         if commit_sha in [None, ""] and run["status"] == "completed":
             workflow_run = run
             break
@@ -76,7 +82,9 @@ def get_last_daily_ci_run(token, workflow_run_id=None, workflow_id=None, commit_
 
 def get_last_daily_ci_workflow_run_id(token, workflow_run_id=None, workflow_id=None, commit_sha=None):
     """Get the last completed workflow run id of the scheduled (daily) CI."""
-    print(f"[DEBUG get_last_daily_ci_workflow_run_id] called with workflow_run_id={workflow_run_id!r} workflow_id={workflow_id!r} commit_sha={commit_sha!r}")
+    print(
+        f"[DEBUG get_last_daily_ci_workflow_run_id] called with workflow_run_id={workflow_run_id!r} workflow_id={workflow_id!r} commit_sha={commit_sha!r}"
+    )
     if workflow_run_id is not None and workflow_run_id != "":
         print(f"[DEBUG get_last_daily_ci_workflow_run_id] returning early with workflow_run_id={workflow_run_id!r}")
         return workflow_run_id

--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -25,11 +25,21 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
     # On `main` branch + event being `schedule` + not returning PRs + only `num_runs` results
     url += f"?branch=main&exclude_pull_requests=true&per_page={num_runs}"
 
-    result = get_github_json(f"{url}&event=schedule", token=token)
+    schedule_url = f"{url}&event=schedule"
+    print(f"[DEBUG get_daily_ci_runs] Querying: {schedule_url}")
+    result = get_github_json(schedule_url, token=token)
     workflow_runs = result["workflow_runs"]
+    print(f"[DEBUG get_daily_ci_runs] event=schedule returned {len(workflow_runs)} runs:")
+    for r in workflow_runs:
+        print(f"  id={r['id']} status={r['status']} conclusion={r.get('conclusion')} created_at={r['created_at']} event={r['event']}")
     if len(workflow_runs) == 0:
-        result = get_github_json(f"{url}&event=workflow_run", token=token)
+        workflow_run_url = f"{url}&event=workflow_run"
+        print(f"[DEBUG get_daily_ci_runs] Falling back to: {workflow_run_url}")
+        result = get_github_json(workflow_run_url, token=token)
         workflow_runs = result["workflow_runs"]
+        print(f"[DEBUG get_daily_ci_runs] event=workflow_run returned {len(workflow_runs)} runs:")
+        for r in workflow_runs:
+            print(f"  id={r['id']} status={r['status']} conclusion={r.get('conclusion')} created_at={r['created_at']} event={r['event']}")
 
     return workflow_runs
 
@@ -49,7 +59,9 @@ def get_last_daily_ci_run(token, workflow_run_id=None, workflow_id=None, commit_
         return workflow_run
 
     workflow_runs = get_daily_ci_runs(token, workflow_id=workflow_id)
+    print(f"[DEBUG get_last_daily_ci_run] Iterating {len(workflow_runs)} runs (commit_sha={commit_sha!r}):")
     for run in workflow_runs:
+        print(f"  checking id={run['id']} status={run['status']} conclusion={run.get('conclusion')} created_at={run['created_at']} head_sha={run['head_sha']}")
         if commit_sha in [None, ""] and run["status"] == "completed":
             workflow_run = run
             break
@@ -58,12 +70,15 @@ def get_last_daily_ci_run(token, workflow_run_id=None, workflow_id=None, commit_
             workflow_run = run
             break
 
+    print(f"[DEBUG get_last_daily_ci_run] Selected run: {workflow_run['id'] if workflow_run else None}")
     return workflow_run
 
 
 def get_last_daily_ci_workflow_run_id(token, workflow_run_id=None, workflow_id=None, commit_sha=None):
     """Get the last completed workflow run id of the scheduled (daily) CI."""
+    print(f"[DEBUG get_last_daily_ci_workflow_run_id] called with workflow_run_id={workflow_run_id!r} workflow_id={workflow_id!r} commit_sha={commit_sha!r}")
     if workflow_run_id is not None and workflow_run_id != "":
+        print(f"[DEBUG get_last_daily_ci_workflow_run_id] returning early with workflow_run_id={workflow_run_id!r}")
         return workflow_run_id
 
     workflow_run = get_last_daily_ci_run(token, workflow_id=workflow_id, commit_sha=commit_sha)
@@ -71,6 +86,7 @@ def get_last_daily_ci_workflow_run_id(token, workflow_run_id=None, workflow_id=N
     if workflow_run is not None:
         workflow_run_id = workflow_run["id"]
 
+    print(f"[DEBUG get_last_daily_ci_workflow_run_id] returning workflow_run_id={workflow_run_id!r}")
     return workflow_run_id
 
 

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1506,8 +1506,12 @@ if __name__ == "__main__":
     other_workflow_run_ids = []
 
     if is_scheduled_ci_run:
-        print(f"[DEBUG notification_service] is_scheduled_ci_run=True, is_nvidia_daily_ci_workflow={is_nvidia_daily_ci_workflow}")
-        print(f"[DEBUG notification_service] GITHUB_RUN_ID={os.getenv('GITHUB_RUN_ID')!r}, workflow_id={workflow_id!r}")
+        print(
+            f"[DEBUG notification_service] is_scheduled_ci_run=True, is_nvidia_daily_ci_workflow={is_nvidia_daily_ci_workflow}"
+        )
+        print(
+            f"[DEBUG notification_service] GITHUB_RUN_ID={os.getenv('GITHUB_RUN_ID')!r}, workflow_id={workflow_id!r}"
+        )
         prev_workflow_run_id = get_last_daily_ci_workflow_run_id(
             token=os.environ["ACCESS_REPO_INFO_TOKEN"], workflow_id=workflow_id
         )
@@ -1520,7 +1524,9 @@ if __name__ == "__main__":
             other_workflow_run_id = get_last_daily_ci_workflow_run_id(
                 token=os.environ["ACCESS_REPO_INFO_TOKEN"], workflow_id=other_workflow_id, commit_sha=ci_sha
             )
-            print(f"[DEBUG notification_service] other_workflow_run_id={other_workflow_run_id!r} (other_workflow_id={other_workflow_id!r}, ci_sha={ci_sha!r})")
+            print(
+                f"[DEBUG notification_service] other_workflow_run_id={other_workflow_run_id!r} (other_workflow_id={other_workflow_id!r}, ci_sha={ci_sha!r})"
+            )
             other_workflow_run_ids.append(other_workflow_run_id)
     else:
         prev_workflow_run_id = os.environ["PREV_WORKFLOW_RUN_ID"]

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1506,9 +1506,12 @@ if __name__ == "__main__":
     other_workflow_run_ids = []
 
     if is_scheduled_ci_run:
+        print(f"[DEBUG notification_service] is_scheduled_ci_run=True, is_nvidia_daily_ci_workflow={is_nvidia_daily_ci_workflow}")
+        print(f"[DEBUG notification_service] GITHUB_RUN_ID={os.getenv('GITHUB_RUN_ID')!r}, workflow_id={workflow_id!r}")
         prev_workflow_run_id = get_last_daily_ci_workflow_run_id(
             token=os.environ["ACCESS_REPO_INFO_TOKEN"], workflow_id=workflow_id
         )
+        print(f"[DEBUG notification_service] prev_workflow_run_id={prev_workflow_run_id!r}")
         # For a scheduled run that is not the Nvidia's scheduled daily CI, add Nvidia's scheduled daily CI run as a target to compare.
         if not is_nvidia_daily_ci_workflow:
             # The id of the workflow `.github/workflows/self-scheduled-caller.yml` (not of a workflow run of it).
@@ -1517,6 +1520,7 @@ if __name__ == "__main__":
             other_workflow_run_id = get_last_daily_ci_workflow_run_id(
                 token=os.environ["ACCESS_REPO_INFO_TOKEN"], workflow_id=other_workflow_id, commit_sha=ci_sha
             )
+            print(f"[DEBUG notification_service] other_workflow_run_id={other_workflow_run_id!r} (other_workflow_id={other_workflow_id!r}, ci_sha={ci_sha!r})")
             other_workflow_run_ids.append(other_workflow_run_id)
     else:
         prev_workflow_run_id = os.environ["PREV_WORKFLOW_RUN_ID"]


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48338&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48338) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48338&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48338)
<!-- ci-dashboard-badge:end -->

## Summary

Adds debug print statements to trace why an unexpectedly old run (Aug 3) was selected as the previous CI baseline instead of the most recent daily run.

## Context

On the Aug 26 CI run, the Slack notification reported 246 new failed tests compared to run 30781855254 — which is the Aug 3 run, ~3 weeks old — instead of the previous day's run (Aug 25). See: https://huggingface.slack.com/archives/C06LR9PQA00/p1787727487500039

Most of those "new" failures were not new at all; they had already been failing in recent daily runs.

## Debug prints added

- `utils/get_previous_daily_ci.py`: exact URL queried, all runs returned by `get_daily_ci_runs` (with id/status/created_at/event), each run checked in the loop, and the final selected run
- `utils/notification_service.py`: `GITHUB_RUN_ID`, `workflow_id`, and the resulting `prev_workflow_run_id`

This will help determine whether the issue is:
- a wrong `workflow_id` being used
- the GitHub API not returning runs in newest-first order
- something else in the selection logic