### PR TITLE
Fix concurrent MPS weight materialization

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -26,6 +26,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
 from copy import deepcopy
 from itertools import chain
+from threading import Lock
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -1231,13 +1232,21 @@ class WeightConverter(WeightTransform):
 # Having too many is actually harming performances quite a lot, i.e. using 16 can sometimes lead to taking TWICE
 # as much time to load the same model
 GLOBAL_WORKERS = min(4, os.cpu_count() or 4)
+_MPS_MATERIALIZE_LOCK = Lock()
 
 
 def _materialize_copy(tensor: torch.Tensor, device=None, dtype=None) -> torch.Tensor:
     # This slicing is what actually loads the tensor from the safetensors slice object
     tensor = tensor[...]
     if dtype is not None or device is not None:
-        tensor = tensor.to(device=device, dtype=dtype)
+        device_type = getattr(device, "type", device)
+        if isinstance(device_type, str):
+            device_type = device_type.split(":", 1)[0]
+        if device_type == "mps":
+            with _MPS_MATERIALIZE_LOCK:
+                tensor = tensor.to(device=device, dtype=dtype)
+        else:
+            tensor = tensor.to(device=device, dtype=dtype)
     return tensor
 
 

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1242,7 +1242,7 @@ def _materialize_copy(tensor: torch.Tensor, device=None, dtype=None) -> torch.Te
         device_type = getattr(device, "type", device)
         if isinstance(device_type, str):
             device_type = device_type.split(":", 1)[0]
-        if device_type == "mps":
+        if tensor.device.type == "mps" or device_type == "mps":
             with _MPS_MATERIALIZE_LOCK:
                 tensor = tensor.to(device=device, dtype=dtype)
         else:

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-import threading
-import time
 import unittest
-from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import torch
 import torch.nn as nn
 from torch.distributed.tensor.placement_types import Shard
 
+import transformers.core_model_loading as core_model_loading
 from transformers import PreTrainedConfig, PreTrainedModel
 from transformers.conversion_mapping import (
     get_checkpoint_conversion_mapping,
@@ -179,39 +178,41 @@ class TestWeightGlobMatching(unittest.TestCase):
         self.assertEqual(renamed_key, key)
 
 
-class TestMaterializeCopyConcurrency(unittest.TestCase):
-    @staticmethod
-    def get_max_concurrency(device):
-        guard = threading.Lock()
-        active = 0
-        max_active = 0
+class TestMaterializeCopyMPSLock(unittest.TestCase):
+    class TrackingTensor:
+        def __init__(self, device):
+            self.device = torch.device(device)
 
-        class TrackingTensor:
-            def __getitem__(self, key):
-                return self
+        def __getitem__(self, key):
+            return self
 
-            def to(self, **kwargs):
-                nonlocal active, max_active
-                with guard:
-                    active += 1
-                    max_active = max(max_active, active)
-                time.sleep(0.05)
-                with guard:
-                    active -= 1
-                return torch.zeros(1)
+        def to(self, **kwargs):
+            return torch.zeros(1)
 
-        with ThreadPoolExecutor(max_workers=4) as pool:
-            futures = [spawn_materialize(pool, TrackingTensor(), device=device) for _ in range(4)]
-            for future in futures:
-                future.result()
+    def materialize_with_lock(self, source_device, target_device):
+        lock = MagicMock()
+        with patch.object(core_model_loading, "_MPS_MATERIALIZE_LOCK", lock):
+            core_model_loading._materialize_copy(
+                self.TrackingTensor(source_device), device=target_device, dtype=torch.float32
+            )
+        return lock
 
-        return max_active
+    def test_mps_source_or_destination_uses_lock(self):
+        cases = [
+            ("cpu", "mps"),
+            ("cpu", "mps:0"),
+            ("cpu", torch.device("mps")),
+            ("mps", "cpu"),
+            ("mps", None),
+        ]
+        for source_device, target_device in cases:
+            with self.subTest(source_device=source_device, target_device=target_device):
+                lock = self.materialize_with_lock(source_device, target_device)
+                lock.__enter__.assert_called_once_with()
 
-    def test_mps_materialization_is_serialized(self):
-        self.assertEqual(self.get_max_concurrency("mps"), 1)
-
-    def test_cpu_materialization_remains_parallel(self):
-        self.assertGreater(self.get_max_concurrency("cpu"), 1)
+    def test_cpu_materialization_does_not_use_lock(self):
+        lock = self.materialize_with_lock("cpu", "cpu")
+        lock.__enter__.assert_not_called()
 
 
 class DummyParamModule(nn.Module):

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import threading
+import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import torch
@@ -174,6 +177,41 @@ class TestWeightGlobMatching(unittest.TestCase):
         key = "unrelated.key"
         renamed_key, _ = rename_source_key(key, renamings, [])
         self.assertEqual(renamed_key, key)
+
+
+class TestMaterializeCopyConcurrency(unittest.TestCase):
+    @staticmethod
+    def get_max_concurrency(device):
+        guard = threading.Lock()
+        active = 0
+        max_active = 0
+
+        class TrackingTensor:
+            def __getitem__(self, key):
+                return self
+
+            def to(self, **kwargs):
+                nonlocal active, max_active
+                with guard:
+                    active += 1
+                    max_active = max(max_active, active)
+                time.sleep(0.05)
+                with guard:
+                    active -= 1
+                return torch.zeros(1)
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [spawn_materialize(pool, TrackingTensor(), device=device) for _ in range(4)]
+            for future in futures:
+                future.result()
+
+        return max_active
+
+    def test_mps_materialization_is_serialized(self):
+        self.assertEqual(self.get_max_concurrency("mps"), 1)
+
+    def test_cpu_materialization_remains_parallel(self):
+        self.assertGreater(self.get_max_concurrency("cpu"), 1)
 
 
 class DummyParamModule(nn.Module):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48410&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48410) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48410&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48410)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48029.

Async weight loading can crash on MPS when several workers concurrently materialize BF16 checkpoint tensors as FP32. This change keeps the existing four-worker loader, but serializes only `tensor.to(...)` calls whose source or destination is MPS. CPU-only materialization remains parallel.

This is narrower than #48196, which disabled the thread pool whenever the device map contained MPS. The thread pool remains active here; only the unsafe MPS conversion is protected by a process-wide lock.

The patch also adds model-free tests verifying that:

- MPS sources and destinations use the lock.
- CPU-only materialization bypasses the lock.

## Verification

Tested on an Apple M4 Pro with macOS 15.6.1, Python 3.13.2, PyTorch 2.13.0, and safetensors 0.8.0. The test checkpoint contains 25 BF16 tensors and was loaded as FP32 on MPS. Every successful load was followed by a real forward pass.

- Unpatched, same commit: 0/3 completed (`SIGABRT`, `SIGBUS`, `SIGSEGV`).
- Patched, `device_map="auto"`: 20/20 completed with identical output checksums.
- Patched, explicit MPS device map: 10/10 completed with identical output checksums.
- Patched, mixed CPU/MPS device map: 10/10 completed with identical output checksums and real forward passes. The earlier destination-only lock failed this case 3/3 with `SIGABRT` or `SIGSEGV`.
- Synchronous MPS control: 5/5 completed.
- Async CPU control: 5/5 completed.

Tests:

```text
python -m pytest -q tests/utils/test_core_model_loading.py
# 37 passed, 1 skipped

python -m pytest -q tests/utils/test_modeling_utils.py -k loading_respect_env_variable_for_threading
# 1 passed, 151 deselected

ruff format --check src/transformers/core_model_loading.py tests/utils/test_core_model_loading.py
# 2 files already formatted
```

## Code Agent Policy

AI tools were used to help investigate the race, implement the patch, and prepare this description. I reviewed every changed line and validated the behavior end-to-end on MPS. The work was coordinated in #48029, and the implementation was compared with the closed attempt in #48196.

## Before submitting

- [x] I read the contributor guidelines and PR checks.
- [x] This was discussed via #48029.
- [x] I reviewed the related PR #48196 and documented how this change differs.
- [x] I added tests for the new behavior.
- [x] Documentation changes are not needed for this internal loading fix.

## Who can review?

Model loading: @Cyrilvallez