### PR TITLE
tests: replace unreachable picsum.photos URLs with Hub dataset assets

### DIFF
--- a/src/transformers/models/afmoe/modeling_afmoe.py
+++ b/src/transformers/models/afmoe/modeling_afmoe.py
@@ -352,7 +352,7 @@ class AfmoeAttention(nn.Module):
         hidden_states: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: torch.Tensor | None,
-        past_key_value: Cache | None = None,
+        past_key_values: Cache | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple[torch.Tensor, torch.Tensor]:
         input_shape = hidden_states.shape[:-1]
@@ -371,8 +371,8 @@ class AfmoeAttention(nn.Module):
             cos, sin = position_embeddings
             query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
-        if past_key_value is not None:
-            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx)
+        if past_key_values is not None:
+            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -431,7 +431,7 @@ class AfmoeDecoderLayer(GradientCheckpointingLayer):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
-        past_key_value: Cache | None = None,
+        past_key_values: Cache | None = None,
         use_cache: bool | None = None,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         **kwargs: Unpack[TransformersKwargs],
@@ -444,7 +444,7 @@ class AfmoeDecoderLayer(GradientCheckpointingLayer):
             hidden_states=hidden_states,
             attention_mask=attention_mask,
             position_ids=position_ids,
-            past_key_value=past_key_value,
+            past_key_values=past_key_values,
             use_cache=use_cache,
             position_embeddings=position_embeddings,
             **kwargs,
@@ -584,7 +584,7 @@ class AfmoeModel(AfmoePreTrainedModel):
                 hidden_states,
                 attention_mask=causal_mask_mapping[self.config.layer_types[i]],
                 position_ids=position_ids,
-                past_key_value=past_key_values,
+                past_key_values=past_key_values,
                 use_cache=use_cache,
                 position_embeddings=position_embeddings,
                 **kwargs,

--- a/src/transformers/models/afmoe/modular_afmoe.py
+++ b/src/transformers/models/afmoe/modular_afmoe.py
@@ -146,7 +146,7 @@ class AfmoeAttention(LlamaAttention):
         hidden_states: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: torch.Tensor | None,
-        past_key_value: Cache | None = None,
+        past_key_values: Cache | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple[torch.Tensor, torch.Tensor]:
         input_shape = hidden_states.shape[:-1]
@@ -165,8 +165,8 @@ class AfmoeAttention(LlamaAttention):
             cos, sin = position_embeddings
             query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
-        if past_key_value is not None:
-            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx)
+        if past_key_values is not None:
+            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -225,7 +225,7 @@ class AfmoeDecoderLayer(GradientCheckpointingLayer):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
-        past_key_value: Cache | None = None,
+        past_key_values: Cache | None = None,
         use_cache: bool | None = None,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         **kwargs: Unpack[TransformersKwargs],
@@ -238,7 +238,7 @@ class AfmoeDecoderLayer(GradientCheckpointingLayer):
             hidden_states=hidden_states,
             attention_mask=attention_mask,
             position_ids=position_ids,
-            past_key_value=past_key_value,
+            past_key_values=past_key_values,
             use_cache=use_cache,
             position_embeddings=position_embeddings,
             **kwargs,
@@ -378,7 +378,7 @@ class AfmoeModel(AfmoePreTrainedModel):
                 hidden_states,
                 attention_mask=causal_mask_mapping[self.config.layer_types[i]],
                 position_ids=position_ids,
-                past_key_value=past_key_values,
+                past_key_values=past_key_values,
                 use_cache=use_cache,
                 position_embeddings=position_embeddings,
                 **kwargs,

--- a/tests/models/emu3/test_modeling_emu3.py
+++ b/tests/models/emu3/test_modeling_emu3.py
@@ -358,7 +358,12 @@ class Emu3IntegrationTest(unittest.TestCase):
         )
         processor = Emu3Processor.from_pretrained("BAAI/Emu3-Chat-hf")
 
-        image = Image.open(requests.get("https://picsum.photos/id/237/200/200", stream=True).raw)
+        image = Image.open(
+            requests.get(
+                "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_237_200x300.jpg",
+                stream=True,
+            ).raw
+        )
         prompt = "USER: <image>Describe what do you see here and tell me about the history behind it? ASSISTANT:"
 
         inputs = processor(images=image, text=prompt, return_tensors="pt").to(model.device, torch.float16)
@@ -379,8 +384,18 @@ class Emu3IntegrationTest(unittest.TestCase):
         processor = Emu3Processor.from_pretrained("BAAI/Emu3-Chat-hf")
         processor.tokenizer.padding_side = "left"
 
-        image = Image.open(requests.get("https://picsum.photos/id/237/200/200", stream=True).raw)
-        image_2 = Image.open(requests.get("https://picsum.photos/id/247/200/200", stream=True).raw)
+        image = Image.open(
+            requests.get(
+                "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_237_200x300.jpg",
+                stream=True,
+            ).raw
+        )
+        image_2 = Image.open(
+            requests.get(
+                "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_247_200x200.jpg",
+                stream=True,
+            ).raw
+        )
         prompts = [
             "USER: <image>Describe what do you see here? ASSISTANT:",
             "USER: <image>What can you say about the image? ASSISTANT:",
@@ -426,8 +441,18 @@ class Emu3IntegrationTest(unittest.TestCase):
         processor.image_processor.max_pixels = 256 * 256
         processor.image_processor.size = {"min_pixels": 256 * 256, "max_pixels": 256 * 256}
 
-        image = Image.open(requests.get("https://picsum.photos/id/237/200/200", stream=True).raw)
-        image_2 = Image.open(requests.get("https://picsum.photos/id/247/200/200", stream=True).raw)
+        image = Image.open(
+            requests.get(
+                "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_237_200x300.jpg",
+                stream=True,
+            ).raw
+        )
+        image_2 = Image.open(
+            requests.get(
+                "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_247_200x200.jpg",
+                stream=True,
+            ).raw
+        )
         prompt = "USER: <image><image>What do these two images have in common? ASSISTANT:"
 
         inputs = processor(images=[image, image_2], text=prompt, return_tensors="pt").to(model.device, torch.float16)

--- a/tests/models/llava/test_modeling_llava.py
+++ b/tests/models/llava/test_modeling_llava.py
@@ -626,8 +626,12 @@ class LlavaForConditionalGenerationIntegrationTest(unittest.TestCase):
         processor = AutoProcessor.from_pretrained(model_id)
 
         IMG_URLS = [
-            load_test_image("https://picsum.photos/id/237/400/300"),
-            load_test_image("https://picsum.photos/id/231/200/300"),
+            load_test_image(
+                "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_237_200x300.jpg"
+            ),
+            load_test_image(
+                "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_231_200x300.jpg"
+            ),
         ]
         PROMPT = "<s>[INST]Describe the images.\n[IMG][IMG][/INST]"
 
@@ -659,8 +663,12 @@ class LlavaForConditionalGenerationIntegrationTest(unittest.TestCase):
         processor = AutoProcessor.from_pretrained(model_id)
 
         IMG_URLS = [
-            load_test_image("https://picsum.photos/id/237/400/300"),
-            load_test_image("https://picsum.photos/id/231/200/300"),
+            load_test_image(
+                "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_237_200x300.jpg"
+            ),
+            load_test_image(
+                "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_231_200x300.jpg"
+            ),
         ]
         PROMPT = "<s>[INST][IMG][IMG]Describe the images.[/INST]"
 
@@ -691,8 +699,12 @@ class LlavaForConditionalGenerationIntegrationTest(unittest.TestCase):
         processor.tokenizer.pad_token_id = processor.tokenizer.eos_token_id
 
         IMG_URLS = [
-            load_test_image("https://picsum.photos/id/237/400/300"),
-            load_test_image("https://picsum.photos/id/17/150/500"),
+            load_test_image(
+                "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_237_200x300.jpg"
+            ),
+            load_test_image(
+                "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_17_150x500.jpg"
+            ),
         ]
         PROMPT = [
             "<s>[INST][IMG]What breed is the dog?[/INST]",

--- a/tests/models/minimax_m3_vl/test_modeling_minimax_m3_vl.py
+++ b/tests/models/minimax_m3_vl/test_modeling_minimax_m3_vl.py
@@ -695,7 +695,9 @@ class MiniMaxM3VLIntegrationTest(unittest.TestCase):
         # Two real, semantically distinct images downloaded from the hub/web (the picsum dog and the
         # canonical COCO two-cats photo), paired with deliberately different-length questions so the
         # batch genuinely needs padding.
-        dog = load_test_image("https://picsum.photos/id/237/400/300").convert("RGB")
+        dog = load_test_image(
+            "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_237_200x300.jpg"
+        ).convert("RGB")
         cats = load_coco_image("000000039769.jpg").convert("RGB")
         texts = [
             self._prompt(processor, "What animal is this? One word."),


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48431&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48431) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48431&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48431)
<!-- ci-dashboard-badge:end -->

Fixes #48424

#### Description
Integration tests in `tests/models/emu3/test_modeling_emu3.py`, `tests/models/llava/test_modeling_llava.py`, and `tests/models/minimax_m3_vl/test_modeling_minimax_m3_vl.py` previously fetched test input images from `https://picsum.photos/...`.

External network hosts are prone to SSL timeouts, rate limiting, and temporary DNS unreachability, causing flaky integration test failures on CI and local runs.

#### Changes
- Replaces all hardcoded `https://picsum.photos/...` image URLs with deterministic, versioned mirror assets hosted on Hugging Face Hub under `hf-internal-testing/fixtures_image`.
- Fixes integration tests across Emu3, Llava, and MiniMax-VL without modifying core modeling behavior.