### PR TITLE
fix: apply _rope_type_labels override to validate_rope for Gemma3 and Olmo3

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -825,9 +825,8 @@ class RotaryEmbeddingConfigMixin:
         if not rope_parameters_dict:
             return
 
-        if getattr(self, "layer_types", None) is not None and set(rope_parameters_dict.keys()).issubset(
-            self.layer_types
-        ):
+        layer_types = getattr(self, "_rope_type_labels", getattr(self, "layer_types", None))
+        if layer_types is not None and set(rope_parameters_dict.keys()).issubset(layer_types):
             pass
         else:
             rope_parameters_dict = {"full_attention": rope_parameters_dict}

--- a/src/transformers/models/gemma3/configuration_gemma3.py
+++ b/src/transformers/models/gemma3/configuration_gemma3.py
@@ -96,6 +96,7 @@ class Gemma3TextConfig(PreTrainedConfig):
     query_pre_attn_scalar: int = 256
     sliding_window: int | None = 4096
     layer_types: list[str] | None = None
+    _rope_type_labels = ["sliding_attention", "full_attention"]
     final_logit_softcapping: float | None = None
     attn_logit_softcapping: float | None = None
     use_bidirectional_attention: bool | None = False

--- a/src/transformers/models/olmo3/configuration_olmo3.py
+++ b/src/transformers/models/olmo3/configuration_olmo3.py
@@ -85,6 +85,7 @@ class Olmo3Config(PreTrainedConfig):
 
     sliding_window: int | None = 4096
     layer_types: list[str] | None = None
+    _rope_type_labels = ["sliding_attention", "full_attention"]
 
     def __post_init__(self, **kwargs):
         if self.num_key_value_heads is None:

--- a/tests/utils/test_modeling_rope_utils.py
+++ b/tests/utils/test_modeling_rope_utils.py
@@ -137,6 +137,11 @@ class RopeTest(unittest.TestCase):
             if same_rope_per_layer:
                 self.assertIn("mrope_sections", logs.output[1])
 
+    def test_gemma3_tiny_rope_validation(self):
+        config = Gemma3TextConfig(num_hidden_layers=2)
+        config.convert_rope_params_to_dict()
+        self.assertIn("sliding_attention", config.rope_parameters)
+
     @parameterized.expand(
         [
             (True, True),


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48427&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48427) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48427&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48427)
<!-- ci-dashboard-badge:end -->

# What does this PR do?


'validate_rope' was incorrectly wrapping nested RoPE config dictionary in modeling_rope_utils.py. This occurs because the 2 conditions within the if line at 828 contradict themselves during edge cases, the fault lies in the line set(rope_parameters_dict.keys()).issubset(self.layer_types).
The first function would call the dictionary key {"sliding_attention", "full_attention"} and the second function would check the keys if they're in the actual layers [sliding_attention", "full_attention"].
The answer here would be False because "full_attention" is missing from the actual layers. This occurs in smaller experimental models where there's not enough layers for a full_attention to occur.
For instance, in configuration_olmo3.py, around line 94-97, we get the code: "sliding_attention" if (i + 1) % 4 != 0 else "full_attention" for i in range(self.num_hidden_layers)
That basically means every 4th layer it will be a full_attention, but in the event of smaller model like hidden layers being just 2, there would not be a full_attention layer, thus triggering a "unrecognized key" error.
In the same util file, we could look up and see the configuration being used by Deepseek V4 being applicable here, using _rope_type_labels. The mechanic is pretty simple: First it copies the line "getattr(self, "_rope_type_labels", ...) logic down into the function validate_rope so both share the same function math. Then it adds _rope_type_labels = ["sliding_attention", "full_attention"] to Gemma3 config file so it can use the same override switch like DeepSeek did. 
Originally, I saw the logic error in the line set(rope_parameters_dict.keys()).issubset(self.layer_types) and intended to simply invert the conditions with set(self.layer_types).issubset(rope_parameters_dict.keys()), but I figured it would be better to follow the configuration pattern in the file.


<!-- Remove if not applicable -->

Fixes #48392

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.

Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
for reviewers and other users and will almost certainly get you blocked.

For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
https://github.com/huggingface/transformers/issues/48392
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @molbap @guarin
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @Abdennacer-Badaoui
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @IlyasMoutawwakil 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->