### PR TITLE
Add offload to gradient checkpointing

### DIFF
--- a/docs/source/en/grad_checkpointing.md
+++ b/docs/source/en/grad_checkpointing.md
@@ -43,6 +43,22 @@ args = TrainingArguments(
 )
 ```
 
+## Offloading the saved activations
+
+Gradient checkpointing still keeps one activation per checkpointed layer on the GPU, and at long sequence lengths that alone is large: `layers x sequence x hidden` bytes, so 36 layers of an 8B model at 128k tokens is 36 GB. Set `offload` to hold those in pinned host memory instead, and pay a device-to-host copy in the forward and a host-to-device copy in the backward for them.
+
+```py
+from transformers import TrainingArguments
+
+args = TrainingArguments(
+    ...,
+    gradient_checkpointing=True,
+    gradient_checkpointing_kwargs={"offload": True},
+)
+```
+
+Both copies run on the compute stream, so this trades a slower step for the memory. Reach for it when a run does not fit otherwise, not to speed one up.
+
 ## Next steps
 
 - Read the [GPU memory usage](./model_memory_anatomy) doc to understand what is driving memory usage on the GPU during training.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -39,6 +39,7 @@ from safetensors import safe_open
 from safetensors.torch import load as _safe_load_bytes
 from safetensors.torch import save_file as safe_save_file
 from torch import Tensor, nn
+from torch.autograd.graph import save_on_cpu
 from torch.distributions import constraints
 from torch.utils.checkpoint import checkpoint
 
@@ -3183,7 +3184,9 @@ class PreTrainedModel(
         # Tie weights needs to be called here, but it can use the pre-computed `all_tied_weights_keys`
         self.tie_weights(recompute_mapping=False)
 
-    def gradient_checkpointing_enable(self, gradient_checkpointing_kwargs=None, every_n_layers: int = 1):
+    def gradient_checkpointing_enable(
+        self, gradient_checkpointing_kwargs=None, every_n_layers: int = 1, offload: bool = False
+    ):
         """
         Activates gradient checkpointing for the current model.
 
@@ -3195,6 +3198,11 @@ class PreTrainedModel(
                 Checkpoint only every `every_n_layers`-th decoder layer, leaving the rest to keep their activations.
                 `1` checkpoints every layer, which is the usual all-or-nothing behavior. Larger values trade memory
                 back for speed, which is worth it whenever the memory freed by full checkpointing is going unused.
+            offload (`bool`, *optional*, defaults to `False`):
+                Hold the activations saved for the recompute in pinned host memory rather than on the accelerator.
+                This frees `layers x sequence x hidden` bytes of device memory, which is what dominates at long
+                sequence lengths, and costs a device-to-host copy in the forward and a host-to-device copy in the
+                backward. Both copies run on the compute stream, so the step gets slower.
             gradient_checkpointing_kwargs (dict, *optional*):
                 Additional keyword arguments passed along to the `torch.utils.checkpoint.checkpoint` function.
         """
@@ -3204,7 +3212,16 @@ class PreTrainedModel(
         if gradient_checkpointing_kwargs is None:
             gradient_checkpointing_kwargs = {"use_reentrant": False}
 
-        gradient_checkpointing_func = functools.partial(checkpoint, **gradient_checkpointing_kwargs)
+        if offload:
+            device_type = torch.accelerator.current_accelerator().type
+
+            def checkpoint_func(function, *args, **kwargs):
+                with save_on_cpu(pin_memory=True, device_type=device_type):
+                    return checkpoint(function, *args, **kwargs)
+        else:
+            checkpoint_func = checkpoint
+
+        gradient_checkpointing_func = functools.partial(checkpoint_func, **gradient_checkpointing_kwargs)
 
         # For old GC format (transformers < 4.35.0) for models that live on the Hub
         # we will fall back to the overwritten `_set_gradient_checkpointing` method

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1401,12 +1401,16 @@ class Trainer:
 
         # Activate gradient checkpointing if needed
         if args.gradient_checkpointing:
-            # `every_n_layers` selects which layers are checkpointed; the remaining keys are forwarded to
-            # `torch.utils.checkpoint.checkpoint`, so it has to come out of the dict before that happens.
+            # `every_n_layers` selects which layers are checkpointed and `offload` where their saved
+            # activations live; the remaining keys are forwarded to `torch.utils.checkpoint.checkpoint`, so both
+            # have to come out of the dict before that happens.
             gc_kwargs = dict(args.gradient_checkpointing_kwargs or {})
             every_n_layers = gc_kwargs.pop("every_n_layers", 1)
+            offload = gc_kwargs.pop("offload", False)
             self.model.gradient_checkpointing_enable(
-                gradient_checkpointing_kwargs=gc_kwargs or None, every_n_layers=every_n_layers
+                gradient_checkpointing_kwargs=gc_kwargs or None,
+                every_n_layers=every_n_layers,
+                offload=offload,
             )
 
         # If the model uses a tokenizer, it may have a new tokens for fine-tuning purposes.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -306,7 +306,9 @@ class TrainingArguments:
         gradient_checkpointing_kwargs (`dict`, *optional*, defaults to `None`):
             Keyword arguments passed to `gradient_checkpointing_enable()`. `every_n_layers` checkpoints only every
             n-th decoder layer instead of all of them; `1` is the usual all-or-nothing behavior, and larger values
-            give some memory back to speed. Any other key is forwarded to `torch.utils.checkpoint.checkpoint`.
+            give some memory back to speed. `offload` holds the saved activations in pinned host memory, which
+            frees `layers x sequence x hidden` bytes of device memory and makes the step slower. Any other key is
+            forwarded to `torch.utils.checkpoint.checkpoint`.
 
         > Compilation
 
@@ -906,7 +908,8 @@ class TrainingArguments:
         metadata={
             "help": "Keyword arguments passed to `gradient_checkpointing_enable()`. `every_n_layers` checkpoints "
             "only every n-th decoder layer instead of all of them; `1` is the usual all-or-nothing behavior, and "
-            "larger values give some memory back to speed. Any other key is forwarded to "
+            "larger values give some memory back to speed. `offload` holds the saved activations in pinned host "
+            "memory, which frees device memory and makes the step slower. Any other key is forwarded to "
             "`torch.utils.checkpoint.checkpoint`."
         },
     )

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -67,6 +67,9 @@ from transformers.testing_utils import (
     LoggingLevel,
     TemporaryHubRepo,
     TestCasePlus,
+    backend_empty_cache,
+    backend_memory_allocated,
+    backend_synchronize,
     force_serialization_as_bin_files,
     hub_retry,
     is_staging_test,
@@ -3953,14 +3956,14 @@ class GradientCheckpointingOffloadTest(unittest.TestCase):
             input_ids = torch.randint(0, 128, (1, seq_len), device=torch_device)
             self._backward(model, input_ids)  # warm the allocator
             model.zero_grad(set_to_none=True)
-            torch.accelerator.synchronize()
-            torch.accelerator.empty_cache()
+            backend_synchronize(torch_device)
+            backend_empty_cache(torch_device)
 
             # Sampled after the forward, where every layer's saved input is still live.
-            base = torch.accelerator.memory_allocated()
+            base = backend_memory_allocated(torch_device)
             output = model(input_ids=input_ids)
-            torch.accelerator.synchronize()
-            resident.append(torch.accelerator.memory_allocated() - base)
+            backend_synchronize(torch_device)
+            resident.append(backend_memory_allocated(torch_device) - base)
             del output, model
 
         self.assertEqual(resident[0] - resident[1], saved_bytes)

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -3903,3 +3903,64 @@ class RemoteAndCustomCodeModelTests(unittest.TestCase):
 
         self.assertTrue(model.is_custom_code())
         self.assertFalse(model.is_remote_code())
+
+
+@require_torch_accelerator
+class GradientCheckpointingOffloadTest(unittest.TestCase):
+    """`gradient_checkpointing_enable(offload=True)` holds the saved activations in host memory."""
+
+    def _model(self, num_hidden_layers=8, hidden_size=256):
+        from transformers import LlamaModel, set_seed
+
+        config = LlamaConfig(
+            num_hidden_layers=num_hidden_layers,
+            hidden_size=hidden_size,
+            intermediate_size=hidden_size * 2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            vocab_size=128,
+        )
+        set_seed(0)
+        return LlamaModel(config).to(torch_device).train()
+
+    def _backward(self, model, input_ids):
+        model(input_ids=input_ids).last_hidden_state.float().pow(2).mean().backward()
+
+    def test_gradients_match_the_non_offloaded_run(self):
+        model = self._model()
+        input_ids = torch.randint(0, 128, (1, 64), device=torch_device)
+
+        model.gradient_checkpointing_enable()
+        self._backward(model, input_ids)
+        expected = [p.grad.clone() for p in model.parameters()]
+
+        model.zero_grad(set_to_none=True)
+        model.gradient_checkpointing_enable(offload=True)
+        self._backward(model, input_ids)
+
+        for expected_grad, param in zip(expected, model.parameters()):
+            torch.testing.assert_close(param.grad, expected_grad)
+
+    def test_frees_exactly_the_saved_activations(self):
+        num_hidden_layers, hidden_size, seq_len = 8, 256, 2048
+        # Each checkpointed layer saves one `seq_len x hidden_size` input for its recompute.
+        saved_bytes = num_hidden_layers * seq_len * hidden_size * 4  # fp32
+
+        resident = []
+        for offload in (False, True):
+            model = self._model(num_hidden_layers, hidden_size)
+            model.gradient_checkpointing_enable(offload=offload)
+            input_ids = torch.randint(0, 128, (1, seq_len), device=torch_device)
+            self._backward(model, input_ids)  # warm the allocator
+            model.zero_grad(set_to_none=True)
+            torch.accelerator.synchronize()
+            torch.accelerator.empty_cache()
+
+            # Sampled after the forward, where every layer's saved input is still live.
+            base = torch.accelerator.memory_allocated()
+            output = model(input_ids=input_ids)
+            torch.accelerator.synchronize()
+            resident.append(torch.accelerator.memory_allocated() - base)
+            del output, model
+
+        self.assertEqual(resident[0] - resident[1], saved_bytes)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48444&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48444) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48444&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48444)
<!-- ci-dashboard-badge:end -->

Gradient checkpointing still keeps one activation per checkpointed layer on the device. At long sequence lengths that is the dominant term: `layers x sequence x hidden` bytes, so Qwen3-8B at 128k tokens is 36 GB of it. This adds an option to hold those in pinned host memory instead.

```py
args = TrainingArguments(
    gradient_checkpointing=True,
    gradient_checkpointing_kwargs={"offload": True},
)
```

It is a wrap of `gradient_checkpointing_func` around torch's `save_on_cpu(pin_memory=True)`, so it follows whichever path the model already uses and needs no per-model support.

## It frees exactly what the arithmetic says

Memory resident after the forward, where every layer's saved input is still live. Qwen3 config, bf16, one H100:

| layers x hidden x seq | resident, plain | resident, offload | freed | `layers x seq x hidden x 2` |
|---|---|---|---|---|
| 8 x 1024 x 8k | 194.1 MB | 66.1 MB | 128.0 MB | 128.0 MB |
| 16 x 1024 x 16k | 644.2 MB | 132.2 MB | 512.0 MB | 512.0 MB |
| 28 x 2048 x 32k | 4112.4 MB | 528.4 MB | 3584.0 MB | 3584.0 MB |

(How much of that shows up in *peak* memory depends on where your peak is. On the 28-layer run above the peak only moved 11.13 -> 10.16 GB, because it sits at the end of the backward where gradients dominate and the saved inputs are already freed. The option pays off when activations dominate the peak, which is the long-sequence case it is meant for.)

## Cost

Both copies run on the compute stream, so the step gets slower. There is no separate copy stream and no backward prefetch; that is pytorch/pytorch#158657, and this option does not wait for it.

## Setups

Qwen3-1.7B base, 32k tokens, peak memory. The DeepSpeed row is at 8k: at 32k that engine takes a materializing attention path and asks for a 64 GiB allocation, unrelated to this option.

| | plain | offload |
|---|---|---|
| single GPU | 11.13 GB | 10.16 GB |
| FSDP2, 2 GPUs | 9.73 GB | 8.06 GB |
| DeepSpeed ZeRO-3, 2 GPUs (8k tokens) | 34.12 GB | 32.93 GB |