### PR TITLE
Retire test_multi_gpu_data_parallel_forward

### DIFF
--- a/tests/models/aimv2/test_modeling_aimv2.py
+++ b/tests/models/aimv2/test_modeling_aimv2.py
@@ -415,10 +415,6 @@ class Aimv2ModelTest(Aimv2ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     def test_model_get_set_embeddings(self):
         pass
 
-    @unittest.skip("Size mismatch on CUDA")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     def test_load_vision_text_config(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/models/align/test_modeling_align.py
+++ b/tests/models/align/test_modeling_align.py
@@ -460,10 +460,6 @@ class AlignModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     def test_batching_equivalence(self, atol=3e-4, rtol=3e-4):
         super().test_batching_equivalence(atol=atol, rtol=rtol)
 
-    @unittest.skip(reason="Start to fail after using torch `cu118`.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(reason="Hidden_states is tested in individual model tests")
     def test_hidden_states_output(self):
         pass

--- a/tests/models/beit/test_modeling_beit.py
+++ b/tests/models/beit/test_modeling_beit.py
@@ -22,7 +22,6 @@ from datasets import load_dataset
 from transformers import BeitConfig
 from transformers.testing_utils import (
     require_torch,
-    require_torch_multi_gpu,
     require_vision,
     slow,
     torch_device,
@@ -280,11 +279,6 @@ class BeitModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
     @unittest.skip(reason="BEiT does not use inputs_embeds")
     def test_inputs_embeds(self):
-        pass
-
-    @require_torch_multi_gpu
-    @unittest.skip(reason="BEiT has some layers using `add_module` which doesn't work well with `nn.DataParallel`")
-    def test_multi_gpu_data_parallel_forward(self):
         pass
 
     @unittest.skip(reason="BEiT does not support feedforward chunking yet")

--- a/tests/models/bros/test_modeling_bros.py
+++ b/tests/models/bros/test_modeling_bros.py
@@ -16,7 +16,7 @@
 import copy
 import unittest
 
-from transformers.testing_utils import require_torch, require_torch_multi_gpu, slow, torch_device
+from transformers.testing_utils import require_torch, slow, torch_device
 from transformers.utils import is_torch_available
 
 from ...test_configuration_common import ConfigTester
@@ -346,10 +346,6 @@ class BrosModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
-
-    @require_torch_multi_gpu
-    def test_multi_gpu_data_parallel_forward(self):
-        super().test_multi_gpu_data_parallel_forward()
 
     def test_for_token_classification(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/models/colmodernvbert/test_modeling_colmodernvbert.py
+++ b/tests/models/colmodernvbert/test_modeling_colmodernvbert.py
@@ -181,10 +181,6 @@ class ColModernVBertForRetrievalModelTest(ModelTesterMixin, unittest.TestCase):
 
             self.assertIsInstance(outputs, ColModernVBertForRetrievalOutput)
 
-    @unittest.skip(reason="Error related to ModernBERT model parallelism: self.dtype is broken.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
 
 @require_torch
 class ColModernVBertModelIntegrationTest(unittest.TestCase):

--- a/tests/models/conditional_detr/test_modeling_conditional_detr.py
+++ b/tests/models/conditional_detr/test_modeling_conditional_detr.py
@@ -234,11 +234,6 @@ class ConditionalDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.T
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_conditional_detr_object_detection_head_model(*config_and_inputs)
 
-    # TODO: check if this works again for PyTorch 2.x.y
-    @unittest.skip(reason="Got `CUDA error: misaligned address` with PyTorch 2.0.0.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(reason="Conditional DETR does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/models/d_fine/test_modeling_d_fine.py
+++ b/tests/models/d_fine/test_modeling_d_fine.py
@@ -335,10 +335,6 @@ class DFineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_d_fine_object_detection_head_model(*config_and_inputs)
 
-    @unittest.skip(reason="DFine doesn't work well with `nn.DataParallel")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(reason="DFine does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/models/dab_detr/test_modeling_dab_detr.py
+++ b/tests/models/dab_detr/test_modeling_dab_detr.py
@@ -265,11 +265,6 @@ class DabDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
                     This can happen if `save_pretrained` remove the targets and not the keys from serialiazation, or you hardcoded `self.xxx = yyy` thus forcing to always tie -> they are removed from serialization.",
             )
 
-    # TODO: check if this works again for PyTorch 2.x.y
-    @unittest.skip(reason="Got `CUDA error: misaligned address` with PyTorch 2.0.0.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(reason="DETR does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/models/data2vec/test_modeling_data2vec_vision.py
+++ b/tests/models/data2vec/test_modeling_data2vec_vision.py
@@ -21,7 +21,6 @@ import pytest
 from transformers import Data2VecVisionConfig
 from transformers.testing_utils import (
     require_torch,
-    require_torch_multi_gpu,
     require_vision,
     slow,
     torch_device,
@@ -220,13 +219,6 @@ class Data2VecVisionModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Te
 
     @unittest.skip(reason="Data2VecVision does not use inputs_embeds")
     def test_inputs_embeds(self):
-        pass
-
-    @require_torch_multi_gpu
-    @unittest.skip(
-        reason="Data2VecVision has some layers using `add_module` which doesn't work well with `nn.DataParallel`"
-    )
-    def test_multi_gpu_data_parallel_forward(self):
         pass
 
     def test_model_get_set_embeddings(self):

--- a/tests/models/deimv2/test_modeling_deimv2.py
+++ b/tests/models/deimv2/test_modeling_deimv2.py
@@ -335,10 +335,6 @@ class Deimv2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_deimv2_object_detection_head_model(*config_and_inputs)
 
-    @unittest.skip(reason="Multi-scale deformable attention is incompatible with nn.DataParallel")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(
         reason="Deimv2 is a vision model but inputs_embeds is in the forward signature (inherited from D-FINE)"
     )
@@ -923,10 +919,6 @@ class Deimv2LiteEncoderModelTest(ModelTesterMixin, PipelineTesterMixin, unittest
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_deimv2_object_detection_head_model(*config_and_inputs)
 
-    @unittest.skip(reason="Multi-scale deformable attention is incompatible with nn.DataParallel")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(
         reason="Deimv2 is a vision model but inputs_embeds is in the forward signature (inherited from D-FINE)"
     )
@@ -1269,10 +1261,6 @@ class Deimv2DINOv3ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Test
     def test_deimv2_dinov3_object_detection_head_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_deimv2_object_detection_head_model(*config_and_inputs)
-
-    @unittest.skip(reason="Multi-scale deformable attention is incompatible with nn.DataParallel")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
 
     @unittest.skip(
         reason="Deimv2 is a vision model but inputs_embeds is in the forward signature (inherited from D-FINE)"

--- a/tests/models/deit/test_modeling_deit.py
+++ b/tests/models/deit/test_modeling_deit.py
@@ -225,13 +225,6 @@ class DeiTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         self.model_tester = DeiTModelTester(self)
         self.config_tester = ConfigTester(self, config_class=DeiTConfig, has_text_modality=False, hidden_size=32)
 
-    @unittest.skip(
-        "Since `torch==2.3+cu121`, although this test passes, many subsequent tests have `CUDA error: misaligned address`."
-        "If `nvidia-xxx-cu118` are also installed, no failure (even with `torch==2.3+cu121`)."
-    )
-    def test_multi_gpu_data_parallel_forward(self):
-        super().test_multi_gpu_data_parallel_forward()
-
     def test_config(self):
         self.config_tester.run_common_tests()
 

--- a/tests/models/detr/test_modeling_detr.py
+++ b/tests/models/detr/test_modeling_detr.py
@@ -241,11 +241,6 @@ class DetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_detr_object_detection_head_model(*config_and_inputs)
 
-    # TODO: check if this works again for PyTorch 2.x.y
-    @unittest.skip(reason="Got `CUDA error: misaligned address` with PyTorch 2.0.0.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(reason="DETR does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/models/dia/test_modeling_dia.py
+++ b/tests/models/dia/test_modeling_dia.py
@@ -524,10 +524,6 @@ class DiaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
     def test_model_get_set_embeddings(self):
         pass
 
-    @unittest.skip(reason="Encoder-Decoder cache can not be initialized.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @parameterized.expand([("linear",), ("dynamic",), ("yarn",)])
     @unittest.skip(
         "Model expects decoder inputs to be of certain shape and thus we cannot test scaling with long inputs"

--- a/tests/models/ernie4_5_vl_moe/test_modeling_ernie4_5_vl_moe.py
+++ b/tests/models/ernie4_5_vl_moe/test_modeling_ernie4_5_vl_moe.py
@@ -267,10 +267,6 @@ class Ernie4_5_VLMoeModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.
                 out_embeds = model(inputs_embeds=inputs_embeds, **inputs)[0]
             torch.testing.assert_close(out_embeds, out_ids)
 
-    @unittest.skip(reason="Size mismatch")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     def _video_features_prepare_config_and_inputs(self):
         """
         Helper method to extract only video-related inputs from the full set of inputs, for testing `get_video_features`.

--- a/tests/models/esm/test_modeling_esmfold.py
+++ b/tests/models/esm/test_modeling_esmfold.py
@@ -242,10 +242,6 @@ class EsmFoldModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
         finally:
             self.model_tester.get_config = original
 
-    @unittest.skip(reason="ESMFold doesn't support data parallel.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
 
 @require_torch
 class EsmModelIntegrationTest(TestCasePlus):

--- a/tests/models/falcon_mamba/test_modeling_falcon_mamba.py
+++ b/tests/models/falcon_mamba/test_modeling_falcon_mamba.py
@@ -391,10 +391,6 @@ class FalconMambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTest
             dict_inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
             check_equivalence(model, tuple_inputs, dict_inputs, {"output_hidden_states": True})
 
-    @unittest.skip("Mamba models do not support DDP.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(
         "FalconMamba shares Mamba1's conv path, which has no chunked-continuation support: on a cached "
         "multi-token forward it rebuilds conv_state from the zero-padded current chunk instead of bridging "

--- a/tests/models/glm46v/test_modeling_glm46v.py
+++ b/tests/models/glm46v/test_modeling_glm46v.py
@@ -232,10 +232,6 @@ class Glm46VModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
     def test_sdpa_can_dispatch_on_flash(self):
         pass
 
-    @unittest.skip(reason="Size mismatch")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip("Error with compilation")
     def test_generate_from_inputs_embeds_with_static_cache(self):
         pass

--- a/tests/models/glm4v/test_modeling_glm4v.py
+++ b/tests/models/glm4v/test_modeling_glm4v.py
@@ -232,10 +232,6 @@ class Glm4vModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase)
     def test_sdpa_can_dispatch_on_flash(self):
         pass
 
-    @unittest.skip(reason="Size mismatch")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip("Error with compilation")
     def test_generate_from_inputs_embeds_with_static_cache(self):
         pass

--- a/tests/models/glm4v_moe/test_modeling_glm4v_moe.py
+++ b/tests/models/glm4v_moe/test_modeling_glm4v_moe.py
@@ -241,10 +241,6 @@ class Glm4vMoeModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
     def test_sdpa_can_dispatch_on_flash(self):
         pass
 
-    @unittest.skip(reason="Size mismatch")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     def test_inputs_embeds(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/models/glm_image/test_modeling_glm_image.py
+++ b/tests/models/glm_image/test_modeling_glm_image.py
@@ -298,10 +298,6 @@ class GlmImageModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
     def test_sdpa_can_dispatch_on_flash(self):
         pass
 
-    @unittest.skip(reason="Size mismatch")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @pytest.mark.xfail(
         reason="GlmImage has a VQ module that uses `weight.data` directly in forward which prevent offloading on that module"
     )

--- a/tests/models/ijepa/test_modeling_ijepa.py
+++ b/tests/models/ijepa/test_modeling_ijepa.py
@@ -213,13 +213,6 @@ class IJepaModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
             hidden_size=32,
         )
 
-    @unittest.skip(
-        "Since `torch==2.3+cu121`, although this test passes, many subsequent tests have `CUDA error: misaligned address`."
-        "If `nvidia-xxx-cu118` are also installed, no failure (even with `torch==2.3+cu121`)."
-    )
-    def test_multi_gpu_data_parallel_forward(self):
-        super().test_multi_gpu_data_parallel_forward()
-
     def test_config(self):
         self.config_tester.run_common_tests()
 

--- a/tests/models/jamba/test_modeling_jamba.py
+++ b/tests/models/jamba/test_modeling_jamba.py
@@ -499,10 +499,6 @@ class JambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
                 # with attention mask
                 _ = model(dummy_input, attention_mask=dummy_attention_mask)
 
-    @unittest.skip("Jamba has a non standard cache which is not compatible with dp/ddp")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(
         "Jamba's Mamba1 conv path has no chunked-continuation support: on a cached multi-token forward it "
         "rebuilds conv_state from the zero-padded current chunk instead of bridging the previous window, so "

--- a/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
@@ -19,7 +19,6 @@ from transformers.testing_utils import (
     require_detectron2,
     require_non_xpu,
     require_torch,
-    require_torch_multi_gpu,
     slow,
     torch_device,
 )
@@ -293,16 +292,6 @@ class LayoutLMv2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
-
-    @require_torch_multi_gpu
-    @unittest.skip(
-        reason=(
-            "LayoutLMV2 and its dependency `detectron2` have some layers using `add_module` which doesn't work well"
-            " with `nn.DataParallel`"
-        )
-    )
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
 
     @unittest.skip("LayoutLM needs specific combination of config values and cannot run with defaults")
     def test_model_forward_default_config_values(self):

--- a/tests/models/mamba/test_modeling_mamba.py
+++ b/tests/models/mamba/test_modeling_mamba.py
@@ -362,10 +362,6 @@ class MambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     def test_beam_sample_generate(self):
         pass
 
-    @unittest.skip("Mamba models do not support DDP.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(
         "Mamba1's conv path has no chunked-continuation support: on a cached multi-token forward it "
         "rebuilds conv_state from the zero-padded current chunk instead of bridging the previous window "

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -314,10 +314,6 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         config_and_inputs[0].n_groups //= 2
         self.model_tester.create_and_check_mamba2_slow_vs_fast_forward(*config_and_inputs)
 
-    @unittest.skip(reason="A large mamba2 would be necessary (and costly) for that")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     def test_model_outputs_equivalence(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/models/mask2former/test_modeling_mask2former.py
+++ b/tests/models/mask2former/test_modeling_mask2former.py
@@ -27,7 +27,6 @@ from transformers.testing_utils import (
     require_torch,
     require_torch_accelerator,
     require_torch_fp16,
-    require_torch_multi_gpu,
     require_vision,
     slow,
     torch_device,
@@ -234,13 +233,6 @@ class Mask2FormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
 
     @unittest.skip(reason="Mask2Former does not use token embeddings")
     def test_resize_tokens_embeddings(self):
-        pass
-
-    @require_torch_multi_gpu
-    @unittest.skip(
-        reason="Mask2Former has some layers using `add_module` which doesn't work well with `nn.DataParallel`"
-    )
-    def test_multi_gpu_data_parallel_forward(self):
         pass
 
     @slow

--- a/tests/models/maskformer/test_modeling_maskformer.py
+++ b/tests/models/maskformer/test_modeling_maskformer.py
@@ -27,7 +27,6 @@ from transformers.testing_utils import (
     require_torch,
     require_torch_accelerator,
     require_torch_fp16,
-    require_torch_multi_gpu,
     require_vision,
     slow,
     torch_device,
@@ -265,13 +264,6 @@ class MaskFormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
 
     @unittest.skip(reason="MaskFormer does not use token embeddings")
     def test_resize_tokens_embeddings(self):
-        pass
-
-    @require_torch_multi_gpu
-    @unittest.skip(
-        reason="MaskFormer has some layers using `add_module` which doesn't work well with `nn.DataParallel`"
-    )
-    def test_multi_gpu_data_parallel_forward(self):
         pass
 
     @slow

--- a/tests/models/maskformer/test_modeling_maskformer_swin.py
+++ b/tests/models/maskformer/test_modeling_maskformer_swin.py
@@ -17,7 +17,7 @@ import collections
 import unittest
 
 from transformers import MaskFormerSwinConfig
-from transformers.testing_utils import require_torch, require_torch_multi_gpu, torch_device
+from transformers.testing_utils import require_torch, torch_device
 from transformers.utils import is_torch_available
 
 from ...test_backbone_common import BackboneTesterMixin
@@ -186,16 +186,6 @@ class MaskFormerSwinModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Te
             embed_dim=37,
             common_properties=["image_size", "patch_size", "num_channels"],
         )
-
-    @require_torch_multi_gpu
-    @unittest.skip(
-        reason=(
-            "`MaskFormerSwinModel` outputs `hidden_states_spatial_dimensions` which doesn't work well with"
-            " `nn.DataParallel`"
-        )
-    )
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/minicpmv4_6/test_modeling_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_modeling_minicpmv4_6.py
@@ -201,10 +201,6 @@ class MiniCPMV4_6ModelTest(VLMModelTest, unittest.TestCase):
     def test_flash_attn_2_fp32_ln(self):
         pass
 
-    @unittest.skip("The Qwen3.5 hybrid cache format cannot be instantiated from dp/ddp data.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(reason="MiniCPM-V 4.6 uses Qwen3.5 hybrid cache layers that are incompatible with QuantizedCache.")
     def test_generate_with_quant_cache(self):
         pass

--- a/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
+++ b/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
@@ -20,7 +20,6 @@ from transformers import MobileViTV2Config
 from transformers.testing_utils import (
     Expectations,
     require_torch,
-    require_torch_multi_gpu,
     require_vision,
     slow,
     torch_device,
@@ -223,11 +222,6 @@ class MobileViTV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
 
     @unittest.skip(reason="MobileViTV2 does not output attentions")
     def test_attention_outputs(self):
-        pass
-
-    @require_torch_multi_gpu
-    @unittest.skip(reason="Got `CUDA error: misaligned address` for tests after this one being run.")
-    def test_multi_gpu_data_parallel_forward(self):
         pass
 
     def test_model(self):

--- a/tests/models/modernvbert/test_modeling_modernvbert.py
+++ b/tests/models/modernvbert/test_modeling_modernvbert.py
@@ -429,10 +429,6 @@ class ModernVBertModelTest(ModelTesterMixin, unittest.TestCase):
             # Check that the model can still do a forward pass successfully (every parameter should be resized)
             model(**self._prepare_for_class(inputs_dict, model_class))
 
-    @unittest.skip(reason="ModernVBERT model parallelism causes error: self.dtype is broken.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(reason="Vision head's probe has no gradient.")
     def test_training_gradient_checkpointing(self):
         pass

--- a/tests/models/nemotron_h/test_modeling_nemotron_h.py
+++ b/tests/models/nemotron_h/test_modeling_nemotron_h.py
@@ -486,10 +486,6 @@ class NemotronHModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_generate_with_quant_cache(self):
         pass
 
-    @unittest.skip(reason="A large nemotron3 would be necessary (and costly) for that")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     def test_reverse_loading_mapping(self):
         super().test_reverse_loading_mapping(skip_base_model=True)
 

--- a/tests/models/olmo_hybrid/test_modeling_olmo_hybrid.py
+++ b/tests/models/olmo_hybrid/test_modeling_olmo_hybrid.py
@@ -154,10 +154,6 @@ class OlmoHybridModelTest(CausalLMModelTest, unittest.TestCase):
             self.assertEqual(len(self_attentions), sum(layer == "full_attention" for layer in config.layer_types))
             self.assertListEqual(list(self_attentions[0].shape[-3:]), [config.num_attention_heads, seq_len, seq_len])
 
-    @unittest.skip("The specific cache format cannot be instantiated from dp/ddp data.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
 
 @require_torch
 class OlmoHybridIntegrationTest(unittest.TestCase):

--- a/tests/models/omdet_turbo/test_modeling_omdet_turbo.py
+++ b/tests/models/omdet_turbo/test_modeling_omdet_turbo.py
@@ -224,12 +224,6 @@ class OmDetTurboModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
         config, inputs_dict = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_object_detection_head_model(config, inputs_dict)
 
-    @unittest.skip(
-        reason="Unsupported as classes_input_ids are classes input are flattened by the processor: https://github.com/huggingface/transformers/issues/33669"
-    )
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(reason="OmDet-Turbo does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/models/oneformer/test_modeling_oneformer.py
+++ b/tests/models/oneformer/test_modeling_oneformer.py
@@ -29,7 +29,6 @@ from transformers.testing_utils import (
     require_torch,
     require_torch_accelerator,
     require_torch_fp16,
-    require_torch_multi_gpu,
     require_vision,
     slow,
     torch_device,
@@ -296,13 +295,6 @@ class OneFormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
 
     @unittest.skip(reason="OneFormer does not use token embeddings")
     def test_resize_tokens_embeddings(self):
-        pass
-
-    @require_torch_multi_gpu
-    @unittest.skip(
-        reason="OneFormer has some layers using `add_module` which doesn't work well with `nn.DataParallel`"
-    )
-    def test_multi_gpu_data_parallel_forward(self):
         pass
 
     def test_forward_signature(self):

--- a/tests/models/paddleocr_vl/test_modeling_paddleocr_vl.py
+++ b/tests/models/paddleocr_vl/test_modeling_paddleocr_vl.py
@@ -294,10 +294,6 @@ class PaddleOCRVLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTest
     def test_generate_compile_model_forward_fullgraph(self):
         pass
 
-    @unittest.skip(reason="PaddleOCRVL does not support.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @pytest.mark.generate
     @unittest.skip(reason="PaddleOCRVL does not support beam search.")
     def test_beam_sample_generate(self):

--- a/tests/models/perceiver/test_modeling_perceiver.py
+++ b/tests/models/perceiver/test_modeling_perceiver.py
@@ -27,7 +27,6 @@ from transformers import PerceiverConfig
 from transformers.testing_utils import (
     IS_ROCM_SYSTEM,
     require_torch,
-    require_torch_multi_gpu,
     require_vision,
     slow,
     torch_device,
@@ -815,16 +814,6 @@ class PerceiverModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
                             )
 
                     loss.backward()
-
-    @require_torch_multi_gpu
-    @unittest.skip(
-        reason=(
-            "Perceiver does not work with data parallel (DP) because of a bug in PyTorch:"
-            " https://github.com/pytorch/pytorch/issues/36035"
-        )
-    )
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
 
     @unittest.skip(reason="Perceiver doesn't support resize_token_embeddings")
     def test_resize_tokens_embeddings(self):

--- a/tests/models/phi4_multimodal/test_modeling_phi4_multimodal.py
+++ b/tests/models/phi4_multimodal/test_modeling_phi4_multimodal.py
@@ -226,10 +226,6 @@ class Phi4MultimodalModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.
     def test_training_gradient_checkpointing_use_reentrant_true(self):
         super().test_training_gradient_checkpointing_use_reentrant_true()
 
-    @unittest.skip(reason="Test tries to instantiate dynamic cache with an arg")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(reason="Test is only for old attention format")
     def test_sdpa_can_dispatch_composite_models(self):
         pass

--- a/tests/models/pp_formulanet/test_modeling_pp_formulanet.py
+++ b/tests/models/pp_formulanet/test_modeling_pp_formulanet.py
@@ -274,10 +274,6 @@ class PPFormulaNetModelTest(VLMModelTest, unittest.TestCase):
     def test_mismatching_num_image_tokens(self):
         pass
 
-    @unittest.skip(reason="PPFormulaNet does not support data parallel")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @parameterized.expand([("random",), ("same",)])
     @pytest.mark.generate
     @unittest.skip(reason="PPFormulaNet does not support assisted decoding.")

--- a/tests/models/pp_ocrv5_mobile_det/test_modeling_pp_ocrv5_mobile_det.py
+++ b/tests/models/pp_ocrv5_mobile_det/test_modeling_pp_ocrv5_mobile_det.py
@@ -166,10 +166,6 @@ class PPOCRV5MobileDetModelTest(ModelTesterMixin, unittest.TestCase):
     def test_model_get_set_embeddings(self):
         pass
 
-    @unittest.skip(reason="PPOCRV5MobileDet does not support.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     def test_forward_signature(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/models/pp_ocrv6_small_det/test_modeling_pp_ocrv6_small_det.py
+++ b/tests/models/pp_ocrv6_small_det/test_modeling_pp_ocrv6_small_det.py
@@ -165,10 +165,6 @@ class PPOCRV6SmallDetModelTest(ModelTesterMixin, unittest.TestCase):
     def test_model_get_set_embeddings(self):
         pass
 
-    @unittest.skip(reason="PPOCRV6SmallDet does not support.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     def test_forward_signature(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/models/qianfan_ocr/test_modeling_qianfan_ocr.py
+++ b/tests/models/qianfan_ocr/test_modeling_qianfan_ocr.py
@@ -140,10 +140,6 @@ class QianfanOCRModelTest(VLMModelTest, unittest.TestCase):
     def test_flash_attn_2_fp32_ln(self):
         pass
 
-    @unittest.skip("DataParallel is a deprecated legacy API and not officially supported")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
 
 @slow
 @require_torch_accelerator

--- a/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
@@ -468,10 +468,6 @@ class Qwen2_5_VLModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Test
     def test_sdpa_can_dispatch_on_flash(self):
         pass
 
-    @unittest.skip(reason="Got `CUDA error: misaligned address` with PyTorch 2.0.0.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
 
 @require_torch
 class Qwen2_5_VLIntegrationTest(unittest.TestCase):

--- a/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
@@ -438,10 +438,6 @@ class Qwen2VLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     def test_sdpa_can_dispatch_on_flash(self):
         pass
 
-    @unittest.skip(reason="Got `CUDA error: misaligned address` with PyTorch 2.0.0.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     def test_enable_input_require_grads_with_gradient_checkpointing(self):
         if not self.model_tester.is_training:
             self.skipTest(reason="ModelTester not in training mode")

--- a/tests/models/qwen3_5/test_modeling_qwen3_5.py
+++ b/tests/models/qwen3_5/test_modeling_qwen3_5.py
@@ -146,10 +146,6 @@ class Qwen3_5TextModelTest(CausalLMModelTest, unittest.TestCase):
             self.assertEqual(len(self_attentions), sum(layer == "full_attention" for layer in config.layer_types))
             self.assertListEqual(list(self_attentions[0].shape[-3:]), [config.num_attention_heads, seq_len, seq_len])
 
-    @unittest.skip("The specific cache format cannot be instantiated from dp/ddp data.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip("Intentionally not reversable (no changes) as only load time within a VLM depends on this")
     def test_reverse_loading_mapping(self, check_keys_were_modified=True):
         pass
@@ -723,10 +719,6 @@ class Qwen3_5ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCas
                 mm_token_type_ids=mm_token_type_ids,
             )
             self.assertIsNotNone(outputs)
-
-    @unittest.skip("The specific cache format cannot be instantiated from dp/ddp data.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
 
 
 @require_torch

--- a/tests/models/qwen3_5_moe/test_modeling_qwen3_5_moe.py
+++ b/tests/models/qwen3_5_moe/test_modeling_qwen3_5_moe.py
@@ -142,10 +142,6 @@ class Qwen3_5MoeTextModelTest(CausalLMModelTest, unittest.TestCase):
     def test_reverse_loading_mapping(self, check_keys_were_modified=True):
         pass
 
-    @unittest.skip("The specific cache format cannot be instantiated from dp/ddp data.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @require_causal_conv1d
     @require_flash_linear_attention
     @require_torch_gpu
@@ -676,7 +672,3 @@ class Qwen3_5MoeModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Test
                 mm_token_type_ids=mm_token_type_ids,
             )
             self.assertIsNotNone(outputs)
-
-    @unittest.skip("The specific cache format cannot be instantiated from dp/ddp data.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass

--- a/tests/models/qwen3_next/test_modeling_qwen3_next.py
+++ b/tests/models/qwen3_next/test_modeling_qwen3_next.py
@@ -254,10 +254,6 @@ class Qwen3NextModelTest(CausalLMModelTest, unittest.TestCase):
             enable_kernels,
         )
 
-    @unittest.skip("The specific cache format cannot be instantiated from dp/ddp data.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @require_torch_multi_accelerator
     def test_can_use_device_map(self):
         """

--- a/tests/models/qwen4_exp/test_modeling_qwen4_exp.py
+++ b/tests/models/qwen4_exp/test_modeling_qwen4_exp.py
@@ -173,10 +173,6 @@ class Qwen4ExpTextModelTest(CausalLMModelTest, unittest.TestCase):
     def test_generate_compilation_all_outputs(self):
         pass
 
-    @unittest.skip("The specific cache format cannot be instantiated from dp/ddp data.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip("Qwen4-Exp hybrid linear-attention cache is not compatible with quantized cache yet.")
     def test_generate_with_quant_cache(self):
         pass
@@ -554,10 +550,6 @@ class Qwen4ExpVisionText2TextModelTest(VLMModelTest, unittest.TestCase):
 
     @unittest.skip("Qwen4-Exp hybrid linear-attention cache is not compatible with quantized cache yet.")
     def test_generate_with_quant_cache(self):
-        pass
-
-    @unittest.skip("The specific cache format cannot be instantiated from dp/ddp data.")
-    def test_multi_gpu_data_parallel_forward(self):
         pass
 
     @unittest.skip(

--- a/tests/models/reformer/test_modeling_reformer.py
+++ b/tests/models/reformer/test_modeling_reformer.py
@@ -20,7 +20,6 @@ from transformers.testing_utils import (
     require_tokenizers,
     require_torch,
     require_torch_fp16,
-    require_torch_multi_gpu,
     slow,
     torch_device,
 )
@@ -571,16 +570,6 @@ class ReformerTesterMixin:
     def test_reformer_model_fp16_generate(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_reformer_model_fp16_generate(*config_and_inputs)
-
-    @require_torch_multi_gpu
-    @unittest.skip(
-        reason=(
-            "Reformer does not work with data parallel (DP) because of a bug in PyTorch:"
-            " https://github.com/pytorch/pytorch/issues/36035"
-        )
-    )
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
 
     def test_for_sequence_classification(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/models/splinter/test_modeling_splinter.py
+++ b/tests/models/splinter/test_modeling_splinter.py
@@ -17,7 +17,7 @@ import copy
 import unittest
 
 from transformers import is_torch_available
-from transformers.testing_utils import require_torch, require_torch_multi_gpu, slow, torch_device
+from transformers.testing_utils import require_torch, slow, torch_device
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, ids_tensor, random_attention_mask
@@ -326,35 +326,6 @@ class SplinterModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
         model_name = "tau/splinter-base"
         model = SplinterModel.from_pretrained(model_name)
         self.assertIsNotNone(model)
-
-    # overwrite from common since `SplinterForPreTraining` could contain different number of question tokens in inputs.
-    # When the batch is distributed to multiple devices, each replica could get different values for the maximal number
-    # of question tokens (see `SplinterForPreTraining._prepare_question_positions()`), and the model returns different
-    # shape along dimension 1 (i.e. `num_questions`) that could not be combined into a single tensor as an output.
-    @require_torch_multi_gpu
-    def test_multi_gpu_data_parallel_forward(self):
-        from torch import nn
-
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-
-        # move input tensors to cuda:O
-        for k, v in inputs_dict.items():
-            if torch.is_tensor(v):
-                inputs_dict[k] = v.to(0)
-
-        for model_class in self.all_model_classes:
-            # Skip this case since it will fail sometimes, as described above.
-            if model_class == SplinterForPreTraining:
-                continue
-
-            model = model_class(config=config)
-            model.to(0)
-            model.eval()
-
-            # Wrap model in nn.DataParallel
-            model = nn.DataParallel(model)
-            with torch.no_grad():
-                _ = model(**self._prepare_for_class(inputs_dict, model_class))
 
 
 @require_torch

--- a/tests/models/swin/test_modeling_swin.py
+++ b/tests/models/swin/test_modeling_swin.py
@@ -276,11 +276,6 @@ class SwinModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
-    # TODO: check if this works again for PyTorch 2.x.y
-    @unittest.skip(reason="Got `CUDA error: misaligned address` with PyTorch 2.0.0.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(
         reason="Swin always passes a non-null combined attention mask (relative position bias + optional "
         "cyclic-shift mask) to the attention interface. Flash attention does not support non-null "

--- a/tests/models/swin2sr/test_modeling_swin2sr.py
+++ b/tests/models/swin2sr/test_modeling_swin2sr.py
@@ -185,11 +185,6 @@ class Swin2SRModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_image_super_resolution(*config_and_inputs)
 
-    # TODO: check if this works again for PyTorch 2.x.y
-    @unittest.skip(reason="Got `CUDA error: misaligned address` with PyTorch 2.0.0.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(reason="Swin2SR does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/models/swinv2/test_modeling_swinv2.py
+++ b/tests/models/swinv2/test_modeling_swinv2.py
@@ -245,11 +245,6 @@ class Swinv2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_backbone(*config_and_inputs)
 
-    # TODO: check if this works again for PyTorch 2.x.y
-    @unittest.skip(reason="Got `CUDA error: misaligned address` with PyTorch 2.0.0.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @unittest.skip(reason="Swinv2 does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/models/univnet/test_modeling_univnet.py
+++ b/tests/models/univnet/test_modeling_univnet.py
@@ -119,10 +119,6 @@ class UnivNetModelTest(ModelTesterMixin, unittest.TestCase):
             self, config_class=UnivNetConfig, has_text_modality=False, common_properties=["num_mel_bins"]
         )
 
-    @unittest.skip(reason="fix this once it gets more usage")
-    def test_multi_gpu_data_parallel_forward(self):
-        super().test_multi_gpu_data_parallel_forward()
-
     def test_config(self):
         self.config_tester.run_common_tests()
 

--- a/tests/models/upernet/test_modeling_upernet.py
+++ b/tests/models/upernet/test_modeling_upernet.py
@@ -21,7 +21,6 @@ from transformers import ConvNextConfig, UperNetConfig
 from transformers.testing_utils import (
     require_timm,
     require_torch,
-    require_torch_multi_gpu,
     require_vision,
     slow,
     torch_device,
@@ -175,11 +174,6 @@ class UperNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
 
     @unittest.skip(reason="UperNet does not support input and output embeddings")
     def test_model_get_set_embeddings(self):
-        pass
-
-    @require_torch_multi_gpu
-    @unittest.skip(reason="UperNet has some layers using `add_module` which doesn't work well with `nn.DataParallel`")
-    def test_multi_gpu_data_parallel_forward(self):
         pass
 
     def test_hidden_states_output(self):

--- a/tests/models/vit/test_modeling_vit.py
+++ b/tests/models/vit/test_modeling_vit.py
@@ -209,13 +209,6 @@ class ViTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         self.model_tester = ViTModelTester(self)
         self.config_tester = ConfigTester(self, config_class=ViTConfig, has_text_modality=False, hidden_size=32)
 
-    @unittest.skip(
-        "Since `torch==2.3+cu121`, although this test passes, many subsequent tests have `CUDA error: misaligned address`."
-        "If `nvidia-xxx-cu118` are also installed, no failure (even with `torch==2.3+cu121`)."
-    )
-    def test_multi_gpu_data_parallel_forward(self):
-        super().test_multi_gpu_data_parallel_forward()
-
     def test_config(self):
         self.config_tester.run_common_tests()
 

--- a/tests/models/vits/test_modeling_vits.py
+++ b/tests/models/vits/test_modeling_vits.py
@@ -28,7 +28,6 @@ from transformers.testing_utils import (
     is_torch_available,
     require_torch,
     require_torch_fp16,
-    require_torch_multi_gpu,
     slow,
     torch_device,
 )
@@ -188,30 +187,6 @@ class VitsModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         global_rng.seed(12345)
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model_forward(*config_and_inputs)
-
-    @require_torch_multi_gpu
-    # override to force all elements of the batch to have the same sequence length across GPUs
-    def test_multi_gpu_data_parallel_forward(self):
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        config.use_stochastic_duration_prediction = False
-
-        # move input tensors to cuda:O
-        for key, value in inputs_dict.items():
-            if torch.is_tensor(value):
-                # make all elements of the batch the same -> ensures the output seq lengths are the same for DP
-                value[1:] = value[0]
-                inputs_dict[key] = value.to(0)
-
-        for model_class in self.all_model_classes:
-            model = model_class(config=config)
-            model.to(0)
-            model.eval()
-
-            # Wrap model in nn.DataParallel
-            model = torch.nn.DataParallel(model)
-            set_seed(555)
-            with torch.no_grad():
-                _ = model(**self._prepare_for_class(inputs_dict, model_class)).waveform
 
     @unittest.skip(reason="VITS is not deterministic")
     def test_determinism(self):

--- a/tests/models/voxtral_realtime/test_modeling_voxtral_realtime.py
+++ b/tests/models/voxtral_realtime/test_modeling_voxtral_realtime.py
@@ -255,12 +255,6 @@ class VoxtralRealtimeForConditionalGenerationModelTest(ALMModelTest, unittest.Te
     def test_left_padding_compatibility(self):
         pass
 
-    @unittest.skip(
-        reason="VoxtralRealtime output contains non-tensor padding_cache state that is incompatible with DataParallel gather"
-    )
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     @parameterized.expand([("linear",), ("dynamic",), ("yarn",)])
     @unittest.skip("Model needs special input preparation!")
     def test_model_rope_scaling_from_config(self, scaling_type):

--- a/tests/models/x_clip/test_modeling_x_clip.py
+++ b/tests/models/x_clip/test_modeling_x_clip.py
@@ -25,7 +25,6 @@ from transformers import XCLIPConfig, XCLIPTextConfig, XCLIPVisionConfig
 from transformers.testing_utils import (
     Expectations,
     require_torch,
-    require_torch_multi_gpu,
     require_vision,
     slow,
     torch_device,
@@ -310,31 +309,6 @@ class XCLIPVisionModelTest(ModelTesterMixin, unittest.TestCase):
                 list(self_attentions[0].shape[-3:]),
                 [self.model_tester.num_attention_heads, encoder_seq_length, encoder_seq_length],
             )
-
-    @require_torch_multi_gpu
-    def test_multi_gpu_data_parallel_forward(self):
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-
-        # move input tensors to cuda:O
-        for k, v in inputs_dict.items():
-            if torch.is_tensor(v):
-                inputs_dict[k] = v.to(0)
-
-        for model_class in self.all_model_classes:
-            model = model_class(config=config)
-            model.to(0)
-            model.eval()
-
-            # Wrap model in nn.DataParallel
-            model = nn.DataParallel(model)
-            with torch.no_grad():
-                test = self._prepare_for_class(inputs_dict, model_class)
-                for k, v in test.items():
-                    if isinstance(v, torch.Tensor):
-                        print(k, v.shape)
-                    else:
-                        print(k, v)
-                _ = model(**self._prepare_for_class(inputs_dict, model_class))
 
 
 class XCLIPTextModelTester:

--- a/tests/models/xlstm/test_modeling_xlstm.py
+++ b/tests/models/xlstm/test_modeling_xlstm.py
@@ -183,10 +183,6 @@ class xLSTMModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     def test_beam_search_generate_dict_outputs_use_cache(self):
         pass
 
-    @unittest.skip(reason="xLSTM cache is not iterable")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     def test_model_outputs_equivalence(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/models/zamba2/test_modeling_zamba2.py
+++ b/tests/models/zamba2/test_modeling_zamba2.py
@@ -381,10 +381,6 @@ class Zamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     def test_generate_continue_from_inputs_embeds(self):
         pass
 
-    @unittest.skip(reason="A large mamba2 would be necessary (and costly) for that")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
     def test_config(self):
         self.config_tester.run_common_tests()
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -105,7 +105,6 @@ from transformers.testing_utils import (
     require_torch_gpu,
     require_torch_mps,
     require_torch_multi_accelerator,
-    require_torch_multi_gpu,
     rocm_has_sdpa_flash_backend,
     run_first,
     run_test_using_subprocess,
@@ -3018,32 +3017,6 @@ class ModelTesterMixin(ExportTesterMixin):
                         inputs_embeds=inputs_embeds, decoder_inputs_embeds=decoder_inputs_embeds, **inputs
                     )[0]
             torch.testing.assert_close(out_embeds, out_ids)
-
-    @require_torch_gpu
-    @require_torch_multi_gpu
-    def test_multi_gpu_data_parallel_forward(self):
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-
-        # move input tensors to accelerator O
-        for k, v in inputs_dict.items():
-            if torch.is_tensor(v):
-                inputs_dict[k] = v.to(0)
-
-        for model_class in self.all_model_classes:
-            model = model_class(config=config)
-            model.to(0)
-            model.eval()
-
-            if model.config._experts_implementation == "grouped_mm":
-                # DataParallel does not respect buffer alignment when replicating the model on
-                # multiple GPUs, which can cause errors in grouped_mm experts implementation.
-                model.set_experts_implementation("eager")
-
-            # Wrap model in nn.DataParallel
-            model = nn.DataParallel(model)
-            torch.cuda.synchronize()  # otherwise the transfer might not be complete
-            with torch.no_grad():
-                _ = model(**self._prepare_for_class(inputs_dict, model_class))
 
     def check_device_map_is_respected(self, model, device_map):
         for param_name, param in model.named_parameters():


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48508&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48508) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48508&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48508)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`nn.DataParallel` cannot replicate or gather the forward patterns and output types modern Transformers models use, so this common test measures PyTorch's legacy DP path rather than model correctness.

DataParallel is a Trainer feature, not a per-model contract, and it keeps its coverage there (tests/trainer/test_trainer.py). This removes the common test and all 66 overrides; no `src/` behavior changes.