### PR TITLE
Fix Unrecognized image processor error for legacy Qwen3VL image processor names

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -43,6 +43,14 @@ from . import logging
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
+# Legacy image processor class names that older checkpoints may reference in
+# their `image_processor_type`. Maps the removed/renamed name to the class that
+# now implements it. Resolved in `_LazyModule.__getattr__`.
+_LEGACY_IMAGE_PROCESSOR_CLASS_ALIASES: dict[str, str] = {
+    "Qwen3VLImageProcessor": "Qwen2VLImageProcessor",
+    "Qwen3VLImageProcessorPil": "Qwen2VLImageProcessorPil",
+}
+
 
 PACKAGE_DISTRIBUTION_MAPPING = importlib.metadata.packages_distributions()
 
@@ -2659,6 +2667,26 @@ class _LazyModule(ModuleType):
                         return value
                     except Exception as e:
                         logger.debug(f"Could not load fallback {fallback_name}: {e}")
+            # V5: Handle renamed image processor classes for backward compatibility.
+            # Older checkpoints reference class names that have since been folded into
+            # other implementations (e.g. Qwen3VL's image processor was merged into
+            # Qwen2VL's before release, but released checkpoints kept the old names
+            # in their image_processor_type). Alias them here so attribute access and
+            # AutoImageProcessor.from_pretrained keep working for those snapshots.
+            if name in _LEGACY_IMAGE_PROCESSOR_CLASS_ALIASES:
+                alias_target = _LEGACY_IMAGE_PROCESSOR_CLASS_ALIASES[name]
+                if alias_target in self._class_to_module:
+                    try:
+                        fb_module = self._get_module(self._class_to_module[alias_target])
+                        value = getattr(fb_module, alias_target)
+                        logger.warning_once(
+                            f"`{name}` is deprecated; it has been folded into `{alias_target}`. "
+                            f"Falling back to `{alias_target}` for backward compatibility."
+                        )
+                        setattr(self, name, value)
+                        return value
+                    except Exception as e:
+                        logger.debug(f"Could not load image processor alias {alias_target}: {e}")
             # V5: Handle *ImageProcessorFast backward compatibility
             # Similar to TokenizerFast, but for image processors
             if name.endswith("ImageProcessorFast"):

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -2677,8 +2677,10 @@ class _LazyModule(ModuleType):
                 alias_target = _LEGACY_IMAGE_PROCESSOR_CLASS_ALIASES[name]
                 if alias_target in self._class_to_module:
                     try:
-                        fb_module = self._get_module(self._class_to_module[alias_target])
-                        value = getattr(fb_module, alias_target)
+                        # Resolve the alias target through the normal __getattr__ path so
+                        # missing-backend placeholders and the *ImageProcessor -> *ImageProcessorPil
+                        # fallback keep working when optional dependencies are absent.
+                        value = getattr(self, alias_target)
                         logger.warning_once(
                             f"`{name}` is deprecated; it has been folded into `{alias_target}`. "
                             f"Falling back to `{alias_target}` for backward compatibility."

--- a/tests/models/auto/test_image_processing_auto.py
+++ b/tests/models/auto/test_image_processing_auto.py
@@ -28,6 +28,8 @@ from transformers import (
     AutoImageProcessor,
     CLIPConfig,
     CLIPImageProcessor,
+    Qwen2VLImageProcessor,
+    Qwen2VLImageProcessorPil,
     ViTImageProcessor,
     ViTImageProcessorPil,
 )
@@ -351,6 +353,26 @@ class AutoImageProcessorTest(unittest.TestCase):
 
             image_processor = AutoImageProcessor.from_pretrained(tmpdirname, backend="pil")
             self.assertIsInstance(image_processor, ViTImageProcessorPil)
+
+    @require_torchvision
+    def test_legacy_renamed_class_name_in_config(self):
+        # Older Qwen3.5-VL/Qwen3-VL checkpoints reference image processor class names that
+        # were folded into Qwen2VL before release. The legacy names must alias to the
+        # Qwen2VL implementations so those snapshots keep loading.
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            processor_tmpfile = Path(tmpdirname) / "preprocessor_config.json"
+            json.dump({"image_processor_type": "Qwen3VLImageProcessor"}, open(processor_tmpfile, "w"))
+
+            image_processor = AutoImageProcessor.from_pretrained(tmpdirname, backend="torchvision")
+            self.assertIsInstance(image_processor, Qwen2VLImageProcessor)
+
+            image_processor = AutoImageProcessor.from_pretrained(tmpdirname, backend="pil")
+            self.assertIsInstance(image_processor, Qwen2VLImageProcessorPil)
+
+            json.dump({"image_processor_type": "Qwen3VLImageProcessorPil"}, open(processor_tmpfile, "w"))
+
+            image_processor = AutoImageProcessor.from_pretrained(tmpdirname, backend="pil")
+            self.assertIsInstance(image_processor, Qwen2VLImageProcessorPil)
 
     def test_unavailable_backend_error_mentions_missing_dependency(self):
         with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48526&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48526) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48526&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48526)
<!-- ci-dashboard-badge:end -->

## Summary

Older Qwen3.5-VL / Qwen3-VL checkpoints ship `preprocessor_config.json` (and `config.json`) with `image_processor_type` values `"Qwen3VLImageProcessor"` / `"Qwen3VLImageProcessorPil"`. Those classes no longer exist — Qwen3VL's image processing was folded into Qwen2VL before release — so `AutoImageProcessor.from_pretrained` (and therefore `AutoProcessor.from_pretrained`) fails with:

```
ValueError: Unrecognized image processor in <path>. Should have a `image_processor_type` key ...
```

This PR resolves the legacy names in `_LazyModule.__getattr__` through a new `_LEGACY_IMAGE_PROCESSOR_CLASS_ALIASES` mapping, following the existing `*ImageProcessorFast` backward-compatibility pattern in the same file. Resolving the alias emits a deprecation warning and falls back to the Qwen2VL implementation, whose preprocessing parameters (patch 16 / merge 2 / mean = std = 0.5) match these checkpoints.

Both direct attribute access (`transformers.Qwen3VLImageProcessor`) and the `AutoImageProcessor` / `AutoProcessor` loading paths work again for those snapshots.

Fixes #48511

## Test plan

- New regression test `test_legacy_renamed_class_name_in_config` in `tests/models/auto/test_image_processing_auto.py`:
  - `image_processor_type: "Qwen3VLImageProcessor"` + `backend="torchvision"` → `Qwen2VLImageProcessor`
  - same config with `backend="pil"` → `Qwen2VLImageProcessorPil`
  - `image_processor_type: "Qwen3VLImageProcessorPil"` with `backend="pil"` → `Qwen2VLImageProcessorPil`
- Manually verified:
  - `AutoProcessor.from_pretrained` on a local Qwen3VL snapshot with the legacy name now returns a working `Qwen3VLProcessor` wrapping `Qwen2VLImageProcessor`
  - existing `Qwen2VLImageProcessorFast` handling and normal (non-legacy) names are unaffected
  - unknown attribute names on `transformers` still raise `AttributeError`

Who can review? @ArthurZucker