### PR TITLE
[VibeVoice] Skip generate export tests (flaky)

### DIFF
--- a/tests/exporters/test_export.py
+++ b/tests/exporters/test_export.py
@@ -119,6 +119,11 @@ EXPORT_SKIPS: dict[str, dict[str, str]] = {
             "exported prefill returns only `logits` while eager surfaces the populated KV cache. "
             "Same shape as Voxtral. TODO: align the generate-decomposition path."
         ),
+        "VibeVoiceForConditionalGeneration": (
+            "Generation uses two forward calls with different input shapes (prefill + noise scheduler); "
+            "`decompose_prefill_decode` can't capture the full generate path reliably, causing flaky "
+            "CUDAGraphs / export failures. TODO: handle in a follow-up PR."
+        ),
     },
     # Every backend, dynamic-shape only.
     "dynamic": {

--- a/tests/models/vibevoice/test_modeling_vibevoice.py
+++ b/tests/models/vibevoice/test_modeling_vibevoice.py
@@ -211,6 +211,11 @@ class VibeVoiceForConditionalGenerationTest(ModelTesterMixin, GenerationTesterMi
             "test_generate_methods_with_logits_to_keep",
             "test_model_parallel_beam_search",
             "test_generate_compile_model_forward_fullgraph",
+            # VibeVoice uses two forward calls with different input shapes (positive + negative guidance
+            # pass), which causes flaky CUDAGraphs tensor overwrites and inductor dtype errors under
+            # static-cache compilation. TODO: fix in a follow-up PR.
+            "test_generate_with_static_cache",
+            "test_static_cache_no_recompile_with_smaller_length",
         ]
         for test in skippable_tests:
             if self._testMethodName.startswith(test):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48396&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48396) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48396&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48396)
<!-- ci-dashboard-badge:end -->

## Summary

- Adds `VibeVoiceForConditionalGeneration` to the `"generate"` scope of `EXPORT_SKIPS` in `tests/exporters/test_export.py`
- VibeVoice's generation uses two forward calls with different input shapes (prefill + noise scheduler), which `decompose_prefill_decode` can't capture reliably
- Confirmed flaky via 10-run flakefinder: `test_torch_export_generate_static_static_cache` = 6/10 failed, `test_onnx_export_generate_static_static_cache` = 8/10 failed
- TODO: handle properly in a follow-up PR (per Ilyas)

cc @Zhiliang-Peng @ilyasmoutawwakil