### PR TITLE
Fix pre patch release utility

### DIFF
--- a/utils/release.py
+++ b/utils/release.py
@@ -188,9 +188,11 @@ def pre_release_work(patch: bool = False):
 
     print(f"Updating version to {version}.")
     global_version_update(version, patch=patch)
-    print("Deleting conversion and internal utils scripts.")
-    remove_conversion_scripts()
-    remove_internal_utils()
+    # If releasing a patch, all those files were already deleted on the branch when releasing the main version
+    if not patch:
+        print("Deleting conversion and internal utils scripts.")
+        remove_conversion_scripts()
+        remove_internal_utils()
 
 
 def post_release_work():


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48499&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48499) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48499&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48499)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

As per the title. The files are already deleted and this leads to a crash as one of them is trying to be deleted without checking its existence first
Becoming too annoyed of it, so fixing