### PR TITLE
Fix fp8 dtype

### DIFF
--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -301,13 +301,17 @@ class FP8Linear(nn.Linear):
         activation_scheme: str = "dynamic",
         scale_fmt: str = "float",
         has_bias: bool = False,
+        dtype: torch.dtype | None = _FP8_DTYPE,
     ):
         super().__init__(in_features, out_features)
 
         self.has_bias = has_bias
         self.block_size = block_size
         self.activation_scheme = activation_scheme
-        self.weight = torch.nn.Parameter(torch.empty(out_features, in_features, dtype=_FP8_DTYPE))
+        # `dtype=None` falls back to the ambient default dtype, i.e. the model dtype, like every other
+        # parameter in the skeleton. Used when quantizing on the fly, where the loader materializes the
+        # checkpoint's dense weight into this parameter before `Fp8Quantize` runs.
+        self.weight = torch.nn.Parameter(torch.empty(out_features, in_features, dtype=dtype))
 
         if self.block_size is None:
             # If block size is None, it means that we are doing per-tensor quantization
@@ -367,6 +371,7 @@ class FP8GroupedLinear(FP8Linear):
         activation_scheme: str = "dynamic",
         scale_fmt: str = "float",
         has_bias: bool = False,
+        dtype: torch.dtype | None = _FP8_DTYPE,
     ):
         super().__init__(
             in_features=in_features_per_group,
@@ -375,6 +380,7 @@ class FP8GroupedLinear(FP8Linear):
             activation_scheme=activation_scheme,
             scale_fmt=scale_fmt,
             has_bias=has_bias,
+            dtype=dtype,
         )
         self.n_groups = n_groups
 
@@ -613,6 +619,7 @@ class FP8Experts(nn.Module):
         scale_fmt: str = "float",
         has_bias: bool = False,
         has_gate: bool = True,
+        dtype: torch.dtype | None = _FP8_DTYPE,
     ):
         super().__init__()
 
@@ -649,7 +656,7 @@ class FP8Experts(nn.Module):
             }
         else:
             alloc_kwargs = {
-                "weight_dtype": _FP8_DTYPE,
+                "weight_dtype": dtype,
                 "sf_dtype": sf_dtype,
                 "sf_gran_n": block_size[0] if block_size is not None else None,
                 "sf_gran_k": block_size[1] if block_size is not None else None,
@@ -814,6 +821,9 @@ def replace_with_fp8_linear(
     if quantization_config.dequantize:
         return model
 
+    # we need this to correctly materialize the weights during quantization
+    module_kwargs = {} if pre_quantized else {"dtype": None}
+
     has_been_replaced = False
     for module_name, module in model.named_modules():
         if not should_convert_module(module_name, modules_to_not_convert):
@@ -838,6 +848,7 @@ def replace_with_fp8_linear(
                     scale_fmt=quantization_config.scale_fmt,
                     has_bias=has_bias,
                     has_gate=has_gate,
+                    **module_kwargs,
                 )
             elif type(module) is nn.Linear:
                 # Vanilla `nn.Linear` → standard FP8Linear swap.
@@ -848,6 +859,7 @@ def replace_with_fp8_linear(
                     activation_scheme=quantization_config.activation_scheme,
                     scale_fmt=quantization_config.scale_fmt,
                     has_bias=module.bias is not None,
+                    **module_kwargs,
                 )
             elif isinstance(module, nn.Linear) and "GroupedLinear" in type(module).__name__:
                 # Block-diagonal grouped linear (e.g. DSv4's `DeepseekV4GroupedLinear`):
@@ -864,6 +876,7 @@ def replace_with_fp8_linear(
                     activation_scheme=quantization_config.activation_scheme,
                     scale_fmt=quantization_config.scale_fmt,
                     has_bias=module.bias is not None,
+                    **module_kwargs,
                 )
             if new_module is not None:
                 # TP must use local tensors because this quantization path does not support DTensor inputs or weights.

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -308,9 +308,6 @@ class FP8Linear(nn.Linear):
         self.has_bias = has_bias
         self.block_size = block_size
         self.activation_scheme = activation_scheme
-        # `dtype=None` falls back to the ambient default dtype, i.e. the model dtype, like every other
-        # parameter in the skeleton. Used when quantizing on the fly, where the loader materializes the
-        # checkpoint's dense weight into this parameter before `Fp8Quantize` runs.
         self.weight = torch.nn.Parameter(torch.empty(out_features, in_features, dtype=dtype))
 
         if self.block_size is None:

--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -185,7 +185,7 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
         from ..integrations.finegrained_fp8 import FP8Experts
 
         impl = getattr(config, "_experts_implementation", None)
-        layer_overrides = FP8Experts._impl_tp_layer_overrides.get(impl)
+        layer_overrides = FP8Experts._impl_tp_layer_overrides.get(impl) or {}
         for plan_attr in ("base_model_tp_plan", "base_model_ep_plan"):
             base_plan = getattr(config, plan_attr, None) or {}
             # Per-impl rewrite of the experts parallel-layer kind. Applied LAST so it composes

--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -264,6 +264,51 @@ class FP8QuantizerTest(unittest.TestCase):
         self.assertEqual(weight_scale_inv.dtype, torch.float32)
         self.assertEqual(weight.shape, (weight_scale_inv.shape[0] * 128, weight_scale_inv.shape[1] * 128))
 
+    def test_on_the_fly_quantization_matches_quantizing_the_dense_weight(self):
+        """Quantizing on the fly must derive the scale from the checkpoint's dense weight.
+
+        The FP8 modules declare an FP8 weight container so a serialized checkpoint loads straight
+        into it. If the loader materialized into that same container when quantizing on the fly,
+        `Fp8Quantize` would see weights already rounded to FP8 *without* a scale, and the result
+        would no longer match quantizing the original dense tensor.
+        """
+        from transformers.integrations.finegrained_fp8 import Fp8Quantize
+
+        target = "model.layers.0.mlp.gate_proj.weight"
+        config = AutoConfig.for_model(
+            "llama",
+            vocab_size=64,
+            hidden_size=64,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            tie_word_embeddings=False,
+        )
+        torch.manual_seed(0)
+        model = AutoModelForCausalLM.from_config(config).to(torch.bfloat16)
+        dense_weight = dict(model.named_parameters())[target].detach().clone()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model.save_pretrained(tmpdir)
+            del model
+            quantized_model = AutoModelForCausalLM.from_pretrained(
+                tmpdir,
+                device_map=torch_device,
+                dtype=torch.bfloat16,
+                quantization_config=FineGrainedFP8Config(weight_block_size=(32, 32)),
+            )
+
+        expected = Fp8Quantize(quantized_model.hf_quantizer).convert({target: dense_weight.to(quantized_model.device)})
+        proj = quantized_model.model.layers[0].mlp.gate_proj
+        torch.testing.assert_close(proj.weight.float(), expected[target].float(), atol=0, rtol=0)
+        torch.testing.assert_close(
+            proj.weight_scale_inv.float(),
+            expected[target.replace(".weight", ".weight_scale_inv")].float(),
+            atol=0,
+            rtol=0,
+        )
+
     def test_block_size(self):
         """
         Simple test that checks if the block size is working properly


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48352&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48352) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48352&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48352)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This PR fixes an issue with on the fly quantization where the weights were casted to fp8 directly before quantization. We need to set dtype = None in order to load the weight correctly.