### PR TITLE
avoid repeated vision attention synchronization

### DIFF
--- a/src/transformers/models/cohere_compass/modeling_cohere_compass.py
+++ b/src/transformers/models/cohere_compass/modeling_cohere_compass.py
@@ -725,6 +725,7 @@ class CohereCompassVisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -762,10 +763,10 @@ class CohereCompassVisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-            splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(
@@ -917,6 +918,9 @@ class CohereCompassVisionModel(CohereCompassPreTrainedModel):
         )
         position_ids = get_vision_position_ids(grid_thw, self.spatial_merge_size, kwargs=kwargs)
         cu_seqlens, max_seqlen = get_vision_attention_seqlens(grid_thw, self.config, kwargs=kwargs)
+        split_sizes = kwargs.pop("split_sizes", None)
+        if split_sizes is None:
+            split_sizes = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
 
         hidden_states = self.patch_embed(hidden_states)
         pos_embeds = (self.pos_embed(interp_indices) * interp_weights[:, :, None]).sum(1)
@@ -935,6 +939,7 @@ class CohereCompassVisionModel(CohereCompassPreTrainedModel):
                 hidden_states,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
+                split_sizes=split_sizes,
                 position_embeddings=position_embeddings,
                 **kwargs,
             )

--- a/src/transformers/models/ernie4_5_vl_moe/modeling_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/modeling_ernie4_5_vl_moe.py
@@ -583,6 +583,7 @@ class Ernie4_5_VLMoeVisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -620,10 +621,10 @@ class Ernie4_5_VLMoeVisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-            splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(

--- a/src/transformers/models/glm4v/modeling_glm4v.py
+++ b/src/transformers/models/glm4v/modeling_glm4v.py
@@ -290,6 +290,7 @@ class Glm4vVisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -327,10 +328,10 @@ class Glm4vVisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-            splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(

--- a/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
@@ -637,6 +637,7 @@ class Glm4vMoeVisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -674,10 +675,10 @@ class Glm4vMoeVisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-            splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(

--- a/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -228,6 +228,7 @@ class Qwen2_5_VLVisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -265,10 +266,10 @@ class Qwen2_5_VLVisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-            splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(

--- a/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -400,9 +400,7 @@ class VisionAttention(nn.Module):
             if split_sizes is None:
                 lengths = cu_seqlens[1:] - cu_seqlens[:-1]
                 split_sizes = lengths.tolist()
-            splits = [
-                torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(

--- a/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -359,6 +359,7 @@ class VisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -396,9 +397,11 @@ class VisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
             splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
+                torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)
             ]
 
             attn_outputs = [

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -987,6 +987,7 @@ class Qwen3_5VisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -1024,10 +1025,10 @@ class Qwen3_5VisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-            splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -1077,6 +1077,7 @@ class Qwen3_5MoeVisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -1114,10 +1115,10 @@ class Qwen3_5MoeVisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-            splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(

--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -899,6 +899,7 @@ class Qwen3OmniMoeVisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -936,10 +937,10 @@ class Qwen3OmniMoeVisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-            splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(
@@ -1178,6 +1179,9 @@ class Qwen3OmniMoeVisionEncoder(Qwen3OmniMoePreTrainedModel):
         )
         position_ids = get_vision_position_ids(grid_thw, self.spatial_merge_size, kwargs=kwargs)
         cu_seqlens, max_seqlen = get_vision_attention_seqlens(grid_thw, self.config, kwargs=kwargs)
+        split_sizes = kwargs.pop("split_sizes", None)
+        if split_sizes is None:
+            split_sizes = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
 
         hidden_states = self.patch_embed(hidden_states)
         pos_embeds = (self.pos_embed(interp_indices) * interp_weights[:, :, None]).sum(1)
@@ -1196,6 +1200,7 @@ class Qwen3OmniMoeVisionEncoder(Qwen3OmniMoePreTrainedModel):
                 hidden_states,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
+                split_sizes=split_sizes,
                 position_embeddings=position_embeddings,
                 **kwargs,
             )

--- a/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -213,6 +213,7 @@ class Qwen3VLVisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -250,10 +251,10 @@ class Qwen3VLVisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-            splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(
@@ -701,6 +702,9 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
         )
         position_ids = get_vision_position_ids(grid_thw, self.spatial_merge_size, kwargs=kwargs)
         cu_seqlens, max_seqlen = get_vision_attention_seqlens(grid_thw, self.config, kwargs=kwargs)
+        split_sizes = kwargs.pop("split_sizes", None)
+        if split_sizes is None:
+            split_sizes = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
 
         hidden_states = self.patch_embed(hidden_states)
         pos_embeds = (self.pos_embed(interp_indices) * interp_weights[:, :, None]).sum(1)
@@ -719,6 +723,7 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
                 hidden_states,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
+                split_sizes=split_sizes,
                 position_embeddings=position_embeddings,
                 **kwargs,
             )

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -515,6 +515,9 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
         )
         position_ids = get_vision_position_ids(grid_thw, self.spatial_merge_size, kwargs=kwargs)
         cu_seqlens, max_seqlen = get_vision_attention_seqlens(grid_thw, self.config, kwargs=kwargs)
+        split_sizes = kwargs.pop("split_sizes", None)
+        if split_sizes is None:
+            split_sizes = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
 
         hidden_states = self.patch_embed(hidden_states)
         pos_embeds = (self.pos_embed(interp_indices) * interp_weights[:, :, None]).sum(1)
@@ -533,6 +536,7 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
                 hidden_states,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
+                split_sizes=split_sizes,
                 position_embeddings=position_embeddings,
                 **kwargs,
             )

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -449,6 +449,7 @@ class Qwen3VLMoeVisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -486,10 +487,10 @@ class Qwen3VLMoeVisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-            splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(
@@ -701,6 +702,9 @@ class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
         )
         position_ids = get_vision_position_ids(grid_thw, self.spatial_merge_size, kwargs=kwargs)
         cu_seqlens, max_seqlen = get_vision_attention_seqlens(grid_thw, self.config, kwargs=kwargs)
+        split_sizes = kwargs.pop("split_sizes", None)
+        if split_sizes is None:
+            split_sizes = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
 
         hidden_states = self.patch_embed(hidden_states)
         pos_embeds = (self.pos_embed(interp_indices) * interp_weights[:, :, None]).sum(1)
@@ -719,6 +723,7 @@ class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
                 hidden_states,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
+                split_sizes=split_sizes,
                 position_embeddings=position_embeddings,
                 **kwargs,
             )

--- a/src/transformers/models/qwen4_exp/modeling_qwen4_exp.py
+++ b/src/transformers/models/qwen4_exp/modeling_qwen4_exp.py
@@ -1826,6 +1826,7 @@ class Qwen4ExpVisionAttention(nn.Module):
         cu_seqlens: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         max_seqlen: int | None = None,
+        split_sizes: list[int] | None = None,
         **kwargs,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
@@ -1863,10 +1864,10 @@ class Qwen4ExpVisionAttention(nn.Module):
             )
         else:
             # Other implementations: Process each chunk separately
-            lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-            splits = [
-                torch.split(tensor, lengths.tolist(), dim=2) for tensor in (query_states, key_states, value_states)
-            ]
+            if split_sizes is None:
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                split_sizes = lengths.tolist()
+            splits = [torch.split(tensor, split_sizes, dim=2) for tensor in (query_states, key_states, value_states)]
 
             attn_outputs = [
                 attention_interface(


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48418&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48418) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48418&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48418)
<!-- ci-dashboard-badge:end -->

Compute packed vision split sizes once per Qwen3-VL forward and reuse them across attention layers. The optional argument is propagated through generated vision attention implementations.