### PR TITLE
Enable associative scan for Zamba

### DIFF
--- a/docs/source/ja/model_sharing.md
+++ b/docs/source/ja/model_sharing.md
@@ -92,7 +92,7 @@ TensorFlowからPyTorchにチェックポイントを変換するには、`from_
 >>> pt_model.save_pretrained("path/to/awesome-name-you-picked")
 ```
 
-## Push a model during traning
+## Push a model during training
 
 <Youtube id="Z1-XMy-GNLQ"/>
 
@@ -201,7 +201,6 @@ Hugging Faceプロフィールに移動すると、新しく作成したモデ�
 * モデルリポジトリ内の**Edit model card**ボタンをクリックする。
 
 モデルカードに含めるべき情報の例については、DistilBert [モデルカード](https://huggingface.co/distilbert/distilbert-base-uncased)をご覧ください。`README.md`ファイルで制御できる他のオプション、例えばモデルの炭素フットプリントやウィジェットの例などについての詳細は、[こちらのドキュメンテーション](https://huggingface.co/docs/hub/models-cards)を参照してください。
-
 
 
 

--- a/src/transformers/models/zamba/configuration_zamba.py
+++ b/src/transformers/models/zamba/configuration_zamba.py
@@ -47,6 +47,8 @@ class ZambaConfig(PreTrainedConfig):
         Flag indicating whether or not to use the fast mamba kernels. These are available only if `mamba-ssm` and
         `causal-conv1d` are installed, and the mamba modules are running on a CUDA device. Raises ValueError if
         `True` and kernels are not available
+    use_associative_scan (`bool`, *optional*, defaults to `True`):
+        Whether to use PyTorch's associative scan for parallel sequence processing when tracing or compiling.
     mamba_dt_rank (`Union[int,str]`, *optional*, defaults to `"auto"`):
         Rank of the mamba discretization projection matrix. `"auto"` means that it will default to `math.ceil(self.hidden_size / 16)`
     layers_block_type (`str`, *optional*):
@@ -81,6 +83,7 @@ class ZambaConfig(PreTrainedConfig):
     attn_layer_period: int = 6
     attn_layer_offset: int = 4
     use_mamba_kernels: bool = True
+    use_associative_scan: bool = True
     mamba_d_state: int = 16
     mamba_d_conv: int = 4
     mamba_expand: int = 2

--- a/src/transformers/models/zamba/modeling_zamba.py
+++ b/src/transformers/models/zamba/modeling_zamba.py
@@ -430,6 +430,7 @@ class ZambaMambaMixer(nn.Module):
         self.act = ACT2FN[config.hidden_mamba_act]
 
         self.use_fast_kernels = config.use_mamba_kernels
+        self.use_associative_scan = config.use_associative_scan
 
         # projection of the input hidden states
         self.in_proj = nn.Linear(self.hidden_size, self.intermediate_size * 2, bias=self.use_bias)
@@ -580,7 +581,7 @@ class ZambaMambaMixer(nn.Module):
                     return_last_state=output_final_state,
                     # Old model: only when user request it explicitly
                     use_mambapy=False,
-                    use_associative_scan=False,
+                    use_associative_scan=self.use_associative_scan,
                 )
 
                 if output_final_state:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48417&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48417) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48417&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48417)
<!-- ci-dashboard-badge:end -->

Expose the associative scan option in ZambaConfig and pass it through the Mamba mixer so compiled inference avoids the sequential fallback.

Test: python3 -m py_compile src/transformers/models/zamba/configuration_zamba.py src/transformers/models/zamba/modeling_zamba.py

AI assistance was used.