### PR TITLE
fix(quantization): guard FineGrainedFP8HfQuantizer.update_tp_plan when config has no tp_plan

### DIFF
--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -186,13 +186,17 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
 
         impl = getattr(config, "_experts_implementation", None)
         layer_overrides = FP8Experts._impl_tp_layer_overrides.get(impl, {})
+        if layer_overrides is None:
+            layer_overrides = {}
         for plan_attr in ("base_model_tp_plan", "base_model_ep_plan"):
-            base_plan = getattr(config, plan_attr, None) or {}
+            base_plan = getattr(config, plan_attr, None)
+            if base_plan is None:
+                continue
             # Per-impl rewrite of the experts parallel-layer kind. Applied LAST so it composes
             # on top of any plan written above (e.g. the Qwen3 dense plan). Models carry the
             # experts mapping under `base_model_tp_plan` and/or `base_model_ep_plan` — rewrite
             # both. See `FP8Experts._impl_tp_layer_overrides`.
-            updated_plan = {k: layer_overrides.get(v, v) for k, v in base_plan.items()}
+            updated_plan = {k: layer_overrides.get(v, v) for k, v in base_plan.items()} if layer_overrides else dict(base_plan)
 
             # Expert scales must be sharded along with their corresponding weights.
             for key, style in list(updated_plan.items()):

--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -80,7 +80,7 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
         from ..integrations.finegrained_fp8 import FP8Experts, FP8Linear
 
         module, tensor_name = get_module_from_name(model, param_name)
-        if isinstance(module, (FP8Linear, FP8Experts)):
+        if isinstance(module, FP8Linear | FP8Experts):
             if self.pre_quantized or tensor_name == "bias":
                 return False
             else:
@@ -196,7 +196,9 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
             # on top of any plan written above (e.g. the Qwen3 dense plan). Models carry the
             # experts mapping under `base_model_tp_plan` and/or `base_model_ep_plan` — rewrite
             # both. See `FP8Experts._impl_tp_layer_overrides`.
-            updated_plan = {k: layer_overrides.get(v, v) for k, v in base_plan.items()} if layer_overrides else dict(base_plan)
+            updated_plan = (
+                {k: layer_overrides.get(v, v) for k, v in base_plan.items()} if layer_overrides else dict(base_plan)
+            )
 
             # Expert scales must be sharded along with their corresponding weights.
             for key, style in list(updated_plan.items()):

--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -494,3 +494,27 @@ class FP8DeepGEMMMultiDeviceTest(unittest.TestCase):
         _disable_deepgemm_on_multi_device(model)
         self.assertFalse(model.a._deepgemm_disabled)
         self.assertFalse(model.b._deepgemm_disabled)
+
+
+class FineGrainedFP8QuantizerTpPlanTest(unittest.TestCase):
+    def test_update_tp_plan_no_tp_plan(self):
+        from transformers.configuration_utils import PretrainedConfig
+        from transformers.quantizers.quantizer_finegrained_fp8 import FineGrainedFP8HfQuantizer
+
+        quantizer = FineGrainedFP8HfQuantizer(FineGrainedFP8Config())
+        config = PretrainedConfig()
+        updated_config = quantizer.update_tp_plan(config)
+        self.assertIsNone(getattr(updated_config, "base_model_tp_plan", None))
+        self.assertIsNone(getattr(updated_config, "base_model_ep_plan", None))
+
+    def test_update_tp_plan_with_overrides(self):
+        from transformers.configuration_utils import PretrainedConfig
+        from transformers.quantizers.quantizer_finegrained_fp8 import FineGrainedFP8HfQuantizer
+
+        quantizer = FineGrainedFP8HfQuantizer(FineGrainedFP8Config())
+        config = PretrainedConfig()
+        config._experts_implementation = "deepgemm_megamoe"
+        config.base_model_tp_plan = {"moe": "moe_tp_experts"}
+        updated_config = quantizer.update_tp_plan(config)
+        self.assertEqual(updated_config.base_model_tp_plan, {"moe": "megamoe_experts"})
+

--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -517,4 +517,3 @@ class FineGrainedFP8QuantizerTpPlanTest(unittest.TestCase):
         config.base_model_tp_plan = {"moe": "moe_tp_experts"}
         updated_config = quantizer.update_tp_plan(config)
         self.assertEqual(updated_config.base_model_tp_plan, {"moe": "megamoe_experts"})
-


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48379&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48379) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48379&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48379)
<!-- ci-dashboard-badge:end -->

### Summary
Guards `update_tp_plan` in `FineGrainedFP8HfQuantizer` when model configurations do not define a `base_model_tp_plan` / `base_model_ep_plan` or when `layer_overrides` is empty / None.

### Problem
When quantizing models without an explicit TP plan (such as text-only models or Qwen4 architectures), `update_tp_plan` previously attempted to access `layer_overrides.get(v, v)` when `layer_overrides` is None or empty, raising an `AttributeError`.

### Fix
1. Guarded `layer_overrides` against None.
2. Skipped rewriting attributes where `base_plan` is `None`.
3. Added unit tests in `tests/quantization/finegrained_fp8/test_fp8.py` verifying behavior with and without TP plans.

Closes #48351