### PR TITLE
[docs] Partial checkpointing and group_by_length

### DIFF
--- a/docs/source/en/grad_checkpointing.md
+++ b/docs/source/en/grad_checkpointing.md
@@ -87,6 +87,10 @@ args = TrainingArguments(
 )
 ```
 
+<div class="flex">
+  <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/partial-grad-ckpt.png" />
+</div>
+
 ## Offloading the saved activations
 
 Gradient checkpointing keeps one activation per checkpointed layer on the GPU. At long sequence lengths, this can

--- a/docs/source/en/grad_checkpointing.md
+++ b/docs/source/en/grad_checkpointing.md
@@ -27,7 +27,8 @@ Gradient checkpointing:
   Backward:  ←reaches L2, recomputes L2→L3 from scratch, uses it, discards it
 ```
 
-Training will be ~20% slower because some activations need to be recomputed, but it reduces activation memory.
+Training is typically slower because the backward pass recomputes discarded activations, but checkpointing reduces
+activation memory.
 
 Set `gradient_checkpointing=True` to enable.
 
@@ -43,9 +44,55 @@ args = TrainingArguments(
 )
 ```
 
+## Partial checkpointing
+
+Full gradient checkpointing recomputes every checkpointable layer. If your run has some memory headroom, checkpoint
+fewer layers to trade some of the memory savings for speed.
+
+Pass `every_n_layers` to [`~PreTrainedModel.gradient_checkpointing_enable`] to choose the
+checkpointing interval.
+
+```text
+every_n_layers=2
+
+Forward:   input  -> [L1] -> [L2] -> [L3] -> [L4] -> [L5] -> [L6]
+                      CP     keep     CP     keep     CP     keep
+
+Backward:  output <- [L6] <- [L5] <- [L4] <- [L3] <- [L2] <- [L1]
+                     keep   rerun    keep   rerun    keep   rerun
+```
+
+With `every_n_layers=2`, the first layer and every second layer after it are checkpointed. Checkpointed layers discard
+their activations during the forward pass and recompute them during the backward pass, while the other layers keep their
+activations in memory.
+
+```py
+model.gradient_checkpointing_enable(every_n_layers=2)
+```
+
+The default, `every_n_layers=1`, checkpoints every layer. Larger values checkpoint the first layer and then every `n`
+layers after it, leaving the other layers' activations in memory. For example, `every_n_layers=2` checkpoints
+layers 1, 3, 5, and so on. Only modules that inherit from [`GradientCheckpointingLayer`] are counted. Other modules
+that support gradient checkpointing remain enabled.
+
+To use partial gradient checkpointing with [`Trainer`], set `every_n_layers` in `gradient_checkpointing_kwargs`.
+
+```py
+from transformers import TrainingArguments
+
+args = TrainingArguments(
+    ...,
+    gradient_checkpointing=True,
+    gradient_checkpointing_kwargs={"every_n_layers": 4},
+)
+```
+
 ## Offloading the saved activations
 
-Gradient checkpointing still keeps one activation per checkpointed layer on the GPU, and at long sequence lengths that alone is large: `layers x sequence x hidden` bytes, so 36 layers of an 8B model at 128k tokens is 36 GB. Set `offload` to hold those in pinned host memory instead, and pay a device-to-host copy in the forward and a host-to-device copy in the backward for them.
+Gradient checkpointing keeps one activation per checkpointed layer on the GPU. At long sequence lengths, this can
+consume substantial memory (approximately `layers x sequence x hidden x bytes_per_element`). Set `offload` to hold
+those activations in pinned host memory instead, at the cost of a device-to-host copy during the forward pass and a
+host-to-device copy during the backward pass.
 
 ```py
 from transformers import TrainingArguments

--- a/docs/source/en/trainer_recipes.md
+++ b/docs/source/en/trainer_recipes.md
@@ -157,6 +157,26 @@ args = TrainingArguments(
 )
 ```
 
+## Group samples by length
+
+Use `train_sampling_strategy="group_by_length"` to batch examples with similar lengths and reduce padding. When you
+don't provide precomputed lengths, [`Trainer`] infers them from the first model input in each dataset item. This also
+works when processor-based multimodal datasets return [`BatchFeature`] objects, because they are mapping-like feature
+containers.
+
+```py
+from transformers import TrainingArguments
+
+training_args = TrainingArguments(
+    output_dir="qwen3-vl-finetuned",
+    train_sampling_strategy="group_by_length",
+)
+```
+
+If a [`~datasets.Dataset`] already has a precomputed length column, [`Trainer`] uses that column instead. The default
+column name is `length`. Set `length_column_name` when your dataset uses another name. This strategy requires a
+dataset with a known length and is ignored for [`~datasets.IterableDataset`].
+
 ## Batch rebalance sampling
 
 On variable-length datasets, imbalance within a micro-batch and across devices causes devices to waste time on padding and to idle at gradient synchronization steps.

--- a/docs/source/en/training.md
+++ b/docs/source/en/training.md
@@ -99,6 +99,7 @@ model = AutoModelForCausalLM.from_pretrained(model_name, dtype="auto")
 - Set `bf16=True` for fast mixed precision training if your hardware supports it (Ampere+ GPUs). Otherwise, fall back to `fp16=True` on older hardware.
 - `gradient_accumulation_steps` simulates a larger effective batch size by accumulating gradients over multiple forward passes before updating weights.
 - `gradient_checkpointing` trades compute for memory by recomputing intermediate activations during the backward pass instead of storing them. For a compromise between memory and speed, see [partial checkpointing](./grad_checkpointing#partial-checkpointing).
+- When `gradient_checkpointing=True`, set `gradient_checkpointing_kwargs={"offload": True}` to keep saved activations in pinned host memory and reduce GPU memory usage for long sequences. See [offloading the saved activations](./grad_checkpointing#offloading-the-saved-activations) for the trade-off.
 - Set `train_sampling_strategy="group_by_length"` to batch examples with similar lengths and reduce padding. See [group samples by length](./trainer_recipes#group-samples-by-length) for processor-based multimodal datasets and precomputed lengths.
 
 </hfoption>

--- a/docs/source/en/training.md
+++ b/docs/source/en/training.md
@@ -98,7 +98,8 @@ model = AutoModelForCausalLM.from_pretrained(model_name, dtype="auto")
 
 - Set `bf16=True` for fast mixed precision training if your hardware supports it (Ampere+ GPUs). Otherwise, fall back to `fp16=True` on older hardware.
 - `gradient_accumulation_steps` simulates a larger effective batch size by accumulating gradients over multiple forward passes before updating weights.
-- `gradient_checkpointing` trades compute for memory by recomputing intermediate activations during the backward pass instead of storing them.
+- `gradient_checkpointing` trades compute for memory by recomputing intermediate activations during the backward pass instead of storing them. For a compromise between memory and speed, see [partial checkpointing](./grad_checkpointing#partial-checkpointing).
+- Set `train_sampling_strategy="group_by_length"` to batch examples with similar lengths and reduce padding. See [group samples by length](./trainer_recipes#group-samples-by-length) for processor-based multimodal datasets and precomputed lengths.
 
 </hfoption>
 <hfoption id="evaluation and checkpointing">
@@ -121,6 +122,7 @@ training_args = TrainingArguments(
     per_device_train_batch_size=2,
     gradient_accumulation_steps=8,
     gradient_checkpointing=True,
+    gradient_checkpointing_kwargs={"every_n_layers": 4},
     bf16=True,
     learning_rate=2e-5,
     logging_steps=10,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48463&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48463) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48463&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48463)
<!-- ci-dashboard-badge:end -->

Adds docs for partial gradient checkpointing (#48200), `group_by_length` for processors (#48034), and a link to activation offloading.