### PR TITLE
[qwen4_exp] disable torch/onnx export tests due to data-dependent control flow

### DIFF
--- a/tests/models/qwen4_exp/test_modeling_qwen4_exp.py
+++ b/tests/models/qwen4_exp/test_modeling_qwen4_exp.py
@@ -101,6 +101,7 @@ class Qwen4ExpTextModelTest(CausalLMModelTest, unittest.TestCase):
 
     # QSA indexer parameters are trained through a separate objective rather than the causal-LM loss.
     test_all_params_have_gradient = False
+    test_torch_exportable = False  # QSA index selection has data-dependent control flow
 
     def _get_conv_state_shape(self, batch_size: int, config):
         intermediate_size = (
@@ -508,6 +509,7 @@ class Qwen4ExpVisionText2TextModelTester(VLMModelTester):
 class Qwen4ExpCompositeModelTest(VLMModelTest, unittest.TestCase):
     model_tester_class = Qwen4ExpVisionText2TextModelTester
     test_all_params_have_gradient = False
+    test_torch_exportable = False  # QSA index selection has data-dependent control flow
 
     def get_config(self):
         return self.model_tester.get_config(ple_layer_ids=[1])


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48345&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48345) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48345&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48345)
<!-- ci-dashboard-badge:end -->

## Summary

- Sets `test_torch_exportable = False` in both `Qwen4ExpTextModelTest` and `Qwen4ExpCompositeModelTest`
- QSA index selection has data-dependent control flow (`(u0//2) > 0`) that cannot be guarded during `torch.export`, causing `GuardOnDataDependentSymNode` errors

Fixes: https://github.com/huggingface/transformers/actions/runs/32975098763/job/98199693688

🤖 Generated with [Claude Code](https://claude.com/claude-code)