### PR TITLE
[InternVL] Normalize num_patches before np.cumsum

### DIFF
--- a/src/transformers/models/internvl/processing_internvl.py
+++ b/src/transformers/models/internvl/processing_internvl.py
@@ -107,7 +107,9 @@ class InternVLProcessor(ProcessorMixin):
 
         # Merge image and video pixel into a single array, as model expects only `pixel_values` as arg
         if images is not None:
-            image_num_patches_indices = np.cumsum(model_inputs.pop("num_patches"))
+            num_patches = model_inputs.pop("num_patches")
+            num_patches = num_patches.tolist() if hasattr(num_patches, "tolist") else num_patches
+            image_num_patches_indices = np.cumsum(num_patches)
         if videos is not None:
             video_pixel_values = model_inputs.pop("pixel_values_videos")
             batch_size, num_frames, *_ = video_pixel_values.shape


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48469&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48469) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48469&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48469)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48177

Normalize `num_patches` before `np.cumsum` in `InternVLProcessor` so tensor-like inputs do not go through NumPy's deprecated wrapping path. List inputs keep the same behavior.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?
@molbap @guarin @zucchini-nlp

## Code Agent Policy

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

