### PR TITLE
Fix SwitchTransformers Top1 router: raw logits, expert capacity accounting, and router losses

### DIFF
--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -77,9 +77,12 @@ class SwitchTransformersTop1Router(nn.Module):
             hidden_states (`torch.Tensor`):
                 (batch_size, sequence_length, hidden_dim) from which router probabilities are computed.
         Returns:
-            router_probabilities (`torch.Tensor`):
-                Tensor of shape (batch_size, sequence_length, num_experts) corresponding to the probabilities for each
-                token and expert. Used for routing tokens to experts.
+            expert_index (`torch.Tensor`):
+                One-hot dispatch mask of shape (batch_size, sequence_length, num_experts) with tokens routed to an
+                expert beyond its capacity masked out.
+            router_probs (`torch.Tensor`):
+                Tensor of shape (batch_size, sequence_length, 1) with the probability of the selected expert for each
+                token. Used to scale the expert outputs.
             router_logits (`torch.Tensor`):
                 Logits tensor of shape (batch_size, sequence_length, num_experts) corresponding to raw router logits.
                 This is used later for computing router z-loss.
@@ -97,14 +100,14 @@ class SwitchTransformersTop1Router(nn.Module):
 
         # Apply Softmax and cast back to the original `dtype`
         router_probs = nn.functional.softmax(router_logits, dim=-1, dtype=self.dtype).to(self.input_dtype)
-        router_logits, expert_index = torch.max(router_probs, dim=-1, keepdim=True)
+        expert_index = torch.argmax(router_probs, dim=-1)
         expert_index = torch.nn.functional.one_hot(expert_index, num_classes=self.num_experts)
         token_priority = torch.cumsum(expert_index, dim=-2)
         # mask if the token routed to the expert will overflow
         expert_capacity_mask = token_priority <= self.expert_capacity
         expert_index = expert_index * expert_capacity_mask
         router_probs = torch.max(router_probs, dim=-1).values.unsqueeze(-1)
-        return router_probs, expert_index, router_logits
+        return expert_index, router_probs, router_logits
 
 
 class SwitchTransformersLayerNorm(nn.Module):
@@ -184,8 +187,11 @@ class SwitchTransformersSparseMLP(nn.Module):  # inherit from mixtral
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         batch_size, sequence_length, hidden_dim = hidden_states.shape
+        # Route on the unflattened hidden states so that expert capacity is accounted per sequence
+        selected_experts, routing_weights, _ = self.router(hidden_states)
         hidden_states = hidden_states.view(-1, hidden_dim)
-        _, selected_experts, routing_weights = self.router(hidden_states)
+        selected_experts = selected_experts.view(-1, 1, self.router.num_experts)
+        routing_weights = routing_weights.view(-1, 1)
         hidden_states = self.experts(hidden_states, selected_experts, routing_weights)
         hidden_states = hidden_states.reshape(batch_size, sequence_length, hidden_dim)
         return hidden_states
@@ -1080,13 +1086,13 @@ class SwitchTransformersForConditionalGeneration(SwitchTransformersPreTrainedMod
         )
 
     def _unpack_router_logits(self, router_outputs):
+        # `router_outputs` holds the raw router logits recorded for each sparse layer, of shape
+        # (batch_size, sequence_length, num_experts)
         total_router_logits = []
         total_expert_indexes = []
-        for router_output in router_outputs:
-            if len(router_output[0].shape) > 1:
-                router_logits, expert_indexes = router_output
-                total_router_logits.append(router_logits)
-                total_expert_indexes.append(expert_indexes)
+        for router_logits in router_outputs:
+            total_router_logits.append(router_logits)
+            total_expert_indexes.append(torch.argmax(router_logits, dim=-1, keepdim=True))
         return torch.cat(total_router_logits, dim=1), torch.cat(total_expert_indexes, dim=1)
 
     def prepare_decoder_input_ids_from_labels(self, labels: torch.Tensor):

--- a/src/transformers/models/switch_transformers/modular_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modular_switch_transformers.py
@@ -143,9 +143,12 @@ class SwitchTransformersTop1Router(nn.Module):
             hidden_states (`torch.Tensor`):
                 (batch_size, sequence_length, hidden_dim) from which router probabilities are computed.
         Returns:
-            router_probabilities (`torch.Tensor`):
-                Tensor of shape (batch_size, sequence_length, num_experts) corresponding to the probabilities for each
-                token and expert. Used for routing tokens to experts.
+            expert_index (`torch.Tensor`):
+                One-hot dispatch mask of shape (batch_size, sequence_length, num_experts) with tokens routed to an
+                expert beyond its capacity masked out.
+            router_probs (`torch.Tensor`):
+                Tensor of shape (batch_size, sequence_length, 1) with the probability of the selected expert for each
+                token. Used to scale the expert outputs.
             router_logits (`torch.Tensor`):
                 Logits tensor of shape (batch_size, sequence_length, num_experts) corresponding to raw router logits.
                 This is used later for computing router z-loss.
@@ -163,14 +166,14 @@ class SwitchTransformersTop1Router(nn.Module):
 
         # Apply Softmax and cast back to the original `dtype`
         router_probs = nn.functional.softmax(router_logits, dim=-1, dtype=self.dtype).to(self.input_dtype)
-        router_logits, expert_index = torch.max(router_probs, dim=-1, keepdim=True)
+        expert_index = torch.argmax(router_probs, dim=-1)
         expert_index = torch.nn.functional.one_hot(expert_index, num_classes=self.num_experts)
         token_priority = torch.cumsum(expert_index, dim=-2)
         # mask if the token routed to the expert will overflow
         expert_capacity_mask = token_priority <= self.expert_capacity
         expert_index = expert_index * expert_capacity_mask
         router_probs = torch.max(router_probs, dim=-1).values.unsqueeze(-1)
-        return router_probs, expert_index, router_logits
+        return expert_index, router_probs, router_logits
 
 
 class SwitchTransformersLayerNorm(T5LayerNorm):
@@ -211,8 +214,11 @@ class SwitchTransformersSparseMLP(nn.Module):  # inherit from mixtral
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         batch_size, sequence_length, hidden_dim = hidden_states.shape
+        # Route on the unflattened hidden states so that expert capacity is accounted per sequence
+        selected_experts, routing_weights, _ = self.router(hidden_states)
         hidden_states = hidden_states.view(-1, hidden_dim)
-        _, selected_experts, routing_weights = self.router(hidden_states)
+        selected_experts = selected_experts.view(-1, 1, self.router.num_experts)
+        routing_weights = routing_weights.view(-1, 1)
         hidden_states = self.experts(hidden_states, selected_experts, routing_weights)
         hidden_states = hidden_states.reshape(batch_size, sequence_length, hidden_dim)
         return hidden_states
@@ -763,13 +769,13 @@ class SwitchTransformersForConditionalGeneration(SwitchTransformersPreTrainedMod
         )
 
     def _unpack_router_logits(self, router_outputs):
+        # `router_outputs` holds the raw router logits recorded for each sparse layer, of shape
+        # (batch_size, sequence_length, num_experts)
         total_router_logits = []
         total_expert_indexes = []
-        for router_output in router_outputs:
-            if len(router_output[0].shape) > 1:
-                router_logits, expert_indexes = router_output
-                total_router_logits.append(router_logits)
-                total_expert_indexes.append(expert_indexes)
+        for router_logits in router_outputs:
+            total_router_logits.append(router_logits)
+            total_expert_indexes.append(torch.argmax(router_logits, dim=-1, keepdim=True))
         return torch.cat(total_router_logits, dim=1), torch.cat(total_expert_indexes, dim=1)
 
     def prepare_decoder_input_ids_from_labels(self, labels: torch.Tensor):

--- a/tests/models/switch_transformers/test_modeling_switch_transformers.py
+++ b/tests/models/switch_transformers/test_modeling_switch_transformers.py
@@ -605,6 +605,35 @@ class SwitchTransformersModelTest(ModelTesterMixin, GenerationTesterMixin, Pipel
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_generate_with_past_key_values(*config_and_inputs)
 
+    def test_router_losses_are_computed_from_router_logits(self):
+        # Regression test for #48293: the router used to return its max routing probability in place of the raw
+        # logits, and `_unpack_router_logits` silently collected nothing from the recorded router outputs.
+        config, input_ids, decoder_input_ids, _, _, lm_labels = self.model_tester.prepare_config_and_inputs()
+        config.encoder_sparse_step = 2
+        config.decoder_sparse_step = 2
+        model = SwitchTransformersForConditionalGeneration(config=config).to(torch_device).eval()
+
+        with torch.no_grad():
+            outputs = model(
+                input_ids=input_ids,
+                decoder_input_ids=decoder_input_ids,
+                labels=lm_labels,
+                output_router_logits=True,
+            )
+
+        for layer_router_logits in outputs.encoder_router_logits:
+            self.assertEqual(layer_router_logits.shape, (*input_ids.shape, config.num_experts))
+        for layer_router_logits in outputs.decoder_router_logits:
+            self.assertEqual(layer_router_logits.shape, (*decoder_input_ids.shape, config.num_experts))
+        for value in (
+            outputs.loss,
+            outputs.encoder_z_loss,
+            outputs.decoder_z_loss,
+            outputs.encoder_aux_loss,
+            outputs.decoder_aux_loss,
+        ):
+            self.assertTrue(torch.isfinite(value).all())
+
     @unittest.skipIf(torch_device == "cpu", "Can't do half precision")
     def test_model_fp16_forward(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
@@ -909,8 +938,9 @@ class SwitchTransformerRouterTest(unittest.TestCase):
         router_z_loss = router_z_loss_func(router_logits)
         auxiliary_loss = load_balancing_loss_func(router_probs, torch.argmax(expert_index, dim=-1))
 
-        self.assertAlmostEqual(router_z_loss.item(), 0.25389, places=5)
-        self.assertAlmostEqual(auxiliary_loss.item(), 1.000, places=5)
+        # Expected values computed with the pre-#40132 (v4.57) implementation, which matched the original router
+        self.assertAlmostEqual(router_z_loss.item(), 0.4789799, places=5)
+        self.assertAlmostEqual(auxiliary_loss.item(), 1.000308, places=5)
         #
         # self.assertTrue(torch.allclose(expert_index.bool().unsqueeze(-1), expected_dispatch_mask))
 
@@ -929,6 +959,35 @@ class SwitchTransformerRouterTest(unittest.TestCase):
         expert_index = expert_index * expert_capacity_mask
 
         assert torch.sum(expert_index) <= batch_size * self.config.num_experts * self.config.expert_capacity
+
+    def test_token_dropping_above_capacity(self):
+        r"""
+        This test checks that tokens routed to an expert beyond its capacity are dropped from the dispatch mask, i.e.
+        that the cumulative token count is accumulated along the sequence dimension (regression test for #48293).
+        """
+        torch.manual_seed(0)
+        model = SwitchTransformersTop1Router(self.config)
+        hidden_states = torch.rand((2, 10, self.config.hidden_size))
+
+        expert_index, _, _ = model(hidden_states)
+
+        tokens_kept_per_expert = expert_index.sum(dim=-2)
+        self.assertTrue((tokens_kept_per_expert <= self.config.expert_capacity).all())
+
+    def test_router_logits_are_raw_logits(self):
+        r"""
+        This test checks that the router returns the raw logits of its classifier and not the routing probabilities,
+        since the router z-loss is computed from the logits (regression test for #48293).
+        """
+        torch.manual_seed(0)
+        model = SwitchTransformersTop1Router(self.config)
+        hidden_states = torch.rand((2, 6, self.config.hidden_size))
+
+        _, router_probs, router_logits = model(hidden_states)
+
+        self.assertEqual(router_logits.shape, (2, 6, self.config.num_experts))
+        expected_probs = torch.softmax(router_logits, dim=-1).max(dim=-1, keepdim=True).values
+        torch.testing.assert_close(router_probs, expected_probs.to(router_probs.dtype))
 
 
 @slow


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48421&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48421) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48421&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48421)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48293 (SwitchTransformers Top1 router regressions, introduced by the MoE refactor in #40132, i.e. broken since v5.0).

## Root cause

In `SwitchTransformersTop1Router.forward`:

```python
router_logits, expert_index = torch.max(router_probs, dim=-1, keepdim=True)
expert_index = torch.nn.functional.one_hot(expert_index, num_classes=self.num_experts)
token_priority = torch.cumsum(expert_index, dim=-2)
```

1. `router_logits` is overwritten with the max routing probability, so the third return value — recorded by `OutputRecorder(..., index=2)` as `router_logits` and fed to the router z-loss — is a probability, identical in value to the first return, instead of the classifier's raw logits.
2. `keepdim=True` makes `one_hot` produce shape `(..., 1, num_experts)`, so `cumsum(dim=-2)` accumulates over the singleton dimension — a no-op. `token_priority` never exceeds 1, so no token is ever dropped for any `expert_capacity >= 1`.
3. `SwitchTransformersSparseMLP` routes the flattened `(batch*seq, hidden)` tensor, so even with the dim fixed, capacity would be accounted globally rather than per sequence as in v4.
4. `_unpack_router_logits` still expects `(router_logits, expert_index)` pairs; with the recorded single tensors it collects nothing, and `output_router_logits=True` with `labels` crashes with `ValueError: torch.cat(): expected a non-empty list of Tensors`.

#40132 also re-baked the broken outputs into the golden equivalency test: the old values (z-loss `0.4789799`, aux `1.000308`) documented equivalence with the original implementation; the new ones (`0.25389`, `1.000`) are artifacts of the bug — `1.000` is literally `softmax` over a singleton dimension, and `0.25389` is the mean of the squared max probability (`~0.504²`).

## Fix

- Restore v4.57 router semantics and return order `(expert_index, router_probs, router_logits)`: `argmax` without `keepdim`, raw logits returned untouched (recorder index 2 still points at `router_logits`).
- Route the unflattened `(batch, seq, hidden)` states in `SparseMLP`, restoring per-sequence capacity accounting, then flatten the dispatch mask and weights for the Mixtral-style experts module.
- `_unpack_router_logits` consumes the recorded per-layer logits `(batch, seq, num_experts)` and derives expert indices via `argmax`, returning the same v4 concatenation shapes.
- Restore the pre-refactor golden values in `test_equivalency_token_chose_masked_router`.

Modeling changes are made in `modular_switch_transformers.py` and regenerated.

## Verification

All commands run from the repo root in a fresh venv (Windows, CPU-only, torch 2.13.0+cpu, editable install of current main).

**On current main (red):**

- `pytest tests/models/switch_transformers/test_modeling_switch_transformers.py -k "Router or SparseMLP or router_losses" -q` → **4 failed, 4 passed, 440 deselected**. Failing: `SwitchTransformerRouterTest::test_equivalency_token_chose_masked_router` (with the original pre-#40132 golden values restored), plus the three new regression tests `test_token_dropping_above_capacity`, `test_router_logits_are_raw_logits`, `SwitchTransformersModelTest::test_router_losses_are_computed_from_router_logits`.
- Standalone repro: the router's first and third return values are `torch.equal` (probabilities returned in place of logits); with `num_experts=2`, `expert_capacity=4`, 10 tokens per sequence, one expert keeps all 10 tokens (capacity never enforced); `SwitchTransformersForConditionalGeneration(..., output_router_logits=True, labels=...)` with `encoder_sparse_step=2` raises `ValueError: torch.cat(): expected a non-empty list of Tensors`.

**After this change (green):**

- `pytest tests/models/switch_transformers/test_modeling_switch_transformers.py -q` → **181 passed, 279 skipped, 2362 subtests passed, 0 failures**. Skips are the pre-existing slow/accelerator/tokenizers-gated tests.
- The same repro now shows raw logits of shape `(2, 10, 2)` distinct from the probabilities, at most 4 tokens kept per expert per sequence, and a working `output_router_logits=True` forward with finite loss and z-losses and per-layer router logits of shape `(batch, seq, num_experts)`.
- The restored golden values (z-loss `0.4789799`, aux loss `1.000308`) were additionally cross-checked with an independent pure-torch reimplementation of the fixed router math, which reproduces them to full float precision.
- `python utils/modular_model_converter.py switch_transformers` regenerated the modeling file; `python utils/check_modular_conversion.py --files src/transformers/models/switch_transformers/modular_switch_transformers.py` passes.
- `ruff check` and `ruff format --check` (repo-pinned ruff) are clean on all three changed files.

**Not run (disclosed):** the `@slow` integration tests (`SwitchTransformerModelIntegrationTests`) — they require a GPU/accelerator, bf16, and the real `google/switch-base-8` checkpoint. Two mitigating facts: the `(None, None)` expected logits in `test_small_logits` are byte-identical between v4.57 and current main, and with `expert_capacity=64` and sequence length 64 no token is dropped under either the old or new code, so this change should not move those logits. Please trigger `run-slow: switch_transformers` to confirm.

## Who can review?

@Rocketknight1 (triaged the issue)