### PR TITLE
Add --experts-implementation flag to transformers serve

### DIFF
--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -76,6 +76,9 @@ class Serve:
         device: Annotated[str, typer.Option(help="Device for inference (e.g. 'auto', 'cuda:0', 'cpu').")] = "auto",
         dtype: Annotated[str | None, typer.Option(help="Override model dtype. 'auto' derives from weights.")] = "auto",
         trust_remote_code: Annotated[bool, typer.Option(help="Trust remote code when loading.")] = False,
+        experts_implementation: Annotated[
+            str | None, typer.Option(help="MoE experts implementation (e.g. 'deepgemm_megamoe').")
+        ] = None,
         model_timeout: Annotated[
             int, typer.Option(help="Seconds before idle model is unloaded. Ignored when force_model is set.")
         ] = 300,
@@ -132,6 +135,7 @@ class Serve:
             trust_remote_code=trust_remote_code,
             attn_implementation=attn_implementation,
             quantization=quantization,
+            experts_implementation=experts_implementation,
             model_timeout=model_timeout,
             force_model=force_model,
         )

--- a/src/transformers/cli/serving/model_manager.py
+++ b/src/transformers/cli/serving/model_manager.py
@@ -113,6 +113,7 @@ class ModelManager:
         trust_remote_code: bool = False,
         attn_implementation: str | None = None,
         quantization: str | None = None,
+        experts_implementation: str | None = None,
         model_timeout: int = 300,
         force_model: str | None = None,
     ):
@@ -132,6 +133,7 @@ class ModelManager:
         self.trust_remote_code = trust_remote_code
         self.attn_implementation = self._resolve_attn_implementation(attn_implementation, self.device)
         self.quantization = quantization
+        self.experts_implementation = experts_implementation
         self.model_timeout = model_timeout
         self.force_model = force_model
 
@@ -258,6 +260,8 @@ class ModelManager:
             "trust_remote_code": self.trust_remote_code,
             "tqdm_class": tqdm_class,
         }
+        if self.experts_implementation is not None:
+            model_kwargs["experts_implementation"] = self.experts_implementation
         quantization_config = self.get_quantization_config()
         if quantization_config is not None:
             model_kwargs["quantization_config"] = quantization_config


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48361&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48361) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48361&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48361)
<!-- ci-dashboard-badge:end -->

transformers serve had no way to pass experts_implementation to from_pretrained. For FP8 MoE checkpoints whose TP/EP plan requires experts_implementation="deepgemm_megamoe" (the only key in FP8Experts._impl_tp_layer_overrides), this meant update_tp_plan always crashed with AttributeError: 'NoneType' object has no attribute 'get' before any weights loaded — reproduced on deepseek-ai/DeepSeek-V4-Flash-0731 and zai-org/GLM-5.2-FP8.