### PR TITLE
[BitNet] Support use_sub_norms=False for weight-quant-only checkpoints

### DIFF
--- a/src/transformers/models/bitnet/configuration_bitnet.py
+++ b/src/transformers/models/bitnet/configuration_bitnet.py
@@ -23,6 +23,10 @@ from ...utils import auto_docstring
 @strict
 class BitNetConfig(PreTrainedConfig):
     r"""
+    Args:
+        use_sub_norms (`bool`, *optional*, defaults to `True`):
+            Whether or not to use sub-norms (RMSNorm) in the MLP and Attention blocks. Set to `False` for Weight-Quant-Only checkpoints.
+            
     ```python
     >>> from transformers import BitNetModel, BitNetConfig
 
@@ -59,6 +63,7 @@ class BitNetConfig(PreTrainedConfig):
     attention_bias: bool = False
     attention_dropout: float | int | None = 0.0
     rope_parameters: RopeParameters | dict | None = None
+    use_sub_norms: bool = True
 
     def __post_init__(self, **kwargs):
         # for backward compatibility

--- a/src/transformers/models/bitnet/configuration_bitnet.py
+++ b/src/transformers/models/bitnet/configuration_bitnet.py
@@ -26,7 +26,7 @@ class BitNetConfig(PreTrainedConfig):
     Args:
         use_sub_norms (`bool`, *optional*, defaults to `True`):
             Whether or not to use sub-norms (RMSNorm) in the MLP and Attention blocks. Set to `False` for Weight-Quant-Only checkpoints.
-            
+
     ```python
     >>> from transformers import BitNetModel, BitNetConfig
 

--- a/src/transformers/models/bitnet/modeling_bitnet.py
+++ b/src/transformers/models/bitnet/modeling_bitnet.py
@@ -71,7 +71,8 @@ class BitNetMLP(nn.Module):
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         self.act_fn = ACT2FN[config.hidden_act]
-        self.ffn_sub_norm = BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps)
+        self.ffn_sub_norm = (BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity())
+        
 
     def forward(self, x):
         down_proj = self.down_proj(self.ffn_sub_norm(self.act_fn(self.gate_proj(x)) * self.up_proj(x)))
@@ -174,7 +175,7 @@ class BitNetAttention(nn.Module):
         self.o_proj = nn.Linear(
             config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
         )
-        self.attn_sub_norm = BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attn_sub_norm = BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity()
 
     def forward(
         self,

--- a/src/transformers/models/bitnet/modeling_bitnet.py
+++ b/src/transformers/models/bitnet/modeling_bitnet.py
@@ -72,7 +72,9 @@ class BitNetMLP(nn.Module):
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         self.act_fn = ACT2FN[config.hidden_act]
         self.ffn_sub_norm = (
-            BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity()
+            BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps)
+            if config.use_sub_norms
+            else torch.nn.Identity()
         )
 
     def forward(self, x):
@@ -177,7 +179,7 @@ class BitNetAttention(nn.Module):
             config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
         )
         self.attn_sub_norm = (
-            BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity()
+            BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else torch.nn.Identity()
         )
 
     def forward(

--- a/src/transformers/models/bitnet/modeling_bitnet.py
+++ b/src/transformers/models/bitnet/modeling_bitnet.py
@@ -71,7 +71,10 @@ class BitNetMLP(nn.Module):
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         self.act_fn = ACT2FN[config.hidden_act]
-        self.ffn_sub_norm = BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity()
+        self.ffn_sub_norm = (
+            BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity()
+        )
+
     def forward(self, x):
         down_proj = self.down_proj(self.ffn_sub_norm(self.act_fn(self.gate_proj(x)) * self.up_proj(x)))
         return down_proj
@@ -173,7 +176,9 @@ class BitNetAttention(nn.Module):
         self.o_proj = nn.Linear(
             config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
         )
-        self.attn_sub_norm = BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity()
+        self.attn_sub_norm = (
+            BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity()
+        )
 
     def forward(
         self,

--- a/src/transformers/models/bitnet/modeling_bitnet.py
+++ b/src/transformers/models/bitnet/modeling_bitnet.py
@@ -71,9 +71,7 @@ class BitNetMLP(nn.Module):
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         self.act_fn = ACT2FN[config.hidden_act]
-        self.ffn_sub_norm = (BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity())
-        
-
+        self.ffn_sub_norm = BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else nn.Identity()
     def forward(self, x):
         down_proj = self.down_proj(self.ffn_sub_norm(self.act_fn(self.gate_proj(x)) * self.up_proj(x)))
         return down_proj

--- a/src/transformers/models/bitnet/modular_bitnet.py
+++ b/src/transformers/models/bitnet/modular_bitnet.py
@@ -45,7 +45,7 @@ class BitNetRMSNorm(LlamaRMSNorm):
 class BitNetMLP(GemmaMLP):
     def __init__(self, config: BitNetConfig):
         super().__init__(config)
-        self.ffn_sub_norm = (BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else torch.nn.Identity())
+        self.ffn_sub_norm = BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else torch.nn.Identity()
 
     def forward(self, x):
         down_proj = self.down_proj(self.ffn_sub_norm(self.act_fn(self.gate_proj(x)) * self.up_proj(x)))
@@ -55,7 +55,7 @@ class BitNetMLP(GemmaMLP):
 class BitNetAttention(LlamaAttention):
     def __init__(self, config: BitNetConfig, layer_idx: int):
         super().__init__(config, layer_idx)
-        self.attn_sub_norm = (BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else torch.nn.Identity())
+        self.attn_sub_norm = BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else torch.nn.Identity()
 
     def forward(
         self,

--- a/src/transformers/models/bitnet/modular_bitnet.py
+++ b/src/transformers/models/bitnet/modular_bitnet.py
@@ -45,7 +45,11 @@ class BitNetRMSNorm(LlamaRMSNorm):
 class BitNetMLP(GemmaMLP):
     def __init__(self, config: BitNetConfig):
         super().__init__(config)
-        self.ffn_sub_norm = BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else torch.nn.Identity()
+        self.ffn_sub_norm = (
+            BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps)
+            if config.use_sub_norms
+            else torch.nn.Identity()
+        )
 
     def forward(self, x):
         down_proj = self.down_proj(self.ffn_sub_norm(self.act_fn(self.gate_proj(x)) * self.up_proj(x)))
@@ -55,7 +59,9 @@ class BitNetMLP(GemmaMLP):
 class BitNetAttention(LlamaAttention):
     def __init__(self, config: BitNetConfig, layer_idx: int):
         super().__init__(config, layer_idx)
-        self.attn_sub_norm = BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else torch.nn.Identity()
+        self.attn_sub_norm = (
+            BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else torch.nn.Identity()
+        )
 
     def forward(
         self,

--- a/src/transformers/models/bitnet/modular_bitnet.py
+++ b/src/transformers/models/bitnet/modular_bitnet.py
@@ -45,7 +45,7 @@ class BitNetRMSNorm(LlamaRMSNorm):
 class BitNetMLP(GemmaMLP):
     def __init__(self, config: BitNetConfig):
         super().__init__(config)
-        self.ffn_sub_norm = BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps)
+        self.ffn_sub_norm = (BitNetRMSNorm(config.intermediate_size, eps=config.rms_norm_eps) if config.use_sub_norms else torch.nn.Identity())
 
     def forward(self, x):
         down_proj = self.down_proj(self.ffn_sub_norm(self.act_fn(self.gate_proj(x)) * self.up_proj(x)))
@@ -55,7 +55,7 @@ class BitNetMLP(GemmaMLP):
 class BitNetAttention(LlamaAttention):
     def __init__(self, config: BitNetConfig, layer_idx: int):
         super().__init__(config, layer_idx)
-        self.attn_sub_norm = BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attn_sub_norm = (BitNetRMSNorm(config.hidden_size, eps=config.rms_norm_eps) if config.use_sub_norms else torch.nn.Identity())
 
     def forward(
         self,

--- a/tests/models/bitnet/test_modeling_bitnet.py
+++ b/tests/models/bitnet/test_modeling_bitnet.py
@@ -173,6 +173,7 @@ class BitNetModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         self.assertIsInstance(model.layers[0].mlp.ffn_sub_norm, torch.nn.Identity)
         self.assertIsInstance(model.layers[0].self_attn.attn_sub_norm, torch.nn.Identity)
 
+
 @require_torch
 class BitNetIntegrationTest(unittest.TestCase):
     @slow

--- a/tests/models/bitnet/test_modeling_bitnet.py
+++ b/tests/models/bitnet/test_modeling_bitnet.py
@@ -166,6 +166,12 @@ class BitNetModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
+    def test_use_sub_norms_false(self):
+        config = self.model_tester.get_config()
+        config.use_sub_norms = False
+        model = BitNetModel(config=config)
+        self.assertIsInstance(model.layers[0].mlp.ffn_sub_norm, torch.nn.Identity)
+        self.assertIsInstance(model.layers[0].self_attn.attn_sub_norm, torch.nn.Identity)
 
 @require_torch
 class BitNetIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48478&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48478) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48478&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48478)
<!-- ci-dashboard-badge:end -->

# What does this PR do?
Fixes #47957
This PR adds a use_sub_norms flag, which is defaulted to True for backwards compatibility for older models, all while allowing researchers to train using the new weight-quant-only architecture safely.
Weight-quant-only checkpoints don't use per-projection RMSnorm in their forward pass, and thus lack *_sub_norm.* weights in their state dict. Setting use_sub_norms=False initializes these layers as nn.Identity(), aligning the Pytorch model's structure with the expected state dict and preventing missing key errors during from_pretrained().

I've also added a focused test BitNetModelTest to verify the conditional initialization.

cc @ArthurZucker @Cyrilvallez 



## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.

Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
for reviewers and other users and will almost certainly get you blocked.

For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
      https://github.com/huggingface/transformers/issues/47957
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @molbap @guarin
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @Abdennacer-Badaoui
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @IlyasMoutawwakil 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->