### PR TITLE
[Parakeet] Isolate concurrent TDT generate state

### DIFF
--- a/src/transformers/models/parakeet/generation_parakeet.py
+++ b/src/transformers/models/parakeet/generation_parakeet.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from contextvars import ContextVar
+from dataclasses import dataclass, field
 
 import torch
 
@@ -110,6 +111,16 @@ class ParakeetRNNTGenerateOutput(ModelOutput):
     hidden_states: tuple[tuple[torch.FloatTensor]] | None = None
 
 
+@dataclass
+class ParakeetGenerationState:
+    encoder_finished: torch.BoolTensor | None = None
+    symbols_at_frame: torch.LongTensor | None = None
+    step_durations: list[torch.Tensor] = field(default_factory=list)
+
+
+_PARAKEET_GENERATION_STATE = ContextVar("parakeet_generation_state", default=None)
+
+
 class EncoderExhaustedCriteria(StoppingCriteria):
     """Stops generation when all batch elements have walked past their encoder output length."""
 
@@ -132,6 +143,66 @@ class ParakeetRNNTGenerationMixin(GenerationMixin):
     frame, mirroring NeMo's greedy RNN-T decoding. The duration-aware [`ParakeetTDTGenerationMixin`] extends this
     by advancing the frame pointer by a predicted duration instead.
     """
+
+    def _generation_state(self):
+        return _PARAKEET_GENERATION_STATE.get()
+
+    @property
+    def _encoder_finished(self):
+        state = self._generation_state()
+        return None if state is None else state.encoder_finished
+
+    @_encoder_finished.setter
+    def _encoder_finished(self, value):
+        state = self._generation_state()
+        if state is None:
+            state = ParakeetGenerationState()
+            _PARAKEET_GENERATION_STATE.set(state)
+        state.encoder_finished = value
+
+    @_encoder_finished.deleter
+    def _encoder_finished(self):
+        state = self._generation_state()
+        if state is not None:
+            state.encoder_finished = None
+
+    @property
+    def _symbols_at_frame(self):
+        state = self._generation_state()
+        return None if state is None else state.symbols_at_frame
+
+    @_symbols_at_frame.setter
+    def _symbols_at_frame(self, value):
+        state = self._generation_state()
+        if state is None:
+            state = ParakeetGenerationState()
+            _PARAKEET_GENERATION_STATE.set(state)
+        state.symbols_at_frame = value
+
+    @_symbols_at_frame.deleter
+    def _symbols_at_frame(self):
+        state = self._generation_state()
+        if state is not None:
+            state.symbols_at_frame = None
+
+    @property
+    def _step_durations(self):
+        state = self._generation_state()
+        return None if state is None else state.step_durations
+
+    @_step_durations.setter
+    def _step_durations(self, value):
+        state = self._generation_state()
+        if state is None:
+            state = ParakeetGenerationState()
+            _PARAKEET_GENERATION_STATE.set(state)
+        state.step_durations = value
+
+    @_step_durations.deleter
+    def _step_durations(self):
+        state = self._generation_state()
+        if state is not None:
+            state.step_durations = []
 
     def _get_stopping_criteria(self, *args, **kwargs):
         criteria = super()._get_stopping_criteria(*args, **kwargs)
@@ -249,23 +320,28 @@ class ParakeetRNNTGenerationMixin(GenerationMixin):
 
     def generate(self, inputs=None, generation_config=None, **kwargs):
         # TODO @eustlb: this is temporary — we're going to modularize generate to allow doing this cleanly.
+        generation_state = ParakeetGenerationState()
+        generation_state_token = _PARAKEET_GENERATION_STATE.set(generation_state)
         self._encoder_finished = None
         self._symbols_at_frame = None
         self._step_durations = []
 
-        outputs = super().generate(inputs=inputs, generation_config=generation_config, **kwargs)
+        try:
+            outputs = super().generate(inputs=inputs, generation_config=generation_config, **kwargs)
 
-        durations = torch.stack(self._step_durations, dim=1)  # (batch, steps)
-        # Prepend a zero duration for the decoder_start_token_id that generate() prepends to sequences
-        durations = torch.cat(
-            [torch.zeros(durations.shape[0], 1, dtype=durations.dtype, device=durations.device), durations], dim=1
-        )
-        del self._encoder_finished, self._symbols_at_frame, self._step_durations
+            durations = torch.stack(self._step_durations, dim=1)  # (batch, steps)
+            # Prepend a zero duration for the decoder_start_token_id that generate() prepends to sequences
+            durations = torch.cat(
+                [torch.zeros(durations.shape[0], 1, dtype=durations.dtype, device=durations.device), durations],
+                dim=1,
+            )
 
-        return ParakeetRNNTGenerateOutput(
-            sequences=outputs.sequences if isinstance(outputs, ModelOutput) else outputs,
-            durations=durations,
-        )
+            return ParakeetRNNTGenerateOutput(
+                sequences=outputs.sequences if isinstance(outputs, ModelOutput) else outputs,
+                durations=durations,
+            )
+        finally:
+            _PARAKEET_GENERATION_STATE.reset(generation_state_token)
 
 
 class ParakeetTDTGenerationMixin(ParakeetRNNTGenerationMixin):

--- a/tests/models/parakeet/test_modeling_parakeet.py
+++ b/tests/models/parakeet/test_modeling_parakeet.py
@@ -714,6 +714,53 @@ class ParakeetForTDTModelTest(ModelTesterMixin, unittest.TestCase):
                     if "SdpaAttention" in class_name or "SdpaSelfAttention" in class_name:
                         raise ValueError("The eager model should not have SDPA attention layers")
 
+    def test_generate_does_not_share_request_state_across_threads(self):
+        import concurrent.futures
+        import itertools
+        import threading
+        import time
+        from unittest.mock import patch
+
+        from transformers.models.parakeet import generation_parakeet
+
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        model = ParakeetForTDT(config)
+        batch_size = self.model_tester.batch_size
+
+        barrier = threading.Barrier(2)
+        call_index = itertools.count()
+        call_index_lock = threading.Lock()
+
+        def fake_generate(self, inputs=None, generation_config=None, **kwargs):
+            with call_index_lock:
+                index = next(call_index)
+
+            durations = torch.full((batch_size,), index + 1, dtype=torch.long)
+            generation_state = getattr(generation_parakeet, "_PARAKEET_GENERATION_STATE", None)
+            state_container = generation_state.get() if generation_state is not None else None
+            if state_container is not None and hasattr(state_container, "step_durations"):
+                state_container.step_durations.append(durations)
+            else:
+                self._step_durations.append(durations)
+
+            barrier.wait()
+            if index == 1:
+                time.sleep(0.05)
+
+            return torch.tensor([[index]], dtype=torch.long)
+
+        with patch("transformers.models.parakeet.generation_parakeet.GenerationMixin.generate", new=fake_generate):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+                outputs = list(pool.map(lambda _: model.generate(), range(2)))
+
+        outputs = sorted(outputs, key=lambda output: int(output.sequences.item()))
+        self.assertEqual(outputs[0].sequences.item(), 0)
+        self.assertEqual(outputs[1].sequences.item(), 1)
+        self.assertEqual(outputs[0].durations.shape, (batch_size, 2))
+        self.assertEqual(outputs[1].durations.shape, (batch_size, 2))
+        torch.testing.assert_close(outputs[0].durations[:, 1], torch.ones(batch_size, dtype=torch.long))
+        torch.testing.assert_close(outputs[1].durations[:, 1], torch.full((batch_size,), 2, dtype=torch.long))
+
 
 @require_torch
 class ParakeetForTDTIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48472&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48472) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48472&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48472)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48286

Parakeet TDT `generate()` shared request-local state across concurrent calls on the same model instance, so one call could clear another call's generation state mid-decode. This change moves that state into a request-local `ContextVar` container and adds a regression test that exercises two concurrent calls.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

@eustlb @ebezzam @vasqu

## Code Agent Policy

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

