### PR TITLE
[i18n-KO] Translate models_timeline to Korean

### DIFF
--- a/docs/source/ko/_toctree.yml
+++ b/docs/source/ko/_toctree.yml
@@ -289,6 +289,8 @@
     title: Glossary
   - local: philosophy
     title: 이념과 목표
+  - local: models_timeline
+    title: 모델 타임라인
   - local: in_translation
     title: (번역중) Notebooks with examples
   - local: community

--- a/docs/source/ko/models_timeline.md
+++ b/docs/source/ko/models_timeline.md
@@ -1,0 +1,28 @@
+<!--Copyright 2025 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# 모델 타임라인 [[models_timeline]]
+
+[모델 타임라인](https://huggingface.co/spaces/yonigozlan/Transformers-Timeline)은 Transformers의 아키텍처가 시간에 따라 어떻게 변화해 왔는지 한눈에 보여주는 인터랙티브 차트입니다. 텍스트, 비전, 오디오, 비디오, 멀티모달 사용 사례를 아우르는 모델들을 추가된 순서대로 스크롤하며 살펴볼 수 있습니다.
+
+필터를 사용하면 모달리티나 태스크별로 모델을 좁혀 볼 수 있습니다. 날짜 범위를 직접 설정해서 특정 기간에 추가된 모델들만 모아 볼 수도 있고요. 모델 카드를 클릭하면 해당 모델이 어떤 기능을 하는지, 어떤 태스크를 지원하는지, 관련 문서는 어디 있는지 확인할 수 있습니다.
+
+<iframe
+	src="https://yonigozlan-transformers-timeline.hf.space"
+	frameborder="0"
+	width="125%"
+	height="1150"
+	style="transform: scale(0.8); transform-origin: top left; max-width: calc(100%/0.8); height: 1150px; margin-bottom: calc(-0.2*1150px);"
+></iframe>


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48471&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48471) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48471&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48471)
<!-- ci-dashboard-badge:end -->

# 🌐 [i18n-KO] Translate `models_timeline` to Korean

Ref: #20179

Translates `docs/source/en/models_timeline.md` → `docs/source/ko/models_timeline.md` and registers it in `ko/_toctree.yml`.

**Scope**

This is a small, self-contained page (a short intro plus an embedded iframe), so it seemed like a reasonable first contribution to the Korean docs. I deliberately picked one of the shortest untranslated pages to keep the diff easy to review while I get familiar with the conventions.

**What I changed**

- `docs/source/ko/models_timeline.md` (new) — translation only. The Apache license header and the `<iframe>` block are carried over verbatim; only the prose is translated.
- `docs/source/ko/_toctree.yml` — added the entry right after `philosophy`, matching the ordering in `en/_toctree.yml` (`glossary` → `philosophy` → `models_timeline` → `notebooks`).

**Notes on the translation**

Some choices worth flagging, in case you'd prefer otherwise:

- **Heading anchor** — used `# 모델 타임라인 [[models_timeline]]`, following the `[[filename]]` convention I saw in neighbouring pages like `philosophy.md`.
- **Terminology** — left `Transformers`, `modal`, and `task` handling as-is: `모달리티` for *modality* and `태스크` for *task* to match how they appear in the existing Korean pages, rather than inventing a new rendering. `Models Timeline` is kept as a link label pointing at the Space.
- **Register** — the issue asks for an informal, friendly tone. I aimed for polite-but-warm (`~할 수 있습니다`, `~살펴볼 수 있고요`) rather than casual 반말, since that's the register the existing Korean pages use and it keeps this page consistent with its neighbours. Happy to dial it more casual if you'd rather take the issue's wording literally.

Happy to adjust any of the above. Also glad to take more pages from the list if this one looks right.

cc @ArthurZucker @sgugger @eunseojo