### PR TITLE
fix(utils): support tuple and set typed fields in HfArgumentParser

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -217,12 +217,17 @@ class HfArgumentParser(ArgumentParser):
                 kwargs["nargs"] = "?"
                 # This is the value that will get picked if we do --{field.name} (without value)
                 kwargs["const"] = True
-        elif isclass(origin_type) and issubclass(origin_type, list):
-            kwargs["type"] = field.type.__args__[0]
-            kwargs["nargs"] = "+"
+        elif isclass(origin_type) and issubclass(origin_type, (list, tuple, set)):
+            kwargs["type"] = field.type.__args__[0] if getattr(field.type, "__args__", None) else str
+            if issubclass(origin_type, tuple) and getattr(field.type, "__args__", None) and Ellipsis not in field.type.__args__:
+                kwargs["nargs"] = len(field.type.__args__)
+            else:
+                kwargs["nargs"] = "+"
             if field.default_factory is not dataclasses.MISSING:
                 kwargs["default"] = field.default_factory()
-            elif field.default is dataclasses.MISSING:
+            elif field.default is not dataclasses.MISSING:
+                kwargs["default"] = field.default
+            else:
                 kwargs["required"] = True
         else:
             kwargs["type"] = field.type
@@ -340,6 +345,16 @@ class HfArgumentParser(ArgumentParser):
         for dtype in self.dataclass_types:
             keys = {f.name for f in dataclasses.fields(dtype) if f.init}
             inputs = {k: v for k, v in vars(namespace).items() if k in keys}
+            for f in dataclasses.fields(dtype):
+                if not f.init or f.name not in inputs:
+                    continue
+                v = inputs[f.name]
+                orig = getattr(f.type, "__origin__", f.type)
+                if isclass(orig):
+                    if issubclass(orig, tuple) and isinstance(v, list):
+                        inputs[f.name] = tuple(v)
+                    elif issubclass(orig, set) and isinstance(v, list):
+                        inputs[f.name] = set(v)
             for k in keys:
                 delattr(namespace, k)
             obj = dtype(**inputs)
@@ -376,6 +391,16 @@ class HfArgumentParser(ArgumentParser):
         for dtype in self.dataclass_types:
             keys = {f.name for f in dataclasses.fields(dtype) if f.init}
             inputs = {k: v for k, v in args.items() if k in keys}
+            for f in dataclasses.fields(dtype):
+                if not f.init or f.name not in inputs:
+                    continue
+                v = inputs[f.name]
+                orig = getattr(f.type, "__origin__", f.type)
+                if isclass(orig):
+                    if issubclass(orig, tuple) and isinstance(v, list):
+                        inputs[f.name] = tuple(v)
+                    elif issubclass(orig, set) and isinstance(v, list):
+                        inputs[f.name] = set(v)
             unused_keys.difference_update(inputs.keys())
             obj = dtype(**inputs)
             outputs.append(obj)

--- a/tests/utils/test_hf_argparser.py
+++ b/tests/utils/test_hf_argparser.py
@@ -490,3 +490,43 @@ class HfArgumentParserTest(unittest.TestCase):
         parser = HfArgumentParser(TrainingArguments)
         training_args = parser.parse_args_into_dataclasses()[0]
         self.assertEqual(training_args.accelerator_config.gradient_accumulation_kwargs["num_steps"], 2)
+
+    def test_17_with_tuple_and_set(self):
+        @dataclass
+        class ContainerExample:
+            fixed_tuple: tuple[int, int] = (1, 2)
+            var_tuple: tuple[str, ...] = ("a", "b")
+            tag_set: set[str] = field(default_factory=lambda: {"default_tag"})
+            int_set: set[int] = field(default_factory=set)
+
+        parser = HfArgumentParser(ContainerExample)
+
+        # Default parsing
+        args = parser.parse_args([])
+        self.assertEqual(args, Namespace(fixed_tuple=(1, 2), var_tuple=("a", "b"), tag_set={"default_tag"}, int_set=set()))
+        container_ex = parser.parse_args_into_dataclasses([])[0]
+        self.assertEqual(container_ex.fixed_tuple, (1, 2))
+        self.assertEqual(container_ex.var_tuple, ("a", "b"))
+        self.assertEqual(container_ex.tag_set, {"default_tag"})
+        self.assertEqual(container_ex.int_set, set())
+
+        # CLI inputs
+        cli_args = "--fixed_tuple 10 20 --var_tuple x y z --tag_set tag1 tag2 --int_set 1 2 3".split()
+        container_ex = parser.parse_args_into_dataclasses(cli_args)[0]
+        self.assertEqual(container_ex.fixed_tuple, (10, 20))
+        self.assertEqual(container_ex.var_tuple, ("x", "y", "z"))
+        self.assertEqual(container_ex.tag_set, {"tag1", "tag2"})
+        self.assertEqual(container_ex.int_set, {1, 2, 3})
+
+        # Dict parsing
+        dict_args = {
+            "fixed_tuple": [3, 4],
+            "var_tuple": ["hello"],
+            "tag_set": ["foo", "bar"],
+            "int_set": [42],
+        }
+        container_ex = parser.parse_dict(dict_args)[0]
+        self.assertEqual(container_ex.fixed_tuple, (3, 4))
+        self.assertEqual(container_ex.var_tuple, ("hello",))
+        self.assertEqual(container_ex.tag_set, {"foo", "bar"})
+        self.assertEqual(container_ex.int_set, {42})


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48420&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48420) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48420&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48420)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48419.

When defining dataclass fields typed as `tuple` (e.g. `tuple[int, int]`, `tuple[str, ...]`) or `set` (e.g. `set[str]`, `set[int]`), `HfArgumentParser` previously only handled `list` subclasses in `_parse_dataclass_field`, leaving `tuple` and `set` to fall back to `type=tuple`/`type=set` with default `nargs=None`. This caused:
1. Strings passed to `tuple` fields to be iterated character-by-character into string tuples `('4', ',', '5')`.
2. Strings passed to `set` fields to be split into individual characters (`{'1', '2', ',', 'a', 'g', 't'}`).
3. Space-separated items (`['--layers', '4', '5']`) to fail with `ValueError: Some specified arguments are not used by the HfArgumentParser: ['5']`.

This PR:
- Adds support for `tuple` (fixed-length and variable-length) and `set` fields in `_parse_dataclass_field`.
- Configures appropriate `nargs` and parses inner element types.
- Coerces parsed list arguments into `tuple` / `set` containers during dataclass instantiation in `parse_args_into_dataclasses` and `parse_dict`.
- Adds unit tests in `tests/utils/test_hf_argparser.py` covering default, CLI, and dict parsing workflows.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#did-you-find-a-bug), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case: #48419.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?