### PR TITLE
CI: improve gated repo failures flow

### DIFF
--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -15,12 +15,14 @@ on:
         default: 'none'
 
 env:
+  # For gated repositories, we still need to agree to share information on the Hub repo. page in order to get access.
+  # This token is created under the bot `hf-transformers-bot`.
   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   HF_HOME: /mnt/cache
   TRANSFORMERS_IS_CI: yes
   OMP_NUM_THREADS: 8
   MKL_NUM_THREADS: 8
-  RUN_SLOW: yes # For gated repositories, we still need to agree to share information on the Hub repo. page in order to get access. # This token is created under the bot `hf-transformers-bot`.
+  RUN_SLOW: yes
   TF_FORCE_GPU_ALLOW_GROWTH: true
   CUDA_VISIBLE_DEVICES: 0,1
 

--- a/docs/source/en/testing.md
+++ b/docs/source/en/testing.md
@@ -382,6 +382,45 @@ expected_texts = Expectations(
 self.assertEqual(output, expected_texts)
 ```
 
+#### Gated checkpoints
+
+The CI workflows export `HF_TOKEN` for every test, so no decorator is needed to *authenticate* — a token is always
+present. What a token does not give you is authorization: gated repos keep a per-account allowlist, and the CI token
+belongs to the [`hf-transformers-bot`](https://huggingface.co/hf-transformers-bot) Hub account. Until that account is
+on the allowlist, every test touching the checkpoint fails with `You are trying to access a gated repo`.
+
+Nothing in the test suite can work around this, and nothing should: a missing allowlist entry is a fixable permission
+gap, so it has to stay visible until someone fixes it. Do not skip the test, and do not fall back to a tiny model —
+either one silently drops coverage of the real checkpoint.
+
+Instead, get the bot access. Check how the repo is gated first:
+
+```py
+from huggingface_hub import model_info
+
+print(model_info("neuphonic/neucodec", expand=["gated"]).gated)  # 'auto', 'manual', or False
+```
+
+- `"auto"` — submitting the access form once as `hf-transformers-bot` grants access immediately.
+- `"manual"` — the repo owner has to approve the request, so it can stay pending indefinitely.
+
+Either way the request has to be made **from a browser, while logged in as the bot**: the Hub has no
+requester-side API for this. The `huggingface_hub` methods that look relevant (`grant_access`,
+`accept_access_request`) are for repo *owners* and need a write token on the gated repo. Access is also always
+granted to an individual account, never to an organization, so it is specifically `hf-transformers-bot` that has to
+be allowlisted. Repos may ask for extra fields beyond the username and email (`neuphonic/neucodec`, for instance,
+asks for an affiliation and a role), so whoever does this has to fill the form in.
+
+Once it is done, confirm the bot can actually read the repo:
+
+```bash
+HF_TOKEN=<bot token> python -c "from huggingface_hub import auth_check; auth_check('neuphonic/neucodec')"
+```
+
+Contributors cannot do any of this themselves; the bot's credentials are held by the maintainers. Ask a maintainer on
+the PR. Note also that a repo owner can revoke access at any time without notice, even for an `"auto"` repo, so a
+checkpoint that used to work can start failing without anything changing in the codebase.
+
 ### Creating tiny models
 
 Tiny models with random weights live on the Hub under the [hf-internal-testing](https://huggingface.co/hf-internal-testing) organization. Pipeline tests rely on tiny models when they need a Hub-hosted checkpoint but don't care about output quality. Fast smoke tests also load tiny models to verify forward pass shapes without downloading large checkpoints.

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -508,9 +508,13 @@ def cached_files(
         if isinstance(e, GatedRepoError):
             if not _raise_exceptions_for_gated_repo:
                 return None
-            raise OSError(
+            # Keep the precise `GatedRepoError` class rather than flattening it into a plain `OSError`: it is itself an
+            # `OSError` subclass, so `except OSError` callers are unaffected, and callers (as well as CI log triage)
+            # can tell a missing permission apart from any other hub failure without matching on the message.
+            raise GatedRepoError(
                 "You are trying to access a gated repo.\nMake sure to have access to it at "
-                f"https://huggingface.co/{path_or_repo_id}.\n{str(e)}"
+                f"https://huggingface.co/{path_or_repo_id}.\n{str(e)}",
+                response=e.response,
             ) from e
         elif isinstance(e, LocalEntryNotFoundError):
             if not _raise_exceptions_for_connection_errors:
@@ -625,10 +629,13 @@ def has_file(
         return True
     except GatedRepoError as e:
         logger.error(e)
-        raise OSError(
+        # See the note in `cached_files`: `GatedRepoError` is an `OSError` subclass, so raising it instead of a plain
+        # `OSError` keeps callers working while preserving what actually went wrong.
+        raise GatedRepoError(
             f"{path_or_repo} is a gated repository. Make sure to request access at "
             f"https://huggingface.co/{path_or_repo} and pass a token having permission to this repo either by "
-            "logging in with `hf auth login` or by passing `token=<your_token>`."
+            "logging in with `hf auth login` or by passing `token=<your_token>`.",
+            response=e.response,
         ) from e
     except RepositoryNotFoundError as e:
         logger.error(e)

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -25,6 +25,48 @@ import git
 from github_utils import get_github_json
 
 
+# A gated-repo failure surfaces as the `GatedRepoError` class name, and as the message text raised by
+# `transformers.utils.hub`. Both are matched because this script re-runs a test at older commits, which may predate
+# either wording, and the failure has to be classified the same way at every commit.
+GATED_REPO_FAILURES = (
+    "You are trying to access a gated repo",
+    "is a gated repository",
+    "GatedRepoError",
+)
+
+# Failure messages that depend on the environment rather than on the code under test. They are normalized before
+# comparing the failures observed at two commits, so that e.g. two OOMs reporting different byte counts still count as
+# the same failure.
+ENVIRONMENT_FAILURES = ("torch.OutOfMemoryError: CUDA out of memory", *GATED_REPO_FAILURES)
+
+# Failures that a code change cannot possibly cause, as (patterns, explanation) pairs. Bisecting them is pointless:
+# they reproduce at every commit where the test exists, so the bisect can only ever land on the commit that added the
+# test and blame its author.
+NON_CODE_FAILURES = (
+    (
+        GATED_REPO_FAILURES,
+        "the token used by the CI is not on the allowlist of a gated Hub repo. A maintainer has to grant access to the "
+        "`hf-transformers-bot` account; see the `Gated checkpoints` section of `docs/source/en/testing.md`.",
+    ),
+)
+
+
+def normalize_failure(failure_message):
+    """Collapse an environment-dependent failure message to a stable form, so two occurrences compare equal."""
+    for pattern in ENVIRONMENT_FAILURES:
+        if pattern in failure_message:
+            return pattern
+    return failure_message
+
+
+def get_non_code_failure(failure_message):
+    """Return an explanation if `failure_message` cannot have been caused by a code change, `None` otherwise."""
+    for patterns, explanation in NON_CODE_FAILURES:
+        if any(pattern in failure_message for pattern in patterns):
+            return explanation
+    return None
+
+
 def create_script(target_test, flake_runs=4):
     """Create a python script to be run by `git bisect run` to determine if `target_test` passes or fails.
     If a test is not found in a commit, the script with exit code `0` (i.e. `Success`).
@@ -131,6 +173,7 @@ def find_bad_commit(target_test, start_commit, end_commit):
     result = {
         "bad_commit": None,
         "status": None,
+        "is_environment_failure": False,
         "failure_at_workflow_commit": None,
         "failure_at_base_commit": None,
         "failure_at_bad_commit": None,
@@ -193,15 +236,18 @@ def find_bad_commit(target_test, start_commit, end_commit):
     #   - if the CI is run on PR: this block checks if the test also failed on `start_commit`.
     #   - otherwise: the test passed on `end_commit` --> an actual new failing test, this block is skipped.
 
-    # TODO: A helper method to handle this and other possible error messages in a clean and centralized way.
-    failure_at_workflow_commit_processed = failure_at_workflow_commit
-    failure_at_base_commit_processed = failure_at_base_commit
-    if "torch.OutOfMemoryError: CUDA out of memory" in failure_at_workflow_commit_processed:
-        failure_at_workflow_commit_processed = "torch.OutOfMemoryError: CUDA out of memory"
-    if "torch.OutOfMemoryError: CUDA out of memory" in failure_at_base_commit_processed:
-        failure_at_base_commit_processed = "torch.OutOfMemoryError: CUDA out of memory"
+    # A failure that no code change could have caused is reported as-is, without a bad commit: bisecting it would
+    # burn runner time to blame whoever added the test for a broken environment.
+    non_code_failure = get_non_code_failure(failure_at_workflow_commit)
+    if non_code_failure is not None:
+        result["status"] = f"not caused by a code change: {non_code_failure}"
+        result["is_environment_failure"] = True
+        result["failure_at_workflow_commit"] = failure_at_workflow_commit
+        result["failure_at_base_commit"] = failure_at_base_commit
+        result["failure_at_bad_commit"] = ""
+        return result
 
-    different_failures = failure_at_workflow_commit_processed != failure_at_base_commit_processed
+    different_failures = normalize_failure(failure_at_workflow_commit) != normalize_failure(failure_at_base_commit)
 
     if is_pr_ci and failure_at_base_commit != "" and different_failures:
         result["bad_commit"] = start_commit

--- a/utils/process_bad_commit_report.py
+++ b/utils/process_bad_commit_report.py
@@ -21,6 +21,11 @@ from get_previous_daily_ci import get_last_daily_ci_run
 from huggingface_hub import HfApi
 
 
+# Bucket for failures that no code change could have caused, so that they stay visible in the report without being
+# attributed to the author of the test that surfaced them.
+ENVIRONMENT_FAILURE_LABEL = "CI environment (not a regression)"
+
+
 if __name__ == "__main__":
     api = HfApi()
 
@@ -103,11 +108,17 @@ if __name__ == "__main__":
     for model, model_result in data.items():
         for device, failed_tests in model_result.items():
             for failed_test in failed_tests:
-                author = failed_test["author"]
+                if failed_test.get("is_environment_failure"):
+                    # No code change could have caused this failure (see `utils/check_bad_commit.py`), so it is not
+                    # anyone's regression. Group it under a fixed label rather than counting it against an author: it
+                    # still needs someone to act on it, but blaming the last person to touch the test is wrong.
+                    author = ENVIRONMENT_FAILURE_LABEL
+                else:
+                    author = failed_test["author"]
 
-                # If author is not a team member, and the PR is already merged: change to the one who merged the PR
-                if author not in team_members and failed_test["merged_by"] is not None:
-                    author = failed_test["merged_by"]
+                    # If author is not a team member, and the PR is already merged: change to the one who merged the PR
+                    if author not in team_members and failed_test["merged_by"] is not None:
+                        author = failed_test["merged_by"]
 
                 if author not in new_data:
                     new_data[author] = Counter()
@@ -123,7 +134,11 @@ if __name__ == "__main__":
                 failed_tests = [
                     x
                     for x in failed_tests
-                    if x["author"] == author or (x["merged_by"] is not None and x["merged_by"] == author)
+                    if (
+                        author == ENVIRONMENT_FAILURE_LABEL
+                        if x.get("is_environment_failure")
+                        else x["author"] == author or (x["merged_by"] is not None and x["merged_by"] == author)
+                    )
                 ]
                 model_result[device] = failed_tests
             _data[model] = {k: v for k, v in model_result.items() if len(v) > 0}


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48451&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48451) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48451&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48451)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

When a gated repo is not allowed in the hub bot, we get a 403, but the current flow will treat this like a code error and will do the heavy bisect work

This patch shortcuts this when we know we can't access the gated repo and make the error explicit. This does not change the reporting in the PR.

I also added a doc section about gated repos