### PR TITLE
fix(models): Drop the position-indexed token type lookup in RoPE encoders

### DIFF
--- a/src/transformers/models/jina_embeddings_v3/modeling_jina_embeddings_v3.py
+++ b/src/transformers/models/jina_embeddings_v3/modeling_jina_embeddings_v3.py
@@ -76,13 +76,7 @@ class JinaEmbeddingsV3Embeddings(nn.Module):
         device = embeddings.device
 
         if token_type_ids is None:
-            if hasattr(self, "token_type_ids"):
-                # NOTE: We assume either pos ids to have bsz == 1 (broadcastable) or bsz == effective bsz (input_shape[0])
-                buffered_token_type_ids = self.token_type_ids.expand(position_ids.shape[0], -1)
-                buffered_token_type_ids = torch.gather(buffered_token_type_ids, dim=1, index=position_ids)
-                token_type_ids = buffered_token_type_ids.expand(*input_shape)
-            else:
-                token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
 
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
 

--- a/src/transformers/models/jina_embeddings_v3/modular_jina_embeddings_v3.py
+++ b/src/transformers/models/jina_embeddings_v3/modular_jina_embeddings_v3.py
@@ -117,13 +117,7 @@ class JinaEmbeddingsV3Embeddings(XLMRobertaEmbeddings):
         device = embeddings.device
 
         if token_type_ids is None:
-            if hasattr(self, "token_type_ids"):
-                # NOTE: We assume either pos ids to have bsz == 1 (broadcastable) or bsz == effective bsz (input_shape[0])
-                buffered_token_type_ids = self.token_type_ids.expand(position_ids.shape[0], -1)
-                buffered_token_type_ids = torch.gather(buffered_token_type_ids, dim=1, index=position_ids)
-                token_type_ids = buffered_token_type_ids.expand(*input_shape)
-            else:
-                token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
 
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
 

--- a/src/transformers/models/nomic_bert/modeling_nomic_bert.py
+++ b/src/transformers/models/nomic_bert/modeling_nomic_bert.py
@@ -75,13 +75,7 @@ class NomicBertEmbeddings(nn.Module):
         device = embeddings.device
 
         if token_type_ids is None:
-            if hasattr(self, "token_type_ids"):
-                # NOTE: We assume either pos ids to have bsz == 1 (broadcastable) or bsz == effective bsz (input_shape[0])
-                buffered_token_type_ids = self.token_type_ids.expand(position_ids.shape[0], -1)
-                buffered_token_type_ids = torch.gather(buffered_token_type_ids, dim=1, index=position_ids)
-                token_type_ids = buffered_token_type_ids.expand(*input_shape)
-            else:
-                token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
 
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
 

--- a/tests/models/jina_embeddings_v3/test_modeling_jina_embeddings_v3.py
+++ b/tests/models/jina_embeddings_v3/test_modeling_jina_embeddings_v3.py
@@ -191,6 +191,17 @@ class JinaEmbeddingsV3ModelTester:
         result = model(input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, labels=token_labels)
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length, self.num_labels))
 
+    def create_and_check_forward_beyond_max_position_embeddings(self, config, input_ids, *args):
+        # This model is rope-only, so `max_position_embeddings` does not bound the input length.
+        # See https://github.com/huggingface/transformers/pull/48407
+        model = JinaEmbeddingsV3Model(config=config)
+        model.to(torch_device)
+        model.eval()
+        seq_length = config.max_position_embeddings + 8
+        long_input_ids = ids_tensor([1, seq_length], config.vocab_size).to(torch_device)
+        result = model(long_input_ids)
+        self.parent.assertEqual(result.last_hidden_state.shape, (1, seq_length, self.hidden_size))
+
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
         (
@@ -263,15 +274,8 @@ class JinaEmbeddingsV3ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.
         self.model_tester.create_and_check_for_token_classification(*config_and_inputs)
 
     def test_forward_beyond_max_position_embeddings(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-        model = JinaEmbeddingsV3Model(config)
-        model.to(torch_device)
-        model.eval()
-        seq_length = config.max_position_embeddings + 8
-        input_ids = ids_tensor([1, seq_length], config.vocab_size).to(torch_device)
-        with torch.no_grad():
-            result = model(input_ids)
-        self.assertEqual(result.last_hidden_state.shape, (1, seq_length, config.hidden_size))
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_forward_beyond_max_position_embeddings(*config_and_inputs)
 
     @unittest.skip("Model doesn't support scaling - due to non-RoPE related reasons")
     @parameterized.expand([("linear",), ("dynamic",), ("yarn",)])

--- a/tests/models/jina_embeddings_v3/test_modeling_jina_embeddings_v3.py
+++ b/tests/models/jina_embeddings_v3/test_modeling_jina_embeddings_v3.py
@@ -262,6 +262,17 @@ class JinaEmbeddingsV3ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_token_classification(*config_and_inputs)
 
+    def test_forward_beyond_max_position_embeddings(self):
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        model = JinaEmbeddingsV3Model(config)
+        model.to(torch_device)
+        model.eval()
+        seq_length = config.max_position_embeddings + 8
+        input_ids = ids_tensor([1, seq_length], config.vocab_size).to(torch_device)
+        with torch.no_grad():
+            result = model(input_ids)
+        self.assertEqual(result.last_hidden_state.shape, (1, seq_length, config.hidden_size))
+
     @unittest.skip("Model doesn't support scaling - due to non-RoPE related reasons")
     @parameterized.expand([("linear",), ("dynamic",), ("yarn",)])
     def test_model_rope_scaling_from_config(self, scaling_type):

--- a/tests/models/nomic_bert/test_modeling_nomic_bert.py
+++ b/tests/models/nomic_bert/test_modeling_nomic_bert.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 import unittest
 
-from parameterized import parameterized
-
 from transformers import AutoModel, AutoTokenizer, NomicBertConfig, is_torch_available
 from transformers.testing_utils import (
     Expectations,
@@ -280,10 +278,16 @@ class NomicBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_token_classification(*config_and_inputs)
 
-    @parameterized.expand([("linear",), ("dynamic",), ("yarn",)])
-    @unittest.skip("Model doesn't support scaling rope and raises shape mismatch errors with token types!")
-    def test_model_rope_scaling_from_config(self, scaling_type):
-        pass
+    def test_forward_beyond_max_position_embeddings(self):
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        model = NomicBertModel(config)
+        model.to(torch_device)
+        model.eval()
+        seq_length = config.max_position_embeddings + 8
+        input_ids = ids_tensor([1, seq_length], config.vocab_size).to(torch_device)
+        with torch.no_grad():
+            result = model(input_ids)
+        self.assertEqual(result.last_hidden_state.shape, (1, seq_length, config.hidden_size))
 
 
 @require_torch

--- a/tests/models/nomic_bert/test_modeling_nomic_bert.py
+++ b/tests/models/nomic_bert/test_modeling_nomic_bert.py
@@ -214,6 +214,17 @@ class NomicBertModelTester:
         result = model(input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, labels=token_labels)
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length, self.num_labels))
 
+    def create_and_check_forward_beyond_max_position_embeddings(self, config, input_ids, *args):
+        # This model is rope-only, so `max_position_embeddings` does not bound the input length.
+        # See https://github.com/huggingface/transformers/pull/48407
+        model = NomicBertModel(config=config)
+        model.to(torch_device)
+        model.eval()
+        seq_length = config.max_position_embeddings + 8
+        long_input_ids = ids_tensor([1, seq_length], config.vocab_size).to(torch_device)
+        result = model(long_input_ids)
+        self.parent.assertEqual(result.last_hidden_state.shape, (1, seq_length, self.hidden_size))
+
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
         (
@@ -279,15 +290,8 @@ class NomicBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
         self.model_tester.create_and_check_for_token_classification(*config_and_inputs)
 
     def test_forward_beyond_max_position_embeddings(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-        model = NomicBertModel(config)
-        model.to(torch_device)
-        model.eval()
-        seq_length = config.max_position_embeddings + 8
-        input_ids = ids_tensor([1, seq_length], config.vocab_size).to(torch_device)
-        with torch.no_grad():
-            result = model(input_ids)
-        self.assertEqual(result.last_hidden_state.shape, (1, seq_length, config.hidden_size))
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_forward_beyond_max_position_embeddings(*config_and_inputs)
 
 
 @require_torch


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48407&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48407) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48407&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48407)
<!-- ci-dashboard-badge:end -->

### What does this PR do?

→ `nomic_bert` and `jina_embeddings_v3` are the only two RoPE encoders that carry BERT's [buffered token_type_ids gather](https://github.com/huggingface/transformers/blob/42ca97014c85d71a88ad60d55f08cb9fb4d26e2c/src/transformers/models/bert/modeling_bert.py#L89-L96). The buffer is all zeros, so the gather is a no-op, but indexing it with `position_ids` still constrains those IDs to `max_position_embeddings`, which RoPE has no reason to obey. Both original implementations build the zeros directly ([nomic](https://huggingface.co/nomic-ai/nomic-bert-2048/blob/7710840340a098cfb869c4f65e87cf2b1b70caca/modeling_hf_nomic_bert.py#L1015-L1019), [jina](https://huggingface.co/jinaai/xlm-roberta-flash-implementation/blob/bd55a5ec8e6c0fb1d6c26efb4b6a4a74ce8a88d3/embedding.py#L91-L94)) and nomic sets [max_position_embeddings = 0](https://huggingface.co/nomic-ai/nomic-bert-2048/blob/7710840340a098cfb869c4f65e87cf2b1b70caca/modeling_hf_nomic_bert.py#L993) whenever rotary is on, so the cap tmk isn't upstream behaviour either.
→ In practice this caps `nomic-embed-text-v1.5` at 2048 tokens on `main` (`RuntimeError: index 2048 is out of bounds for dimension 1 with size 2048`) despite `n_positions: 8192`; it reaches 8192 here. Un-skips `test_model_rope_scaling_from_config` for nomic, which passes now :)

cc: @vasqu

### Before submitting

* [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request section](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
* [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?