### PR TITLE
[Qwen3VLMoe] Update `test_small_model_integration_test_batch` expected output (value drift)

### DIFF
--- a/tests/models/qwen3_vl_moe/test_modeling_qwen3_vl_moe.py
+++ b/tests/models/qwen3_vl_moe/test_modeling_qwen3_vl_moe.py
@@ -442,8 +442,8 @@ class Qwen3VLMoeIntegrationTest(unittest.TestCase):
         output = model.generate(**inputs, max_new_tokens=30, do_sample=False)
 
         EXPECTED_DECODED_TEXT = [
-            "user\nWhat kind of dog is this?\nassistant\nThis is a Pallas's cat, also known as the manul. It's a small wild cat native to the grasslands and montane regions",
-            "user\nWhat kind of dog is this?\nassistant\nThis is a Pallas's cat, also known as the manul. It's a small wild cat native to the grasslands and montane regions"
+            "user\nWhat kind of dog is this?\nassistant\nThis is a Pallas's cat, also known as the manul. It's a wild cat species native to the grasslands and steppes",
+            "user\nWhat kind of dog is this?\nassistant\nThis is a Pallas's cat, also known as the manul. It's a wild cat species native to the grasslands and steppes"
         ]  # fmt: skip
         self.assertEqual(
             self.processor.batch_decode(output, skip_special_tokens=True),


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48376&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48376) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48376&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48376)
<!-- ci-dashboard-badge:end -->

## Summary

- Updates `EXPECTED_DECODED_TEXT` in `test_small_model_integration_test_batch` to match current model output
- This test has been failing since 2025-11-13 for various reasons (OOM, config errors, value drift).
- The model has been consistently producing `"It's a wild cat species native to the grasslands and steppes"` since ~Feb 2026; the old expected value `"It's a small wild cat native to the grasslands and montane regions"` was stale
- This test is not handled in #48171  because it is not a regression from Aug 3 (switch to torch 2.13 cuda 130) but a long standing failing test.

## Related

- Companion to #48171 (which fixed other Qwen3VLMoe tests but not this one)