### PR TITLE
fix: flash-attn fallback failing on torch2.13

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1194,9 +1194,11 @@ def is_flash_attn_2_available(kernels_fallback_ok: bool = False) -> bool:
         try:
             from kernels import get_kernel
 
+            from transformers.integrations.hub_kernels import get_attn_kernel_version
             from transformers.modeling_flash_attention_utils import FLASH_ATTN_KERNEL_FALLBACK
 
-            get_kernel(FLASH_ATTN_KERNEL_FALLBACK["flash_attention_2"], version=1)
+            repo_id = FLASH_ATTN_KERNEL_FALLBACK["flash_attention_2"]
+            get_kernel(repo_id, version=get_attn_kernel_version(repo_id))
             return True
         except Exception:  # noqa: S110  # we don't care about the Exception here: we just want to check availability
             pass
@@ -1220,9 +1222,11 @@ def is_flash_attn_3_available(kernels_fallback_ok: bool = False) -> bool:
         try:
             from kernels import get_kernel
 
+            from transformers.integrations.hub_kernels import get_attn_kernel_version
             from transformers.modeling_flash_attention_utils import FLASH_ATTN_KERNEL_FALLBACK
 
-            get_kernel(FLASH_ATTN_KERNEL_FALLBACK["flash_attention_3"], version=1)
+            repo_id = FLASH_ATTN_KERNEL_FALLBACK["flash_attention_3"]
+            get_kernel(repo_id, version=get_attn_kernel_version(repo_id))
             return True
         except Exception:  # noqa: S110  # we don't care about the Exception here: we just want to check availability
             pass

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -137,6 +137,7 @@ def test_flash_attn_3_available_with_package():
     [(2, False, False), (2, True, False), (2, True, True), (3, False, False), (3, True, False), (3, True, True)]
 )
 def test_flash_attn_cuda_kernels_fallback(fa_version: int, kernels_available: bool, download_fails: bool):
+    from transformers.integrations.hub_kernels import get_attn_kernel_version
     from transformers.modeling_flash_attention_utils import FLASH_ATTN_KERNEL_FALLBACK
 
     # Test is expected to pass only if the kernels library is available and the kernel download does not fail
@@ -167,8 +168,8 @@ def test_flash_attn_cuda_kernels_fallback(fa_version: int, kernels_available: bo
 
         # Check the number of calls to get_kernel
         if kernels_available:
-            key = f"flash_attention_{fa_version}"
-            get_kernel.assert_called_once_with(FLASH_ATTN_KERNEL_FALLBACK[key], version=1)
+            repo_id = FLASH_ATTN_KERNEL_FALLBACK[f"flash_attention_{fa_version}"]
+            get_kernel.assert_called_once_with(repo_id, version=get_attn_kernel_version(repo_id))
         else:
             get_kernel.assert_not_called()
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48388&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48388) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48388&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48388)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Discussed on internal Slack with Axolotl-HF. 

**Credit:** A similar fix also exists in but this PR keeps it single focused (credit `sywangyi`): https://github.com/huggingface/transformers/pull/48252

---

When FA2 isn't available in the environment, the kernel fallback would run and pull from hub. However, our CI found this failing on torch2.13. This is due to the check using revision `v1` which does not include build for this torch (only `v2+`).

https://github.com/huggingface/transformers/blob/83d024e1bfed0d425d20bcde2b46a56b2333906e/src/transformers/utils/import_utils.py#L1192-L1199

Other areas had the proper fix to call `get_attn_kernel_version` but `import_utils` missed it. This PR re-uses that same utility.




## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@IlyasMoutawwakil 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @molbap @guarin
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @Abdennacer-Badaoui
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @IlyasMoutawwakil 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->