### PR TITLE
Fall back to config model_type mapping when image_processor_type is unresolvable (qwen3_vl/qwen3_5)

### DIFF
--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -649,6 +649,29 @@ class AutoImageProcessor:
         if base_class_name is not None:
             image_processor_class = _load_backend_class(base_class_name, backend, is_legacy_fast)
 
+            if image_processor_class is None and image_processor_auto_map is None:
+                # The checkpoint's `image_processor_type` does not resolve to any class known to this
+                # version of the library (e.g. a stale or legacy name saved by older versions or by
+                # checkpoints of models that reuse another model's image processor, such as
+                # Qwen3-VL-family checkpoints). Instead of failing outright, fall back to the mapping
+                # keyed on the model config's `model_type` (handled below).
+                try:
+                    if not isinstance(config, PreTrainedConfig):
+                        config = AutoConfig.from_pretrained(
+                            pretrained_model_name_or_path, trust_remote_code=trust_remote_code, **kwargs
+                        )
+                except (OSError, ValueError):
+                    # No usable model config (missing config.json, unrecognized model_type, ...):
+                    # keep the original error paths below.
+                    pass
+                else:
+                    if type(config) in IMAGE_PROCESSOR_MAPPING:
+                        logger.warning(
+                            f"Could not resolve `image_processor_type` {image_processor_type!r} to an image "
+                            f"processor class. Falling back to the image processor mapped for the "
+                            f"`{type(config).__name__}` model type."
+                        )
+
         # Handle remote code
         has_remote_code = image_processor_auto_map is not None
         has_local_code = image_processor_class is not None or type(config) in IMAGE_PROCESSOR_MAPPING

--- a/tests/models/auto/test_image_processing_auto.py
+++ b/tests/models/auto/test_image_processing_auto.py
@@ -352,6 +352,52 @@ class AutoImageProcessorTest(unittest.TestCase):
             image_processor = AutoImageProcessor.from_pretrained(tmpdirname, backend="pil")
             self.assertIsInstance(image_processor, ViTImageProcessorPil)
 
+    @require_torchvision
+    def test_fallback_to_config_mapping_when_image_processor_type_unresolvable(self):
+        # If the checkpoint ships an `image_processor_type` that does not resolve to any class in the
+        # current version of the library, we should fall back to the mapping keyed on the model config's
+        # `model_type` instead of raising "Unrecognized image processor".
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            processor_tmpfile = Path(tmpdirname) / "preprocessor_config.json"
+            config_tmpfile = Path(tmpdirname) / "config.json"
+            with open(processor_tmpfile, "w") as fp:
+                json.dump({"image_processor_type": "ThisImageProcessorDoesNotExist"}, fp)
+            with open(config_tmpfile, "w") as fp:
+                json.dump({"model_type": "clip"}, fp)
+
+            image_processor = AutoImageProcessor.from_pretrained(tmpdirname)
+            self.assertIsInstance(image_processor, CLIPImageProcessor)
+
+    @require_torchvision
+    def test_qwen3_vl_checkpoint_resolves_to_qwen2_vl_image_processor(self):
+        # Regression test for #48511: Qwen3-VL-family checkpoints reuse the Qwen2-VL image processor and
+        # ship legacy or unresolvable `image_processor_type` values. Both the legacy Fast name they ship
+        # and an unresolvable name must resolve through to the Qwen2-VL image processor.
+        from transformers import Qwen2VLImageProcessor
+
+        preprocessor_dict = {
+            "image_mean": [0.5, 0.5, 0.5],
+            "image_std": [0.5, 0.5, 0.5],
+            "patch_size": 16,
+            "merge_size": 2,
+            "temporal_patch_size": 2,
+            "processor_class": "Qwen3VLProcessor",
+        }
+        config_dict = {
+            "model_type": "qwen3_vl",
+            "text_config": {"model_type": "qwen3_vl_text"},
+            "vision_config": {"model_type": "qwen3_vl"},
+        }
+        for image_processor_type in ["Qwen2VLImageProcessorFast", "Qwen3VLImageProcessor"]:
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                with open(Path(tmpdirname) / "preprocessor_config.json", "w") as fp:
+                    json.dump({**preprocessor_dict, "image_processor_type": image_processor_type}, fp)
+                with open(Path(tmpdirname) / "config.json", "w") as fp:
+                    json.dump(config_dict, fp)
+
+                image_processor = AutoImageProcessor.from_pretrained(tmpdirname)
+                self.assertIsInstance(image_processor, Qwen2VLImageProcessor)
+
     def test_unavailable_backend_error_mentions_missing_dependency(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor_tmpfile = Path(tmpdirname) / "preprocessor_config.json"


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48513&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48513) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48513&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48513)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48511

## Root cause

`AutoImageProcessor.from_pretrained` resolves the class from the checkpoint's `image_processor_type` first, and only loads the model config (to key into `IMAGE_PROCESSOR_MAPPING` by `model_type`) when `image_processor_type` is absent. When `image_processor_type` is present but cannot be resolved to any class in the current version of the library, `_load_backend_class` returns `None`, `config` is never loaded (so `type(config) in IMAGE_PROCESSOR_MAPPING` is `False`), and the call falls through to the generic

```
ValueError: Unrecognized image processor in <path>. Should have a `image_processor_type` key ...
```

even though the checkpoint's `config.json` sits right next to it and its `model_type` maps cleanly.

This is exactly what happens for Qwen3-VL/Qwen3.5-family checkpoints when the shipped `image_processor_type` doesn't resolve: the trace in the issue shows the convention fallback `{'torchvision': 'Qwen3VLImageProcessor', 'pil': 'Qwen3VLImageProcessorPil'}` built by `_load_backend_class` for an unresolvable name (`transformers/models/qwen3_vl/` ships no image processing module), while `IMAGE_PROCESSOR_MAPPING_NAMES` already maps `qwen3_vl`/`qwen3_5` to `Qwen2VLImageProcessor`/`Qwen2VLImageProcessorPil` — the classes the issue confirms are functional stand-ins (same patch/merge/normalization parameters). The mapping just never got consulted.

## Fix

When the `image_processor_type` path resolves to no class (and there is no `auto_map` remote code), load the model config and let the existing `IMAGE_PROCESSOR_MAPPING[type(config)]` branch resolve the processor, with a warning. This keeps all existing error paths intact:

- no `config.json` / unrecognized `model_type`: the original errors are raised unchanged (existing tests `test_unrecognized_image_processor_error_when_no_backend_mapping_exists` and `test_unavailable_backend_error_mentions_missing_dependency` still pass);
- checkpoints with resolvable types (including legacy `*Fast` names) are untouched — the fallback only runs on the previously-failing path, so no extra config fetch for normal loads;
- remote-code (`auto_map`) resolution is untouched.

## Verification

Reproduced before the fix with a local snapshot containing the official `Qwen/Qwen3.8-27B` `config.json` (`model_type: qwen3_5`) and a `preprocessor_config.json` whose `image_processor_type` doesn't resolve:

```
ValueError: Unrecognized image processor in snap_badtype. Should have a `image_processor_type` key ...
```

After the fix, `AutoImageProcessor.from_pretrained` returns `Qwen2VLImageProcessor` (and `Qwen2VLImageProcessorPil` with `backend="pil"`), and `AutoProcessor.from_pretrained` returns a working `Qwen3VLProcessor`, for both `qwen3_5` and `qwen3_vl` configs, including the shipped legacy `image_processor_type: "Qwen2VLImageProcessorFast"`.

Added two regression tests in `tests/models/auto/test_image_processing_auto.py`:

- `test_fallback_to_config_mapping_when_image_processor_type_unresolvable` (generic, CLIP-based)
- `test_qwen3_vl_checkpoint_resolves_to_qwen2_vl_image_processor` (issue scenario: `qwen3_vl` config with both `Qwen2VLImageProcessorFast` and an unresolvable name)

`pytest tests/models/auto/test_image_processing_auto.py`: 24 passed. `ruff check` / `ruff format --check` (ruff 0.14.10) pass on both changed files.

## Who can review?

@yonigozlan @qubvel