### PR TITLE
Shape cross-attention keys and values by the states they come from

### DIFF
--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -364,8 +364,9 @@ class EsmSelfAttention(nn.Module):
         is_cross_attention = encoder_hidden_states is not None
         current_states = encoder_hidden_states if is_cross_attention else hidden_states
         attention_mask = encoder_attention_mask if is_cross_attention else attention_mask
-        key_layer = self.key(current_states).view(hidden_shape).transpose(1, 2)
-        value_layer = self.value(current_states).view(hidden_shape).transpose(1, 2)
+        kv_shape = (*current_states.shape[:-1], -1, self.attention_head_size)
+        key_layer = self.key(current_states).view(kv_shape).transpose(1, 2)
+        value_layer = self.value(current_states).view(kv_shape).transpose(1, 2)
 
         # Matt: Our BERT model (which this code was derived from) scales attention logits down by sqrt(head_dim).
         # ESM scales the query down by the same factor instead. Modulo numerical stability these are equivalent,

--- a/src/transformers/models/evolla/modeling_evolla.py
+++ b/src/transformers/models/evolla/modeling_evolla.py
@@ -330,8 +330,9 @@ class EvollaSaProtSelfAttention(nn.Module):
         is_cross_attention = encoder_hidden_states is not None
         current_states = encoder_hidden_states if is_cross_attention else hidden_states
         attention_mask = encoder_attention_mask if is_cross_attention else attention_mask
-        key_layer = self.key(current_states).view(hidden_shape).transpose(1, 2)
-        value_layer = self.value(current_states).view(hidden_shape).transpose(1, 2)
+        kv_shape = (*current_states.shape[:-1], -1, self.attention_head_size)
+        key_layer = self.key(current_states).view(kv_shape).transpose(1, 2)
+        value_layer = self.value(current_states).view(kv_shape).transpose(1, 2)
 
         # Matt: Our BERT model (which this code was derived from) scales attention logits down by sqrt(head_dim).
         # EVOLLA_SA_PROT scales the query down by the same factor instead. Modulo numerical stability these are equivalent,

--- a/src/transformers/models/lightglue/modeling_lightglue.py
+++ b/src/transformers/models/lightglue/modeling_lightglue.py
@@ -214,8 +214,9 @@ class LightGlueAttention(nn.Module):
         current_states = encoder_hidden_states if is_cross_attention else hidden_states
         current_attention_mask = encoder_attention_mask if is_cross_attention else attention_mask
 
-        key_states = self.k_proj(current_states).view(hidden_shape).transpose(1, 2)
-        value_states = self.v_proj(current_states).view(hidden_shape).transpose(1, 2)
+        kv_shape = (*current_states.shape[:-1], -1, self.head_dim)
+        key_states = self.k_proj(current_states).view(kv_shape).transpose(1, 2)
+        value_states = self.v_proj(current_states).view(kv_shape).transpose(1, 2)
 
         if position_embeddings is not None:
             cos, sin = position_embeddings

--- a/src/transformers/models/lightglue/modular_lightglue.py
+++ b/src/transformers/models/lightglue/modular_lightglue.py
@@ -223,8 +223,9 @@ class LightGlueAttention(LlamaAttention):
         current_states = encoder_hidden_states if is_cross_attention else hidden_states
         current_attention_mask = encoder_attention_mask if is_cross_attention else attention_mask
 
-        key_states = self.k_proj(current_states).view(hidden_shape).transpose(1, 2)
-        value_states = self.v_proj(current_states).view(hidden_shape).transpose(1, 2)
+        kv_shape = (*current_states.shape[:-1], -1, self.head_dim)
+        key_states = self.k_proj(current_states).view(kv_shape).transpose(1, 2)
+        value_states = self.v_proj(current_states).view(kv_shape).transpose(1, 2)
 
         if position_embeddings is not None:
             cos, sin = position_embeddings

--- a/src/transformers/models/megatron_bert/modeling_megatron_bert.py
+++ b/src/transformers/models/megatron_bert/modeling_megatron_bert.py
@@ -154,10 +154,11 @@ class MegatronBertSelfAttention(nn.Module):
             key_layer = curr_past_key_values.layers[self.layer_idx].keys
             value_layer = curr_past_key_values.layers[self.layer_idx].values
         else:
+            kv_shape = (*current_states.shape[:-1], -1, self.attention_head_size)
             key_layer = self.key(current_states)
-            key_layer = key_layer.view(hidden_shape).transpose(1, 2)
+            key_layer = key_layer.view(kv_shape).transpose(1, 2)
             value_layer = self.value(current_states)
-            value_layer = value_layer.view(hidden_shape).transpose(1, 2)
+            value_layer = value_layer.view(kv_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 # save all key/value_layer to cache to be re-used for fast auto-regressive generation

--- a/src/transformers/models/tapas/modeling_tapas.py
+++ b/src/transformers/models/tapas/modeling_tapas.py
@@ -194,8 +194,9 @@ class TapasSelfAttention(nn.Module):
             key_layer = curr_past_key_values.layers[self.layer_idx].keys
             value_layer = curr_past_key_values.layers[self.layer_idx].values
         else:
-            key_layer = self.key(current_states).view(hidden_shape).transpose(1, 2)
-            value_layer = self.value(current_states).view(hidden_shape).transpose(1, 2)
+            kv_shape = (*current_states.shape[:-1], -1, self.attention_head_size)
+            key_layer = self.key(current_states).view(kv_shape).transpose(1, 2)
+            value_layer = self.value(current_states).view(kv_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 # save all key/value_layer to cache to be re-used for fast auto-regressive generation


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48356&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48356) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48356&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48356)
<!-- ci-dashboard-badge:end -->

`hidden_shape` comes from the query length, so viewing cross-attention K/V with it infers a wrong head count and the matmul fails whenever the encoder length differs. Each site now derives `kv_shape` from `current_states`. The equal-length path is unchanged.

Repro on `main`, and passing after:

```
MegatronBertSelfAttention  q=4 kv=7: RuntimeError: The size of tensor a (4) must match the size of tensor b (7)
TapasSelfAttention         q=4 kv=7: RuntimeError: ...
EsmSelfAttention           q=4 kv=7: RuntimeError: ...
```

`lightglue` matches keypoints between two images, so its cross-attention lengths differ by construction. Every suite stayed green before because they only ever pass encoder states as long as the query.

Tests: esm, esmc, evolla, lightglue, megatron_bert, tapas all pass (809 tests). `check_copies` and `check_modular_conversion` exit 0.