### PR TITLE
Fix dataclass and nested sequence serialization in GenerationConfig.to_json_string

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -19,7 +19,7 @@ import os
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from dataclasses import dataclass, is_dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from .. import __version__
@@ -1221,26 +1221,29 @@ class GenerationConfig(PushToHubMixin):
             for metadata_field in METADATA_FIELDS:
                 config_dict.pop(metadata_field, None)
 
+        def convert_dataclass_to_dict(obj):
+            if isinstance(obj, dict):
+                return {key: convert_dataclass_to_dict(value) for key, value in obj.items()}
+            elif isinstance(obj, (list, tuple)):
+                return [convert_dataclass_to_dict(item) for item in obj]
+            elif is_dataclass(obj) and not isinstance(obj, type):
+                # Some of our dataclasses have a custom `to_dict()` method, and we prefer it
+                if hasattr(obj, "to_dict") and callable(obj.to_dict):
+                    return convert_dataclass_to_dict(obj.to_dict())
+                return convert_dataclass_to_dict(asdict(obj))
+            else:
+                return obj
+
         def convert_keys_to_string(obj):
             if isinstance(obj, dict):
                 return {str(key): convert_keys_to_string(value) for key, value in obj.items()}
-            elif isinstance(obj, list):
+            elif isinstance(obj, (list, tuple)):
                 return [convert_keys_to_string(item) for item in obj]
             else:
                 return obj
 
-        def convert_dataclass_to_dict(obj):
-            if isinstance(obj, dict):
-                return {key: convert_dataclass_to_dict(value) for key, value in obj.items()}
-            elif is_dataclass(obj):
-                # Some of our dataclasses have a custom `to_dict()` method, and we prefer it
-                if hasattr(obj, "to_dict"):
-                    return obj.to_dict()
-            else:
-                return obj
-
-        config_dict = convert_keys_to_string(config_dict)
         config_dict = convert_dataclass_to_dict(config_dict)
+        config_dict = convert_keys_to_string(config_dict)
 
         return json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
 

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import json
 import logging
 import os
 import tempfile
@@ -119,6 +120,30 @@ class GenerationConfigTest(unittest.TestCase):
 
         # `.update()` returns a dictionary of unused kwargs
         self.assertEqual(unused_kwargs, {"foo": "bar"})
+
+    def test_to_json_string_dataclass(self):
+        from dataclasses import dataclass
+
+        @dataclass
+        class CustomParam:
+            foo: str = "bar"
+            value: int = 123
+
+        @dataclass
+        class CustomWithDict:
+            mapping: dict
+
+        config = GenerationConfig()
+        config.custom_param = CustomParam(foo="baz", value=456)
+        config.custom_list = [CustomParam(foo="item1", value=1), CustomParam(foo="item2", value=2)]
+        config.custom_nested = CustomWithDict(mapping={1: "a", 2: "b"})
+
+        json_str = config.to_json_string(use_diff=False)
+        parsed = json.loads(json_str)
+
+        self.assertEqual(parsed["custom_param"], {"foo": "baz", "value": 456})
+        self.assertEqual(parsed["custom_list"], [{"foo": "item1", "value": 1}, {"foo": "item2", "value": 2}])
+        self.assertEqual(parsed["custom_nested"], {"mapping": {"1": "a", "2": "b"}})
 
     def test_kwarg_init(self):
         """Tests that we can overwrite attributes at `from_pretrained` time."""


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48399&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48399) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48399&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48399)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes dataclass and nested sequence serialization in `GenerationConfig.to_json_string()`:

1. **Standard dataclasses without `to_dict`**: `convert_dataclass_to_dict` previously only checked `if hasattr(obj, "to_dict"): return obj.to_dict()`, causing standard Python dataclasses without custom `to_dict()` methods to fall through and evaluate to `None` (erasing their values during serialization). Now falls back to `dataclasses.asdict(obj)`.
2. **Dataclasses in sequences (lists/tuples)**: Recursively processes elements in lists/tuples within `convert_dataclass_to_dict` so lists of dataclasses (e.g. prompt components, custom configs) are cleanly serialized without triggering `TypeError: Object of type X is not JSON serializable`.
3. **Key conversion order**: Executes `convert_dataclass_to_dict` before `convert_keys_to_string` to ensure any non-string dictionary keys inside dataclasses are properly converted to valid string keys for `json.dumps`.

## Before submitting
- [x] This PR fixes a bug / improves serialization robustness.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

## Who can review?
@ArthurZucker @gante @younesbelkada