### PR TITLE
Expose `use_associative_scan` in ZambaConfig

### DIFF
--- a/src/transformers/models/zamba/configuration_zamba.py
+++ b/src/transformers/models/zamba/configuration_zamba.py
@@ -47,6 +47,9 @@ class ZambaConfig(PreTrainedConfig):
         Flag indicating whether or not to use the fast mamba kernels. These are available only if `mamba-ssm` and
         `causal-conv1d` are installed, and the mamba modules are running on a CUDA device. Raises ValueError if
         `True` and kernels are not available
+    use_associative_scan (`bool`, *optional*, defaults to `True`):
+        Whether to use `torch._higher_order_ops.associative_scan` during `torch.compile` tracing instead of the
+        sequential fallback.
     mamba_dt_rank (`Union[int,str]`, *optional*, defaults to `"auto"`):
         Rank of the mamba discretization projection matrix. `"auto"` means that it will default to `math.ceil(self.hidden_size / 16)`
     layers_block_type (`str`, *optional*):
@@ -81,6 +84,7 @@ class ZambaConfig(PreTrainedConfig):
     attn_layer_period: int = 6
     attn_layer_offset: int = 4
     use_mamba_kernels: bool = True
+    use_associative_scan: bool = True
     mamba_d_state: int = 16
     mamba_d_conv: int = 4
     mamba_expand: int = 2

--- a/src/transformers/models/zamba/modeling_zamba.py
+++ b/src/transformers/models/zamba/modeling_zamba.py
@@ -430,6 +430,7 @@ class ZambaMambaMixer(nn.Module):
         self.act = ACT2FN[config.hidden_mamba_act]
 
         self.use_fast_kernels = config.use_mamba_kernels
+        self.use_associative_scan = config.use_associative_scan
 
         # projection of the input hidden states
         self.in_proj = nn.Linear(self.hidden_size, self.intermediate_size * 2, bias=self.use_bias)
@@ -580,7 +581,7 @@ class ZambaMambaMixer(nn.Module):
                     return_last_state=output_final_state,
                     # Old model: only when user request it explicitly
                     use_mambapy=False,
-                    use_associative_scan=False,
+                    use_associative_scan=self.use_associative_scan,
                 )
 
                 if output_final_state:

--- a/tests/models/zamba/test_modeling_zamba.py
+++ b/tests/models/zamba/test_modeling_zamba.py
@@ -325,6 +325,43 @@ class ZambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     def test_config(self):
         self.config_tester.run_common_tests()
 
+    def test_mamba_mixer_uses_configured_associative_scan(self):
+        from transformers.models.zamba import modeling_zamba
+
+        config = ZambaConfig(
+            hidden_size=8,
+            num_hidden_layers=3,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            n_mamba_heads=2,
+            use_mamba_kernels=False,
+            use_associative_scan=True,
+        )
+        mixer = modeling_zamba.ZambaMambaMixer(config, layer_idx=0)
+        captured_kwargs = {}
+
+        def fake_causal_conv1d_fn(hidden_states, *args, **kwargs):
+            return hidden_states
+
+        def fake_mamba_selective_scan(hidden_states, *args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return torch.zeros_like(hidden_states)
+
+        original_causal_conv1d_fn = modeling_zamba.causal_conv1d_fn
+        original_mamba_selective_scan = modeling_zamba.mamba_selective_scan
+        try:
+            modeling_zamba.causal_conv1d_fn = fake_causal_conv1d_fn
+            modeling_zamba.mamba_selective_scan = fake_mamba_selective_scan
+
+            output = mixer(torch.zeros(1, 2, 8))
+
+            self.assertEqual(output.shape, (1, 2, 8))
+            self.assertTrue(mixer.use_associative_scan)
+            self.assertTrue(captured_kwargs["use_associative_scan"])
+        finally:
+            modeling_zamba.causal_conv1d_fn = original_causal_conv1d_fn
+            modeling_zamba.mamba_selective_scan = original_mamba_selective_scan
+
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48470&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48470) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48470&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48470)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48080

`ZambaMambaMixer` hard-coded `use_associative_scan=False`, so `ZambaConfig` could not control whether `torch.compile` used the associative-scan path.

This adds `use_associative_scan` to `ZambaConfig` (default `True`, matching `MambaConfig`) and forwards it from the mixer instead of the hard-coded value. The associative-scan branch only runs while `torch.compile` is tracing (`is_torchdynamo_compiling()`), so eager execution is unchanged. A regression test in `tests/models/zamba/test_modeling_zamba.py` pins that the configured value reaches `mamba_selective_scan`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@ArthurZucker
@Cyrilvallez
@albertvillanova

## Code Agent Policy

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent


