### PR TITLE
Fix per-layer rope_parameters misparsing when layer_types omits keys

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -765,15 +765,19 @@ class RotaryEmbeddingConfigMixin:
     def standardize_rope_params(self):
         """
         Helper to standardize the config's rope params field by ensuring the params are defined for each
-        later type. For old model the fn will duplicate a single rope param in each layer type (backward compatibility)
+        layer type. For old model the fn will duplicate a single rope param in each layer type (backward compatibility)
         """
+        from .configuration_utils import ALLOWED_LAYER_TYPES
+
         # Move `rope_theta` and `partial_rotary_factor` to the `rope_parameters`, if not there yet
         rope_theta = getattr(self, "rope_theta", None)
         partial_rotary_factor = getattr(self, "partial_rotary_factor", None)
         rope_parameters = getattr(self, "rope_parameters", None) or {}
 
         # Deepseekv4 has `layer_types` which are different from `_rope_type_labels`
-        layer_types = getattr(self, "_rope_type_labels", getattr(self, "layer_types", None))
+        rope_type_labels = getattr(self, "_rope_type_labels", None)
+        has_layer_types = getattr(self, "layer_types", None) is not None or rope_type_labels is not None
+        allowed_layer_types = rope_type_labels if rope_type_labels is not None else ALLOWED_LAYER_TYPES
 
         # Case 0: no RoPE params defined
         if not (rope_parameters or rope_theta):
@@ -781,7 +785,11 @@ class RotaryEmbeddingConfigMixin:
             logger.warning("`standardize_rope_params` was called but no RoPE parameters were found.")
             return
         # Case 1: RoPE param keys do not intersect with possible `layer_types` -> one global dict
-        elif layer_types is None or rope_parameters == {} or not set(rope_parameters.keys()).issubset(layer_types):
+        elif (
+            not has_layer_types
+            or rope_parameters == {}
+            or not set(rope_parameters.keys()).issubset(allowed_layer_types)
+        ):
             rope_parameters.setdefault("rope_type", rope_parameters.get("type", "default"))
             rope_parameters.setdefault("rope_theta", rope_theta)
             if partial_rotary_factor is not None:
@@ -799,7 +807,7 @@ class RotaryEmbeddingConfigMixin:
 
         # Case 2: different RoPE for each layer -> several params as nested dict
         else:
-            for layer_type in set(layer_types):
+            for layer_type in set(rope_parameters.keys()):
                 # skip if saved with `None` value
                 if rope_parameters[layer_type] is None:
                     continue
@@ -819,15 +827,19 @@ class RotaryEmbeddingConfigMixin:
         """
         Validate the RoPE config arguments, given a `"PreTrainedConfig"` object
         """
+        from .configuration_utils import ALLOWED_LAYER_TYPES
+
         # Don't validate if no rope_parameters found (`None`) or if it's an empty dict
         # Note that validation runs every time a new config is created, even if config is non-RoPE
         rope_parameters_dict = getattr(self, "rope_parameters", None)
         if not rope_parameters_dict:
             return
 
-        if getattr(self, "layer_types", None) is not None and set(rope_parameters_dict.keys()).issubset(
-            self.layer_types
-        ):
+        rope_type_labels = getattr(self, "_rope_type_labels", None)
+        has_layer_types = getattr(self, "layer_types", None) is not None or rope_type_labels is not None
+        allowed_layer_types = rope_type_labels if rope_type_labels is not None else ALLOWED_LAYER_TYPES
+
+        if has_layer_types and set(rope_parameters_dict.keys()).issubset(allowed_layer_types):
             pass
         else:
             rope_parameters_dict = {"full_attention": rope_parameters_dict}

--- a/tests/utils/test_modeling_rope_utils.py
+++ b/tests/utils/test_modeling_rope_utils.py
@@ -15,11 +15,12 @@
 
 import logging as stdlib_logging
 import math
+import tempfile
 import unittest
 
 from parameterized import parameterized
 
-from transformers import Gemma3TextConfig, LlamaConfig
+from transformers import Gemma3TextConfig, LlamaConfig, Olmo3Config
 from transformers.testing_utils import is_torch_available, require_torch, torch_device
 
 
@@ -1573,3 +1574,52 @@ class RopeTest(unittest.TestCase):
         for layer_type in layer_types:
             inv_freq, _ = rope_fn(config=config, layer_type=layer_type)
             torch.testing.assert_close(inv_freq, EXPECTED_INV_FREQ, atol=1e-04, rtol=1e-04)
+
+    def test_nested_rope_parameters_partial_layer_types(self):
+        """
+        Regression test for #48392: when a model defines per-layer rope_parameters
+        (e.g., sliding_attention and full_attention) but instantiates fewer layers such that
+        layer_types does not contain every possible layer type, standardize_rope_params and
+        validate_rope should still treat rope_parameters as a per-layer nested dict.
+        """
+        # Gemma3TextConfig with num_hidden_layers=2 only instantiates ['sliding_attention', 'sliding_attention']
+        config = Gemma3TextConfig(num_hidden_layers=2)
+        self.assertEqual(config.layer_types, ["sliding_attention", "sliding_attention"])
+        self.assertIn("sliding_attention", config.rope_parameters)
+        self.assertIn("full_attention", config.rope_parameters)
+
+        # 1. Top-level keys must not be polluted by standardize_rope_params
+        self.assertNotIn("rope_type", config.rope_parameters)
+        self.assertNotIn("rope_theta", config.rope_parameters)
+
+        # 2. validate_rope should not emit spurious warnings for valid per-layer config
+        with self.assertRaises(AssertionError):  # Assert that NO warnings are logged
+            with self.assertLogs("transformers.modeling_rope_utils", level="WARNING"):
+                config.validate_rope()
+
+        # 3. validate_rope must validate all per-layer configs, including those not currently instantiated
+        config.rope_parameters["full_attention"] = {"rope_type": "yarn", "rope_theta": 10000.0}  # missing factor
+        with self.assertRaises(KeyError):
+            config.validate_rope()
+
+        # 4. Olmo3Config with num_hidden_layers=2 also has partial layer_types
+        olmo_config = Olmo3Config(num_hidden_layers=2)
+        self.assertEqual(olmo_config.layer_types, ["sliding_attention", "sliding_attention"])
+        self.assertNotIn("rope_type", olmo_config.rope_parameters)
+        self.assertNotIn("rope_theta", olmo_config.rope_parameters)
+        with self.assertRaises(AssertionError):
+            with self.assertLogs("transformers.modeling_rope_utils", level="WARNING"):
+                olmo_config.validate_rope()
+
+    def test_nested_rope_parameters_save_and_reload_roundtrip(self):
+        """
+        Tests that saving and reloading a config with partial layer_types does not
+        persist extraneous top-level keys in rope_parameters.
+        """
+        config = Gemma3TextConfig(num_hidden_layers=2)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config.save_pretrained(tmp_dir)
+            reloaded = Gemma3TextConfig.from_pretrained(tmp_dir)
+            self.assertNotIn("rope_type", reloaded.rope_parameters)
+            self.assertNotIn("rope_theta", reloaded.rope_parameters)
+            self.assertEqual(set(reloaded.rope_parameters.keys()), {"sliding_attention", "full_attention"})


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48411&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48411) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48411&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48411)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48392.

### Problem
Models that use heterogeneous attention layers (e.g. `Gemma3`, `Olmo3` mixing sliding and full attention) populate `rope_parameters` with entries for every possible layer type (`sliding_attention` and `full_attention`). However, when a model configuration is instantiated with fewer layers than the sliding window period (such as `Gemma3TextConfig(num_hidden_layers=2)` or `Olmo3Config(num_hidden_layers=2)`), `config.layer_types` contains only `["sliding_attention", "sliding_attention"]`.

Previously, `standardize_rope_params` and `validate_rope` checked `set(rope_parameters.keys()).issubset(layer_types)`. When not all layer types were instantiated, this check returned `False`, causing the nested dictionary to be misclassified as a single flat config dict:
1. Emitting a spurious warning: `Unrecognized keys in rope_parameters for 'rope_type'='default': {'full_attention', 'sliding_attention'}`.
2. Polluting `config.rope_parameters` with top-level `"rope_type": "default"` and `"rope_theta": None` which was then persisted to disk on `save_pretrained`.
3. Bypassing validation of actual per-layer RoPE parameters (e.g., `yarn`, `linear`) for non-instantiated layer types.

### Solution
- In `src/transformers/modeling_rope_utils.py`, validate that `rope_parameters` keys are a subset of `allowed_layer_types` (checking `_rope_type_labels` if present, or `ALLOWED_LAYER_TYPES` from `configuration_utils.py`) rather than only currently instantiated `self.layer_types`.
- In `standardize_rope_params`, iterate over `set(rope_parameters.keys())` so all configured layer types are standardized.
- Added comprehensive unit tests in `tests/utils/test_modeling_rope_utils.py` verifying clean standardization, warning suppression, validation, and `save_pretrained`/`from_pretrained` round-tripping for partial layer configurations.

---

## Before submitting checklist

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case: Fixes #48392
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

---

## Who can review?

@zucchini-nlp @ArthurZucker @Cyrilvallez