### PR TITLE
Preserve full request history for continuous batching logits processors

### DIFF
--- a/src/transformers/generation/continuous_batching/cb_logits_processors.py
+++ b/src/transformers/generation/continuous_batching/cb_logits_processors.py
@@ -91,6 +91,8 @@ class ContinuousBatchingLogitsProcessorList:
         self._retrieve_processors_kwargs()
         # Static boolean to know if there is any logits processing to do. Helps with torch.compile().
         self.do_processing = len(self.logits_processor) > 0
+        # Supported classic processors other than the input-independent warpers need each request's exact token history.
+        self.requires_full_history = any(self._requires_full_history(processor) for processor in self.logits_processor)
 
     def __repr__(self) -> str:
         return f"ContinuousBatchingLogitsProcessorList(logits_processor={self.logits_processor}, tensors_required={self.tensors_required})"
@@ -101,6 +103,15 @@ class ContinuousBatchingLogitsProcessorList:
         self.supported_keys = {}
         self.ignored_keys = set()
         self.do_processing = False
+        self.requires_full_history = False
+
+    @staticmethod
+    def _requires_full_history(processor) -> bool:
+        return (
+            not isinstance(processor, ContinuousBatchingLogitsProcessor)
+            and not isinstance(processor, tuple(CLASSIC_TO_CB_PROCESSORS_MAP))
+            and getattr(processor, "supports_continuous_batching", None) is True
+        )
 
     def _convert_to_per_request_processors(self) -> None:
         """Replaces the compatible logits processors with their per-request versions."""
@@ -210,6 +221,34 @@ class ContinuousBatchingLogitsProcessorList:
                 current_arg_id += 1
             else:
                 scores = processor(input_ids, scores)
+        return scores
+
+    def apply_with_full_history(
+        self,
+        input_ids: list[torch.LongTensor],
+        scores: torch.FloatTensor,
+        logits_processor_args: torch.Tensor,
+    ) -> torch.FloatTensor:
+        """Apply processors while preserving the exact token history of every request."""
+        if len(input_ids) != scores.size(0):
+            raise ValueError(f"Expected {scores.size(0)} token histories, but received {len(input_ids)}.")
+
+        current_arg_id = 0
+        for processor in self.logits_processor:
+            if isinstance(processor, ContinuousBatchingLogitsProcessor):
+                scores = processor(scores, logits_processor_args[current_arg_id])
+                current_arg_id += 1
+                continue
+
+            if self._requires_full_history(processor):
+                processed_scores = [
+                    processor(request_input_ids.unsqueeze(0), request_scores.unsqueeze(0))
+                    for request_input_ids, request_scores in zip(input_ids, scores)
+                ]
+                scores = torch.cat(processed_scores, dim=0)
+            else:
+                current_input_ids = torch.stack([request_input_ids[-1] for request_input_ids in input_ids])
+                scores = processor(current_input_ids, scores)
         return scores
 
 

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -644,6 +644,7 @@ class ContinuousBatchingManager:
             cb_config=continuous_batching_config,
             workload_hints=workload_hints,
             has_logit_processors=self.logit_processor.do_processing,
+            requires_full_history=self.logit_processor.requires_full_history,
         )
         # This is an approximation until the cache is created: it will infer the correct value in cache.__init__
         self._use_prefix_sharing = self.continuous_batching_config.allow_block_sharing

--- a/src/transformers/generation/continuous_batching/initialization.py
+++ b/src/transformers/generation/continuous_batching/initialization.py
@@ -41,6 +41,7 @@ def resolve_continuous_batching_config(
     cb_config: ContinuousBatchingConfig,
     workload_hints: WorkloadHints | None,
     has_logit_processors: bool,
+    requires_full_history: bool = False,
 ) -> ContinuousBatchingConfig:
     """Returns a deep-copied and fully-resolved `ContinuousBatchingConfig`. The original `cb_config` is not mutated."""
     cb_config = deepcopy(cb_config)
@@ -75,6 +76,9 @@ def resolve_continuous_batching_config(
 
     # Decide if asynchronous batching should be used. Should happen after CUDA graphs are decided.
     decide_use_async_batching(cb_config=cb_config, is_attn_mask_needed=is_attn_mask_needed)
+
+    if requires_full_history:
+        disable_acceleration_for_full_history_processors(cb_config)
 
     # Resolve the max memory percent. This can happen anytime before cache creation.
     resolve_max_memory_percent(cb_config=cb_config, has_logit_processors=has_logit_processors)
@@ -264,6 +268,28 @@ def decide_use_async_batching(cb_config: ContinuousBatchingConfig, is_attn_mask_
             f"No behavior specified for use_async_batching, choosing {cb_config.use_async_batching = } because "
             f"{use_cuda_graphs = } and {is_attn_mask_needed = }. If you want to save memory, you can "
             "disable asynchronous batching but it will degrade performance."
+        )
+
+
+def disable_acceleration_for_full_history_processors(cb_config: ContinuousBatchingConfig) -> None:
+    """Use eager synchronous execution when logits processors require variable-length request histories."""
+    disabled = []
+    if cb_config.varlen_compile_config is not None or cb_config.decode_compile_config is not None:
+        disabled.append("torch.compile")
+    if any(cb_config.cuda_graph_booleans):
+        disabled.append("CUDA graphs")
+    if cb_config.use_async_batching:
+        disabled.append("asynchronous batching")
+
+    cb_config.varlen_compile_config = None
+    cb_config.decode_compile_config = None
+    cb_config.use_cuda_graph = (False, False)
+    cb_config.use_async_batching = False
+
+    if disabled:
+        logger.warning(
+            "Logits processors that inspect token history require eager synchronous execution. Disabling "
+            f"{', '.join(disabled)}."
         )
 
 

--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -297,6 +297,18 @@ class ContinuousBatchingIOs:
         """Get the cumulative sequence lengths for the current batch."""
         return self.cumulative_seqlens_q, self.cumulative_seqlens_k
 
+    def get_token_histories(self, device: torch.device) -> list[torch.LongTensor]:
+        """Return the complete token history for each request that will produce a new token."""
+        return [
+            torch.tensor(
+                future_state.state.initial_tokens + future_state.state.generated_tokens,
+                dtype=torch.long,
+                device=device,
+            )
+            for future_state in self.requests_in_batch
+            if future_state.has_new_token
+        ]
+
     def carry_over_tokens(
         self, input_ids: torch.Tensor, carry_over_ids: torch.Tensor, prev_output_ids: torch.Tensor
     ) -> None:

--- a/src/transformers/generation/continuous_batching/model_runner.py
+++ b/src/transformers/generation/continuous_batching/model_runner.py
@@ -184,9 +184,14 @@ class ModelRunner:
             # Handle shape inconsistency between generate and continuous batching (dummy_dim is always 1)
             dummy_dim, num_logits, vocab_size = logits.shape
             logits_2d = logits.view(dummy_dim * num_logits, vocab_size)
-            sliced_input_ids_2d = batch_data["input_ids"][0, logits_indices]  # shape [num_logits]
-            # Process with 2D tensors
-            logits_2d = self.logit_processor(sliced_input_ids_2d, logits_2d, batch_data["logits_processor_args"])
+            if self.logit_processor.requires_full_history:
+                token_histories = self.inputs_and_outputs.get_token_histories(logits.device)
+                logits_2d = self.logit_processor.apply_with_full_history(
+                    token_histories, logits_2d, batch_data["logits_processor_args"]
+                )
+            else:
+                sliced_input_ids_2d = batch_data["input_ids"][0, logits_indices]  # shape [num_logits]
+                logits_2d = self.logit_processor(sliced_input_ids_2d, logits_2d, batch_data["logits_processor_args"])
             # Reshape back to 3D
             scores = logits_2d.view(dummy_dim, num_logits, vocab_size)
         else:

--- a/src/transformers/generation/continuous_batching/model_runner.py
+++ b/src/transformers/generation/continuous_batching/model_runner.py
@@ -185,6 +185,8 @@ class ModelRunner:
             dummy_dim, num_logits, vocab_size = logits.shape
             logits_2d = logits.view(dummy_dim * num_logits, vocab_size)
             if self.logit_processor.requires_full_history:
+                if isinstance(self.inputs_and_outputs, ContinuousBatchingAsyncIOs):
+                    raise RuntimeError("Full-history logits processors require synchronous batching.")
                 token_histories = self.inputs_and_outputs.get_token_histories(logits.device)
                 logits_2d = self.logit_processor.apply_with_full_history(
                     token_histories, logits_2d, batch_data["logits_processor_args"]

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -137,7 +137,7 @@ class MinLengthLogitsProcessor(LogitsProcessor):
     ```
     """
 
-    supports_continuous_batching: bool = False
+    supports_continuous_batching: bool = True
 
     def __init__(self, min_length: int, eos_token_id: int | list[int] | torch.Tensor, device: str = "cpu"):
         if not isinstance(min_length, int) or min_length < 0:
@@ -353,7 +353,7 @@ class RepetitionPenaltyLogitsProcessor(LogitsProcessor):
     ```
     """
 
-    supports_continuous_batching = False
+    supports_continuous_batching = True
 
     def __init__(self, penalty: float, prompt_ignore_length: int | None = None):
         if not isinstance(penalty, float) or not (penalty > 0):
@@ -1112,6 +1112,8 @@ class NoRepeatNGramLogitsProcessor(LogitsProcessor):
     ```
     """
 
+    supports_continuous_batching = True
+
     def __init__(self, ngram_size: int):
         if not isinstance(ngram_size, int) or ngram_size <= 0:
             raise ValueError(f"`ngram_size` has to be a strictly positive integer, but is {ngram_size}")
@@ -1272,6 +1274,8 @@ class SequenceBiasLogitsProcessor(LogitsProcessor):
     The full name of Donald is Donald Duck. He is
     ```
     """
+
+    supports_continuous_batching = True
 
     def __init__(self, sequence_bias: list[list[list[int] | float]]):
         # After _convert_list_arguments_into_dict(), becomes dict[tuple[int, ...], float]
@@ -1585,6 +1589,8 @@ class ForcedBOSTokenLogitsProcessor(LogitsProcessor):
     ```
     """
 
+    supports_continuous_batching = True
+
     def __init__(self, bos_token_id: int):
         self.bos_token_id = bos_token_id
 
@@ -1631,6 +1637,8 @@ class ForcedEOSTokenLogitsProcessor(LogitsProcessor):
     A sequence: 1, 2, 3, 4, 5, 6, 7,<|endoftext|>
     ```
     """
+
+    supports_continuous_batching = True
 
     def __init__(self, max_length: int, eos_token_id: int | list[int] | torch.Tensor, device: str = "cpu"):
         self.max_length = max_length
@@ -1847,6 +1855,8 @@ class SuppressTokensAtBeginLogitsProcessor(LogitsProcessor):
     tensor(11.2027)
     ```
     """
+
+    supports_continuous_batching = True
 
     def __init__(self, begin_suppress_tokens, begin_index, device: str = "cpu"):
         self.begin_suppress_tokens = torch.tensor(list(begin_suppress_tokens), device=device)

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -41,15 +41,34 @@ from transformers.generation.continuous_batching.cache import (
     group_layers_by_attn_type,
 )
 from transformers.generation.continuous_batching.cache_manager import FullAttentionCacheAllocator
+from transformers.generation.continuous_batching.cb_logits_processors import (
+    ContinuousBatchingLogitsProcessorList,
+)
 from transformers.generation.continuous_batching.continuous_api import OutputRouter
 from transformers.generation.continuous_batching.distributed import DistributedHelper
-from transformers.generation.continuous_batching.input_outputs import build_attention_mask
+from transformers.generation.continuous_batching.initialization import (
+    disable_acceleration_for_full_history_processors,
+)
+from transformers.generation.continuous_batching.input_outputs import ContinuousBatchingIOs, build_attention_mask
 from transformers.generation.continuous_batching.offloading_manager import OffloadingManager
 from transformers.generation.continuous_batching.requests import (
+    FutureRequestState,
     GenerationOutput,
     RequestState,
     RequestStatus,
     get_device_and_memory_breakdown,
+)
+from transformers.generation.logits_process import (
+    ForcedBOSTokenLogitsProcessor,
+    ForcedEOSTokenLogitsProcessor,
+    LogitsProcessorList,
+    MinLengthLogitsProcessor,
+    NoBadWordsLogitsProcessor,
+    NoRepeatNGramLogitsProcessor,
+    RepetitionPenaltyLogitsProcessor,
+    SequenceBiasLogitsProcessor,
+    SuppressTokensAtBeginLogitsProcessor,
+    TemperatureLogitsWarper,
 )
 from transformers.integrations.eager_paged import eager_paged_attention_forward
 from transformers.integrations.sdpa_paged import sdpa_attention_paged_forward
@@ -218,6 +237,96 @@ def regular_generate(
 
 # Class for all continuous batching tests that do not require any accelerator. Usualy those test are faster to run.
 class ContinuousBatchingNoAcceleratorTest(unittest.TestCase):
+    def test_full_history_logits_processors_match_independent_generation(self):
+        processor_cases = [
+            ("min_length", lambda: MinLengthLogitsProcessor(4, eos_token_id=9), [[4, 5, 4], [1, 2, 1, 2]]),
+            ("repetition_penalty", lambda: RepetitionPenaltyLogitsProcessor(1.2), [[4, 5, 4], [1, 2, 1, 2]]),
+            ("no_repeat_ngram", lambda: NoRepeatNGramLogitsProcessor(2), [[4, 5, 4], [1, 2, 1, 2]]),
+            (
+                "sequence_bias",
+                lambda: SequenceBiasLogitsProcessor([[[5, 4], 3.5], [[1, 2, 3], -2.0]]),
+                [[4, 5], [1, 2]],
+            ),
+            ("bad_words", lambda: NoBadWordsLogitsProcessor([[5, 4], [1, 2, 3]]), [[4, 5], [1, 2]]),
+            ("forced_bos", lambda: ForcedBOSTokenLogitsProcessor(7), [[4], [1, 2, 3]]),
+            ("forced_eos", lambda: ForcedEOSTokenLogitsProcessor(4, eos_token_id=9), [[4, 5, 6], [1, 2]]),
+            (
+                "suppress_at_begin",
+                lambda: SuppressTokensAtBeginLogitsProcessor([6, 7], begin_index=3),
+                [[4, 5, 6], [1, 2]],
+            ),
+        ]
+        scores = torch.arange(20, dtype=torch.float32).view(2, 10)
+
+        for name, processor_factory, history_values in processor_cases:
+            with self.subTest(name=name):
+                histories = [torch.tensor(values) for values in history_values]
+                expected_processor = processor_factory()
+                expected = torch.cat(
+                    [
+                        expected_processor(history.unsqueeze(0), row.unsqueeze(0))
+                        for history, row in zip(histories, scores)
+                    ]
+                )
+
+                processors = ContinuousBatchingLogitsProcessorList(LogitsProcessorList([processor_factory()]))
+                actual = processors.apply_with_full_history(
+                    histories, scores.clone(), logits_processor_args=torch.empty((0, 2), dtype=torch.int32)
+                )
+
+                self.assertTrue(processors.requires_full_history)
+                torch.testing.assert_close(actual, expected)
+
+    def test_full_history_processors_preserve_processor_order(self):
+        histories = [torch.tensor([4, 5, 4]), torch.tensor([1, 2, 1, 2])]
+        scores = torch.arange(20, dtype=torch.float32).view(2, 10)
+        expected_processors = LogitsProcessorList([TemperatureLogitsWarper(2.0), NoRepeatNGramLogitsProcessor(2)])
+        expected = torch.cat(
+            [expected_processors(history.unsqueeze(0), row.unsqueeze(0)) for history, row in zip(histories, scores)]
+        )
+        processors = ContinuousBatchingLogitsProcessorList(
+            LogitsProcessorList([TemperatureLogitsWarper(2.0), NoRepeatNGramLogitsProcessor(2)])
+        )
+
+        actual = processors.apply_with_full_history(
+            histories, scores.clone(), logits_processor_args=torch.empty((0, 2), dtype=torch.int32)
+        )
+
+        torch.testing.assert_close(actual, expected)
+
+    def test_token_histories_include_prompt_and_generated_tokens(self):
+        first = RequestState(request_id="first", initial_tokens=[10, 11])
+        first.generated_tokens = [12, 13]
+        skipped = RequestState(request_id="skipped", initial_tokens=[20])
+        skipped.generated_tokens = [21]
+        second = RequestState(request_id="second", initial_tokens=[30, 31, 32])
+
+        inputs_and_outputs = ContinuousBatchingIOs.__new__(ContinuousBatchingIOs)
+        inputs_and_outputs.requests_in_batch = [
+            FutureRequestState(first, has_new_token=True, complete_blocks=0, query_length=1),
+            FutureRequestState(skipped, has_new_token=False, complete_blocks=0, query_length=1),
+            FutureRequestState(second, has_new_token=True, complete_blocks=0, query_length=1),
+        ]
+
+        histories = inputs_and_outputs.get_token_histories(torch.device("cpu"))
+
+        self.assertEqual([history.tolist() for history in histories], [[10, 11, 12, 13], [30, 31, 32]])
+
+    def test_full_history_processors_disable_incompatible_execution_modes(self):
+        config = ContinuousBatchingConfig(
+            use_cuda_graph=(True, True),
+            use_async_batching=True,
+            varlen_compile_config=CompileConfig(),
+            decode_compile_config=CompileConfig(),
+        )
+
+        disable_acceleration_for_full_history_processors(config)
+
+        self.assertEqual(config.use_cuda_graph, (False, False))
+        self.assertFalse(config.use_async_batching)
+        self.assertIsNone(config.varlen_compile_config)
+        self.assertIsNone(config.decode_compile_config)
+
     @parameterized.expand(
         [("paged|eager", eager_paged_attention_forward), ("paged|sdpa", sdpa_attention_paged_forward)]
     )
@@ -996,7 +1105,14 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
         manager.stop(block=True)
         self.assertEqual(model.config._attn_implementation, original_attn_impl)
 
-    # FIXME: Qwen2.5-0.5B-Instruct is not here because it's  broken (it uses a repetition penalty logits processor)
+    @slow
+    def test_continuous_batching_history_dependent_logits_processor(self) -> None:
+        self._test_continuous_batching_parity(
+            model_id="Qwen/Qwen2.5-0.5B-Instruct",
+            continuous_batching_config=ContinuousBatchingConfig(use_cuda_graph=False, use_async_batching=False),
+            attn_implementation="sdpa",
+        )
+
     # TODO: replace gemma2 with a tiny version of GPT-OSS? That way we can test sliding window AND attention sink
     @parameterized.expand(
         list(


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48468&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48468) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48468&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48468)
<!-- ci-dashboard-badge:end -->

I was looking at how logits processors work with continuous batching and noticed that history-dependent processors were only receiving the current token instead of each request's prompt + generated history.

This preserves the full history for processors such as repetition penalty, no-repeat n-grams, sequence bias, forced BOS/EOS, and min length. The existing optimized temperature/top-k/top-p path remains unchanged.

I added focused parity tests and an end-to-end Qwen regression test. I can also attach the corresponding TorchLean/Lean formalization if useful :)