### PR TITLE
Fix flaky `MellumModelTest.test_load_balancing_loss`

### DIFF
--- a/tests/models/mellum/test_modeling_mellum.py
+++ b/tests/models/mellum/test_modeling_mellum.py
@@ -19,6 +19,7 @@ from transformers import is_torch_available
 from transformers.testing_utils import (
     Expectations,
     cleanup,
+    is_flaky,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -54,6 +55,7 @@ class MellumModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = MellumModelTester
     model_split_percents = [0.5, 0.8, 0.9]
 
+    @is_flaky(max_attempts=2)
     def test_load_balancing_loss(self):
         # Copied from Qwen3-Moe
         config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48389&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48389) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48389&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48389)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`MellumModelTest.test_load_balancing_loss` is the only copy of this test without `@is_flaky(max_attempts=2)` — the body is copied from Qwen3-Moe but the decorator didn't come along. Weights and inputs are unseeded, so `aux_loss` occasionally lands outside the ±0.03 band; one of these evicted #48072 from the merge queue (`Expected 2.0 but got 2.037735939025879`). Same fix as #40617.

Fixes #48138

cc @ydshieh