### PR TITLE
[Gemma4] Fix pad_embedding device mismatch with accelerate CPU offloading

### DIFF
--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -56,8 +56,11 @@ from ...utils import (
     auto_docstring,
     can_return_tuple,
     is_accelerate_available,
+    logging,
     torch_compilable_check,
 )
+
+logger = logging.get_logger(__name__)
 from ...utils.deprecation import deprecate_kwarg
 from ...utils.generic import maybe_autocast, merge_with_config_defaults
 from ...utils.output_capturing import OutputRecorder, capture_outputs
@@ -2315,7 +2318,10 @@ class Gemma4Model(Gemma4PreTrainedModel):
 
         if per_layer_inputs is None and self.config.get_text_config().hidden_size_per_layer_input:
             pad_embedding = self.language_model.embed_tokens.weight[self.config.text_config.pad_token_id, :]
+            logger.warning(f"[gemma4] before .to(): pad_embedding.device={pad_embedding.device}, multimodal_mask.device={multimodal_mask.device}")
+            pad_embedding = pad_embedding.to(inputs_embeds.device, inputs_embeds.dtype)
             multimodal_mask = multimodal_mask.to(inputs_embeds.device)
+            logger.warning(f"[gemma4] after  .to(): pad_embedding.device={pad_embedding.device}, multimodal_mask.device={multimodal_mask.device}")
             llm_inputs_embeds = torch.where(multimodal_mask[..., None], pad_embedding.view(1, 1, -1), inputs_embeds)
             per_layer_inputs = self.language_model.get_per_layer_inputs(llm_input_ids, llm_inputs_embeds)
 

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -2314,10 +2314,7 @@ class Gemma4Model(Gemma4PreTrainedModel):
             inputs_embeds = self.get_input_embeddings()(llm_input_ids)
 
         if per_layer_inputs is None and self.config.get_text_config().hidden_size_per_layer_input:
-            pad_token = torch.tensor(
-                [[self.config.text_config.pad_token_id]], device=inputs_embeds.device, dtype=torch.long
-            )
-            pad_embedding = self.language_model.embed_tokens(pad_token).squeeze(0).squeeze(0)
+            pad_embedding = self.language_model.embed_tokens.weight[self.config.text_config.pad_token_id]
             multimodal_mask = multimodal_mask.to(inputs_embeds.device)
             llm_inputs_embeds = torch.where(multimodal_mask[..., None], pad_embedding.view(1, 1, -1), inputs_embeds)
             per_layer_inputs = self.language_model.get_per_layer_inputs(llm_input_ids, llm_inputs_embeds)

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -56,11 +56,8 @@ from ...utils import (
     auto_docstring,
     can_return_tuple,
     is_accelerate_available,
-    logging,
     torch_compilable_check,
 )
-
-logger = logging.get_logger(__name__)
 from ...utils.deprecation import deprecate_kwarg
 from ...utils.generic import maybe_autocast, merge_with_config_defaults
 from ...utils.output_capturing import OutputRecorder, capture_outputs
@@ -2317,11 +2314,11 @@ class Gemma4Model(Gemma4PreTrainedModel):
             inputs_embeds = self.get_input_embeddings()(llm_input_ids)
 
         if per_layer_inputs is None and self.config.get_text_config().hidden_size_per_layer_input:
-            pad_embedding = self.language_model.embed_tokens.weight[self.config.text_config.pad_token_id, :]
-            logger.warning(f"[gemma4] before .to(): pad_embedding.device={pad_embedding.device}, multimodal_mask.device={multimodal_mask.device}")
-            pad_embedding = pad_embedding.to(inputs_embeds.device, inputs_embeds.dtype)
+            pad_token = torch.tensor(
+                [[self.config.text_config.pad_token_id]], device=inputs_embeds.device, dtype=torch.long
+            )
+            pad_embedding = self.language_model.embed_tokens(pad_token).squeeze(0).squeeze(0)
             multimodal_mask = multimodal_mask.to(inputs_embeds.device)
-            logger.warning(f"[gemma4] after  .to(): pad_embedding.device={pad_embedding.device}, multimodal_mask.device={multimodal_mask.device}")
             llm_inputs_embeds = torch.where(multimodal_mask[..., None], pad_embedding.view(1, 1, -1), inputs_embeds)
             per_layer_inputs = self.language_model.get_per_layer_inputs(llm_input_ids, llm_inputs_embeds)
 

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -2314,7 +2314,10 @@ class Gemma4Model(Gemma4PreTrainedModel):
             inputs_embeds = self.get_input_embeddings()(llm_input_ids)
 
         if per_layer_inputs is None and self.config.get_text_config().hidden_size_per_layer_input:
-            pad_embedding = self.language_model.embed_tokens.weight[self.config.text_config.pad_token_id]
+            pad_token = torch.tensor(
+                [[self.config.text_config.pad_token_id]], device=inputs_embeds.device, dtype=torch.long
+            )
+            pad_embedding = self.language_model.embed_tokens(pad_token).squeeze(0).squeeze(0)
             multimodal_mask = multimodal_mask.to(inputs_embeds.device)
             llm_inputs_embeds = torch.where(multimodal_mask[..., None], pad_embedding.view(1, 1, -1), inputs_embeds)
             per_layer_inputs = self.language_model.get_per_layer_inputs(llm_input_ids, llm_inputs_embeds)

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -2034,11 +2034,11 @@ class Gemma4Model(Gemma3nModel):
             inputs_embeds = self.get_input_embeddings()(llm_input_ids)
 
         if per_layer_inputs is None and self.config.get_text_config().hidden_size_per_layer_input:
-            pad_embedding = self.language_model.embed_tokens.weight[self.config.text_config.pad_token_id, :]
-            logger.warning(f"[gemma4] before .to(): pad_embedding.device={pad_embedding.device}, multimodal_mask.device={multimodal_mask.device}")
-            pad_embedding = pad_embedding.to(inputs_embeds.device, inputs_embeds.dtype)
+            pad_token = torch.tensor(
+                [[self.config.text_config.pad_token_id]], device=inputs_embeds.device, dtype=torch.long
+            )
+            pad_embedding = self.language_model.embed_tokens(pad_token).squeeze(0).squeeze(0)
             multimodal_mask = multimodal_mask.to(inputs_embeds.device)
-            logger.warning(f"[gemma4] after  .to(): pad_embedding.device={pad_embedding.device}, multimodal_mask.device={multimodal_mask.device}")
             llm_inputs_embeds = torch.where(multimodal_mask[..., None], pad_embedding.view(1, 1, -1), inputs_embeds)
             per_layer_inputs = self.language_model.get_per_layer_inputs(llm_input_ids, llm_inputs_embeds)
 

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -2034,10 +2034,7 @@ class Gemma4Model(Gemma3nModel):
             inputs_embeds = self.get_input_embeddings()(llm_input_ids)
 
         if per_layer_inputs is None and self.config.get_text_config().hidden_size_per_layer_input:
-            pad_token = torch.tensor(
-                [[self.config.text_config.pad_token_id]], device=inputs_embeds.device, dtype=torch.long
-            )
-            pad_embedding = self.language_model.embed_tokens(pad_token).squeeze(0).squeeze(0)
+            pad_embedding = self.language_model.embed_tokens.weight[self.config.text_config.pad_token_id]
             multimodal_mask = multimodal_mask.to(inputs_embeds.device)
             llm_inputs_embeds = torch.where(multimodal_mask[..., None], pad_embedding.view(1, 1, -1), inputs_embeds)
             per_layer_inputs = self.language_model.get_per_layer_inputs(llm_input_ids, llm_inputs_embeds)

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -2035,7 +2035,10 @@ class Gemma4Model(Gemma3nModel):
 
         if per_layer_inputs is None and self.config.get_text_config().hidden_size_per_layer_input:
             pad_embedding = self.language_model.embed_tokens.weight[self.config.text_config.pad_token_id, :]
+            logger.warning(f"[gemma4] before .to(): pad_embedding.device={pad_embedding.device}, multimodal_mask.device={multimodal_mask.device}")
+            pad_embedding = pad_embedding.to(inputs_embeds.device, inputs_embeds.dtype)
             multimodal_mask = multimodal_mask.to(inputs_embeds.device)
+            logger.warning(f"[gemma4] after  .to(): pad_embedding.device={pad_embedding.device}, multimodal_mask.device={multimodal_mask.device}")
             llm_inputs_embeds = torch.where(multimodal_mask[..., None], pad_embedding.view(1, 1, -1), inputs_embeds)
             per_layer_inputs = self.language_model.get_per_layer_inputs(llm_input_ids, llm_inputs_embeds)
 

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -2034,7 +2034,10 @@ class Gemma4Model(Gemma3nModel):
             inputs_embeds = self.get_input_embeddings()(llm_input_ids)
 
         if per_layer_inputs is None and self.config.get_text_config().hidden_size_per_layer_input:
-            pad_embedding = self.language_model.embed_tokens.weight[self.config.text_config.pad_token_id]
+            pad_token = torch.tensor(
+                [[self.config.text_config.pad_token_id]], device=inputs_embeds.device, dtype=torch.long
+            )
+            pad_embedding = self.language_model.embed_tokens(pad_token).squeeze(0).squeeze(0)
             multimodal_mask = multimodal_mask.to(inputs_embeds.device)
             llm_inputs_embeds = torch.where(multimodal_mask[..., None], pad_embedding.view(1, 1, -1), inputs_embeds)
             per_layer_inputs = self.language_model.get_per_layer_inputs(llm_input_ids, llm_inputs_embeds)

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -43,6 +43,7 @@ from transformers.cli.serving.utils import (
     response_events_to_chunks,
 )
 from transformers.testing_utils import (
+    cleanup,
     require_librosa,
     require_multipart,
     require_serve,
@@ -50,6 +51,7 @@ from transformers.testing_utils import (
     require_torchcodec,
     require_vision,
     slow,
+    torch_device,
 )
 from transformers.utils.chat_parsing import ResponseParser
 from transformers.utils.import_utils import is_serve_available
@@ -1987,6 +1989,14 @@ class _TestToolCallBase:
     @classmethod
     def tearDownClass(cls):
         cls.serve.kill_server()
+
+    def setUp(self):
+        self.serve.reset_loaded_models()
+        cleanup(torch_device, gc_collect=True)
+
+    def tearDown(self):
+        self.serve.reset_loaded_models()
+        cleanup(torch_device, gc_collect=True)
 
     def _get_tool_def(self):
         return {

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -43,7 +43,6 @@ from transformers.cli.serving.utils import (
     response_events_to_chunks,
 )
 from transformers.testing_utils import (
-    cleanup,
     require_librosa,
     require_multipart,
     require_serve,
@@ -51,7 +50,6 @@ from transformers.testing_utils import (
     require_torchcodec,
     require_vision,
     slow,
-    torch_device,
 )
 from transformers.utils.chat_parsing import ResponseParser
 from transformers.utils.import_utils import is_serve_available
@@ -1989,14 +1987,6 @@ class _TestToolCallBase:
     @classmethod
     def tearDownClass(cls):
         cls.serve.kill_server()
-
-    def setUp(self):
-        self.serve.reset_loaded_models()
-        cleanup(torch_device, gc_collect=True)
-
-    def tearDown(self):
-        self.serve.reset_loaded_models()
-        cleanup(torch_device, gc_collect=True)
 
     def _get_tool_def(self):
         return {


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48409&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48409) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48409&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48409)
<!-- ci-dashboard-badge:end -->

## Summary

When loading Gemma4 with `device_map=\"auto\"` under GPU memory pressure, accelerate may offload `embed_tokens` to CPU, keeping its weight as a `meta` placeholder in the GPU model. Accessing `.weight` directly (outside the module's own forward pass) bypasses accelerate's `AlignDevicesHook`, returning the raw `meta` tensor. The subsequent `torch.where` then fails:

```
RuntimeError: Tensor on device meta is not on the expected device cuda:0!
```

This was confirmed in CI — all 14 `TestToolCallGemma` tests fail, with `logger.warning` showing `pad_embedding.device=meta` before the crash.

## Why `.to()` doesn't work

An initial attempt to fix this with `pad_embedding.to(inputs_embeds.device, inputs_embeds.dtype)` also fails:

```
NotImplementedError: Cannot copy out of meta tensor; no data!
```

Meta tensors have no storage, so they cannot be copied to a real device.

## Fix

Replace the direct `.weight` access with a call through the module's forward:

```python
pad_token = torch.tensor([[pad_token_id]], device=inputs_embeds.device, dtype=torch.long)
pad_embedding = self.language_model.embed_tokens(pad_token).squeeze(0).squeeze(0)
```

This goes through `embed_tokens.forward()`, which triggers accelerate's `AlignDevicesHook` to load the weight from CPU → GPU, run the embedding, and return a proper `cuda` tensor.