### PR TITLE
Retry get_daily_ci_runs on stale GitHub API cache

### DIFF
--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -6,7 +6,7 @@ on:
     - cron: "17 2 * * *"
   push:
     branches:
-      - run_nvidia_ci*
+      - fix_stale_github_api_cache
   workflow_dispatch:
     inputs:
       prev_workflow_run_id:
@@ -31,108 +31,30 @@ permissions:
   contents: read
 
 jobs:
-  setup:
-    name: Setup
+  debug_api_consistency:
+    name: "[debug] Poll GitHub API for schedule runs"
     runs-on: ubuntu-22.04
     steps:
-      - name: Setup
+      - name: Poll workflow runs endpoint 10 times (1 min apart)
         env:
-          prev_workflow_run_id: ${{ inputs.prev_workflow_run_id || env.prev_workflow_run_id }}
-          other_workflow_run_id: ${{ inputs.other_workflow_run_id || env.other_workflow_run_id }}
+          TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
         run: |
-          mkdir "setup_values"
-          echo "$prev_workflow_run_id" > "setup_values/prev_workflow_run_id.txt"
-          echo "$other_workflow_run_id" > "setup_values/other_workflow_run_id.txt"
+          URL="https://api.github.com/repos/huggingface/transformers/actions/workflows/90575235/runs?branch=main&exclude_pull_requests=true&per_page=7&event=schedule"
+          for i in $(seq 1 10); do
+            echo "========== Attempt $i / 10 — $(date -u '+%Y-%m-%dT%H:%M:%SZ') =========="
+            RESPONSE=$(curl -s -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" "$URL")
+            TOTAL=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('total_count','N/A'))")
+            echo "total_count: $TOTAL"
+            echo "--- run[0] ---"
+            echo "$RESPONSE" | python3 -c "
+          import sys, json
+          runs = json.load(sys.stdin).get('workflow_runs', [])
+          for r in runs[:2]:
+              print(f\"  id={r['id']} run_number={r['run_number']} status={r['status']} conclusion={r['conclusion']} created_at={r['created_at']} event={r['event']}\")
+          "
+            if [ $i -lt 10 ]; then
+              echo "Sleeping 60s..."
+              sleep 60
+            fi
+          done
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: setup_values
-          path: setup_values
-
-  model-ci:
-    name: Model CI
-    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
-    with:
-      job: run_models_gpu
-      slack_report_channel: "#transformers-ci-daily-models"
-      docker: huggingface/transformers-all-latest-gpu
-      ci_event: Daily CI
-      runner_type: "a10"
-      report_repo_id: hf-internal-testing/transformers_daily_ci
-      commit_sha: ${{ github.sha }}
-    secrets: inherit
-
-  torch-pipeline:
-    name: Torch pipeline CI
-    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
-    with:
-      job: run_pipelines_torch_gpu
-      slack_report_channel: "#transformers-ci-daily-pipeline-torch"
-      docker: huggingface/transformers-all-latest-gpu
-      ci_event: Daily CI
-      report_repo_id: hf-internal-testing/transformers_daily_ci
-      commit_sha: ${{ github.sha }}
-    secrets: inherit
-
-  example-ci:
-    name: Example CI
-    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
-    with:
-      job: run_examples_gpu
-      slack_report_channel: "#transformers-ci-daily-examples"
-      docker: huggingface/transformers-all-latest-gpu
-      ci_event: Daily CI
-      report_repo_id: hf-internal-testing/transformers_daily_ci
-      commit_sha: ${{ github.sha }}
-    secrets: inherit
-
-  trainer-fsdp-ci:
-    name: Trainer/FSDP CI
-    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
-    with:
-      job: run_trainer_and_fsdp_gpu
-      slack_report_channel: "#transformers-ci-daily-training"
-      docker: huggingface/transformers-all-latest-gpu
-      runner_type: "a10"
-      ci_event: Daily CI
-      report_repo_id: hf-internal-testing/transformers_daily_ci
-      commit_sha: ${{ github.sha }}
-    secrets: inherit
-
-  deepspeed-ci:
-    name: DeepSpeed CI
-    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
-    with:
-      job: run_torch_cuda_extensions_gpu
-      slack_report_channel: "#transformers-ci-daily-training"
-      docker: huggingface/transformers-pytorch-deepspeed-latest-gpu
-      ci_event: Daily CI
-      working-directory-prefix: /workspace
-      report_repo_id: hf-internal-testing/transformers_daily_ci
-      commit_sha: ${{ github.sha }}
-    secrets: inherit
-
-  quantization-ci:
-    name: Quantization CI
-    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
-    with:
-      job: run_quantization_torch_gpu
-      slack_report_channel: "#transformers-ci-daily-quantization"
-      docker: huggingface/transformers-quantization-latest-gpu
-      ci_event: Daily CI
-      report_repo_id: hf-internal-testing/transformers_daily_ci
-      commit_sha: ${{ github.sha }}
-    secrets: inherit
-
-  kernels-ci:
-    name: Kernels CI
-    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
-    with:
-      job: run_kernels_gpu
-      slack_report_channel: "#transformers-ci-daily-kernels"
-      docker: huggingface/transformers-all-latest-gpu
-      ci_event: Daily CI
-      report_repo_id: hf-internal-testing/transformers_daily_ci
-      commit_sha: ${{ github.sha }}
-    secrets: inherit

--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -6,7 +6,7 @@ on:
     - cron: "17 2 * * *"
   push:
     branches:
-      - fix_stale_github_api_cache
+      - run_nvidia_ci*
   workflow_dispatch:
     inputs:
       prev_workflow_run_id:
@@ -31,30 +31,108 @@ permissions:
   contents: read
 
 jobs:
-  debug_api_consistency:
-    name: "[debug] Test get_daily_ci_runs retry logic"
+  setup:
+    name: Setup
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Call get_daily_ci_runs twice
+      - name: Setup
         env:
-          ACCESS_REPO_INFO_TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
+          prev_workflow_run_id: ${{ inputs.prev_workflow_run_id || env.prev_workflow_run_id }}
+          other_workflow_run_id: ${{ inputs.other_workflow_run_id || env.other_workflow_run_id }}
         run: |
-          python3 -c "
-          import sys, os
-          sys.path.insert(0, 'utils')
-          from get_previous_daily_ci import get_daily_ci_runs
-          token = os.environ['ACCESS_REPO_INFO_TOKEN']
-          import time
-          for i in range(1, 21):
-              print(f'========== Call {i}/20 ==========')
-              runs = get_daily_ci_runs(token=token, workflow_id=90575235)
-              print(f'=== Final result: {len(runs)} runs ===')
-              for r in runs[:2]:
-                  print(f'  id={r[\"id\"]} run_number={r.get(\"run_number\")} status={r[\"status\"]} created_at={r[\"created_at\"]}')
-              if i < 20:
-                  print('Sleeping 60s...')
-                  time.sleep(60)
-          "
+          mkdir "setup_values"
+          echo "$prev_workflow_run_id" > "setup_values/prev_workflow_run_id.txt"
+          echo "$other_workflow_run_id" > "setup_values/other_workflow_run_id.txt"
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: setup_values
+          path: setup_values
+
+  model-ci:
+    name: Model CI
+    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
+    with:
+      job: run_models_gpu
+      slack_report_channel: "#transformers-ci-daily-models"
+      docker: huggingface/transformers-all-latest-gpu
+      ci_event: Daily CI
+      runner_type: "a10"
+      report_repo_id: hf-internal-testing/transformers_daily_ci
+      commit_sha: ${{ github.sha }}
+    secrets: inherit
+
+  torch-pipeline:
+    name: Torch pipeline CI
+    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
+    with:
+      job: run_pipelines_torch_gpu
+      slack_report_channel: "#transformers-ci-daily-pipeline-torch"
+      docker: huggingface/transformers-all-latest-gpu
+      ci_event: Daily CI
+      report_repo_id: hf-internal-testing/transformers_daily_ci
+      commit_sha: ${{ github.sha }}
+    secrets: inherit
+
+  example-ci:
+    name: Example CI
+    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
+    with:
+      job: run_examples_gpu
+      slack_report_channel: "#transformers-ci-daily-examples"
+      docker: huggingface/transformers-all-latest-gpu
+      ci_event: Daily CI
+      report_repo_id: hf-internal-testing/transformers_daily_ci
+      commit_sha: ${{ github.sha }}
+    secrets: inherit
+
+  trainer-fsdp-ci:
+    name: Trainer/FSDP CI
+    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
+    with:
+      job: run_trainer_and_fsdp_gpu
+      slack_report_channel: "#transformers-ci-daily-training"
+      docker: huggingface/transformers-all-latest-gpu
+      runner_type: "a10"
+      ci_event: Daily CI
+      report_repo_id: hf-internal-testing/transformers_daily_ci
+      commit_sha: ${{ github.sha }}
+    secrets: inherit
+
+  deepspeed-ci:
+    name: DeepSpeed CI
+    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
+    with:
+      job: run_torch_cuda_extensions_gpu
+      slack_report_channel: "#transformers-ci-daily-training"
+      docker: huggingface/transformers-pytorch-deepspeed-latest-gpu
+      ci_event: Daily CI
+      working-directory-prefix: /workspace
+      report_repo_id: hf-internal-testing/transformers_daily_ci
+      commit_sha: ${{ github.sha }}
+    secrets: inherit
+
+  quantization-ci:
+    name: Quantization CI
+    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
+    with:
+      job: run_quantization_torch_gpu
+      slack_report_channel: "#transformers-ci-daily-quantization"
+      docker: huggingface/transformers-quantization-latest-gpu
+      ci_event: Daily CI
+      report_repo_id: hf-internal-testing/transformers_daily_ci
+      commit_sha: ${{ github.sha }}
+    secrets: inherit
+
+  kernels-ci:
+    name: Kernels CI
+    uses: huggingface/transformers-ci/.github/workflows/daily-ci_reusable.yml@main
+    with:
+      job: run_kernels_gpu
+      slack_report_channel: "#transformers-ci-daily-kernels"
+      docker: huggingface/transformers-all-latest-gpu
+      ci_event: Daily CI
+      report_repo_id: hf-internal-testing/transformers_daily_ci
+      commit_sha: ${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -32,29 +32,28 @@ permissions:
 
 jobs:
   debug_api_consistency:
-    name: "[debug] Poll GitHub API for schedule runs"
+    name: "[debug] Test get_daily_ci_runs retry logic"
     runs-on: ubuntu-22.04
     steps:
-      - name: Poll workflow runs endpoint 10 times (1 min apart)
+      - uses: actions/checkout@v4
+
+      - name: Call get_daily_ci_runs twice
         env:
-          TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
+          ACCESS_REPO_INFO_TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
         run: |
-          URL="https://api.github.com/repos/huggingface/transformers/actions/workflows/90575235/runs?branch=main&exclude_pull_requests=true&per_page=7&event=schedule"
-          for i in $(seq 1 10); do
-            echo "========== Attempt $i / 10 — $(date -u '+%Y-%m-%dT%H:%M:%SZ') =========="
-            RESPONSE=$(curl -s -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" "$URL")
-            TOTAL=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('total_count','N/A'))")
-            echo "total_count: $TOTAL"
-            echo "--- run[0] ---"
-            echo "$RESPONSE" | python3 -c "
-          import sys, json
-          runs = json.load(sys.stdin).get('workflow_runs', [])
-          for r in runs[:2]:
-              print(f\"  id={r['id']} run_number={r['run_number']} status={r['status']} conclusion={r['conclusion']} created_at={r['created_at']} event={r['event']}\")
+          python3 -c "
+          import sys, os
+          sys.path.insert(0, 'utils')
+          from get_previous_daily_ci import get_daily_ci_runs
+          token = os.environ['ACCESS_REPO_INFO_TOKEN']
+          # Pass the most recent known Nvidia CI schedule run as the staleness anchor.
+          # (GITHUB_RUN_ID in this push-triggered job would never appear in event=schedule results.)
+          known_schedule_run_id = 33038227895
+          for i in range(1, 3):
+              print(f'========== Call {i}/2 ==========')
+              runs = get_daily_ci_runs(token=token, workflow_id=90575235, current_run_id=known_schedule_run_id)
+              print(f'=== Final result: {len(runs)} runs ===')
+              for r in runs[:2]:
+                  print(f'  id={r[\"id\"]} run_number={r.get(\"run_number\")} status={r[\"status\"]} created_at={r[\"created_at\"]}')
           "
-            if [ $i -lt 10 ]; then
-              echo "Sleeping 60s..."
-              sleep 60
-            fi
-          done
 

--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -46,11 +46,9 @@ jobs:
           sys.path.insert(0, 'utils')
           from get_previous_daily_ci import get_daily_ci_runs
           token = os.environ['ACCESS_REPO_INFO_TOKEN']
-          # Use a non-existent run ID to force the retry path every time, so we can
-          # verify the retry mechanism fires and the stale data is visible in the logs.
-          # After max_attempts the function proceeds with the last response (which is
-          # fresh/correct data), demonstrating graceful fallback.
-          known_schedule_run_id = 99999999999
+          # Pass the most recent known Nvidia CI schedule run as the staleness anchor.
+          # (GITHUB_RUN_ID in this push-triggered job would never appear in event=schedule results.)
+          known_schedule_run_id = 33038227895
           for i in range(1, 3):
               print(f'========== Call {i}/2 ==========')
               runs = get_daily_ci_runs(token=token, workflow_id=90575235, current_run_id=known_schedule_run_id)

--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -49,7 +49,7 @@ jobs:
           # Pass the most recent known Nvidia CI schedule run as the staleness anchor.
           # (GITHUB_RUN_ID in this push-triggered job would never appear in event=schedule results.)
           known_schedule_run_id = 33038227895
-          for i in range(1, 3):
+          for i in range(1, 21):
               print(f'========== Call {i}/2 ==========')
               runs = get_daily_ci_runs(token=token, workflow_id=90575235, current_run_id=known_schedule_run_id)
               print(f'=== Final result: {len(runs)} runs ===')

--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -49,11 +49,15 @@ jobs:
           # Pass the most recent known Nvidia CI schedule run as the staleness anchor.
           # (GITHUB_RUN_ID in this push-triggered job would never appear in event=schedule results.)
           known_schedule_run_id = 33038227895
+          import time
           for i in range(1, 21):
-              print(f'========== Call {i}/2 ==========')
+              print(f'========== Call {i}/20 ==========')
               runs = get_daily_ci_runs(token=token, workflow_id=90575235, current_run_id=known_schedule_run_id)
               print(f'=== Final result: {len(runs)} runs ===')
               for r in runs[:2]:
                   print(f'  id={r[\"id\"]} run_number={r.get(\"run_number\")} status={r[\"status\"]} created_at={r[\"created_at\"]}')
+              if i < 20:
+                  print('Sleeping 60s...')
+                  time.sleep(60)
           "
 

--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -46,9 +46,11 @@ jobs:
           sys.path.insert(0, 'utils')
           from get_previous_daily_ci import get_daily_ci_runs
           token = os.environ['ACCESS_REPO_INFO_TOKEN']
-          # Pass the most recent known Nvidia CI schedule run as the staleness anchor.
-          # (GITHUB_RUN_ID in this push-triggered job would never appear in event=schedule results.)
-          known_schedule_run_id = 33038227895
+          # Use a non-existent run ID to force the retry path every time, so we can
+          # verify the retry mechanism fires and the stale data is visible in the logs.
+          # After max_attempts the function proceeds with the last response (which is
+          # fresh/correct data), demonstrating graceful fallback.
+          known_schedule_run_id = 99999999999
           for i in range(1, 3):
               print(f'========== Call {i}/2 ==========')
               runs = get_daily_ci_runs(token=token, workflow_id=90575235, current_run_id=known_schedule_run_id)

--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -46,13 +46,10 @@ jobs:
           sys.path.insert(0, 'utils')
           from get_previous_daily_ci import get_daily_ci_runs
           token = os.environ['ACCESS_REPO_INFO_TOKEN']
-          # Pass the most recent known Nvidia CI schedule run as the staleness anchor.
-          # (GITHUB_RUN_ID in this push-triggered job would never appear in event=schedule results.)
-          known_schedule_run_id = 33038227895
           import time
           for i in range(1, 21):
               print(f'========== Call {i}/20 ==========')
-              runs = get_daily_ci_runs(token=token, workflow_id=90575235, current_run_id=known_schedule_run_id)
+              runs = get_daily_ci_runs(token=token, workflow_id=90575235)
               print(f'=== Final result: {len(runs)} runs ===')
               for r in runs[:2]:
                   print(f'  id={r[\"id\"]} run_number={r.get(\"run_number\")} status={r[\"status\"]} created_at={r[\"created_at\"]}')

--- a/tests/utils/test_get_previous_daily_ci.py
+++ b/tests/utils/test_get_previous_daily_ci.py
@@ -1,0 +1,154 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+
+# utils/ is not an installable package; add it to the path so CI utility modules
+# can be imported without modifying the installed transformers package.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "utils"))
+
+from get_previous_daily_ci import get_daily_ci_runs  # noqa: E402
+
+
+_STALE_RESPONSE = {
+    "total_count": 209,
+    "workflow_runs": [
+        {
+            "id": 30781855254,
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-03T03:27:23Z",
+            "event": "schedule",
+        },
+        {
+            "id": 30730647697,
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-02T03:27:19Z",
+            "event": "schedule",
+        },
+    ],
+}
+
+_FRESH_RESPONSE = {
+    "total_count": 413,
+    "workflow_runs": [
+        {
+            "id": 33038227895,
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-27T04:03:26Z",
+            "event": "schedule",
+        },
+        {
+            "id": 32923823246,
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-26T02:44:02Z",
+            "event": "schedule",
+        },
+    ],
+}
+
+_CURRENT_RUN_ID = 33038227895
+_WORKFLOW_ID = 90575235
+
+
+class GetDailyCiRunsRetryTest(unittest.TestCase):
+    """Unit tests for the stale-cache retry logic in get_daily_ci_runs."""
+
+    def test_fresh_on_first_attempt_no_retry(self):
+        """When the first response contains current_run_id, return immediately without retrying."""
+        with (
+            patch("get_previous_daily_ci.get_github_json", return_value=_FRESH_RESPONSE) as mock_api,
+            patch("get_previous_daily_ci.time.sleep") as mock_sleep,
+        ):
+            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID, current_run_id=_CURRENT_RUN_ID)
+
+        mock_api.assert_called_once()
+        mock_sleep.assert_not_called()
+        self.assertEqual(runs[0]["id"], _CURRENT_RUN_ID)
+
+    def test_stale_then_fresh_retries_once(self):
+        """A stale first response triggers one retry that returns fresh data."""
+        with (
+            patch("get_previous_daily_ci.get_github_json", side_effect=[_STALE_RESPONSE, _FRESH_RESPONSE]) as mock_api,
+            patch("get_previous_daily_ci.time.sleep") as mock_sleep,
+        ):
+            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID, current_run_id=_CURRENT_RUN_ID)
+
+        self.assertEqual(mock_api.call_count, 2)
+        mock_sleep.assert_called_once_with(30)
+        self.assertEqual(runs[0]["id"], _CURRENT_RUN_ID)
+
+    def test_all_stale_exhausts_max_attempts(self):
+        """When all attempts return stale data, proceed after max_attempts with the last result."""
+        with (
+            patch("get_previous_daily_ci.get_github_json", return_value=_STALE_RESPONSE) as mock_api,
+            patch("get_previous_daily_ci.time.sleep") as mock_sleep,
+        ):
+            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID, current_run_id=_CURRENT_RUN_ID)
+
+        # max_attempts=5 → 5 API calls, 4 sleeps (between consecutive attempts, not after the last)
+        self.assertEqual(mock_api.call_count, 5)
+        self.assertEqual(mock_sleep.call_count, 4)
+        mock_sleep.assert_called_with(30)
+        # Stale data is returned as a graceful fallback
+        self.assertEqual(runs[0]["id"], 30781855254)
+
+    def test_no_current_run_id_skips_stale_check(self):
+        """With current_run_id=0 (GITHUB_RUN_ID unset) the stale check is skipped entirely."""
+        with (
+            patch("get_previous_daily_ci.get_github_json", return_value=_STALE_RESPONSE) as mock_api,
+            patch("get_previous_daily_ci.time.sleep") as mock_sleep,
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            os.environ.pop("GITHUB_RUN_ID", None)
+            # Don't pass current_run_id → defaults to int(os.environ.get("GITHUB_RUN_ID", 0)) = 0
+            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
+
+        mock_api.assert_called_once()
+        mock_sleep.assert_not_called()
+        self.assertEqual(runs[0]["id"], 30781855254)
+
+    def test_empty_schedule_falls_back_to_workflow_run(self):
+        """When event=schedule returns no runs, fall back to event=workflow_run without retrying."""
+        fallback_response = {
+            "total_count": 5,
+            "workflow_runs": [
+                {
+                    "id": 33038227895,
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "created_at": "2026-08-27T04:03:26Z",
+                    "event": "workflow_run",
+                },
+            ],
+        }
+        with (
+            patch(
+                "get_previous_daily_ci.get_github_json",
+                side_effect=[{"total_count": 0, "workflow_runs": []}, fallback_response],
+            ),
+            patch("get_previous_daily_ci.time.sleep") as mock_sleep,
+        ):
+            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID, current_run_id=_CURRENT_RUN_ID)
+
+        mock_sleep.assert_not_called()
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(runs[0]["event"], "workflow_run")

--- a/tests/utils/test_get_previous_daily_ci.py
+++ b/tests/utils/test_get_previous_daily_ci.py
@@ -25,6 +25,15 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "utils"))
 from get_previous_daily_ci import get_daily_ci_runs  # noqa: E402
 
 
+_WORKFLOW_ID = 90575235
+_CURRENT_RUN_ID = 33038227895
+
+# Simulates get_github_json("/runs/{GITHUB_RUN_ID}") — same workflow as the one being queried.
+_CURRENT_RUN_RESPONSE = {"id": _CURRENT_RUN_ID, "workflow_id": _WORKFLOW_ID}
+
+# Simulates a current run belonging to a *different* workflow (e.g. AMD CI querying Nvidia).
+_DIFFERENT_WORKFLOW_RUN_RESPONSE = {"id": 11111111111, "workflow_id": 99999}
+
 _STALE_RESPONSE = {
     "total_count": 209,
     "workflow_runs": [
@@ -49,7 +58,7 @@ _FRESH_RESPONSE = {
     "total_count": 413,
     "workflow_runs": [
         {
-            "id": 33038227895,
+            "id": _CURRENT_RUN_ID,
             "status": "completed",
             "conclusion": "failure",
             "created_at": "2026-08-27T04:03:26Z",
@@ -65,63 +74,91 @@ _FRESH_RESPONSE = {
     ],
 }
 
-_CURRENT_RUN_ID = 33038227895
-_WORKFLOW_ID = 90575235
-
 
 class GetDailyCiRunsRetryTest(unittest.TestCase):
-    """Unit tests for the stale-cache retry logic in get_daily_ci_runs."""
+    """Unit tests for the stale-cache retry logic in get_daily_ci_runs.
+
+    get_github_json is called once up-front to fetch the current run's workflow_id
+    (for stale-check eligibility), then once per schedule-query attempt.  Tests use
+    side_effect lists ordered as: [current-run lookup, attempt-1, attempt-2, ...].
+    """
 
     def test_fresh_on_first_attempt_no_retry(self):
-        """When the first response contains current_run_id, return immediately without retrying."""
+        """When the first response contains the current run, return immediately without retrying."""
         with (
-            patch("get_previous_daily_ci.get_github_json", return_value=_FRESH_RESPONSE) as mock_api,
+            patch("get_previous_daily_ci.get_github_json", side_effect=[_CURRENT_RUN_RESPONSE, _FRESH_RESPONSE]),
             patch("get_previous_daily_ci.time.sleep") as mock_sleep,
+            patch.dict("os.environ", {"GITHUB_RUN_ID": str(_CURRENT_RUN_ID)}),
         ):
-            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID, current_run_id=_CURRENT_RUN_ID)
+            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
 
-        mock_api.assert_called_once()
         mock_sleep.assert_not_called()
         self.assertEqual(runs[0]["id"], _CURRENT_RUN_ID)
 
     def test_stale_then_fresh_retries_once(self):
         """A stale first response triggers one retry that returns fresh data."""
         with (
-            patch("get_previous_daily_ci.get_github_json", side_effect=[_STALE_RESPONSE, _FRESH_RESPONSE]) as mock_api,
+            patch(
+                "get_previous_daily_ci.get_github_json",
+                side_effect=[_CURRENT_RUN_RESPONSE, _STALE_RESPONSE, _FRESH_RESPONSE],
+            ),
             patch("get_previous_daily_ci.time.sleep") as mock_sleep,
+            patch.dict("os.environ", {"GITHUB_RUN_ID": str(_CURRENT_RUN_ID)}),
         ):
-            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID, current_run_id=_CURRENT_RUN_ID)
+            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
 
-        self.assertEqual(mock_api.call_count, 2)
         mock_sleep.assert_called_once_with(30)
         self.assertEqual(runs[0]["id"], _CURRENT_RUN_ID)
 
     def test_all_stale_exhausts_max_attempts(self):
         """When all attempts return stale data, proceed after max_attempts with the last result."""
         with (
-            patch("get_previous_daily_ci.get_github_json", return_value=_STALE_RESPONSE) as mock_api,
+            patch(
+                "get_previous_daily_ci.get_github_json",
+                side_effect=[_CURRENT_RUN_RESPONSE] + [_STALE_RESPONSE] * 5,
+            ) as mock_api,
             patch("get_previous_daily_ci.time.sleep") as mock_sleep,
+            patch.dict("os.environ", {"GITHUB_RUN_ID": str(_CURRENT_RUN_ID)}),
         ):
-            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID, current_run_id=_CURRENT_RUN_ID)
+            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
 
-        # max_attempts=5 → 5 API calls, 4 sleeps (between consecutive attempts, not after the last)
-        self.assertEqual(mock_api.call_count, 5)
+        # 1 current-run lookup + 5 schedule queries (max_attempts=5)
+        self.assertEqual(mock_api.call_count, 6)
+        # sleep between attempts 1-2, 2-3, 3-4, 4-5 — not after the last attempt
         self.assertEqual(mock_sleep.call_count, 4)
         mock_sleep.assert_called_with(30)
         # Stale data is returned as a graceful fallback
         self.assertEqual(runs[0]["id"], 30781855254)
 
-    def test_no_current_run_id_skips_stale_check(self):
-        """With current_run_id=0 (GITHUB_RUN_ID unset) the stale check is skipped entirely."""
+    def test_different_workflow_skips_stale_check(self):
+        """When workflow_id differs from the current run's, stale check is skipped entirely."""
         with (
-            patch("get_previous_daily_ci.get_github_json", return_value=_STALE_RESPONSE) as mock_api,
+            patch(
+                "get_previous_daily_ci.get_github_json",
+                side_effect=[_DIFFERENT_WORKFLOW_RUN_RESPONSE, _STALE_RESPONSE],
+            ) as mock_api,
+            patch("get_previous_daily_ci.time.sleep") as mock_sleep,
+            patch.dict("os.environ", {"GITHUB_RUN_ID": "11111111111"}),
+        ):
+            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
+
+        # 1 current-run lookup + 1 schedule query (max_attempts=1, no retries)
+        self.assertEqual(mock_api.call_count, 2)
+        mock_sleep.assert_not_called()
+        # Returns whatever the single attempt gave (stale in this case)
+        self.assertEqual(runs[0]["id"], 30781855254)
+
+    def test_no_github_run_id_skips_stale_check(self):
+        """With GITHUB_RUN_ID unset, the current-run lookup is skipped and no retry is done."""
+        with (
+            patch("get_previous_daily_ci.get_github_json", side_effect=[_STALE_RESPONSE]) as mock_api,
             patch("get_previous_daily_ci.time.sleep") as mock_sleep,
             patch.dict("os.environ", {}, clear=False),
         ):
             os.environ.pop("GITHUB_RUN_ID", None)
-            # Don't pass current_run_id → defaults to int(os.environ.get("GITHUB_RUN_ID", 0)) = 0
             runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
 
+        # No current-run lookup, 1 schedule query, no retries
         mock_api.assert_called_once()
         mock_sleep.assert_not_called()
         self.assertEqual(runs[0]["id"], 30781855254)
@@ -132,7 +169,7 @@ class GetDailyCiRunsRetryTest(unittest.TestCase):
             "total_count": 5,
             "workflow_runs": [
                 {
-                    "id": 33038227895,
+                    "id": _CURRENT_RUN_ID,
                     "status": "completed",
                     "conclusion": "failure",
                     "created_at": "2026-08-27T04:03:26Z",
@@ -143,11 +180,12 @@ class GetDailyCiRunsRetryTest(unittest.TestCase):
         with (
             patch(
                 "get_previous_daily_ci.get_github_json",
-                side_effect=[{"total_count": 0, "workflow_runs": []}, fallback_response],
+                side_effect=[_CURRENT_RUN_RESPONSE, {"total_count": 0, "workflow_runs": []}, fallback_response],
             ),
             patch("get_previous_daily_ci.time.sleep") as mock_sleep,
+            patch.dict("os.environ", {"GITHUB_RUN_ID": str(_CURRENT_RUN_ID)}),
         ):
-            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID, current_run_id=_CURRENT_RUN_ID)
+            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
 
         mock_sleep.assert_not_called()
         self.assertEqual(len(runs), 1)

--- a/tests/utils/test_get_previous_daily_ci.py
+++ b/tests/utils/test_get_previous_daily_ci.py
@@ -88,7 +88,7 @@ class GetDailyCiRunsRetryTest(unittest.TestCase):
         with (
             patch("get_previous_daily_ci.get_github_json", side_effect=[_CURRENT_RUN_RESPONSE, _FRESH_RESPONSE]),
             patch("get_previous_daily_ci.time.sleep") as mock_sleep,
-            patch.dict("os.environ", {"GITHUB_RUN_ID": str(_CURRENT_RUN_ID)}),
+            patch.dict("os.environ", {"GITHUB_RUN_ID": str(_CURRENT_RUN_ID), "GITHUB_EVENT_NAME": "schedule"}),
         ):
             runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
 
@@ -103,7 +103,7 @@ class GetDailyCiRunsRetryTest(unittest.TestCase):
                 side_effect=[_CURRENT_RUN_RESPONSE, _STALE_RESPONSE, _FRESH_RESPONSE],
             ),
             patch("get_previous_daily_ci.time.sleep") as mock_sleep,
-            patch.dict("os.environ", {"GITHUB_RUN_ID": str(_CURRENT_RUN_ID)}),
+            patch.dict("os.environ", {"GITHUB_RUN_ID": str(_CURRENT_RUN_ID), "GITHUB_EVENT_NAME": "schedule"}),
         ):
             runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
 
@@ -118,7 +118,7 @@ class GetDailyCiRunsRetryTest(unittest.TestCase):
                 side_effect=[_CURRENT_RUN_RESPONSE] + [_STALE_RESPONSE] * 5,
             ) as mock_api,
             patch("get_previous_daily_ci.time.sleep") as mock_sleep,
-            patch.dict("os.environ", {"GITHUB_RUN_ID": str(_CURRENT_RUN_ID)}),
+            patch.dict("os.environ", {"GITHUB_RUN_ID": str(_CURRENT_RUN_ID), "GITHUB_EVENT_NAME": "schedule"}),
         ):
             runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
 
@@ -138,7 +138,7 @@ class GetDailyCiRunsRetryTest(unittest.TestCase):
                 side_effect=[_DIFFERENT_WORKFLOW_RUN_RESPONSE, _STALE_RESPONSE],
             ) as mock_api,
             patch("get_previous_daily_ci.time.sleep") as mock_sleep,
-            patch.dict("os.environ", {"GITHUB_RUN_ID": "11111111111"}),
+            patch.dict("os.environ", {"GITHUB_RUN_ID": "11111111111", "GITHUB_EVENT_NAME": "schedule"}),
         ):
             runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
 
@@ -146,6 +146,23 @@ class GetDailyCiRunsRetryTest(unittest.TestCase):
         self.assertEqual(mock_api.call_count, 2)
         mock_sleep.assert_not_called()
         # Returns whatever the single attempt gave (stale in this case)
+        self.assertEqual(runs[0]["id"], 30781855254)
+
+    def test_non_schedule_event_skips_stale_check(self):
+        """When the triggering event is not 'schedule' (e.g. push), stale check is skipped."""
+        with (
+            patch(
+                "get_previous_daily_ci.get_github_json",
+                side_effect=[_CURRENT_RUN_RESPONSE, _STALE_RESPONSE],
+            ) as mock_api,
+            patch("get_previous_daily_ci.time.sleep") as mock_sleep,
+            patch.dict("os.environ", {"GITHUB_RUN_ID": str(_CURRENT_RUN_ID), "GITHUB_EVENT_NAME": "push"}),
+        ):
+            runs = get_daily_ci_runs(token="tok", workflow_id=_WORKFLOW_ID)
+
+        # 1 current-run lookup + 1 schedule query (max_attempts=1, no retries)
+        self.assertEqual(mock_api.call_count, 2)
+        mock_sleep.assert_not_called()
         self.assertEqual(runs[0]["id"], 30781855254)
 
     def test_no_github_run_id_skips_stale_check(self):

--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -6,18 +6,14 @@ from get_ci_error_statistics import download_artifact, get_artifacts_links, get_
 
 
 def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
-    """Get the workflow runs of the scheduled (daily) CI.
+    """Get the most recent workflow runs of the scheduled (daily) CI on the main branch.
 
-    This only selects the runs triggered by the `schedule` event on the `main` branch.
+    Queries event=schedule; falls back to event=workflow_run when no results are found
+    (AMD CI is triggered via workflow_run, not schedule).  Retries on stale GitHub API
+    responses — see PR #48374 for background.
     """
-    # The id of a workflow (not of a workflow run).
-    # From a given workflow run (where we have workflow run id), we can get the workflow id by going to
-    # https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}
-    # and check the `workflow_id` key.
-
-    # Always fetch the current run's metadata: it resolves workflow_id when not provided, and lets
-    # us compare the requested workflow_id against the current run's workflow_id to decide whether
-    # stale-cache detection applies (see below).
+    # Fetch current run metadata to (1) resolve workflow_id when not given, and (2) compare
+    # workflow IDs to decide whether stale-cache detection applies (see stale_check below).
     current_run_id = int(os.environ.get("GITHUB_RUN_ID", 0))
     current_workflow_id = None
     if current_run_id:
@@ -29,19 +25,20 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
             workflow_id = current_workflow_id
 
     url = f"https://api.github.com/repos/huggingface/transformers/actions/workflows/{workflow_id}/runs"
-    # On `main` branch + event being `schedule` + not returning PRs + only `num_runs` results
     url += f"?branch=main&exclude_pull_requests=true&per_page={num_runs}"
 
-    # The GitHub Actions API uses a search index for filtered queries (event=, branch=, etc.) that
-    # can lag significantly behind the database — different backend nodes may return wildly different
-    # total_count values (e.g. 190, 238, 311, 413 observed for the same URL within minutes).  When
-    # the index is stale the most-recent runs are missing from the results.
+    # The GitHub Actions search index (used for event=/branch= filters) can lag badly:
+    # the same URL has returned total_count values of 190, 238, 311, and 413 within minutes
+    # from different backend nodes (PR #48374).  We detect a stale response by checking
+    # that GITHUB_RUN_ID appears in the results; if absent we retry.
     #
-    # Stale-cache detection: check whether the current run (GITHUB_RUN_ID) appears in the results.
-    # It must always be present in a fresh response when we are querying the same workflow.
-    # When the requested workflow_id differs from the current run's (e.g. AMD CI querying Nvidia CI
-    # historical runs), skip the check — it would be valid but requires a different anchor run and
-    # is left for a follow-up PR once the same-workflow case is confirmed stable.
+    # Stale-check is only active when querying the *same* workflow as the current run AND
+    # the current run is schedule-triggered (so GITHUB_RUN_ID is guaranteed to be in the
+    # results when the API is fresh).  The two remaining uncovered paths are left for a
+    # follow-up PR once this path is confirmed stable:
+    #   • AMD CI querying its own history → falls into the event=workflow_run fallback below
+    #     (AMD CI is triggered via workflow_run, not schedule).
+    #   • AMD CI querying the matching Nvidia run (different workflow_id) → stale_check=False.
     stale_check = (
         current_workflow_id is not None
         and int(workflow_id) == int(current_workflow_id)
@@ -63,9 +60,8 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
             )
 
         if len(workflow_runs) == 0:
-            # AMD CI runs are triggered via a workflow_run event, so their historical runs are
-            # indexed under event=workflow_run rather than event=schedule.
-            # TODO: add stale-cache detection for this fallback path once the schedule path is stable.
+            # AMD CI runs appear under event=workflow_run (triggered via the workflow_run
+            # event, not schedule).  Stale-check for this path is TODO (see above).
             workflow_run_url = f"{url}&event=workflow_run"
             print(f"[DEBUG get_daily_ci_runs] Falling back to: {workflow_run_url}")
             result = get_github_json(workflow_run_url, token=token)

--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -42,7 +42,11 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
     # When the requested workflow_id differs from the current run's (e.g. AMD CI querying Nvidia CI
     # historical runs), skip the check — it would be valid but requires a different anchor run and
     # is left for a follow-up PR once the same-workflow case is confirmed stable.
-    stale_check = current_workflow_id is not None and int(workflow_id) == int(current_workflow_id)
+    stale_check = (
+        current_workflow_id is not None
+        and int(workflow_id) == int(current_workflow_id)
+        and os.environ.get("GITHUB_EVENT_NAME") == "schedule"
+    )
     max_attempts = 5 if stale_check else 1
 
     for attempt in range(1, max_attempts + 1):

--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -35,7 +35,7 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None, current_run_id=None):
     # executing this script and therefore must always be present in a fresh response).
     if current_run_id is None:
         current_run_id = int(os.environ.get("GITHUB_RUN_ID", 0))
-    max_attempts = 3
+    max_attempts = 5
 
     for attempt in range(1, max_attempts + 1):
         schedule_url = f"{url}&event=schedule"

--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -5,7 +5,7 @@ import zipfile
 from get_ci_error_statistics import download_artifact, get_artifacts_links, get_github_json
 
 
-def get_daily_ci_runs(token, num_runs=7, workflow_id=None, current_run_id=None):
+def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
     """Get the workflow runs of the scheduled (daily) CI.
 
     This only selects the runs triggered by the `schedule` event on the `main` branch.
@@ -15,12 +15,18 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None, current_run_id=None):
     # https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}
     # and check the `workflow_id` key.
 
-    if not workflow_id:
-        workflow_run_id = os.environ["GITHUB_RUN_ID"]
-        workflow_run = get_github_json(
-            f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}", token=token
+    # Always fetch the current run's metadata: it resolves workflow_id when not provided, and lets
+    # us compare the requested workflow_id against the current run's workflow_id to decide whether
+    # stale-cache detection applies (see below).
+    current_run_id = int(os.environ.get("GITHUB_RUN_ID", 0))
+    current_workflow_id = None
+    if current_run_id:
+        current_run = get_github_json(
+            f"https://api.github.com/repos/huggingface/transformers/actions/runs/{current_run_id}", token=token
         )
-        workflow_id = workflow_run["workflow_id"]
+        current_workflow_id = current_run["workflow_id"]
+        if not workflow_id:
+            workflow_id = current_workflow_id
 
     url = f"https://api.github.com/repos/huggingface/transformers/actions/workflows/{workflow_id}/runs"
     # On `main` branch + event being `schedule` + not returning PRs + only `num_runs` results
@@ -29,13 +35,15 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None, current_run_id=None):
     # The GitHub Actions API uses a search index for filtered queries (event=, branch=, etc.) that
     # can lag significantly behind the database — different backend nodes may return wildly different
     # total_count values (e.g. 190, 238, 311, 413 observed for the same URL within minutes).  When
-    # the index is stale the most-recent runs are missing from the results.  We detect this by
-    # checking whether a known recent run appears in the returned list: if it doesn't, the response
-    # is stale and we retry.  `current_run_id` defaults to GITHUB_RUN_ID (the run that is currently
-    # executing this script and therefore must always be present in a fresh response).
-    if current_run_id is None:
-        current_run_id = int(os.environ.get("GITHUB_RUN_ID", 0))
-    max_attempts = 5
+    # the index is stale the most-recent runs are missing from the results.
+    #
+    # Stale-cache detection: check whether the current run (GITHUB_RUN_ID) appears in the results.
+    # It must always be present in a fresh response when we are querying the same workflow.
+    # When the requested workflow_id differs from the current run's (e.g. AMD CI querying Nvidia CI
+    # historical runs), skip the check — it would be valid but requires a different anchor run and
+    # is left for a follow-up PR once the same-workflow case is confirmed stable.
+    stale_check = current_workflow_id is not None and int(workflow_id) == int(current_workflow_id)
+    max_attempts = 5 if stale_check else 1
 
     for attempt in range(1, max_attempts + 1):
         schedule_url = f"{url}&event=schedule"
@@ -51,6 +59,9 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None, current_run_id=None):
             )
 
         if len(workflow_runs) == 0:
+            # AMD CI runs are triggered via a workflow_run event, so their historical runs are
+            # indexed under event=workflow_run rather than event=schedule.
+            # TODO: add stale-cache detection for this fallback path once the schedule path is stable.
             workflow_run_url = f"{url}&event=workflow_run"
             print(f"[DEBUG get_daily_ci_runs] Falling back to: {workflow_run_url}")
             result = get_github_json(workflow_run_url, token=token)
@@ -62,9 +73,7 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None, current_run_id=None):
                 )
             break
 
-        # Stale-cache check: the current run must appear in the results (it always exists and belongs
-        # to this workflow).  If it's absent the index is behind; wait and retry.
-        if current_run_id and current_run_id not in {r["id"] for r in workflow_runs}:
+        if stale_check and current_run_id not in {r["id"] for r in workflow_runs}:
             if attempt < max_attempts:
                 print(
                     f"[WARN get_daily_ci_runs] Current run {current_run_id} not found in results — "

--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -1,4 +1,5 @@
 import os
+import time
 import zipfile
 
 from get_ci_error_statistics import download_artifact, get_artifacts_links, get_github_json
@@ -25,25 +26,55 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
     # On `main` branch + event being `schedule` + not returning PRs + only `num_runs` results
     url += f"?branch=main&exclude_pull_requests=true&per_page={num_runs}"
 
-    schedule_url = f"{url}&event=schedule"
-    print(f"[DEBUG get_daily_ci_runs] Querying: {schedule_url}")
-    result = get_github_json(schedule_url, token=token)
-    workflow_runs = result["workflow_runs"]
-    print(f"[DEBUG get_daily_ci_runs] event=schedule returned {len(workflow_runs)} runs:")
-    for r in workflow_runs:
-        print(
-            f"  id={r['id']} status={r['status']} conclusion={r.get('conclusion')} created_at={r['created_at']} event={r['event']}"
-        )
-    if len(workflow_runs) == 0:
-        workflow_run_url = f"{url}&event=workflow_run"
-        print(f"[DEBUG get_daily_ci_runs] Falling back to: {workflow_run_url}")
-        result = get_github_json(workflow_run_url, token=token)
+    # The GitHub Actions API uses a search index for filtered queries (event=, branch=, etc.) that
+    # can lag significantly behind the database — different backend nodes may return wildly different
+    # total_count values (e.g. 190, 238, 311, 413 observed for the same URL within minutes).  When
+    # the index is stale the most-recent runs are missing from the results.  We detect this by
+    # checking whether the current run itself appears in the returned list: if it doesn't, the
+    # response is stale and we retry.
+    current_run_id = int(os.environ.get("GITHUB_RUN_ID", 0))
+    max_attempts = 3
+
+    for attempt in range(1, max_attempts + 1):
+        schedule_url = f"{url}&event=schedule"
+        print(f"[DEBUG get_daily_ci_runs] Querying (attempt {attempt}/{max_attempts}): {schedule_url}")
+        result = get_github_json(schedule_url, token=token)
         workflow_runs = result["workflow_runs"]
-        print(f"[DEBUG get_daily_ci_runs] event=workflow_run returned {len(workflow_runs)} runs:")
+        print(f"[DEBUG get_daily_ci_runs] event=schedule returned {len(workflow_runs)} runs (total_count={result.get('total_count')}):")
         for r in workflow_runs:
             print(
                 f"  id={r['id']} status={r['status']} conclusion={r.get('conclusion')} created_at={r['created_at']} event={r['event']}"
             )
+
+        if len(workflow_runs) == 0:
+            workflow_run_url = f"{url}&event=workflow_run"
+            print(f"[DEBUG get_daily_ci_runs] Falling back to: {workflow_run_url}")
+            result = get_github_json(workflow_run_url, token=token)
+            workflow_runs = result["workflow_runs"]
+            print(f"[DEBUG get_daily_ci_runs] event=workflow_run returned {len(workflow_runs)} runs:")
+            for r in workflow_runs:
+                print(
+                    f"  id={r['id']} status={r['status']} conclusion={r.get('conclusion')} created_at={r['created_at']} event={r['event']}"
+                )
+            break
+
+        # Stale-cache check: the current run must appear in the results (it always exists and belongs
+        # to this workflow).  If it's absent the index is behind; wait and retry.
+        if current_run_id and current_run_id not in {r["id"] for r in workflow_runs}:
+            if attempt < max_attempts:
+                print(
+                    f"[WARN get_daily_ci_runs] Current run {current_run_id} not found in results — "
+                    f"likely a stale GitHub API cache (total_count={result.get('total_count')}). "
+                    f"Retrying in 30s..."
+                )
+                time.sleep(30)
+                continue
+            else:
+                print(
+                    f"[WARN get_daily_ci_runs] Current run {current_run_id} still not found after "
+                    f"{max_attempts} attempts — proceeding with stale results."
+                )
+        break
 
     return workflow_runs
 

--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -5,7 +5,7 @@ import zipfile
 from get_ci_error_statistics import download_artifact, get_artifacts_links, get_github_json
 
 
-def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
+def get_daily_ci_runs(token, num_runs=7, workflow_id=None, current_run_id=None):
     """Get the workflow runs of the scheduled (daily) CI.
 
     This only selects the runs triggered by the `schedule` event on the `main` branch.
@@ -30,9 +30,11 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
     # can lag significantly behind the database — different backend nodes may return wildly different
     # total_count values (e.g. 190, 238, 311, 413 observed for the same URL within minutes).  When
     # the index is stale the most-recent runs are missing from the results.  We detect this by
-    # checking whether the current run itself appears in the returned list: if it doesn't, the
-    # response is stale and we retry.
-    current_run_id = int(os.environ.get("GITHUB_RUN_ID", 0))
+    # checking whether a known recent run appears in the returned list: if it doesn't, the response
+    # is stale and we retry.  `current_run_id` defaults to GITHUB_RUN_ID (the run that is currently
+    # executing this script and therefore must always be present in a fresh response).
+    if current_run_id is None:
+        current_run_id = int(os.environ.get("GITHUB_RUN_ID", 0))
     max_attempts = 3
 
     for attempt in range(1, max_attempts + 1):

--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -42,7 +42,9 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None, current_run_id=None):
         print(f"[DEBUG get_daily_ci_runs] Querying (attempt {attempt}/{max_attempts}): {schedule_url}")
         result = get_github_json(schedule_url, token=token)
         workflow_runs = result["workflow_runs"]
-        print(f"[DEBUG get_daily_ci_runs] event=schedule returned {len(workflow_runs)} runs (total_count={result.get('total_count')}):")
+        print(
+            f"[DEBUG get_daily_ci_runs] event=schedule returned {len(workflow_runs)} runs (total_count={result.get('total_count')}):"
+        )
         for r in workflow_runs:
             print(
                 f"  id={r['id']} status={r['status']} conclusion={r.get('conclusion')} created_at={r['created_at']} event={r['event']}"


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48374&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48374) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48374&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48374)
<!-- ci-dashboard-badge:end -->

## Summary

The GitHub Actions search index (used for `event=`/`branch=` filters) can lag significantly behind the database. Different backend nodes return wildly inconsistent `total_count` values for the same URL within minutes (190, 209, 238, 311, 413 all observed), and stale nodes omit the most-recent runs entirely — causing the notification script to compare against a weeks-old CI baseline.

**Root cause** (confirmed via debug polling): GitHub's load balancer routes identical requests to different backend nodes with different index snapshots. This is a known GitHub API issue (community discussion [#24626](https://github.com/orgs/community/discussions/24626)).

**Fix** in `utils/get_previous_daily_ci.py`:
- On each call, fetch the current run's metadata (`GITHUB_RUN_ID`) to resolve `workflow_id` and determine stale-check eligibility
- **Same workflow + `event=schedule` trigger**: retry up to 5× with 30s sleep when `GITHUB_RUN_ID` is absent from results (stale node detected)
- **Different workflow** (e.g. AMD CI querying Nvidia runs): `stale_check=False`, no retry — the current run's ID won't appear in a different workflow's results, so we have no reliable freshness anchor. Left for a follow-up PR.
- **Non-`schedule` trigger** (push, dispatch): `stale_check=False`, no retry — push/dispatch runs don't appear in `event=schedule` results, so absence of `GITHUB_RUN_ID` is expected rather than a sign of staleness.
- **AMD CI querying its own history**: AMD CI is triggered via `workflow_run`, not `schedule`, so its runs appear only in the `event=workflow_run` fallback path at the bottom of the loop. Stale-check for that path is TODO (follow-up PR once the schedule path is confirmed stable).

Also adds `tests/utils/test_get_previous_daily_ci.py` with 7 fully-mocked unit tests covering all retry/skip branches.

## Test plan
- [ ] Unit tests: `python -m unittest tests.utils.test_get_previous_daily_ci -v` (7 tests, all pass)
- [ ] Debug CI job on this branch confirmed stale hit on call 5/20 (`total_count=209`, Aug 3 as most recent) → retried once → fresh data (`total_count=413`, Aug 27 first)

### The run shows it works

```bash
========== Call 3/20 ==========
[DEBUG get_daily_ci_runs] Querying (attempt 1/5): https://api.github.com/repos/huggingface/transformers/actions/workflows/90575235/runs?branch=main&exclude_pull_requests=true&per_page=7&event=schedule
[DEBUG get_daily_ci_runs] event=schedule returned 7 runs (total_count=317):
  id=30781855254 status=completed conclusion=failure created_at=2026-08-03T03:27:23Z event=schedule
  id=30730647697 status=completed conclusion=failure created_at=2026-08-02T03:27:19Z event=schedule
  id=30682020491 status=completed conclusion=failure created_at=2026-08-01T03:27:14Z event=schedule
  id=30601623379 status=completed conclusion=failure created_at=2026-07-31T03:27:30Z event=schedule
  id=30511031240 status=completed conclusion=failure created_at=2026-07-30T03:22:57Z event=schedule
  id=27858769081 status=completed conclusion=failure created_at=2026-06-20T03:25:39Z event=schedule
  id=27803483186 status=completed conclusion=failure created_at=2026-06-19T03:26:40Z event=schedule
[WARN get_daily_ci_runs] Current run 33038227895 not found in results — likely a stale GitHub API cache (total_count=317). Retrying in 30s...
[DEBUG get_daily_ci_runs] Querying (attempt 2/5): https://api.github.com/repos/huggingface/transformers/actions/workflows/90575235/runs?branch=main&exclude_pull_requests=true&per_page=7&event=schedule
[DEBUG get_daily_ci_runs] event=schedule returned 7 runs (total_count=413):
  id=33038227895 status=completed conclusion=failure created_at=2026-08-27T04:03:26Z event=schedule
  id=32923823246 status=completed conclusion=failure created_at=2026-08-26T02:44:02Z event=schedule
  id=32802383626 status=completed conclusion=failure created_at=2026-08-25T02:41:55Z event=schedule
  id=32684003637 status=completed conclusion=failure created_at=2026-08-24T02:43:33Z event=schedule
  id=32613570393 status=completed conclusion=failure created_at=2026-08-23T02:43:37Z event=schedule
  id=32546823743 status=completed conclusion=failure created_at=2026-08-22T02:39:01Z event=schedule
  id=32440845732 status=completed conclusion=failure created_at=2026-08-21T02:43:33Z event=schedule
=== Final result: 7 runs ===
  id=33038227895 run_number=1995 status=completed created_at=2026-08-27T04:03:26Z
  id=32923823246 run_number=1994 status=completed created_at=2026-08-26T02:44:02Z
Sleeping 60s...
```