### PR TITLE
extend some case to xpu as well

### DIFF
--- a/tests/models/pe_audio/test_modeling_pe_audio.py
+++ b/tests/models/pe_audio/test_modeling_pe_audio.py
@@ -17,7 +17,6 @@ from transformers import PeAudioConfig, PeAudioEncoderConfig
 from transformers.audio_utils import load_audio
 from transformers.testing_utils import (
     require_torch,
-    require_torch_gpu,
     slow,
     torch_device,
 )
@@ -327,7 +326,6 @@ class PeAudioModelTest(ModelTesterMixin, unittest.TestCase):
     def test_can_init_all_missing_weights(self):
         pass
 
-    @require_torch_gpu  # pe-audio contains triton code which cannot run on CPU, so we only test on GPU
     def test_all_tensors_are_parameter_or_buffer(self):
         super().test_all_tensors_are_parameter_or_buffer()
 

--- a/tests/models/pe_audio/test_modeling_pe_audio.py
+++ b/tests/models/pe_audio/test_modeling_pe_audio.py
@@ -326,9 +326,6 @@ class PeAudioModelTest(ModelTesterMixin, unittest.TestCase):
     def test_can_init_all_missing_weights(self):
         pass
 
-    def test_all_tensors_are_parameter_or_buffer(self):
-        super().test_all_tensors_are_parameter_or_buffer()
-
 
 @require_torch
 class PeAudioIntegrationTest(unittest.TestCase):

--- a/tests/models/pe_video/test_modeling_pe_video.py
+++ b/tests/models/pe_video/test_modeling_pe_video.py
@@ -27,7 +27,6 @@ from ...test_modeling_common import (
     floats_tensor,
     ids_tensor,
     random_attention_mask,
-    require_torch_gpu,
 )
 
 
@@ -372,7 +371,6 @@ class PeVideoModelTest(ModelTesterMixin, unittest.TestCase):
     def test_can_init_all_missing_weights(self):
         pass
 
-    @require_torch_gpu  # pe-video contains triton code which cannot run on CPU, so we only test on GPU
     def test_all_tensors_are_parameter_or_buffer(self):
         super().test_all_tensors_are_parameter_or_buffer()
 

--- a/tests/models/pe_video/test_modeling_pe_video.py
+++ b/tests/models/pe_video/test_modeling_pe_video.py
@@ -371,9 +371,6 @@ class PeVideoModelTest(ModelTesterMixin, unittest.TestCase):
     def test_can_init_all_missing_weights(self):
         pass
 
-    def test_all_tensors_are_parameter_or_buffer(self):
-        super().test_all_tensors_are_parameter_or_buffer()
-
 
 @require_torch
 class PeVideoIntegrationTest(unittest.TestCase):

--- a/tests/models/pi0/test_modeling_pi0.py
+++ b/tests/models/pi0/test_modeling_pi0.py
@@ -23,7 +23,7 @@ from transformers import PI0Config, PI0Processor, Trainer, TrainingArguments, is
 from transformers.image_utils import load_image
 from transformers.testing_utils import (
     require_torch,
-    require_torch_large_gpu,
+    require_torch_large_accelerator,
     require_torch_non_multi_accelerator,
     slow,
     torch_device,
@@ -414,7 +414,7 @@ class PI0ModelIntegrationTest(unittest.TestCase):
             sampled[0, -1, :4], torch.tensor([-0.2541, -0.1213, -0.2637, 0.2935]), atol=1e-3, rtol=1e-3
         )
 
-    @require_torch_large_gpu
+    @require_torch_large_accelerator
     @require_torch_non_multi_accelerator
     def test_train_pi0_base_libero(self):
         model = PI0ForConditionalGeneration.from_pretrained("lerobot/pi0_base", torch_dtype=torch.bfloat16).eval()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48502&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48502) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48502&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48502)
<!-- ci-dashboard-badge:end -->

pe-audio/pe-video do not have triton specific code, the case could run in cpu as well


- Intel XPU: @IlyasMoutawwakil