### PR TITLE
[MTP] Save memory by only capturing the last layer's hidden_states

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1422,7 +1422,8 @@ class SinglePositionMultiTokenCandidateGenerator(AssistedCandidateGenerator):
 
 class MTPCandidateGenerator(AssistedCandidateGenerator):
     requires_model_outputs: bool = True
-    # We always need to pass the hidden states from the main model
+    # We always need to pass the hidden states from the main model - it will be overriden in the __init__ to capture only the
+    # last layer's hidden_states
     model_kwargs_overrides: dict[str, Any] = {"output_hidden_states": True}
 
     def __init__(
@@ -1441,6 +1442,10 @@ class MTPCandidateGenerator(AssistedCandidateGenerator):
                 "Could not find `num_mtp_layers` in the model config. This model probably has no associated "
                 "mtp weights."
             )
+
+        # Override to capture only the last main model's layer to save memory
+        last_layer_idx = main_model.config.get_text_config().num_hidden_layers - 1
+        self.model_kwargs_overrides = {"output_hidden_states": [last_layer_idx]}
 
         # Heuristic: use the device of the last layer of the main model for the MTP layers
         base_model = main_model.get_decoder()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48475&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48475) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48475&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48475)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

As per the title. We added selective capture in https://github.com/huggingface/transformers/pull/48081