### PR TITLE
Fix incorrect token classification prefix for ESMC

### DIFF
--- a/src/transformers/models/esmc/modeling_esmc.py
+++ b/src/transformers/models/esmc/modeling_esmc.py
@@ -591,7 +591,7 @@ class EsmcForSequenceClassification(EsmcPreTrainedModel):
 
 
 class EsmcForTokenClassification(GenericForTokenClassification, EsmcPreTrainedModel):
-    pass
+    base_model_prefix = "esmc"
 
 
 __all__ = [

--- a/src/transformers/models/esmc/modular_esmc.py
+++ b/src/transformers/models/esmc/modular_esmc.py
@@ -432,7 +432,7 @@ class EsmcForSequenceClassification(EsmForSequenceClassification):
 
 
 class EsmcForTokenClassification(GenericForTokenClassification, EsmcPreTrainedModel):
-    pass
+    base_model_prefix = "esmc"
 
 
 __all__ = [


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48348&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48348) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48348&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48348)
<!-- ci-dashboard-badge:end -->

ESMC token classification had the wrong prefix, which meant it didn't load stem weights correctly. This fixes it!