### PR TITLE
Fix DynamicCache.reset() leaving the cache in a corrupt, non-empty state

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -157,6 +157,22 @@ class DynamicLayer(CacheLayerMixin):
             return 0
         return self.keys.shape[-2]
 
+    def reset(self) -> None:
+        """Reset the layer to its uninitialized (empty) state.
+
+        A dynamic layer has no separate length counter -- its length *is* its
+        tensor shape -- so zeroing the tensors in place (the base implementation)
+        would leave ``get_seq_length()`` reporting the old length and
+        ``is_initialized`` ``True``, and the next ``update()`` would concatenate
+        onto the stale zeros.
+        """
+        self.keys = None
+        self.values = None
+        self.is_initialized = False
+        # Present on DynamicSlidingWindowLayer (always an int for dynamic layers).
+        if hasattr(self, "cumulative_length"):
+            self.cumulative_length = 0
+
     def get_max_length(self) -> int:
         """Returns the maximum sequence length of the cache object. DynamicLayer does not have a maximum length."""
         return -1
@@ -362,8 +378,10 @@ class DynamicIndexedLayer(DynamicLayer):
 
     def reset(self) -> None:
         super().reset()
-        if self.is_indexer_initialized:
-            self.indexer_keys.zero_()
+        # The indexer key cache also grows by concatenation, so it must be
+        # emptied rather than zeroed in place (see DynamicLayer.reset).
+        self.indexer_keys = None
+        self.is_indexer_initialized = False
 
     def reorder_cache(self, beam_idx: torch.LongTensor) -> None:
         super().reorder_cache(beam_idx)

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -1191,6 +1191,33 @@ class SyntheticCacheTest(unittest.TestCase):
             "DynamicCache Scenario 2 layer 1 failed",
         )
 
+    def test_dynamic_cache_reset_returns_to_empty_state(self):
+        """reset() must empty a DynamicCache, not zero its tensors in place.
+
+        A dynamic layer's length *is* its tensor shape, so the in-place zeroing
+        inherited from CacheLayerMixin left get_seq_length() reporting the old
+        length, is_initialized True, and the next update() concatenating onto
+        stale zeros.
+        """
+        prefill = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])[None, None, :, None]
+        update = torch.tensor([7.0, 8.0, 9.0])[None, None, :, None]
+
+        cache = DynamicCache()
+        cache.update(prefill, prefill, 0)
+        self.assertEqual(cache.get_seq_length(), 6)
+        self.assertTrue(cache.is_initialized)
+
+        cache.reset()
+        self.assertEqual(cache.get_seq_length(), 0)
+        self.assertFalse(cache.is_initialized)
+
+        keys, _ = cache.update(update, update, 0)
+        self.assertEqual(keys.shape[-2], 3)  # no stale positions prepended
+        self.assertEqual(keys[0, 0, :, 0].tolist(), [7.0, 8.0, 9.0])
+
+        # reset() on a fresh cache is a no-op, not a crash
+        DynamicCache().reset()
+
     def test_dynamic_cache_batch_select_indices(self):
         """Select a subset of batches in-place using batch_select_indices."""
         cache = DynamicCache()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48509&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48509) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48509&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48509)
<!-- ci-dashboard-badge:end -->

# Fix `DynamicCache.reset()` leaving the cache in a corrupt, non-empty state

## What does this PR do?

`Cache.reset()` is a public method. On a `DynamicCache` (the default cache for
generative models) it does **not** empty the cache — it leaves it in a corrupt
state where `get_seq_length()` still reports the old length and the next
`update()` concatenates onto stale zeros.

### Reproduction (on `main`)

```python
import torch
from transformers import DynamicCache

c = DynamicCache()
c.update(torch.randn(1, 4, 6, 8), torch.randn(1, 4, 6, 8), layer_idx=0)
print(c.get_seq_length(), c.is_initialized)   # 6 True

c.reset()
print(c.get_seq_length(), c.is_initialized)   # 6 True    <-- expected 0, False

k, _ = c.update(torch.randn(1, 4, 3, 8), torch.randn(1, 4, 3, 8), layer_idx=0)
print(k.shape[-2])                             # 9         <-- expected 3
# k[..., :6, :] is all-zero stale state
```

### Root cause

`CacheLayerMixin.reset()` zeroes `keys` / `values` **in place** (shape unchanged)
and leaves `is_initialized = True`:

```python
def reset(self) -> None:
    if self.is_initialized:
        self.keys.zero_()
        self.values.zero_()
    if hasattr(self, "cumulative_length"):
        ...
```

That is correct for `StaticLayer` — a pre-allocated buffer whose logical length
is a separate `cumulative_length` counter. `DynamicLayer` has **no** length
counter: its length *is* `keys.shape[-2]`, and it grows via `torch.cat`. It does
not override `reset()`, so after `reset()` the tensors are zeroed but keep their
old shape and `is_initialized` stays `True` → `get_seq_length()` returns the
stale length and `update()` does `torch.cat([stale_zeros, new_states], dim=-2)`.

Same for `DynamicSlidingWindowLayer` (`cumulative_length` gets reset by the base,
but the K/V tensors and `is_initialized` do not) and `DynamicIndexedLayer` (its
`reset()` calls `super().reset()` and then zeroes the also-concatenation-grown
`indexer_keys` in place).

`generate()` itself is unaffected — it only ever resets a `StaticCache` — but any
user code that reuses a cache across calls hits this.

## Fix

- Add `DynamicLayer.reset()` that returns the layer to its **uninitialised**
  state (`keys = values = None`, `is_initialized = False`, and
  `cumulative_length = 0` when present, covering `DynamicSlidingWindowLayer`).
- `DynamicIndexedLayer.reset()`: empty `indexer_keys` (`None` +
  `is_indexer_initialized = False`) instead of zeroing it in place.
- `LinearAttentionAndFullAttentionLayer.reset()` /
  `LinearAttentionAndSlidingWindowAttentionLayer.reset()` already delegate to
  `DynamicLayer.reset` / `DynamicSlidingWindowLayer.reset`, so they are fixed
  transitively.

After the fix, `DynamicCache.reset()` gives `get_seq_length() == 0`,
`is_initialized is False`, and a subsequent `update(3)` returns a length-3
sequence with no stale positions. `reset()` on a fresh cache stays a no-op.

## Not in scope (noted)

`QuantizedLayer` (KIVI-style quantized KV cache) subclasses `DynamicLayer` and
gets the `keys` / `values` / `is_initialized` reset from this change, but keeps
its `_quantized_keys` / `_quantized_values` residual buffers. If you'd like, I can
add a small `QuantizedLayer.reset()` in this PR or a follow-up.

## Tests

`tests/utils/test_cache_utils.py::SyntheticCacheTest::test_dynamic_cache_reset_returns_to_empty_state`
— fails on `main` (`AssertionError: 6 != 0`), passes with this change.

```
pytest tests/utils/test_cache_utils.py -q -k "SyntheticCacheTest or CacheTest or Cropping"
# 17 passed
```
`ruff check` / `ruff format --check` clean on both files.

## Before submitting

- [x] Read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).
- [x] This is a bug fix with a repro and a regression test.
- [ ] Did you write any new necessary tests? — yes, one.