### PR TITLE
Fix hybrid-cache get_mask_sizes redirect to prefer full-attention layers

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1578,14 +1578,17 @@ class Cache:
                     f"You called `get_mask_sizes` on layer index {layer_idx}, but this layer is a LinearAttention layer, which "
                     "does not track sequence length."
                 )
-            try:
-                # Use the first attention layer
-                layer_idx = next(idx for idx in range(len(self)) if isinstance(self.layers[idx], CacheLayerMixin))
-            except StopIteration:
+            attention_idxs = [idx for idx in range(len(self)) if isinstance(self.layers[idx], CacheLayerMixin)]
+            if not attention_idxs:
                 raise ValueError(
                     "`get_mask_sizes` can only be called on Attention layers, and the current Cache seem to only contain "
                     "LinearAttention layers."
                 )
+            # Prefer a full-attention layer: this fallback serves `create_causal_mask`, and redirecting to a
+            # sliding layer would bound the full-attention mask to the sliding window.
+            layer_idx = next(
+                (idx for idx in attention_idxs if not self.layers[idx].is_sliding), attention_idxs[0]
+            )
 
         return self.layers[layer_idx].get_mask_sizes(query_length)
 

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -189,6 +189,26 @@ class CacheTest(unittest.TestCase):
             keys, _ = cache.update(*_kv(1), layer_idx)
             self.assertEqual(keys.device.type, torch.device(torch_device).type)
 
+    def test_hybrid_cache_mask_sizes_prefer_full_attention_layers(self):
+        """
+        In a hybrid cache mixing linear-attention, sliding and full-attention layers (a [linear, sliding, full]
+        layout), `create_causal_mask` can resolve its reference layer to a linear-attention index. The
+        `get_mask_sizes` redirect must then land on a full-attention layer, not the sliding one -- otherwise the
+        full-attention mask is bounded to the sliding window and decoding crashes one token past it.
+        """
+        sliding_window = 4
+        layers = [LinearAttentionLayer(), DynamicSlidingWindowLayer(sliding_window), DynamicLayer()]
+        cache = Cache(layers=layers)
+        seen = 2 * sliding_window
+        states = torch.rand(1, 1, seen, 8)
+        cache.update(states, states.clone(), 1)
+        cache.update(states.clone(), states.clone(), 2)
+
+        self.assertEqual(
+            cache.get_mask_sizes(query_length=1, layer_idx=0), cache.get_mask_sizes(query_length=1, layer_idx=2)
+        )
+        self.assertEqual(cache.get_mask_sizes(query_length=1, layer_idx=0), (seen + 1, 0))
+
 
 def _skip_on_failed_cache_prerequisites(test, cache_implementation):
     """Function to skip tests on failed cache prerequisites, given a cache implementation"""


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48510&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48510) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48510&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48510)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes mask-size resolution for hybrid caches that mix linear-attention, sliding-window and full-attention layers.

`create_causal_mask` resolves its reference layer as `past_key_values.is_sliding.index(False)`. Linear-attention layers report `is_sliding=False`, so on a model whose first layer is linear (e.g. a `[linear, sliding, full]` layout) this resolves to a linear-attention index, and `Cache.get_mask_sizes` then redirects to the first attention layer of **any** kind — the sliding layer. The full-attention mask comes out bounded to `sliding_window - 1 + q` while the full-attention layer's cache holds every key, and decoding crashes with a mask/kv shape mismatch one token past the window.

No released model currently combines `sliding_attention` with linear-attention layers, which is why this path was never hit: sliding-window families (Mistral, Gemma, GPT-OSS, ...) have no linear layers, and linear hybrids (LFM2, Jamba, Bamba, Zamba2, Qwen3-Next, ...) pair linear layers with full attention only, where the redirect happens to land correctly. Architectures with all three layer kinds hit it immediately. The same blind spot was previously fixed for cache offloading (`prefetch` skips linear layers) but not for mask sizes.

The fix makes the redirect prefer the first non-sliding attention layer, falling back to any attention layer only when the cache has no full-attention layer. This is semantically exact for the only caller that reaches the redirect: `create_causal_mask` wants full-attention sizes, and `create_sliding_window_causal_mask` always passes a real sliding index directly.

Repro (before the fix):

```python
from transformers.cache_utils import Cache, DynamicLayer, DynamicSlidingWindowLayer, LinearAttentionLayer
import torch

cache = Cache(layers=[LinearAttentionLayer(), DynamicSlidingWindowLayer(4), DynamicLayer()])
states = torch.rand(1, 1, 8, 8)
cache.update(states, states.clone(), 1)
cache.update(states.clone(), states.clone(), 2)
print(cache.get_mask_sizes(query_length=1, layer_idx=0))  # (4, 5) — window-bounded
print(cache.get_mask_sizes(query_length=1, layer_idx=2))  # (9, 0) — correct full-attention sizes
```

Adds a regression test on that layout.

## Before submitting
- [x] Did you write any new necessary tests?

## Who can review?

gante, Cyrilvallez (cache / masking)