### PR TITLE
Pass kwargs to the Mamba2 mixer in Nemotron-H, Falcon-H1 and Mamba2

### DIFF
--- a/src/transformers/models/falcon_h1/modeling_falcon_h1.py
+++ b/src/transformers/models/falcon_h1/modeling_falcon_h1.py
@@ -915,6 +915,7 @@ class FalconH1DecoderLayer(GradientCheckpointingLayer):
             hidden_states=hidden_states,
             cache_params=past_key_values,
             attention_mask=mamba_attention_mask,
+            **kwargs,
         )
         mamba_hidden_states = mamba_hidden_states * self.ssm_out_multiplier
 
@@ -1093,6 +1094,7 @@ class FalconH1Model(FalconH1PreTrainedModel):
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 position_embeddings=position_embeddings,
+                **kwargs,
             )
 
             hidden_states = layer_outputs[0]

--- a/src/transformers/models/falcon_h1/modular_falcon_h1.py
+++ b/src/transformers/models/falcon_h1/modular_falcon_h1.py
@@ -403,6 +403,7 @@ class FalconH1DecoderLayer(GradientCheckpointingLayer):
             hidden_states=hidden_states,
             cache_params=past_key_values,
             attention_mask=mamba_attention_mask,
+            **kwargs,
         )
         mamba_hidden_states = mamba_hidden_states * self.ssm_out_multiplier
 
@@ -581,6 +582,7 @@ class FalconH1Model(FalconH1PreTrainedModel):
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 position_embeddings=position_embeddings,
+                **kwargs,
             )
 
             hidden_states = layer_outputs[0]

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -626,7 +626,7 @@ class Mamba2Block(GradientCheckpointingLayer):
         if self.residual_in_fp32:
             residual = residual.to(torch.float32)
 
-        hidden_states = self.mixer(hidden_states, cache_params=cache_params, attention_mask=attention_mask)
+        hidden_states = self.mixer(hidden_states, cache_params=cache_params, attention_mask=attention_mask, **kwargs)
         hidden_states = residual + hidden_states
         return hidden_states
 
@@ -793,6 +793,7 @@ class Mamba2Model(Mamba2PreTrainedModel):
                 hidden_states,
                 cache_params=cache_params,
                 attention_mask=attention_mask,
+                **kwargs,
             )
 
             if output_hidden_states:

--- a/src/transformers/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modeling_nemotron_h.py
@@ -924,7 +924,12 @@ class NemotronHBlock(GradientCheckpointingLayer):
         hidden_states = self.norm(hidden_states.to(dtype=self.norm.weight.dtype))
 
         if self.block_type == "linear_attention":
-            hidden_states = self.mixer(hidden_states, cache_params=past_key_values, attention_mask=attention_mask)
+            hidden_states = self.mixer(
+                hidden_states,
+                cache_params=past_key_values,
+                attention_mask=attention_mask,
+                **kwargs,
+            )
         elif self.block_type == "full_attention":
             hidden_states, _ = self.mixer(
                 hidden_states=hidden_states,

--- a/src/transformers/models/nemotron_h/modular_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modular_nemotron_h.py
@@ -261,7 +261,12 @@ class NemotronHBlock(GradientCheckpointingLayer):
         hidden_states = self.norm(hidden_states.to(dtype=self.norm.weight.dtype))
 
         if self.block_type == "linear_attention":
-            hidden_states = self.mixer(hidden_states, cache_params=past_key_values, attention_mask=attention_mask)
+            hidden_states = self.mixer(
+                hidden_states,
+                cache_params=past_key_values,
+                attention_mask=attention_mask,
+                **kwargs,
+            )
         elif self.block_type == "full_attention":
             hidden_states, _ = self.mixer(
                 hidden_states=hidden_states,

--- a/tests/models/falcon_h1/test_modeling_falcon_h1.py
+++ b/tests/models/falcon_h1/test_modeling_falcon_h1.py
@@ -276,6 +276,34 @@ class FalconH1ModelTester:
             msg=f"Max diff: {(ref_first - under_test_first).abs().max().item():.6f}",
         )
 
+    def create_and_check_kwargs_reach_mamba2_mixer(self, config, input_ids, *args):
+        """
+        Kernel kwargs given to the model must reach the Mamba2 mixer, which splats them into
+        the fused conv1d+scan, the conv and the chunk scan. This is how `seq_idx` reaches the
+        kernels for packed / variable-length batches.
+        """
+        model = FalconH1Model(config=config)
+        model.to(torch_device)
+        model.eval()
+
+        mixer = model.layers[0].mamba
+        original_forward = mixer.forward
+        seen = []
+
+        def recording_forward(*fwd_args, **fwd_kwargs):
+            seen.append(set(fwd_kwargs))
+            return original_forward(*fwd_args, **fwd_kwargs)
+
+        mixer.forward = recording_forward
+
+        input_ids = input_ids.to(torch_device)
+        seq_idx = torch.zeros(input_ids.shape, dtype=torch.int32, device=torch_device)
+        with torch.no_grad():
+            model(input_ids, seq_idx=seq_idx)
+
+        self.parent.assertTrue(seen, "the Mamba2 mixer was never called")
+        self.parent.assertIn("seq_idx", seen[0])
+
 
 @require_torch
 class FalconH1ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, unittest.TestCase):
@@ -325,6 +353,10 @@ class FalconH1ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
     def test_mamba2_chunked_prefill_cpu(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mamba_chunked_prefill(*config_and_inputs, device="cpu")
+
+    def test_kwargs_reach_mamba2_mixer(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_kwargs_reach_mamba2_mixer(*config_and_inputs)
 
     @require_torch_accelerator
     @require_kernels

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -255,6 +255,34 @@ class Mamba2ModelTester:
 
         self.parent.assertTrue(torch.allclose(outputs_fast, outputs_slow, atol=1e-3, rtol=1e-3))
 
+    def create_and_check_kwargs_reach_mamba2_mixer(self, config, input_ids, *args):
+        """
+        Kernel kwargs given to the model must reach the Mamba2 mixer, which splats them into
+        the fused conv1d+scan, the conv and the chunk scan. This is how `seq_idx` reaches the
+        kernels for packed / variable-length batches.
+        """
+        model = Mamba2Model(config)
+        model.to(torch_device)
+        model.eval()
+
+        mixer = model.layers[0].mixer
+        original_forward = mixer.forward
+        seen = []
+
+        def recording_forward(*fwd_args, **fwd_kwargs):
+            seen.append(set(fwd_kwargs))
+            return original_forward(*fwd_args, **fwd_kwargs)
+
+        mixer.forward = recording_forward
+
+        input_ids = input_ids.to(torch_device)
+        seq_idx = torch.zeros(input_ids.shape, dtype=torch.int32, device=torch_device)
+        with torch.no_grad():
+            model(input_ids, seq_idx=seq_idx)
+
+        self.parent.assertTrue(seen, "the Mamba2 mixer was never called")
+        self.parent.assertIn("seq_idx", seen[0])
+
 
 @require_torch
 class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, unittest.TestCase):
@@ -287,6 +315,10 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     def test_mamba2_caching(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mamba2_caching(*config_and_inputs)
+
+    def test_kwargs_reach_mamba2_mixer(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_kwargs_reach_mamba2_mixer(*config_and_inputs)
 
     def test_mamba2_chunked_prefill_cpu(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/models/nemotron_h/test_modeling_nemotron_h.py
+++ b/tests/models/nemotron_h/test_modeling_nemotron_h.py
@@ -320,6 +320,34 @@ class NemotronHModelTester:
 
         self.parent.assertTrue(torch.allclose(outputs_fast_cached, outputs_slow_cached, atol=1e-3, rtol=1e-3))
 
+    def create_and_check_kwargs_reach_mamba2_mixer(self, config, input_ids, *args):
+        """
+        Kernel kwargs given to the model must reach the Mamba2 mixer, which splats them into
+        the fused conv1d+scan, the conv and the chunk scan. This is how `seq_idx` reaches the
+        kernels for packed / variable-length batches.
+        """
+        model = NemotronHModel(config)
+        model.to(torch_device)
+        model.eval()
+
+        mixer = next(block.mixer for block in model.layers if block.block_type == "linear_attention")
+        original_forward = mixer.forward
+        seen = []
+
+        def recording_forward(*fwd_args, **fwd_kwargs):
+            seen.append(set(fwd_kwargs))
+            return original_forward(*fwd_args, **fwd_kwargs)
+
+        mixer.forward = recording_forward
+
+        input_ids = input_ids.to(torch_device)
+        seq_idx = torch.zeros(input_ids.shape, dtype=torch.int32, device=torch_device)
+        with torch.no_grad():
+            model(input_ids, seq_idx=seq_idx)
+
+        self.parent.assertTrue(seen, "the linear-attention mixer was never called")
+        self.parent.assertIn("seq_idx", seen[0])
+
     def create_and_check_nemotron_h_chunked_prefill(self, config, input_ids, *args, device="cpu"):
         """
         Adapted from `test_linear_attention_multi_token_cached_forward_matches_single_token`
@@ -521,33 +549,8 @@ class NemotronHModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         self.model_tester.create_and_check_mamba2_slow_vs_fast_forward(*config_and_inputs)
 
     def test_kwargs_reach_mamba2_mixer(self):
-        """
-        Kernel kwargs given to the model must reach the Mamba2 mixer, which splats
-        them into the fused conv1d+scan, conv and chunk-scan calls. This is how
-        `seq_idx` gets to the kernels for packed / variable-length batches, and it
-        matches Bamba, GraniteMoEHybrid and Zamba2.
-        """
-        config, input_ids, *_ = self.model_tester.prepare_config_and_inputs()
-        model = NemotronHModel(config).to(torch_device).eval()
-
-        seen = []
-        mixer = next(block.mixer for block in model.layers if block.block_type == "linear_attention")
-        original_forward = mixer.forward
-
-        def recording_forward(*args, **kwargs):
-            seen.append(set(kwargs))
-            # The torch fallback kernels do not implement seq_idx, so only record it.
-            kwargs.pop("seq_idx", None)
-            return original_forward(*args, **kwargs)
-
-        mixer.forward = recording_forward
-
-        seq_idx = torch.zeros(input_ids.shape, dtype=torch.int32, device=torch_device)
-        with torch.no_grad():
-            model(input_ids, seq_idx=seq_idx)
-
-        self.assertTrue(seen, "the linear-attention mixer was never called")
-        self.assertIn("seq_idx", seen[0])
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_kwargs_reach_mamba2_mixer(*config_and_inputs)
 
     def test_attention_outputs(self):
         r"""

--- a/tests/models/nemotron_h/test_modeling_nemotron_h.py
+++ b/tests/models/nemotron_h/test_modeling_nemotron_h.py
@@ -520,6 +520,35 @@ class NemotronHModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mamba2_slow_vs_fast_forward(*config_and_inputs)
 
+    def test_kwargs_reach_mamba2_mixer(self):
+        """
+        Kernel kwargs given to the model must reach the Mamba2 mixer, which splats
+        them into the fused conv1d+scan, conv and chunk-scan calls. This is how
+        `seq_idx` gets to the kernels for packed / variable-length batches, and it
+        matches Bamba, GraniteMoEHybrid and Zamba2.
+        """
+        config, input_ids, *_ = self.model_tester.prepare_config_and_inputs()
+        model = NemotronHModel(config).to(torch_device).eval()
+
+        seen = []
+        mixer = next(block.mixer for block in model.layers if block.block_type == "linear_attention")
+        original_forward = mixer.forward
+
+        def recording_forward(*args, **kwargs):
+            seen.append(set(kwargs))
+            # The torch fallback kernels do not implement seq_idx, so only record it.
+            kwargs.pop("seq_idx", None)
+            return original_forward(*args, **kwargs)
+
+        mixer.forward = recording_forward
+
+        seq_idx = torch.zeros(input_ids.shape, dtype=torch.int32, device=torch_device)
+        with torch.no_grad():
+            model(input_ids, seq_idx=seq_idx)
+
+        self.assertTrue(seen, "the linear-attention mixer was never called")
+        self.assertIn("seq_idx", seen[0])
+
     def test_attention_outputs(self):
         r"""
         Overriding the test_attention_outputs test as the NemotronH model outputs attention only for its attention layers


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48490&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48490) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48490&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48490)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Three models with a Mamba2 mixer never deliver kernel kwargs to it, because the block accepts `**kwargs` and then drops them at the mixer call:

```python
# nemotron_h, before
if self.block_type == "linear_attention":
    hidden_states = self.mixer(hidden_states, cache_params=past_key_values, attention_mask=attention_mask)
```

The Mamba2 mixer is already written to receive them — it splats them into all three kernel calls (`mamba2_split_conv1d_scan_combined` via `fused_kwargs`, `causal_conv1d_fn`, and `mamba2_chunk_scan`) — so this is the missing hop.

The main consequence is `seq_idx`, which the Mamba2 kernels use to keep state from bleeding across concatenated sequences. Without it there is no way to run these models on packed / variable-length batches: the conv and scan treat a packed row as one long sequence. With this change, `model(input_ids, seq_idx=seq_idx)` reaches the kernels.

## Which models

Checked all six models with a Mamba2 mixer, on both hops:

| model | model → block | block → mixer |
| --- | --- | --- |
| `bamba` | passes `**kwargs` | passes `**kwargs` |
| `granitemoehybrid` | passes `**kwargs` | passes `**kwargs` |
| `zamba2` | passes `**kwargs` | passes `**kwargs` |
| `nemotron_h` | passes `**kwargs` | **fixed here** |
| `falcon_h1` | **fixed here** | **fixed here** |
| `mamba2` | **fixed here** | **fixed here** |

`bamba`, `granitemoehybrid` and `zamba2` already forward kwargs in exactly this position, so this brings the other three in line rather than introducing a new pattern. `falcon_h1` and `mamba2` lost them at both hops.

`nemotron_h` and `falcon_h1` are changed through their modular files and regenerated; `mamba2` has no modular file.

## Tests

`test_kwargs_reach_mamba2_mixer` plus a `create_and_check_kwargs_reach_mamba2_mixer` tester method for each of the three models, asserting a kwarg handed to the model arrives at the mixer. Each fails without its corresponding fix.

```
tests/models/nemotron_h tests/models/falcon_h1 tests/models/mamba2
389 passed, 462 skipped, 2808 subtests passed
```

`utils/check_modular_conversion.py` and `ruff check` / `ruff format` are clean.

## Context

Found while adding Mamba2 packing support to Unsloth ([unslothai/unsloth#9812](https://github.com/unslothai/unsloth/pull/9812)). Without this, reaching the kernels from outside requires rebinding the kernel symbol in the modeling module's globals, which this makes unnecessary.

## Who can review?

@ArthurZucker @vasqu