### PR TITLE
No inherit decorator for NeoMME

### DIFF
--- a/src/transformers/models/neomme/modeling_neomme.py
+++ b/src/transformers/models/neomme/modeling_neomme.py
@@ -27,7 +27,6 @@ from torch import nn
 
 from ... import initialization as init
 from ...activations import ACT2FN
-from ...integrations import use_kernelized_func
 from ...masking_utils import create_bidirectional_mask, create_bidirectional_sliding_window_mask
 from ...modeling_layers import GradientCheckpointingLayer
 from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling, MaskedLMOutput
@@ -269,7 +268,6 @@ def eager_attention_forward(
     return attn_output, attn_weights
 
 
-@use_kernelized_func(apply_rotary_pos_emb)
 class NeoMMEAttention(nn.Module):
     """Bidirectional grouped-query attention with QK-norm, M-RoPE, and a sigmoid output gate.
 

--- a/src/transformers/models/neomme/modular_neomme.py
+++ b/src/transformers/models/neomme/modular_neomme.py
@@ -37,6 +37,7 @@ from ...utils import (
     TensorType,
     TransformersKwargs,
     auto_docstring,
+    no_inherit_decorator,
     torch_compilable_check,
 )
 from ...utils.constants import IMAGENET_STANDARD_MEAN, IMAGENET_STANDARD_STD
@@ -328,6 +329,7 @@ class NeoMMESigmoidGatedProjection(nn.Module):
         return self.o_proj(attn_output * torch.sigmoid(self.gate_proj(hidden_states)))
 
 
+@no_inherit_decorator
 class NeoMMEAttention(MuseGlimmerTextAttention):
     """Bidirectional grouped-query attention with QK-norm, M-RoPE, and a sigmoid output gate.
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48457&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48457) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48457&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48457)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

In kernels==0.16.0 we get an error when trying to import the model  -`f"Function `apply_rotary_pos_emb` is not decorated with @use_kernel_forward_from_hub and cannot be used with @use_kernelized_func"`

Seems like we do not have `kernels` in CI otherwise I dont know how it got merged and never failed