### PR TITLE
Fix GPT-NeoX float64 attention softmax precision downcast

### DIFF
--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -166,7 +166,8 @@ def eager_attention_forward(
     if attention_mask is not None:
         attn_weights = attn_weights + attention_mask
 
-    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    dtype = torch.promote_types(query.dtype, torch.float32)
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=dtype).to(query.dtype)
 
     attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
     attn_output = torch.matmul(attn_weights, value)

--- a/src/transformers/models/gpt_neox/modular_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modular_gpt_neox.py
@@ -115,7 +115,8 @@ def eager_attention_forward(
     if attention_mask is not None:
         attn_weights = attn_weights + attention_mask
 
-    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    dtype = torch.promote_types(query.dtype, torch.float32)
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=dtype).to(query.dtype)
 
     attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
     attn_output = torch.matmul(attn_weights, value)

--- a/tests/models/gpt_neox/test_modeling_gpt_neox.py
+++ b/tests/models/gpt_neox/test_modeling_gpt_neox.py
@@ -334,6 +334,29 @@ class GPTNeoXModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     def test_feed_forward_chunking(self):
         pass
 
+    def test_eager_attention_float64_resolution(self):
+        """Ensure float64 attention softmax retains float64 resolution without downcasting to float32."""
+        from transformers.models.gpt_neox.modeling_gpt_neox import eager_attention_forward
+
+        class DummyModule(torch.nn.Module):
+            pass
+
+        dummy = DummyModule()
+        q = torch.randn(1, 4, 16, 32, dtype=torch.float64)
+        k = torch.randn(1, 4, 16, 32, dtype=torch.float64)
+        v = torch.randn(1, 4, 16, 32, dtype=torch.float64)
+
+        out1, _ = eager_attention_forward(dummy, q, k, v, attention_mask=None, scaling=1.0)
+
+        delta = torch.zeros_like(q)
+        delta[0, 0, 0, 0] = 1e-9
+
+        out2, _ = eager_attention_forward(dummy, q + delta, k, v, attention_mask=None, scaling=1.0)
+        diff = (out2 - out1).abs().max().item()
+
+        # In float64, a 1e-9 perturbation in query should produce a measurable non-zero difference
+        self.assertGreater(diff, 0.0)
+
 
 @require_torch
 class GPTNeoXLanguageGenerationTest(unittest.TestCase):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48466&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48466) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48466&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48466)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48459.

In `GPTNeoX` eager attention (`eager_attention_forward`), the attention softmax previously hardcoded `dtype=torch.float32`:
```python
attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
```
While `dtype=torch.float32` provides numerical stability when running lower-precision (`float16`/`bfloat16`) models, it unconditionally downcasts `torch.float64` inputs to `float32` resolution before casting back to `float64`.

This PR updates the softmax dtype to:
```python
dtype = torch.promote_types(query.dtype, torch.float32)
attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=dtype).to(query.dtype)
```
- For `float16` and `bfloat16`, `dtype` resolves to `float32`, preserving the existing numerical stability upcasting.
- For `float32`, `dtype` resolves to `float32` (bitwise identical output).
- For `float64`, `dtype` resolves to `float64`, preserving full double-precision resolution without intermediate downcasting.

## Changes
1. Updated `eager_attention_forward` in `src/transformers/models/gpt_neox/modular_gpt_neox.py`.
2. Synchronized `src/transformers/models/gpt_neox/modeling_gpt_neox.py` via modular model converter.
3. Added `test_eager_attention_float64_resolution` to `tests/models/gpt_neox/test_modeling_gpt_neox.py`.

## Testing
- Verified with unit tests: `pytest tests/models/gpt_neox/test_modeling_gpt_neox.py` (150 passed).
- Verified `ruff check` and `ruff format` on touched files.