### PR TITLE
Fix some tests by removing the deprecation cycle

### DIFF
--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -177,7 +177,6 @@ def _alloc_expert_proj(
     return weight, sf
 
 
-@deprecate_kwarg("output_dtype", version="v5.16")
 def finegrained_fp8_linear(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -185,7 +184,6 @@ def finegrained_fp8_linear(
     block_size: list[int] | None = None,
     bias: torch.Tensor | None = None,
     activation_scale: torch.Tensor | None = None,
-    output_dtype: torch.dtype | None = None,
 ) -> torch.Tensor:
     """Triton FP8/FP4 linear: fused act-quant + matmul, then optional bias add.
 
@@ -208,7 +206,6 @@ def finegrained_fp8_linear(
     return output
 
 
-@deprecate_kwarg("output_dtype", version="v5.16")
 def fp8_linear(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -216,7 +213,6 @@ def fp8_linear(
     block_size: list[int] | None = None,
     bias: torch.Tensor | None = None,
     activation_scale: torch.Tensor | None = None,
-    output_dtype: torch.dtype | None = None,
     allow_deepgemm: bool = True,
 ) -> torch.Tensor:
     """End-to-end FP8/FP4 linear used by `FP8Linear` and the eager `FP8Experts` loop.

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -26,7 +26,6 @@ from ..activations import ACT2FN
 from ..core_model_loading import ConversionOps
 from ..quantizers.quantizers_utils import get_module_from_name, should_convert_module
 from ..utils import logging
-from ..utils.deprecation import deprecate_kwarg
 from ..utils.import_utils import is_kernels_available
 from .deepgemm import (
     deepgemm_fp8_fp4_experts_forward,

--- a/tests/kernels/test_deepgemm.py
+++ b/tests/kernels/test_deepgemm.py
@@ -453,21 +453,6 @@ class DeepGemmForwardTest(unittest.TestCase):
                 deepgemm_fp8_fp4_linear(input, weight, weight_scale, block_size=(128, 128))
         self.assertEqual(captured, {})  # raised before the kernel ran
 
-    def test_linear_adds_bias_and_ignores_deprecated_output_dtype(self):
-        input = torch.randn(4, 128, dtype=torch.bfloat16, device=torch_device)
-        weight = torch.randn(16, 128, device=torch_device).to(torch.float8_e4m3fn)
-        weight_scale = torch.ones(1, 1, dtype=torch.float32, device=torch_device)
-        bias = torch.randn(16, dtype=torch.bfloat16, device=torch_device)
-        with self._bundle(is_sm100=False):
-            with self.assertWarnsRegex(FutureWarning, "output_dtype"):
-                out = deepgemm_fp8_fp4_linear(
-                    input, weight, weight_scale, bias=bias, block_size=(128, 128), output_dtype=torch.float32
-                )
-        # output_dtype is deprecated and ignored: output follows input.dtype, not the requested float32.
-        self.assertEqual(out.dtype, torch.bfloat16)
-        # The fake matmul zeros the output buffer, so the result is exactly the broadcast bias.
-        self.assertTrue(torch.equal(out, bias.expand(4, 16)))
-
     # ── deepgemm_bf16_experts_forward ──────────────────────────────────────────
 
     def _bf16_hidden(self, experts, *, num_tokens=3, top_k=2):

--- a/tests/kernels/test_finegrained_fp8.py
+++ b/tests/kernels/test_finegrained_fp8.py
@@ -209,27 +209,6 @@ class FinegrainedFp8ForwardTest(unittest.TestCase):
         self.assertIsNone(call["activation_scale"])
         self.assertEqual(out.dtype, torch.bfloat16)
 
-    def test_linear_forwards_activation_scale_and_ignores_deprecated_output_dtype(self):
-        input = torch.randn(3, 8, dtype=torch.bfloat16, device=torch_device)
-        weight = torch.randn(16, 8, device=torch_device).to(torch.float8_e4m3fn)
-        weight_scale_inv = torch.randn(1, 1, dtype=torch.float32, device=torch_device)
-        activation_scale = torch.tensor(2.0, device=torch_device)
-        with self._mocked_kernel() as calls:
-            with self.assertWarnsRegex(FutureWarning, "output_dtype"):
-                out = finegrained_fp8_linear(
-                    input,
-                    weight,
-                    weight_scale_inv,
-                    block_size=None,
-                    activation_scale=activation_scale,
-                    output_dtype=torch.float32,  # deprecated + ignored
-                )
-        call = calls["matmul"][0]
-        self.assertIs(call["activation_scale"], activation_scale)
-        # output_dtype is deprecated and ignored: the kernel receives input.dtype, not the requested float32.
-        self.assertEqual(call["output_dtype"], torch.bfloat16)
-        self.assertEqual(out.dtype, torch.bfloat16)
-
     def test_linear_adds_bias_in_place(self):
         input = torch.randn(3, 8, dtype=torch.bfloat16, device=torch_device)
         weight = torch.randn(16, 8, device=torch_device).to(torch.float8_e4m3fn)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48503&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48503) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48503&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48503)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

As per the title. Those tests started failing after https://github.com/huggingface/transformers/pull/48498 which does not really make sense as this commit only bumps the current dev version
cc @IlyasMoutawwakil to double-check! Also this kind of tests should not be used as they start failing very weirdly as we increase the versions numbers haha