### PR TITLE
Restore .item() on the packed-path max_seqlen (third site missed by #47134)

### DIFF
--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -489,7 +489,9 @@ def prepare_fa_kwargs_from_position_ids(position_ids):
     # https://github.com/Dao-AILab/flash-attention/blob/2dd8078adc1d9b74e315ee99718c0dea0de8eeb6/flash_attn/flash_attn_interface.py#L1423-L1424
     # We should use cu_seq_lens instead of position_ids to get the max length since position_ids is not always increasing
     # for some models (e.g. qwen2-vl).
-    max_length_q = cu_seq_lens_q.diff().max()
+    # using .item() here is required to prevent a performance regression (#46693), and because
+    # FlashAttention 4's varlen kernel rejects a tensor `max_seqlen` outright
+    max_length_q = cu_seq_lens_q.diff().max().item()
     max_length_k = max_length_q
 
     return (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48353&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48353) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48353&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48353)
<!-- ci-dashboard-badge:end -->

### What

`prepare_fa_kwargs_from_position_ids` still returns `max_length_q` / `max_length_k` as 0-dim tensors. #42435 removed `.item()` from three sites feeding `flash_attn_varlen_func`; #47134 restored it at two of them (`_unpad_input`, `_get_unpad_data`) to fix #46693, but the packed / `position_ids` path was left as-is. This applies the same one-line fix to the third site.

### Why it is more than a perf regression here

On FlashAttention 4 the tensor is a hard failure, not a slowdown — `flash_attn.cute`'s varlen binding type-checks its arguments:

```
DSLRuntimeError: expects argument #26 (max_seqlen_q) to be one of
(<class 'cutlass.base_dsl.typing.Int32'>, <class 'int'>, <class 'NoneType'>),
but got <class 'torch.Tensor'>
```

So any packed / padding-free batch raises under `attn_implementation="flash_attention_4"` in eager mode. FA2's binding tolerates a tensor, which is why this stayed hidden. The conversion in `_process_flash_attention_kwargs` does not cover it, since that branch only fires under `is_tracing`.

### Verification

Converting just these two values to `int` and touching nothing else makes packed FA4 run, and its output agrees with the sdpa reference (cos 0.9999), on an H200 (sm_90) and a B300 (sm_103). transformers 5.15.0, torch 2.13.0+cu132, flash-attn-4 4.0.0b26.

Tracing behaviour is unchanged, because the existing `is_tracing` branch already calls `.item()` — this only affects eager. `max_length_k = max_length_q` stays an identity assignment, so the `same_max_seqlen = max_seqlen_q is max_seqlen_k` sync-avoidance downstream still holds, and `_process_flash_attention_kwargs` now skips its own conversion since the value is already an `int`.

### Related

- #42435 — removed the `.item()` calls
- #46693 / #47134 — the perf regression, and the fix for the two padded-path sites
- #47215 — proposed covering this third site as well; closed for unrelated branch hygiene
- #44962 — same class of bug, hardcoded in the Qwen2.5-VL / Qwen3-VL vision attention

No test, to match #47134's shape — the two sibling sites landed without one. Happy to add a short assertion that the returned max lengths are `int` if you would prefer it.