### PR TITLE
fix(hf_argparser): support tuple and set typed dataclass fields

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -217,13 +217,16 @@ class HfArgumentParser(ArgumentParser):
                 kwargs["nargs"] = "?"
                 # This is the value that will get picked if we do --{field.name} (without value)
                 kwargs["const"] = True
-        elif isclass(origin_type) and issubclass(origin_type, list):
-            kwargs["type"] = field.type.__args__[0]
+        elif isclass(origin_type) and issubclass(origin_type, (list, set, tuple)):
+            if hasattr(field.type, "__args__") and len(field.type.__args__) > 0:
+                kwargs["type"] = field.type.__args__[0]
             kwargs["nargs"] = "+"
             if field.default_factory is not dataclasses.MISSING:
                 kwargs["default"] = field.default_factory()
             elif field.default is dataclasses.MISSING:
                 kwargs["required"] = True
+            elif isinstance(field.default, (list, set, tuple)):
+                kwargs["default"] = field.default
         else:
             kwargs["type"] = field.type
             if field.default is not dataclasses.MISSING:
@@ -340,6 +343,20 @@ class HfArgumentParser(ArgumentParser):
         for dtype in self.dataclass_types:
             keys = {f.name for f in dataclasses.fields(dtype) if f.init}
             inputs = {k: v for k, v in vars(namespace).items() if k in keys}
+            for f in dataclasses.fields(dtype):
+                if not f.init or f.name not in inputs:
+                    continue
+                v = inputs[f.name]
+                if v is None:
+                    continue
+                f_origin = getattr(f.type, "__origin__", None)
+                if f_origin is None and isclass(f.type):
+                    f_origin = f.type
+                if isclass(f_origin):
+                    if issubclass(f_origin, set) and isinstance(v, (list, tuple)):
+                        inputs[f.name] = set(v)
+                    elif issubclass(f_origin, tuple) and isinstance(v, (list, set)):
+                        inputs[f.name] = tuple(v)
             for k in keys:
                 delattr(namespace, k)
             obj = dtype(**inputs)
@@ -376,6 +393,20 @@ class HfArgumentParser(ArgumentParser):
         for dtype in self.dataclass_types:
             keys = {f.name for f in dataclasses.fields(dtype) if f.init}
             inputs = {k: v for k, v in args.items() if k in keys}
+            for f in dataclasses.fields(dtype):
+                if not f.init or f.name not in inputs:
+                    continue
+                v = inputs[f.name]
+                if v is None:
+                    continue
+                f_origin = getattr(f.type, "__origin__", None)
+                if f_origin is None and isclass(f.type):
+                    f_origin = f.type
+                if isclass(f_origin):
+                    if issubclass(f_origin, set) and isinstance(v, (list, tuple)):
+                        inputs[f.name] = set(v)
+                    elif issubclass(f_origin, tuple) and isinstance(v, (list, set)):
+                        inputs[f.name] = tuple(v)
             unused_keys.difference_update(inputs.keys())
             obj = dtype(**inputs)
             outputs.append(obj)

--- a/tests/utils/test_hf_argparser.py
+++ b/tests/utils/test_hf_argparser.py
@@ -490,3 +490,30 @@ class HfArgumentParserTest(unittest.TestCase):
         parser = HfArgumentParser(TrainingArguments)
         training_args = parser.parse_args_into_dataclasses()[0]
         self.assertEqual(training_args.accelerator_config.gradient_accumulation_kwargs["num_steps"], 2)
+
+    def test_17_set_and_tuple_parsing(self):
+        @dataclass
+        class ContainerExample:
+            tags: set[str] = field(default_factory=set)
+            coords: tuple[int, ...] = (0, 0)
+            items: list[str] = field(default_factory=list)
+
+        parser = HfArgumentParser(ContainerExample)
+
+        # CLI args
+        parsed = parser.parse_args_into_dataclasses(
+            ["--tags", "tag1", "tag2", "--coords", "10", "20", "--items", "a", "b"]
+        )[0]
+        self.assertIsInstance(parsed.tags, set)
+        self.assertEqual(parsed.tags, {"tag1", "tag2"})
+        self.assertIsInstance(parsed.coords, tuple)
+        self.assertEqual(parsed.coords, (10, 20))
+        self.assertIsInstance(parsed.items, list)
+        self.assertEqual(parsed.items, ["a", "b"])
+
+        # Dict parsing
+        parsed_dict = parser.parse_dict({"tags": ["tagA", "tagB"], "coords": [1, 2], "items": ["c"]})[0]
+        self.assertIsInstance(parsed_dict.tags, set)
+        self.assertEqual(parsed_dict.tags, {"tagA", "tagB"})
+        self.assertIsInstance(parsed_dict.coords, tuple)
+        self.assertEqual(parsed_dict.coords, (1, 2))


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48432&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48432) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48432&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48432)
<!-- ci-dashboard-badge:end -->

### Summary

Fixes #48419.

When defining dataclass fields with `tuple` or `set` types (e.g. `tuple[int, ...]` or `set[str]`), `HfArgumentParser` previously treated them as scalar fields (`nargs=None`), causing character-level splitting (e.g. `tuple('4,5') -> ('4', ',', '5')`) or unused argument errors.

### Changes Made

1. **`_parse_dataclass_field`**: Extended collection detection to `issubclass(origin_type, (list, set, tuple))`, assigning `nargs='+'` and inspecting inner type `field.type.__args__[0]`.
2. **`parse_args_into_dataclasses` and `parse_dict`**: Added container conversion to cast parsed lists to `set` or `tuple` based on the dataclass field type annotation.
3. **Tests**: Added `test_17_set_and_tuple_parsing` in `tests/utils/test_hf_argparser.py` verifying CLI and dictionary parsing for `set`, `tuple`, and `list` fields.

### Testing

Added comprehensive unit tests covering both command-line arguments and dict parsing for tuple and set dataclass types.