### PR TITLE
Carry weight_global_scale when decompressing NVFP4 MoE experts

### DIFF
--- a/src/transformers/integrations/compressed_tensors.py
+++ b/src/transformers/integrations/compressed_tensors.py
@@ -106,11 +106,15 @@ class DecompressExperts(ConversionOps):
         compressor = BaseCompressor.get_value_from_registry(format)
 
         class DummyModule(nn.Module):
-            def __init__(self, weight, scale, shape):
+            def __init__(self, weight, scale, shape, global_scale=None):
                 super().__init__()
                 self.weight_packed = nn.Parameter(weight, requires_grad=False)
                 self.weight_scale = nn.Parameter(scale, requires_grad=False)
                 self.weight_shape = nn.Parameter(shape, requires_grad=False)
+                if global_scale is not None:
+                    # `tensor_group` schemes (NVFP4) only. The compressor reads this with
+                    # `.get(..., None)`, so omitting it dequantizes without raising.
+                    self.weight_global_scale = nn.Parameter(global_scale, requires_grad=False)
 
         # `pack_factor` low-bit weights are packed per int32 along the packed dim.
         # Used only as a fallback for `weight_shape` (see below): rebuilding the
@@ -126,6 +130,7 @@ class DecompressExperts(ConversionOps):
             quantized = value
             scales = input_dict[key.replace("weight_packed", "weight_scale")]
             shapes = input_dict.get(key.replace("weight_packed", "weight_shape"))
+            global_scales = input_dict.get(key.replace("weight_packed", "weight_global_scale"))
 
             # Pre-allocate the stacked output buffer to reduce cuda mem fragmentation
             # Without pre-allocation the loop accumulates N tensors per expert and next
@@ -141,7 +146,7 @@ class DecompressExperts(ConversionOps):
                     shape = stored_shape
                 else:
                     shape = torch.tensor([quant.shape[0], quant.shape[1] * pack_factor])
-                module = DummyModule(quant, scale, shape)
+                module = DummyModule(quant, scale, shape, None if global_scales is None else global_scales[i])
                 module.quantization_scheme = quantization_scheme
                 compressor.decompress_module(module)
 

--- a/src/transformers/quantizers/quantizer_compressed_tensors.py
+++ b/src/transformers/quantizers/quantizer_compressed_tensors.py
@@ -35,6 +35,17 @@ def _is_fp8_scheme(scheme) -> bool:
     return weights is not None and weights.type == "float" and weights.num_bits == 8
 
 
+def _has_weight_global_scale(scheme) -> bool:
+    """Whether a scheme stores a per-tensor ``weight_global_scale`` next to the group scales.
+
+    ``tensor_group`` strategies (NVFP4) scale the group scales by a per-tensor global scale so
+    they fit the FP8 range, and compressed-tensors registers ``weight_global_scale`` only for
+    that strategy. Dequantization needs it: without it the group scales are off by that factor.
+    """
+    weights = scheme.weights
+    return weights is not None and weights.strategy == "tensor_group"
+
+
 class CompressedTensorsHfQuantizer(HfQuantizer):
     """
     Quantizer for the compressed_tensors package. Loads and restores models to
@@ -209,7 +220,14 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
                 else:
                     packed_weight = [p + "_packed$" for p in weight_sources]
                     shape_sources = [p + "_shape$" for p in weight_sources]
-                    new_sources = packed_weight + scale_sources + shape_sources + other
+                    # NVFP4 stores a per-tensor global scale beside the group scales. It has no
+                    # other source, and its absence is not an error downstream -- the compressor
+                    # reads it with `.get(..., None)` and dequantizes without it -- so leaving it
+                    # out returns experts scaled by a wrong constant, silently.
+                    global_scale_sources = (
+                        [p + "_global_scale$" for p in weight_sources] if _has_weight_global_scale(scheme) else []
+                    )
+                    new_sources = packed_weight + scale_sources + shape_sources + global_scale_sources + other
                 new_ops = [DecompressExperts(self, scheme=scheme)] + list(conv.operations)
                 conv = WeightConverter(
                     source_patterns=new_sources,

--- a/tests/quantization/compressed_tensors_integration/test_compressed_tensors.py
+++ b/tests/quantization/compressed_tensors_integration/test_compressed_tensors.py
@@ -270,3 +270,130 @@ class CompressedTensorsTest(unittest.TestCase):
         model = AutoModelForCausalLM.from_pretrained(int8_model, device_map="auto")
         fp8_count = sum(1 for m in model.modules() if isinstance(m, CompressedTensorsFP8Linear))
         self.assertEqual(fp8_count, 0, "INT8 model should NOT use CompressedTensorsFP8Linear")
+
+
+@require_compressed_tensors
+@require_torch
+class CompressedTensorsMoEExpertGlobalScaleTest(unittest.TestCase):
+    """`tensor_group` (NVFP4) MoE experts must be dequantized with their per-tensor global scale.
+
+    NVFP4 stores `weight_global_scale` beside the group scales, and the compressor reads it with
+    `state_dict.get(..., None)`. A missing global scale is therefore not an error: the experts are
+    dequantized by a wrong constant factor, nothing is raised, and nothing lands in `missing_keys`.
+    These tests are hermetic — they build the packed tensors directly, so no checkpoint is needed.
+    """
+
+    group_size = 16
+
+    def _scheme(self, tensor_group: bool):
+        from compressed_tensors.quantization import (
+            QuantizationArgs,
+            QuantizationScheme,
+            QuantizationStrategy,
+            QuantizationType,
+        )
+
+        if tensor_group:
+            args = QuantizationArgs(
+                num_bits=4,
+                type=QuantizationType.FLOAT,
+                group_size=self.group_size,
+                strategy=QuantizationStrategy.TENSOR_GROUP,
+                symmetric=True,
+            )
+        else:
+            args = QuantizationArgs(
+                num_bits=4,
+                type=QuantizationType.INT,
+                group_size=128,
+                strategy=QuantizationStrategy.GROUP,
+                symmetric=True,
+            )
+        return QuantizationScheme(targets=["Linear"], weights=args)
+
+    def _derived_sources(self, tensor_group: bool) -> set:
+        """Per-module tensor names `update_weight_conversions` derives for an expert converter."""
+        import types
+
+        from transformers.core_model_loading import Concatenate, MergeModulelist, WeightConverter
+        from transformers.quantizers.quantizer_compressed_tensors import CompressedTensorsHfQuantizer
+
+        quantizer = object.__new__(CompressedTensorsHfQuantizer)
+        inner = types.SimpleNamespace(config_groups={"group_0": self._scheme(tensor_group)})
+        quantizer.quantization_config = types.SimpleNamespace(quantization_config=inner)
+        quantizer.get_weight_conversions = lambda: []
+        converter = WeightConverter(
+            source_patterns=["experts.*.gate_proj.weight", "experts.*.up_proj.weight"],
+            target_patterns="experts.gate_up_proj",
+            operations=[MergeModulelist(dim=0), Concatenate(dim=1)],
+        )
+        updated = CompressedTensorsHfQuantizer.update_weight_conversions(quantizer, [converter])
+        return {p.rsplit(".", 1)[-1].removesuffix("$") for conv in updated for p in conv.source_patterns}
+
+    def test_tensor_group_scheme_derives_the_global_scale_source(self):
+        """Without this source the global scale never reaches the decompressor."""
+        self.assertIn("weight_global_scale", self._derived_sources(tensor_group=True))
+
+    def test_non_tensor_group_scheme_is_unchanged(self):
+        """INT `group` schemes have no global scale; their source list must not grow."""
+        derived = self._derived_sources(tensor_group=False)
+        self.assertNotIn("weight_global_scale", derived)
+        self.assertEqual(derived, {"weight_packed", "weight_scale", "weight_shape"})
+
+    def test_experts_are_dequantized_with_their_global_scale(self):
+        """`DecompressExperts` must reproduce a faithful per-expert decompression.
+
+        The regression this pins is silent: dropping the global scale returns experts scaled by
+        it (a factor of ~100s), with no exception and an empty `missing_keys`.
+        """
+        import types
+
+        from compressed_tensors.compressors import BaseCompressor
+        from compressed_tensors.compressors.format import infer_module_format
+        from compressed_tensors.quantization.utils.helpers import calculate_qparams, generate_gparam
+
+        from transformers.integrations.compressed_tensors import DecompressExperts
+
+        scheme = self._scheme(tensor_group=True)
+        compressor = BaseCompressor.get_value_from_registry(infer_module_format(torch.nn.Linear, scheme))
+
+        torch.manual_seed(0)
+        num_experts = 3
+        packed, scales, shapes, global_scales, faithful = [], [], [], [], []
+        for expert in range(num_experts):
+            # Different magnitudes per expert, so a shared or dropped global scale cannot pass.
+            weight = (torch.randn(32, 64) * (expert + 1) * 3.0).to(torch.bfloat16)
+            global_scale = generate_gparam(weight.min(), weight.max())
+            grouped = weight.reshape(weight.shape[0], -1, self.group_size)
+            scale, _ = calculate_qparams(
+                grouped.min(dim=-1).values, grouped.max(dim=-1).values, scheme.weights, global_scale=global_scale
+            )
+            compressed = compressor.compress(
+                {"weight": weight, "weight_scale": scale, "weight_global_scale": global_scale}, scheme
+            )
+            packed.append(compressed["weight_packed"])
+            scales.append(compressed["weight_scale"])
+            global_scales.append(compressed["weight_global_scale"])
+            shapes.append(torch.tensor(list(weight.shape)))
+            faithful.append(compressor.decompress(dict(compressed), scheme)["weight"])
+
+        # `convert` reads the config off the quantizer even when handed an explicit scheme.
+        quantizer = types.SimpleNamespace(
+            compressor=types.SimpleNamespace(
+                quantization_config=types.SimpleNamespace(config_groups={"group_0": scheme})
+            )
+        )
+        op = DecompressExperts(quantizer, scheme=scheme)
+        out = op.convert(
+            {
+                "experts.gate_proj.weight_packed": packed,
+                "experts.gate_proj.weight_scale": scales,
+                "experts.gate_proj.weight_shape": shapes,
+                "experts.gate_proj.weight_global_scale": global_scales,
+            },
+            source_patterns=[],
+            target_patterns=[],
+        )
+        stacked = out["experts.gate_proj.weight_packed"]
+        expected = torch.stack([w.to(stacked.dtype) for w in faithful])
+        torch.testing.assert_close(stacked, expected, rtol=0, atol=0)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48372&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48372) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48372&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48372)
<!-- ci-dashboard-badge:end -->

## What this fixes

NVFP4 (`tensor_group`) compressed-tensors MoE checkpoints whose routed experts are stored per expert are dequantized without their per-tensor `weight_global_scale`, so the experts come back scaled by a wrong constant — no exception, and the fused parameter is filled so `missing_keys` stays empty.

Fixes #48371.

## Root cause

[`quantizer_compressed_tensors.py#L210-L212`](https://github.com/huggingface/transformers/blob/323f24345ed92f88e68a14aeef7db78ee2b52475/src/transformers/quantizers/quantizer_compressed_tensors.py#L210-L212) derives the expert conversion sources from the base `.weight` patterns as `_packed$` / `_scale$` / `_shape$`, so NVFP4's fourth per-module tensor is never collected; [`compressed_tensors.py#L108-L113`](https://github.com/huggingface/transformers/blob/323f24345ed92f88e68a14aeef7db78ee2b52475/src/transformers/integrations/compressed_tensors.py#L108-L113) gives `DummyModule` no slot for one either.

It is silent rather than a crash because `NVFP4Compressor.decompress` reads `state_dict.get("weight_global_scale", None)` and `dequantize` treats `None` as "no global scaling". Not a regression: `DummyModule` has had the same three-tensor signature since `DecompressExperts` landed in #45630 (`09835700`).

## Impact

**Synthetic, through `DecompressExperts.convert`** (the repro in #48371, run at `323f243` with `compressed-tensors==0.18.0`). Three experts of differing magnitude, so their global scales differ (`218.0 / 109.5 / 79.5`):

| | relative L2 vs the reference weights | max abs weight |
|---|---|---|
| with this PR | **0.099** — the NVFP4 quantization error alone | 33.75 |
| on `main` | **103.5** | 2688.0 |

**Real checkpoint, controlled pair.** `Qwen/Qwen3.6-35B-A3B` quantized RTN W4A16 two ways, reloaded with `from_pretrained`, and every fused expert parameter compared against an independent decompression of the same safetensors (the loader is not trusted for the numeric claim; each parameter is also scored against a random-init control). All 40 MoE blocks, both fused parameters each — 80 of 80 compared, no sampling:

| pack scheme | verdict | relative L2 (min / median / max) | `missing_keys` | weight-side tensors left unconsumed |
|---|---|---|---|---|
| CT INT4 g128 | reads back exactly, 80/80 | 0 / 0 / 0 | 0 | 0 |
| CT NVFP4 g16 | wrong values, 80/80 | 2.19e4 / 3.78e4 / 4.95e4 | **0** | 30720 (`weight_global_scale`) |

This pair is the argument. Same checkpoint, same architecture, and `qwen3_5_moe_text` inherits the `qwen2_moe` per-expert merge conversion ([`conversion_mapping.py#L1791-L1792`](https://github.com/huggingface/transformers/blob/323f24345ed92f88e68a14aeef7db78ee2b52475/src/transformers/conversion_mapping.py#L1791-L1792)), so the conversion path is not a variable — **only the pack scheme differs.** The INT4 row rules out everything except the global scale, and the NVFP4 row's empty `missing_keys` beside a relative L2 of ~4e4 is why no missing-key or key-count check can catch this: every parameter the model asked for was supplied, just reconstructed without one of its inputs.

That measurement ran on `transformers==5.14.1` rather than `main`; the two sites this PR touches — the three `_packed$`/`_scale$`/`_shape$` derivations and `DummyModule`'s three-tensor signature — are unchanged between that release and `323f243`.

## The fix

Option 1 from the issue — collect `weight_global_scale$` **gated on the `tensor_group` strategy**, which is exactly when `initialize_module_for_quantization` registers the parameter, and thread an optional `global_scale` through `DummyModule`. The gate is what keeps every other scheme byte-identical (see the table); the generic alternative (enumerate the scheme's registered per-module tensors, subsuming #47430's `zero_point` too) is option 2 in the issue and I'm happy to switch if you prefer it.

A `tensor_group` checkpoint that ships no global scale degrades to today's behaviour rather than failing.

## Blast radius

Executed against `323f243` with this branch:

| Scheme | Before | After | Verified |
|---|---|---|---|
| NVFP4 `float4` `tensor_group` g16 | packed, scale, shape | **+ `weight_global_scale`** | executed |
| INT4 `int` `group` g128 | packed, scale, shape | unchanged | executed |
| INT4 `int` `channel` | packed, scale, shape | unchanged | executed |
| INT8 `int` `tensor` | packed, scale, shape | unchanged | executed |
| FP8 `float` `channel` | weight, scale | unchanged (separate branch) | executed |
| `tensor_group` checkpoint with no global scale | — | `.get` → `None`, no raise | executed |
| The 24 MoE families aliased to `qwen2_moe`/`mixtral` | — | affected iff quantized NVFP4 | source-read only |

## Tests

`CompressedTensorsMoEExpertGlobalScaleTest` in `tests/quantization/compressed_tensors_integration/test_compressed_tensors.py`. It asserts the dequantized values after the conversion op runs — not that a tensor is present — because presence is exactly what is *not* wrong here: the fused parameter is filled either way and only the numbers differ. Three experts of differing magnitude, so a dropped **or shared** global scale cannot pass.

```bash
# fails at 323f243 without the fix:
pytest tests/quantization/compressed_tensors_integration/test_compressed_tensors.py -k MoEExpertGlobalScale
```
```
FAILED ...::test_experts_are_dequantized_with_their_global_scale
FAILED ...::test_tensor_group_scheme_derives_the_global_scale_source
============ 2 failed, 1 passed, 13 deselected, 1 warning in 0.22s =============
```
```bash
# passes with the fix:
pytest tests/quantization/compressed_tensors_integration/test_compressed_tensors.py -k MoEExpertGlobalScale
```
```
================= 3 passed, 13 deselected, 1 warning in 0.18s ==================
```

The third case (`test_non_tensor_group_scheme_is_unchanged`) passes both ways on purpose — it is the no-regression control for the gate.

Whole file, same venv: **10 failed / 3 passed at `323f243`**, **10 failed / 6 passed on this branch** — the same 10 pre-existing failures (this venv is CPU-only torch with no FP8-capable accelerator), plus the 3 new cases.

## Verification

```bash
make style
make typing
make check-repo
```

`make style` — clean, modified nothing:
```
Ruff formatting ... 4792 files left unchanged   OK (0.20s)
Import ordering  OK (0.05s)
Sort auto mappings  OK (0.04s)
All 4 checks passed in 0.53s.
```

`make typing` / `make check-repo` — every checker OK except one `ty` diagnostic, which I confirmed is **pre-existing**: it reproduces identically with the branch checked out at `323f243`, and is in a file this PR does not touch.
```
error[unresolved-attribute]: Attribute `weights` is not defined on `list[str]` ...
    --> src/transformers/utils/quantization_config.py:1276:23
Found 1 diagnostic
```

Tool versions per `setup.py`: `ruff==0.14.10`, `ty==0.0.20`.

## Relation to #47430

That PR fixes the same two functions for the asymmetric `zero_point`, so the two will conflict textually. They are independent bugs — different tensor, different scheme, and that one raises where this one corrupts silently. Happy to rebase onto it in whichever order suits you.

## AI assistance

AI assistance was used for root-cause analysis and test planning. I reviewed every changed line and ran the tests and gates listed above.

- Coordination: #48371
- Differentiation from existing PRs: `gh pr list --state open --search` for `"compressed_tensors MoE experts"`, `"global_scale"`, `"nvfp4"`, and issue searches for `weight_global_scale` (`total_count: 0`), `DecompressExperts`, `update_weight_conversions`. Nothing covers `weight_global_scale`. The closest is #47430, which fixes the same two functions for `zero_point` — a different tensor and scheme, and it crashes rather than corrupting silently.
- Test commands and results: see **Tests** and **Verification** above.


## Who can review?

@SunMarc (quantization) — see the comment below for why, and for the one design question this PR leaves open.
