### PR TITLE
docs: document DynamicCache key_cache/value_cache/legacy_cache removals in v5 migration guide 

### DIFF
--- a/MIGRATION_GUIDE_V5.md
+++ b/MIGRATION_GUIDE_V5.md
@@ -612,6 +612,18 @@ Linked PR: https://github.com/huggingface/transformers/pull/43514
 - If `generate` doesn't receive any KV Cache argument, the default cache class used is now defined by the model (as opposed to always being `DynamicCache`) (https://github.com/huggingface/transformers/pull/41505)
 - Generation parameters are no longer accessible via model's config. If generation parameters are serialized in `config.json` for any old model, it will be loaded back into model's generation config. Users are expected to access or modify generation parameters only with `model.generation_config.do_sample = True`.
 
+### DynamicCache API changes
+
+Several `DynamicCache` attributes and methods used for manually reading or
+rebuilding KV caches (e.g. in speculative decoding, prefix caching, or cache
+splicing) were removed in v5:
+
+| Removed in v5 | Replacement |
+|---|---|
+| `cache.key_cache[i]` / `cache.value_cache[i]` | `cache.layers[i].keys` / `cache.layers[i].values` |
+| `DynamicCache.from_legacy_cache(past_key_values)` | `DynamicCache(ddp_cache_data=past_key_values)` |
+| `cache.to_legacy_cache()` | Iterate over `cache.layers`, collecting `.keys` / `.values` per layer |
+
 ## Trainer
 
 ### Removing arguments without deprecation cycle in `TrainingArguments` due to low usage


### PR DESCRIPTION
## What does this PR do? 

Fixes #48479 

I added a table for DynamicCache that mentions the previous attributes that are no longer being used or got replaced. I verified the following against current `main`:

* `cache.layers[i].keys` / `.values` are replacements of `key_cache`/`value_cache`.
* `DynamicCache(ddp_cache_data=[(k, v)])` correctly initializes layers with matching tensors.
* `from_legacy_cache` / `to_legacy_cache` are removed from `src/transformers`.

## Code Agent Policy

* [x] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting

* [x] This PR fixes a typo or improves the docs.
* [x] Did you read the contributor guideline and the Pull Request checks?
* [x] Did you make sure to update the documentation with your changes according to the guidelines?
* [ ] Was this discussed/approved via a Github issue or the forum?
* [ ] Did you write any new necessary tests?

## **Who can review?** 

Documentation: @stevhliu 
