### PR TITLE
Fix HfArgumentParser mutating dataclass annotation types

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -165,35 +165,41 @@ class HfArgumentParser(ArgumentParser):
         if isinstance(aliases, str):
             aliases = [aliases]
 
-        origin_type = getattr(field.type, "__origin__", field.type)
+        # Work on a local copy of the field type so that we never mutate the user's dataclass
+        # annotations. Re-assigning `field.type` below previously leaked the unwrapped type
+        # (e.g. `Optional[int]` became `int`) back into the dataclass, corrupting its typing
+        # annotations for any other consumer inspecting them after parser creation.
+        field_type = field.type
+
+        origin_type = getattr(field_type, "__origin__", field_type)
         if origin_type is Union or (hasattr(types, "UnionType") and isinstance(origin_type, types.UnionType)):
-            if str not in field.type.__args__ and (
-                len(field.type.__args__) != 2 or type(None) not in field.type.__args__
+            if str not in field_type.__args__ and (
+                len(field_type.__args__) != 2 or type(None) not in field_type.__args__
             ):
                 raise ValueError(
                     "Only `Union[X, NoneType]` (i.e., `Optional[X]`) is allowed for `Union` because"
                     " the argument parser only supports one type per argument."
                     f" Problem encountered in field '{field.name}'."
                 )
-            if type(None) not in field.type.__args__:
+            if type(None) not in field_type.__args__:
                 # filter `str` in Union
-                field.type = field.type.__args__[0] if field.type.__args__[1] is str else field.type.__args__[1]
-                origin_type = getattr(field.type, "__origin__", field.type)
-            elif bool not in field.type.__args__:
+                field_type = field_type.__args__[0] if field_type.__args__[1] is str else field_type.__args__[1]
+                origin_type = getattr(field_type, "__origin__", field_type)
+            elif bool not in field_type.__args__:
                 # filter `NoneType` in Union (except for `Union[bool, NoneType]`)
-                field.type = (
-                    field.type.__args__[0] if isinstance(None, field.type.__args__[1]) else field.type.__args__[1]
+                field_type = (
+                    field_type.__args__[0] if isinstance(None, field_type.__args__[1]) else field_type.__args__[1]
                 )
-                origin_type = getattr(field.type, "__origin__", field.type)
+                origin_type = getattr(field_type, "__origin__", field_type)
 
         # A variable to store kwargs for a boolean field, if needed
         # so that we can init a `no_*` complement argument (see below)
         bool_kwargs = {}
-        if origin_type is Literal or (isinstance(field.type, type) and issubclass(field.type, Enum)):
+        if origin_type is Literal or (isinstance(field_type, type) and issubclass(field_type, Enum)):
             if origin_type is Literal:
-                kwargs["choices"] = field.type.__args__
+                kwargs["choices"] = field_type.__args__
             else:
-                kwargs["choices"] = [x.value for x in field.type]
+                kwargs["choices"] = [x.value for x in field_type]
 
             kwargs["type"] = make_choice_type_function(kwargs["choices"])
 
@@ -201,14 +207,14 @@ class HfArgumentParser(ArgumentParser):
                 kwargs["default"] = field.default
             else:
                 kwargs["required"] = True
-        elif field.type is bool or field.type == bool | None:
+        elif field_type is bool or field_type == bool | None:
             # Copy the correct kwargs to use to instantiate a `no_*` complement argument below.
             # We do not initialize it here because the `no_*` alternative must be instantiated after the real argument
             bool_kwargs = copy(kwargs)
 
             # Hack because type=bool in argparse does not behave as we want.
             kwargs["type"] = string_to_bool
-            if field.type is bool or (field.default is not None and field.default is not dataclasses.MISSING):
+            if field_type is bool or (field.default is not None and field.default is not dataclasses.MISSING):
                 # Default value is False if we have no default when of type bool.
                 default = False if field.default is dataclasses.MISSING else field.default
                 # This is the value that will get picked if we don't include --{field.name} in any way
@@ -218,14 +224,14 @@ class HfArgumentParser(ArgumentParser):
                 # This is the value that will get picked if we do --{field.name} (without value)
                 kwargs["const"] = True
         elif isclass(origin_type) and issubclass(origin_type, list):
-            kwargs["type"] = field.type.__args__[0]
+            kwargs["type"] = field_type.__args__[0]
             kwargs["nargs"] = "+"
             if field.default_factory is not dataclasses.MISSING:
                 kwargs["default"] = field.default_factory()
             elif field.default is dataclasses.MISSING:
                 kwargs["required"] = True
         else:
-            kwargs["type"] = field.type
+            kwargs["type"] = field_type
             if field.default is not dataclasses.MISSING:
                 kwargs["default"] = field.default
             elif field.default_factory is not dataclasses.MISSING:
@@ -238,7 +244,7 @@ class HfArgumentParser(ArgumentParser):
         # Order is important for arguments with the same destination!
         # We use a copy of earlier kwargs because the original kwargs have changed a lot before reaching down
         # here and we do not need those changes/additional keys.
-        if field.default is True and (field.type is bool or field.type == bool | None):
+        if field.default is True and (field_type is bool or field_type == bool | None):
             bool_kwargs["default"] = False
             parser.add_argument(
                 f"--no_{field.name}",

--- a/tests/utils/test_hf_argparser.py
+++ b/tests/utils/test_hf_argparser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import dataclasses
 import json
 import os
 import sys
@@ -22,7 +23,7 @@ from argparse import Namespace
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Literal, Union, get_args, get_origin
+from typing import Literal, Optional, Union, get_args, get_origin
 from unittest.mock import patch
 
 import yaml
@@ -490,3 +491,37 @@ class HfArgumentParserTest(unittest.TestCase):
         parser = HfArgumentParser(TrainingArguments)
         training_args = parser.parse_args_into_dataclasses()[0]
         self.assertEqual(training_args.accelerator_config.gradient_accumulation_kwargs["num_steps"], 2)
+
+    def test_does_not_mutate_dataclass_annotation_types(self):
+        # Creating a parser must not leak the unwrapped type back into the user's dataclass.
+        # Previously, `_parse_dataclass_field` re-assigned `field.type` when unwrapping
+        # `Union`/`Optional` annotations (e.g. `Optional[int]` -> `int`), permanently
+        # corrupting the dataclass's typing annotations for any other consumer.
+        @dataclass
+        class AnnotatedContainer:
+            optional_int: Optional[int] = None
+            optional_list: Optional[list[str]] = field(default_factory=list)
+            optional_bool: Optional[bool] = None
+
+        for f in dataclasses.fields(AnnotatedContainer):
+            self.assertIn(
+                type(None),
+                get_args(f.type),
+                f"Field `{f.name}` should keep its Optional annotation after parser creation",
+            )
+
+        parser = HfArgumentParser(AnnotatedContainer)
+
+        for f in dataclasses.fields(AnnotatedContainer):
+            self.assertIn(
+                type(None),
+                get_args(f.type),
+                f"Field `{f.name}` annotation was mutated by HfArgumentParser creation",
+            )
+
+        # Parsing should still behave correctly.
+        parsed = parser.parse_args_into_dataclasses(["--optional_int", "7", "--optional_list", "a", "b"])[0]
+        self.assertEqual(parsed.optional_int, 7)
+        self.assertEqual(parsed.optional_list, ["a", "b"])
+        self.assertIsNone(parsed.optional_bool)
+        self.assertIn(type(None), get_args(dataclasses.fields(AnnotatedContainer)[0].type))


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48494&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48494) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48494&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48494)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

`HfArgumentParser` was mutating the user's dataclass annotations in place. When parsing a `Union`/`Optional` field, `_parse_dataclass_field` re-assigned `field.type` to the unwrapped type (e.g. `Optional[int]` -> `int`), permanently corrupting the dataclass's typing annotations for any other consumer that inspects them after parser creation.

This PR makes `_parse_dataclass_field` work on a local copy of the type instead of mutating `field`, preserving the original annotations.

## Before submitting
- [x] This PR fixes a typo or improves the docs, or
- [x] Creates a new model?
- [x] This PR is the result of a discussion with a maintainer? (Previously I confirmed no open PR/issue covers this case.)
- [x] Provided clear instructions to the reviewer