### PR TITLE
Fix D-FINE / RT-DETR main loss being computed over the denoising queries

### DIFF
--- a/src/transformers/loss/loss_d_fine.py
+++ b/src/transformers/loss/loss_d_fine.py
@@ -330,6 +330,15 @@ def DFineForObjectDetectionLoss(
 ):
     criterion = DFineLoss(config)
     criterion.to(device)
+    if denoising_meta_values is not None:
+        # `logits` and `pred_boxes` (last decoder layer) also contain the contrastive denoising queries, which are
+        # prepended to the normal queries. The main loss must only see the normal queries: the positive denoising
+        # queries are initialized next to the ground truth, so the Hungarian matcher would assign the targets to
+        # them instead of to the normal queries, which are the ones used at inference. The original implementation
+        # splits them in the decoder:
+        # https://github.com/Peterande/D-FINE/blob/master/src/zoo/dfine/dfine_decoder.py
+        _, logits = torch.split(logits, denoising_meta_values["dn_num_split"], dim=1)
+        _, pred_boxes = torch.split(pred_boxes, denoising_meta_values["dn_num_split"], dim=1)
     # Second: compute the losses, based on outputs and labels
     outputs_loss = {}
     outputs_loss["logits"] = logits

--- a/src/transformers/loss/loss_d_fine.py
+++ b/src/transformers/loss/loss_d_fine.py
@@ -331,12 +331,7 @@ def DFineForObjectDetectionLoss(
     criterion = DFineLoss(config)
     criterion.to(device)
     if denoising_meta_values is not None:
-        # `logits` and `pred_boxes` (last decoder layer) also contain the contrastive denoising queries, which are
-        # prepended to the normal queries. The main loss must only see the normal queries: the positive denoising
-        # queries are initialized next to the ground truth, so the Hungarian matcher would assign the targets to
-        # them instead of to the normal queries, which are the ones used at inference. The original implementation
-        # splits them in the decoder:
-        # https://github.com/Peterande/D-FINE/blob/master/src/zoo/dfine/dfine_decoder.py
+        # Drop denoising queries and calculate loss only over normal queries.
         _, logits = torch.split(logits, denoising_meta_values["dn_num_split"], dim=1)
         _, pred_boxes = torch.split(pred_boxes, denoising_meta_values["dn_num_split"], dim=1)
     # Second: compute the losses, based on outputs and labels

--- a/src/transformers/loss/loss_d_fine.py
+++ b/src/transformers/loss/loss_d_fine.py
@@ -332,6 +332,7 @@ def DFineForObjectDetectionLoss(
     criterion.to(device)
     if denoising_meta_values is not None:
         # Drop denoising queries and calculate loss only over normal queries.
+        # See https://github.com/huggingface/transformers/pull/48528
         _, logits = torch.split(logits, denoising_meta_values["dn_num_split"], dim=1)
         _, pred_boxes = torch.split(pred_boxes, denoising_meta_values["dn_num_split"], dim=1)
     # Second: compute the losses, based on outputs and labels

--- a/src/transformers/loss/loss_rt_detr.py
+++ b/src/transformers/loss/loss_rt_detr.py
@@ -445,6 +445,15 @@ def RTDetrForObjectDetectionLoss(
 ):
     criterion = RTDetrLoss(config)
     criterion.to(device)
+    if denoising_meta_values is not None:
+        # `logits` and `pred_boxes` (last decoder layer) also contain the contrastive denoising queries, which are
+        # prepended to the normal queries. The main loss must only see the normal queries: the positive denoising
+        # queries are initialized next to the ground truth, so the Hungarian matcher would assign the targets to
+        # them instead of to the normal queries, which are the ones used at inference. The original implementation
+        # splits them in the decoder:
+        # https://github.com/lyuwenyu/RT-DETR/blob/main/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_decoder.py
+        _, logits = torch.split(logits, denoising_meta_values["dn_num_split"], dim=1)
+        _, pred_boxes = torch.split(pred_boxes, denoising_meta_values["dn_num_split"], dim=1)
     # Second: compute the losses, based on outputs and labels
     outputs_loss = {}
     outputs_loss["logits"] = logits

--- a/src/transformers/loss/loss_rt_detr.py
+++ b/src/transformers/loss/loss_rt_detr.py
@@ -446,12 +446,7 @@ def RTDetrForObjectDetectionLoss(
     criterion = RTDetrLoss(config)
     criterion.to(device)
     if denoising_meta_values is not None:
-        # `logits` and `pred_boxes` (last decoder layer) also contain the contrastive denoising queries, which are
-        # prepended to the normal queries. The main loss must only see the normal queries: the positive denoising
-        # queries are initialized next to the ground truth, so the Hungarian matcher would assign the targets to
-        # them instead of to the normal queries, which are the ones used at inference. The original implementation
-        # splits them in the decoder:
-        # https://github.com/lyuwenyu/RT-DETR/blob/main/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_decoder.py
+        # Drop denoising queries and calculate loss only over normal queries.
         _, logits = torch.split(logits, denoising_meta_values["dn_num_split"], dim=1)
         _, pred_boxes = torch.split(pred_boxes, denoising_meta_values["dn_num_split"], dim=1)
     # Second: compute the losses, based on outputs and labels

--- a/src/transformers/loss/loss_rt_detr.py
+++ b/src/transformers/loss/loss_rt_detr.py
@@ -447,6 +447,7 @@ def RTDetrForObjectDetectionLoss(
     criterion.to(device)
     if denoising_meta_values is not None:
         # Drop denoising queries and calculate loss only over normal queries.
+        # See https://github.com/huggingface/transformers/pull/48528
         _, logits = torch.split(logits, denoising_meta_values["dn_num_split"], dim=1)
         _, pred_boxes = torch.split(pred_boxes, denoising_meta_values["dn_num_split"], dim=1)
     # Second: compute the losses, based on outputs and labels

--- a/src/transformers/loss/loss_rt_detr.py
+++ b/src/transformers/loss/loss_rt_detr.py
@@ -446,7 +446,7 @@ def RTDetrForObjectDetectionLoss(
     criterion = RTDetrLoss(config)
     criterion.to(device)
     if denoising_meta_values is not None:
-        # Drop denoising queries and calculate loss only over normal queries.
+        # Drop denoising queries and calculate loss only over normal queries.
         _, logits = torch.split(logits, denoising_meta_values["dn_num_split"], dim=1)
         _, pred_boxes = torch.split(pred_boxes, denoising_meta_values["dn_num_split"], dim=1)
     # Second: compute the losses, based on outputs and labels

--- a/tests/models/d_fine/test_modeling_d_fine.py
+++ b/tests/models/d_fine/test_modeling_d_fine.py
@@ -654,6 +654,55 @@ class DFineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
             any("dn_" in k for k in outputs.loss_dict), "Denoising losses should not be present when num_denoising=0"
         )
 
+    def test_main_loss_excludes_denoising_queries(self):
+        """The Hungarian-matched main loss must only see the normal queries, not the contrastive denoising ones."""
+        from transformers.loss.loss_d_fine import DFineLoss
+
+        config = copy.deepcopy(self.model_tester.get_config())
+        config.num_denoising = 10
+        config.auxiliary_loss = True
+        config.num_labels = self.model_tester.num_labels
+
+        model = DFineForObjectDetection(config)
+        model.to(torch_device)
+        model.train()
+
+        pixel_values = torch.rand(
+            self.model_tester.batch_size,
+            self.model_tester.num_channels,
+            self.model_tester.image_size,
+            self.model_tester.image_size,
+        ).to(torch_device)
+        labels = []
+        for _ in range(self.model_tester.batch_size):
+            labels.append(
+                {
+                    "class_labels": torch.randint(0, self.model_tester.num_labels, (self.model_tester.n_targets,)).to(
+                        torch_device
+                    ),
+                    "boxes": torch.rand(self.model_tester.n_targets, 4).to(torch_device),
+                }
+            )
+
+        outputs = model(pixel_values=pixel_values, labels=labels)
+
+        # In training mode the last-layer outputs contain the denoising queries followed by the normal queries
+        num_denoising_queries, num_queries = outputs.denoising_meta_values["dn_num_split"]
+        self.assertGreater(num_denoising_queries, 0)
+        self.assertEqual(outputs.logits.shape[1], num_denoising_queries + num_queries)
+
+        # The main loss terms must equal the loss computed on the normal queries alone
+        criterion = DFineLoss(config).to(torch_device)
+        reference = criterion(
+            {
+                "logits": outputs.logits[:, num_denoising_queries:],
+                "pred_boxes": outputs.pred_boxes[:, num_denoising_queries:].clamp(min=0, max=1),
+            },
+            labels,
+        )
+        for key in ("loss_vfl", "loss_bbox", "loss_giou"):
+            torch.testing.assert_close(outputs.loss_dict[key], reference[key])
+
     @parameterized.expand(["float32", "float16", "bfloat16"])
     @require_torch_accelerator
     @slow

--- a/tests/models/d_fine/test_modeling_d_fine.py
+++ b/tests/models/d_fine/test_modeling_d_fine.py
@@ -42,6 +42,7 @@ if is_torch_available():
     import torch
 
     from transformers import DFineForObjectDetection, DFineModel
+    from transformers.loss.loss_d_fine import DFineLoss
 
 if is_vision_available():
     from PIL import Image
@@ -656,39 +657,23 @@ class DFineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
     def test_main_loss_excludes_denoising_queries(self):
         """The Hungarian-matched main loss must only see the normal queries, not the contrastive denoising ones."""
-        from transformers.loss.loss_d_fine import DFineLoss
-
-        config = copy.deepcopy(self.model_tester.get_config())
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.num_denoising = 10
         config.auxiliary_loss = True
-        config.num_labels = self.model_tester.num_labels
+        inputs_dict = self._prepare_for_class(inputs_dict, DFineForObjectDetection, return_labels=True)
 
         model = DFineForObjectDetection(config)
         model.to(torch_device)
         model.train()
 
-        pixel_values = torch.rand(
-            self.model_tester.batch_size,
-            self.model_tester.num_channels,
-            self.model_tester.image_size,
-            self.model_tester.image_size,
-        ).to(torch_device)
-        labels = []
-        for _ in range(self.model_tester.batch_size):
-            labels.append(
-                {
-                    "class_labels": torch.randint(0, self.model_tester.num_labels, (self.model_tester.n_targets,)).to(
-                        torch_device
-                    ),
-                    "boxes": torch.rand(self.model_tester.n_targets, 4).to(torch_device),
-                }
-            )
+        outputs = model(**inputs_dict)
 
-        outputs = model(pixel_values=pixel_values, labels=labels)
-
-        # In training mode the last-layer outputs contain the denoising queries followed by the normal queries
+        # In training mode the last-layer outputs contain the denoising queries followed by the normal queries.
+        # `num_denoising` is split into groups of one positive and one negative query per (padded) target.
         num_denoising_queries, num_queries = outputs.denoising_meta_values["dn_num_split"]
-        self.assertGreater(num_denoising_queries, 0)
+        max_num_targets = max(len(target["class_labels"]) for target in inputs_dict["labels"])
+        num_groups = config.num_denoising // max_num_targets
+        self.assertEqual(num_denoising_queries, 2 * max_num_targets * num_groups)
         self.assertEqual(outputs.logits.shape[1], num_denoising_queries + num_queries)
 
         # The main loss terms must equal the loss computed on the normal queries alone
@@ -696,9 +681,9 @@ class DFineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         reference = criterion(
             {
                 "logits": outputs.logits[:, num_denoising_queries:],
-                "pred_boxes": outputs.pred_boxes[:, num_denoising_queries:].clamp(min=0, max=1),
+                "pred_boxes": outputs.pred_boxes[:, num_denoising_queries:],
             },
-            labels,
+            inputs_dict["labels"],
         )
         for key in ("loss_vfl", "loss_bbox", "loss_giou"):
             torch.testing.assert_close(outputs.loss_dict[key], reference[key])

--- a/tests/models/d_fine/test_modeling_d_fine.py
+++ b/tests/models/d_fine/test_modeling_d_fine.py
@@ -656,7 +656,9 @@ class DFineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         )
 
     def test_main_loss_excludes_denoising_queries(self):
-        """The Hungarian-matched main loss must only see the normal queries, not the contrastive denoising ones."""
+        """The main loss must only see the normal queries, not the denoising ones.
+        See https://github.com/huggingface/transformers/pull/48528
+        """
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.num_denoising = 10
         config.auxiliary_loss = True

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -571,6 +571,55 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config = config.__class__(**config_dict)
         _validate_backbone_init(config)
 
+    def test_main_loss_excludes_denoising_queries(self):
+        """The Hungarian-matched main loss must only see the normal queries, not the contrastive denoising ones."""
+        from transformers.loss.loss_rt_detr import RTDetrLoss
+
+        config = copy.deepcopy(self.model_tester.get_config())
+        config.num_denoising = 10
+        config.auxiliary_loss = True
+        config.num_labels = self.model_tester.num_labels
+
+        model = RTDetrForObjectDetection(config)
+        model.to(torch_device)
+        model.train()
+
+        pixel_values = torch.rand(
+            self.model_tester.batch_size,
+            self.model_tester.num_channels,
+            self.model_tester.image_size,
+            self.model_tester.image_size,
+        ).to(torch_device)
+        labels = []
+        for _ in range(self.model_tester.batch_size):
+            labels.append(
+                {
+                    "class_labels": torch.randint(0, self.model_tester.num_labels, (self.model_tester.n_targets,)).to(
+                        torch_device
+                    ),
+                    "boxes": torch.rand(self.model_tester.n_targets, 4).to(torch_device),
+                }
+            )
+
+        outputs = model(pixel_values=pixel_values, labels=labels)
+
+        # In training mode the last-layer outputs contain the denoising queries followed by the normal queries
+        num_denoising_queries, num_queries = outputs.denoising_meta_values["dn_num_split"]
+        self.assertGreater(num_denoising_queries, 0)
+        self.assertEqual(outputs.logits.shape[1], num_denoising_queries + num_queries)
+
+        # The main loss terms must equal the loss computed on the normal queries alone
+        criterion = RTDetrLoss(config).to(torch_device)
+        reference = criterion(
+            {
+                "logits": outputs.logits[:, num_denoising_queries:],
+                "pred_boxes": outputs.pred_boxes[:, num_denoising_queries:],
+            },
+            labels,
+        )
+        for key in ("loss_vfl", "loss_bbox", "loss_giou"):
+            torch.testing.assert_close(outputs.loss_dict[key], reference[key])
+
     @parameterized.expand(["float32", "float16", "bfloat16"])
     @require_torch_accelerator
     @slow

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -48,6 +48,7 @@ if is_torch_available():
     import torch
 
     from transformers import RTDetrForObjectDetection, RTDetrModel
+    from transformers.loss.loss_rt_detr import RTDetrLoss
 
 if is_vision_available():
     from PIL import Image
@@ -573,39 +574,23 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
     def test_main_loss_excludes_denoising_queries(self):
         """The Hungarian-matched main loss must only see the normal queries, not the contrastive denoising ones."""
-        from transformers.loss.loss_rt_detr import RTDetrLoss
-
-        config = copy.deepcopy(self.model_tester.get_config())
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.num_denoising = 10
         config.auxiliary_loss = True
-        config.num_labels = self.model_tester.num_labels
+        inputs_dict = self._prepare_for_class(inputs_dict, RTDetrForObjectDetection, return_labels=True)
 
         model = RTDetrForObjectDetection(config)
         model.to(torch_device)
         model.train()
 
-        pixel_values = torch.rand(
-            self.model_tester.batch_size,
-            self.model_tester.num_channels,
-            self.model_tester.image_size,
-            self.model_tester.image_size,
-        ).to(torch_device)
-        labels = []
-        for _ in range(self.model_tester.batch_size):
-            labels.append(
-                {
-                    "class_labels": torch.randint(0, self.model_tester.num_labels, (self.model_tester.n_targets,)).to(
-                        torch_device
-                    ),
-                    "boxes": torch.rand(self.model_tester.n_targets, 4).to(torch_device),
-                }
-            )
+        outputs = model(**inputs_dict)
 
-        outputs = model(pixel_values=pixel_values, labels=labels)
-
-        # In training mode the last-layer outputs contain the denoising queries followed by the normal queries
+        # In training mode the last-layer outputs contain the denoising queries followed by the normal queries.
+        # `num_denoising` is split into groups of one positive and one negative query per (padded) target.
         num_denoising_queries, num_queries = outputs.denoising_meta_values["dn_num_split"]
-        self.assertGreater(num_denoising_queries, 0)
+        max_num_targets = max(len(target["class_labels"]) for target in inputs_dict["labels"])
+        num_groups = config.num_denoising // max_num_targets
+        self.assertEqual(num_denoising_queries, 2 * max_num_targets * num_groups)
         self.assertEqual(outputs.logits.shape[1], num_denoising_queries + num_queries)
 
         # The main loss terms must equal the loss computed on the normal queries alone
@@ -615,7 +600,7 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
                 "logits": outputs.logits[:, num_denoising_queries:],
                 "pred_boxes": outputs.pred_boxes[:, num_denoising_queries:],
             },
-            labels,
+            inputs_dict["labels"],
         )
         for key in ("loss_vfl", "loss_bbox", "loss_giou"):
             torch.testing.assert_close(outputs.loss_dict[key], reference[key])

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -573,7 +573,9 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         _validate_backbone_init(config)
 
     def test_main_loss_excludes_denoising_queries(self):
-        """The Hungarian-matched main loss must only see the normal queries, not the contrastive denoising ones."""
+        """The main loss must only see the normal queries, not the denoising ones.
+        See https://github.com/huggingface/transformers/pull/48528
+        """
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.num_denoising = 10
         config.auxiliary_loss = True


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48528&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48528) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48528&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48528)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Fixes a training bug in the D-FINE and RT-DETR (incl. RT-DETRv2) losses: the **main**, Hungarian-matched loss term was computed over the contrastive-denoising queries as well, which starves the normal queries of the inference layer of positive supervision.

### The bug

`DFineForObjectDetectionLoss` (`src/transformers/loss/loss_d_fine.py`) and `RTDetrForObjectDetectionLoss` (`src/transformers/loss/loss_rt_detr.py`, also mapped for `RTDetrV2ForObjectDetection`) receive the last decoder layer's `logits` / `pred_boxes` from the model. In training mode with `num_denoising > 0` these tensors contain the contrastive denoising (CDN) queries **followed by** the normal queries, e.g. `[batch, 200 + 300, num_labels]`. Both functions split the CDN queries off for the auxiliary and `dn_*` terms (`torch.split(..., dn_num_split, dim=2)`), but never for the main term:

```python
outputs_loss["logits"] = logits            # still [batch, 200 + 300, num_labels] during training
outputs_loss["pred_boxes"] = pred_boxes    # -> Hungarian matching over all 500 queries
```

The positive CDN queries are initialized from lightly noised ground-truth boxes, so the matcher of the main term assigns most targets to them. The normal queries of the last decoder layer, the only ones used at inference (`eval_idx = -1`), then get almost no positive signal from the main term. Training losses look healthy while validation mAP stalls with low, badly calibrated scores and class confusion, which makes this hard to spot.

The reference implementations split the denoising queries **before** building the main term:
- D-FINE: https://github.com/Peterande/D-FINE/blob/master/src/zoo/dfine/dfine_decoder.py (`torch.split(out_logits, dn_meta["dn_num_split"], dim=2)` → `"pred_logits": out_logits[-1]`)
- RT-DETR: https://github.com/lyuwenyu/RT-DETR/blob/main/rtdetrv2_pytorch/src/zoo/rtdetr/rtdetr_decoder.py

`loss_deimv2.py` already does this for DEIMv2, so it is not affected.

### Measurements

Fine-tuning `ustc-community/dfine-nano-coco` on a 4-class document layout dataset (6.4k images) with the original D-FINE hyper-parameters. Matching of the main term on a real training batch (8 images, 12 ground-truth boxes) after 7 epochs:

```python
out = model(pixel_values=pixel_values, labels=labels)       # model.train()
criterion = DFineLoss(model.config)
indices = criterion.matcher({"logits": out.logits, "pred_boxes": out.pred_boxes.clamp(0, 1)}, labels)
matched = torch.cat([src for src, _ in indices])
num_dn = out.denoising_meta_values["dn_num_split"][0]        # 200
print((matched < num_dn).sum().item(), "/", len(matched))    # -> 10 / 12 targets matched to denoising queries
```

The last-layer `loss_vfl` restricted to the normal queries was 2.55, while the value entering the training loss was 0.92.

Class-aware COCO AP on the validation split (no score threshold), same data, hyper-parameters and schedule:

| epoch | before (stock loss) | after (this PR) | original D-FINE repo |
|---|---|---|---|
| 3 | 0.17 | 0.51 | 0.14 |
| 7 | 0.25 | 0.68 | 0.41 |
| 15 | – | 0.73 | 0.60 |

With the stock loss the model localized boxes fine but labelled nearly everything as a single class with low scores; the class-agnostic AP at the 0.3 score threshold plateaued around 0.4 for 45 epochs, while the original D-FINE repo reaches 0.71 on that metric.

### The fix

At the top of both loss functions, before the `config.auxiliary_loss` branch (so it also applies with auxiliary losses disabled):

```python
if denoising_meta_values is not None:
    _, logits = torch.split(logits, denoising_meta_values["dn_num_split"], dim=1)
    _, pred_boxes = torch.split(pred_boxes, denoising_meta_values["dn_num_split"], dim=1)
```

### Reproduction

Fails on `main` with `AssertionError: Scalars are not close!`, passes with this PR:

```python
import torch
from transformers import DFineConfig, DFineForObjectDetection
from transformers.loss.loss_d_fine import DFineLoss

config = DFineConfig(num_labels=4, num_denoising=10, num_queries=30)
model = DFineForObjectDetection(config).train()
pixel_values = torch.rand(2, 3, 256, 256)
labels = [{"class_labels": torch.randint(0, 4, (3,)), "boxes": torch.rand(3, 4)} for _ in range(2)]
out = model(pixel_values=pixel_values, labels=labels)
num_dn = out.denoising_meta_values["dn_num_split"][0]
ref = DFineLoss(config)({"logits": out.logits[:, num_dn:], "pred_boxes": out.pred_boxes[:, num_dn:].clamp(0, 1)}, labels)
for k in ("loss_vfl", "loss_bbox", "loss_giou"):
    torch.testing.assert_close(out.loss_dict[k], ref[k])
```

### Tests

`test_main_loss_excludes_denoising_queries` in `tests/models/d_fine/test_modeling_d_fine.py` and `tests/models/rt_detr/test_modeling_rt_detr.py` trains a small model with denoising enabled and asserts that the main loss terms equal the loss recomputed on the normal queries alone. Both fail on `main` and pass with this PR. The full (non-slow) D-FINE, RT-DETR and RT-DETRv2 test files pass:

```
pytest tests/models/d_fine/test_modeling_d_fine.py tests/models/rt_detr/test_modeling_rt_detr.py tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
```

Side note, not part of this PR: the original D-FINE also applies the fine-grained localization loss (`loss_fgl`) to the last decoder layer, whereas the HF main term only has `loss_vfl` / `loss_bbox` / `loss_giou`. That is a smaller fidelity gap and can be addressed separately.

The bug was found while porting a D-FINE fine-tuning pipeline to Transformers, with the analysis done by Claude Fable 5.1 (Claude Code).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@qubvel

🤖 Generated with [Claude Code](https://claude.com/claude-code)