### PR TITLE
Support for MoE in the GGUF integration

### DIFF
--- a/src/transformers/cli/serving/model_manager.py
+++ b/src/transformers/cli/serving/model_manager.py
@@ -494,8 +494,7 @@ class ModelManager:
             for ref, revision_info in repo.refs.items():
                 author = repo.repo_id.split("/")[0] if "/" in repo.repo_id else ""
 
-                # A GGUF repo holds a quantization per file, each a separate model to a caller, so the
-                # files are listed rather than the repo. Their config is in the file's own metadata.
+                # One quantization per file, each a separate model, so list files rather than the repo.
                 gguf_files = sorted(f.file_name for f in revision_info.files if f.file_name.endswith(".gguf"))
                 for gguf_file in gguf_files:
                     generative_models.append(

--- a/src/transformers/cli/serving/model_manager.py
+++ b/src/transformers/cli/serving/model_manager.py
@@ -492,6 +492,21 @@ class ModelManager:
                 continue
 
             for ref, revision_info in repo.refs.items():
+                author = repo.repo_id.split("/")[0] if "/" in repo.repo_id else ""
+
+                # A GGUF repo holds a quantization per file, each a separate model to a caller, so the
+                # files are listed rather than the repo. Their config is in the file's own metadata.
+                gguf_files = sorted(f.file_name for f in revision_info.files if f.file_name.endswith(".gguf"))
+                for gguf_file in gguf_files:
+                    generative_models.append(
+                        {
+                            "owned_by": author,
+                            "id": f"{repo.repo_id}:{gguf_file}",
+                            "object": "model",
+                            "created": repo.last_modified,
+                        }
+                    )
+
                 config_path = next((f.file_path for f in revision_info.files if f.file_name == "config.json"), None)
                 if not config_path:
                     continue
@@ -506,7 +521,6 @@ class ModelManager:
                 multimodal = MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES.values()
 
                 if any(arch for arch in architectures if arch in [*llms, *vlms, *multimodal]):
-                    author = repo.repo_id.split("/")[0] if "/" in repo.repo_id else ""
                     repo_handle = repo.repo_id + (f"@{ref}" if ref != "main" else "")
                     generative_models.append(
                         {

--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -148,7 +148,7 @@ _RESPONSE_TEMPLATE_FALLBACKS = {
     # <function=NAME><parameter=KEY>VALUE</parameter></function> markup that holds the call data.
     # The chat template prefills the assistant turn with either "<think>\n" (thinking on) or
     # "<think>\n\n</think>\n\n" (default), which prefix-aware parsing picks up via start_anchor.
-    ("qwen3_5", "qwen3_5_moe"): {
+    ("qwen3_5", "qwen3_5_text", "qwen3_5_moe", "qwen3_5_moe_text"): {
         "defaults": {"role": "assistant"},
         "start_anchor": "<|im_start|>assistant\n",
         "fields": {

--- a/src/transformers/integrations/ggml.py
+++ b/src/transformers/integrations/ggml.py
@@ -809,6 +809,7 @@ GGUF_TO_FAST_CONVERTERS = {
     "qwen3": GGUFQwen2Converter,
     "qwen3_moe": GGUFQwen2Converter,
     "qwen3_5_text": GGUFQwen2Converter,
+    "qwen3_5_moe_text": GGUFQwen2Converter,
     "phi3": GGUFPhi3Converter,
     "bloom": GGUFGPTConverter,
     "falcon": GGUFGPTConverter,

--- a/src/transformers/integrations/gguf/dequant.py
+++ b/src/transformers/integrations/gguf/dequant.py
@@ -27,6 +27,13 @@ GGML_BLOCK = {
     GGML_Q6_K: (256, 210),
 }
 
+
+def row_bytes(ggml_type: int, in_features: int) -> int:
+    """Bytes one row of `in_features` values occupies, packed as `ggml_type`."""
+    block_elems, block_bytes = GGML_BLOCK[ggml_type]
+    return in_features // block_elems * block_bytes
+
+
 # ggml type id -> its name, for messages
 GGML_NAME = {GGML_Q8_0: "Q8_0", GGML_Q4_K: "Q4_K", GGML_Q5_K: "Q5_K", GGML_Q6_K: "Q6_K"}
 

--- a/src/transformers/integrations/gguf/gguf_config_mapping.py
+++ b/src/transformers/integrations/gguf/gguf_config_mapping.py
@@ -21,21 +21,20 @@ default, since those defaults are one checkpoint's values and would silently app
 """
 
 
-def _qwen35_config(metadata: dict, tensor_names: tuple[str, ...]) -> dict:
+def _qwen35_config(metadata: dict, tensor_names: tuple[str, ...], prefix: str = "qwen35") -> dict:
     """Qwen3.5: hybrid GatedDeltaNet + full attention, with an mrope and an MTP block."""
-    key = lambda name: metadata[f"qwen35.{name}"]  # noqa: E731
+    key = lambda name: metadata[f"{prefix}.{name}"]  # noqa: E731
     head_dim = key("attention.key_length")
     value_heads = key("ssm.time_step_rank")
-    mtp_layers = metadata.get("qwen35.nextn_predict_layers", 0)
+    mtp_layers = metadata.get(f"{prefix}.nextn_predict_layers", 0)
 
-    return {
+    config = {
         "model_type": "qwen3_5_text",
         # Nothing in the file states this, but callers that pick a class from `config.architectures`
         # would otherwise need a GGUF special case.
         "architectures": ["Qwen3_5ForCausalLM"],
         "max_position_embeddings": key("context_length"),
         "hidden_size": key("embedding_length"),
-        "intermediate_size": key("feed_forward_length"),
         "num_attention_heads": key("attention.head_count"),
         "num_key_value_heads": key("attention.head_count_kv"),
         "head_dim": head_dim,
@@ -66,10 +65,29 @@ def _qwen35_config(metadata: dict, tensor_names: tuple[str, ...]) -> dict:
         "bos_token_id": metadata.get("tokenizer.ggml.bos_token_id"),
         "pad_token_id": metadata.get("tokenizer.ggml.padding_token_id"),
     }
+    # An all-expert file has no dense FFN to describe, so llama.cpp omits its width.
+    if (feed_forward := metadata.get(f"{prefix}.feed_forward_length")) is not None:
+        config["intermediate_size"] = feed_forward
+    return config
+
+
+def _qwen35moe_config(metadata: dict, tensor_names: tuple[str, ...]) -> dict:
+    """Qwen3.5 MoE: `_qwen35_config`'s model, with each layer's FFN replaced by an expert bank."""
+    config = _qwen35_config(metadata, tensor_names, prefix="qwen35moe")
+    key = lambda name: metadata[f"qwen35moe.{name}"]  # noqa: E731
+    return config | {
+        "model_type": "qwen3_5_moe_text",
+        "architectures": ["Qwen3_5MoeForCausalLM"],
+        "moe_intermediate_size": key("expert_feed_forward_length"),
+        "shared_expert_intermediate_size": key("expert_shared_feed_forward_length"),
+        "num_experts": key("expert_count"),
+        "num_experts_per_tok": key("expert_used_count"),
+    }
 
 
 GGUF_CONFIG_ARCHS = {
     "qwen35": _qwen35_config,
+    "qwen35moe": _qwen35moe_config,
 }
 
 

--- a/src/transformers/integrations/gguf/gguf_conversion_mapping.py
+++ b/src/transformers/integrations/gguf/gguf_conversion_mapping.py
@@ -191,7 +191,6 @@ def _qwen35moe(config) -> list[WeightTransform]:
     routed = [
         WeightRenaming(r"\.ffn_gate_inp\.", ".mlp.gate."),
         WeightRenaming(r"\.ffn_down_exps\.weight", ".mlp.experts.down_proj"),
-        # the shared expert is an ordinary MLP, and its gate a single row
         WeightRenaming(r"\.ffn_gate_inp_shexp\.", ".mlp.shared_expert_gate."),
         WeightRenaming(r"\.ffn_gate_shexp\.", ".mlp.shared_expert.gate_proj."),
         WeightRenaming(r"\.ffn_up_shexp\.", ".mlp.shared_expert.up_proj."),
@@ -441,8 +440,7 @@ class Dequantize(ConversionOps):
         if ggml_type is None:
             return input_dict
         block_elements, block_bytes = GGML_BLOCK[ggml_type]
-        # Every source, not just one: a chain can start with more than one tensor (MoE's gate and up
-        # banks, fused by the next op), so all of them have to arrive unpacked, under their own keys.
+        # Every source: a chain can start with more than one tensor, and all must arrive unpacked.
         values = {}
         for key, tensors in input_dict.items():
             blocks = tensors[0] if isinstance(tensors, list) else tensors

--- a/src/transformers/integrations/gguf/gguf_conversion_mapping.py
+++ b/src/transformers/integrations/gguf/gguf_conversion_mapping.py
@@ -19,7 +19,13 @@ undo llama.cpp's value/layout transforms, matching on the renamed key, at most o
 
 import torch
 
-from ...core_model_loading import ConversionOps, WeightConverter, WeightRenaming, WeightTransform
+from ...core_model_loading import (
+    Concatenate,
+    ConversionOps,
+    WeightConverter,
+    WeightRenaming,
+    WeightTransform,
+)
 from .dequant import GGML_BLOCK
 from .kernels import dequantize_blocks
 
@@ -171,9 +177,44 @@ def _qwen35(config) -> list[WeightTransform]:
     return renamings + offset_norms + per_value_head + value_reorder
 
 
+def _qwen35moe(config) -> list[WeightTransform]:
+    """Qwen3.5 MoE: the same hybrid stack as `_qwen35`, with each layer's FFN replaced by an expert bank.
+
+    Everything about the attention and linear-attention halves is `_qwen35`'s, including the value-head
+    reorder -- llama.cpp converts both through the same base class, so what it does to those tensors does
+    not change. What is new is the FFN: a router, a bank of stacked experts, and a shared expert that
+    runs for every token.
+
+    Experts arrive stacked, `(n_experts, rows, cols)`, which is the layout the model wants; the
+    per-expert `experts.{i}` split some safetensors checkpoints use never appears in a GGUF.
+    """
+    routed = [
+        WeightRenaming(r"\.ffn_gate_inp\.", ".mlp.gate."),
+        WeightRenaming(r"\.ffn_down_exps\.weight", ".mlp.experts.down_proj"),
+        # the shared expert is an ordinary MLP, and its gate a single row
+        WeightRenaming(r"\.ffn_gate_inp_shexp\.", ".mlp.shared_expert_gate."),
+        WeightRenaming(r"\.ffn_gate_shexp\.", ".mlp.shared_expert.gate_proj."),
+        WeightRenaming(r"\.ffn_up_shexp\.", ".mlp.shared_expert.up_proj."),
+        WeightRenaming(r"\.ffn_down_shexp\.", ".mlp.shared_expert.down_proj."),
+    ]
+    # `gate_up_proj` is chunked in two on dim 1, so gate comes first and up second.
+    fuse_gate_up = WeightConverter(
+        source_patterns=[r"\.ffn_gate_exps\.weight", r"\.ffn_up_exps\.weight"],
+        target_patterns=".mlp.experts.gate_up_proj",
+        operations=[ConcatenateRows(dim=1)],
+    )
+    restore_gate = WeightConverter(
+        source_patterns="mlp.shared_expert_gate.weight",
+        target_patterns="mlp.shared_expert_gate.weight",
+        operations=[RestoreLeadingAxis()],
+    )
+    return _qwen35(config) + routed + [fuse_gate_up, restore_gate]
+
+
 # gguf `general.architecture` -> builder taking the model config
 GGUF_ARCHS = {
     "qwen35": _qwen35,
+    "qwen35moe": _qwen35moe,
 }
 
 
@@ -337,6 +378,44 @@ class Cast(ConversionOps):
         return {name: tensor.to(self.dtype)}
 
 
+class RestoreLeadingAxis(ConversionOps):
+    """Put back a leading axis of 1 that `llama-quantize` drops.
+
+    ggml stores a `(1, n)` tensor as `n` values with one dimension, and the quantizer rewrites the
+    tensor table that way even for a tensor it leaves in f32 -- so the same weight reads `(1, n)` out
+    of an unquantized file and `(n,)` out of a quantized one. Qwen3.5 MoE's `shared_expert_gate` is
+    one row, so it lands on exactly that difference, and the mismatch only shows up as a broadcast
+    error deep in the MLP.
+
+    Idempotent, because both files have to load through one mapping: a tensor that still has the axis
+    passes through untouched.
+    """
+
+    supports_packed = True
+
+    @torch.no_grad
+    def convert(
+        self, input_dict: dict[str, torch.Tensor], source_patterns: list[str], target_patterns: list[str], **kwargs
+    ) -> dict[str, torch.Tensor]:
+        tensor = _single_tensor(input_dict)
+        return {target_patterns[0]: tensor if tensor.dim() > 1 else tensor.unsqueeze(0)}
+
+
+class ConcatenateRows(Concatenate):
+    """`Concatenate` along an axis of whole rows, which packed GGUF blocks survive.
+
+    A quantized weight is stored as `(..., rows, bytes_per_row)`: a block never spans two rows, so
+    joining tensors along a row axis moves whole blocks and their scales together. Concatenating along
+    the *last* axis would cut through them, which is why this is a separate op rather than a flag on
+    the shared one -- it is only safe for the axis it is given.
+
+    Qwen3.5 MoE needs it: the file keeps a layer's gate and up expert banks apart, the model wants them
+    fused, and doing that on blocks is what lets the experts stay packed.
+    """
+
+    supports_packed = True
+
+
 class Dequantize(ConversionOps):
     """Unpack GGUF blocks into values, on the parameter's own device.
 
@@ -361,10 +440,23 @@ class Dequantize(ConversionOps):
         ggml_type = self.ggml_types.get(full_layer_name)
         if ggml_type is None:
             return input_dict
-        blocks = _single_tensor(input_dict)
         block_elements, block_bytes = GGML_BLOCK[ggml_type]
-        rows, cols = blocks.shape[0], blocks.shape[1] // block_bytes * block_elements
-        return {full_layer_name: dequantize_blocks(blocks, ggml_type, rows, cols, self.dtype)}
+        # Every source, not just one: a chain can start with more than one tensor (MoE's gate and up
+        # banks, fused by the next op), so all of them have to arrive unpacked, under their own keys.
+        values = {}
+        for key, tensors in input_dict.items():
+            blocks = tensors[0] if isinstance(tensors, list) else tensors
+            if blocks.dtype != torch.uint8:  # already dense: another op in the chain got there first
+                values[key] = blocks
+                continue
+            # Only the last axis holds bytes, so a stacked bank's leading axes are flattened and restored.
+            cols = blocks.shape[-1] // block_bytes * block_elements
+            flat = blocks.reshape(-1, blocks.shape[-1])
+            unpacked = dequantize_blocks(flat, ggml_type, flat.shape[0], cols, self.dtype)
+            values[key] = unpacked.reshape(*blocks.shape[:-1], cols)
+        if len(values) == 1:
+            return {full_layer_name: next(iter(values.values()))}
+        return values
 
 
 def _single_tensor(input_dict: dict[str, torch.Tensor]) -> torch.Tensor:

--- a/src/transformers/integrations/gguf/gguf_tokenizer_mapping.py
+++ b/src/transformers/integrations/gguf/gguf_tokenizer_mapping.py
@@ -24,7 +24,6 @@ from .reader import read_gguf_metadata
 # `general.architecture` -> the `model_type` whose `GGUF_TO_FAST_CONVERTERS` entry reads this vocabulary.
 GGUF_TOKENIZER_ARCHS = {
     "qwen35": "qwen3_5_text",
-    # The MoE writes the same vocabulary; only the layer stack differs.
     "qwen35moe": "qwen3_5_moe_text",
 }
 

--- a/src/transformers/integrations/gguf/gguf_tokenizer_mapping.py
+++ b/src/transformers/integrations/gguf/gguf_tokenizer_mapping.py
@@ -24,6 +24,8 @@ from .reader import read_gguf_metadata
 # `general.architecture` -> the `model_type` whose `GGUF_TO_FAST_CONVERTERS` entry reads this vocabulary.
 GGUF_TOKENIZER_ARCHS = {
     "qwen35": "qwen3_5_text",
+    # The MoE writes the same vocabulary; only the layer stack differs.
+    "qwen35moe": "qwen3_5_moe_text",
 }
 
 # The metadata arrays a tokenizer needs in full; everything else the reader can leave as a count.

--- a/src/transformers/integrations/gguf/kernels.py
+++ b/src/transformers/integrations/gguf/kernels.py
@@ -156,11 +156,8 @@ def kernelize_ggml_layers(model) -> None:
 
     from kernels import Mode, kernelize, register_kernel_mapping, use_kernel_mapping
 
-    # Resolve every repository first and keep only the ones that answer. `kernelize` walks the model
-    # once for the whole mapping and stops where it raises, so an entry that cannot be fetched -- a
-    # repo that does not exist yet, a machine with no network, a build with no variant for this torch
-    # -- would otherwise cost every layer after it. Each kernel is independent; a missing one should
-    # only mean that layer keeps its own forward.
+    # Resolve first and keep what answers: `kernelize` stops at the first entry it cannot fetch, which
+    # would cost every layer after it.
     mapping = {}
     for layer_name, devices in get_ggml_layer_mapping().items():
         try:

--- a/src/transformers/integrations/gguf/kernels.py
+++ b/src/transformers/integrations/gguf/kernels.py
@@ -27,6 +27,16 @@ MAX_GEMV_ROWS = 8
 DEQUANT_CHUNK_ELEMS = 64 << 20  # ~128 MB of bf16 per unpacked chunk
 
 
+def mul_mat_id(blocks: torch.Tensor, x: torch.Tensor, ids: torch.Tensor, ggml_type: int, out_features: int):
+    """One dispatch for a bank of routed experts -- ggml's `mul_mv_id`.
+
+    `blocks` is `(n_experts, out_features, bytes_per_row)`, `x` is `(n_tokens, in_features)`, `ids` is
+    `(n_tokens, n_used)`; the result is `(n_tokens, n_used, out_features)` f32. The alternative is a
+    gemv per expert per layer, which is dispatch overhead rather than arithmetic.
+    """
+    return _gguf_kernel.mul_mat_id(blocks, x, ids, ggml_type, out_features)
+
+
 def mul_mat_vec(weight: torch.Tensor, x: torch.Tensor, ggml_type: int, out_features: int) -> torch.Tensor:
     """(N, bytes_per_row) uint8 @ (M, K) -> (M, N). May return f32 whatever `x` is."""
     return _gguf_kernel.mul_mat_vec(weight, x, ggml_type, out_features)
@@ -73,6 +83,7 @@ class GgufKernel:
         self.mul_mat_vec = module.mul_mat_vec
         self.dequantize = module.dequantize
         self.get_rows = module.get_rows
+        self.mul_mat_id = module.mul_mat_id
         self.gemv_types = module.GEMV_TYPES
 
     def supports(self, ggml_type: int) -> bool:
@@ -106,6 +117,17 @@ def get_ggml_layer_mapping() -> dict:
     return {
         # Named for the weight convention rather than the model: this is the norm that computes
         # `x * (1 + w)`, which the plain `RMSNorm` kernels would get silently wrong.
+        # Named for the scoring function: the kernel rewrites the routing maths, exact for softmax only.
+        "SoftmaxTopKRouter": {
+            "mps": {
+                Mode.INFERENCE: LayerRepository(
+                    repo_id="kernels-staging/topk",
+                    layer_name="SoftmaxTopKRouter",
+                    # TODO: `version=1` once kernels-staging/topk#1124 is merged and tagged
+                    revision="pr-1124",
+                )
+            },
+        },
         "RMSNormZeroCentered": {
             "mps": {
                 Mode.INFERENCE: LayerRepository(
@@ -134,7 +156,24 @@ def kernelize_ggml_layers(model) -> None:
 
     from kernels import Mode, kernelize, register_kernel_mapping, use_kernel_mapping
 
-    mapping = get_ggml_layer_mapping()
+    # Resolve every repository first and keep only the ones that answer. `kernelize` walks the model
+    # once for the whole mapping and stops where it raises, so an entry that cannot be fetched -- a
+    # repo that does not exist yet, a machine with no network, a build with no variant for this torch
+    # -- would otherwise cost every layer after it. Each kernel is independent; a missing one should
+    # only mean that layer keeps its own forward.
+    mapping = {}
+    for layer_name, devices in get_ggml_layer_mapping().items():
+        try:
+            for modes in devices.values():
+                for repo in modes.values():
+                    repo.load()
+        except Exception as error:  # noqa: BLE001
+            logger.info(f"no ggml kernel for {layer_name} ({error}); it keeps the model's own layer.")
+            continue
+        mapping[layer_name] = devices
+    if not mapping:
+        return
+
     register_kernel_mapping(mapping)
     try:
         # `inherit_mapping=False` narrows what `kernelize` can see to ggml's own layers. Inheriting would
@@ -144,6 +183,5 @@ def kernelize_ggml_layers(model) -> None:
         with use_kernel_mapping(mapping, inherit_mapping=False):
             kernelize(model, mode=Mode.INFERENCE, device=model.device.type)
     except Exception as error:  # noqa: BLE001
-        # `kernelize` stops where it raises, so with more than one entry this can leave the layers it had
-        # already reached grafted. Harmless -- each is a drop-in for the implementation it replaced.
+        # Every entry resolved above, so reaching here is a graft that failed rather than a fetch.
         logger.info(f"ggml layer kernels not fully grafted ({error}); the rest keeps the model's own layers.")

--- a/src/transformers/integrations/gguf/kernels.py
+++ b/src/transformers/integrations/gguf/kernels.py
@@ -117,7 +117,6 @@ def get_ggml_layer_mapping() -> dict:
     return {
         # Named for the weight convention rather than the model: this is the norm that computes
         # `x * (1 + w)`, which the plain `RMSNorm` kernels would get silently wrong.
-        # Named for the scoring function: the kernel rewrites the routing maths, exact for softmax only.
         "SoftmaxTopKRouter": {
             "mps": {
                 Mode.INFERENCE: LayerRepository(
@@ -156,8 +155,7 @@ def kernelize_ggml_layers(model) -> None:
 
     from kernels import Mode, kernelize, register_kernel_mapping, use_kernel_mapping
 
-    # Resolve first and keep what answers: `kernelize` stops at the first entry it cannot fetch, which
-    # would cost every layer after it.
+    # Resolve first and keep what answers: `kernelize` stops at the first entry it cannot fetch.
     mapping = {}
     for layer_name, devices in get_ggml_layer_mapping().items():
         try:
@@ -180,5 +178,4 @@ def kernelize_ggml_layers(model) -> None:
         with use_kernel_mapping(mapping, inherit_mapping=False):
             kernelize(model, mode=Mode.INFERENCE, device=model.device.type)
     except Exception as error:  # noqa: BLE001
-        # Every entry resolved above, so reaching here is a graft that failed rather than a fetch.
         logger.info(f"ggml layer kernels not fully grafted ({error}); the rest keeps the model's own layers.")

--- a/src/transformers/integrations/gguf/reader.py
+++ b/src/transformers/integrations/gguf/reader.py
@@ -220,8 +220,10 @@ def load_gguf_state_dict(header: GgufHeader) -> dict[str, LazyGgufTensor]:
     for info in header.tensors:
         shape = info.shape
         if info.ggml_type not in _TORCH_DTYPE:  # blocks, not values: as many bytes per row as it takes
+            # Only the last axis becomes bytes; the ones before it are whole rows, and a stacked expert
+            # bank has one more of them -- `(n_experts, rows, cols)` -> `(n_experts, rows, bytes_per_row)`.
             block_elements, block_bytes = GGML_BLOCK[info.ggml_type]
-            shape = (shape[0], shape[1] // block_elements * block_bytes)
+            shape = (*shape[:-1], shape[-1] // block_elements * block_bytes)
         start = header.data_start + info.offset
         state_dict[info.name] = LazyGgufTensor(blob[start : start + info.nbytes], info.ggml_type, shape)
 

--- a/src/transformers/integrations/gguf/utils.py
+++ b/src/transformers/integrations/gguf/utils.py
@@ -22,7 +22,7 @@ from ...core_model_loading import WeightConverter, WeightRenaming, WeightTransfo
 from ...utils import logging
 from .dequant import GGML_BLOCK
 from .gguf_conversion_mapping import GGUF_ARCHS, Cast, Dequantize
-from .kernels import DEQUANT_CHUNK_ELEMS, MAX_GEMV_ROWS, dequantize_blocks, mul_mat_vec
+from .kernels import DEQUANT_CHUNK_ELEMS, MAX_GEMV_ROWS, dequantize_blocks, mul_mat_id, mul_mat_vec
 from .reader import GgufHeader
 
 
@@ -64,8 +64,14 @@ def get_gguf_plan(
         names.append(param_name)
         if ggml_type not in GGML_BLOCK:
             continue
+        # A converter may rename as well as transform, so a parameter's name is the converter's target.
+        converter = None
+        for entry in converters:
+            renamed, matched = entry.rename_source_key(param_name)
+            if matched:
+                converter, param_name = entry, renamed
+                break
         quantized[param_name] = ggml_type
-        converter = next((entry for entry in converters if entry.rename_source_key(param_name)[1]), None)
         operations = getattr(converter, "operations", ())
         # every conversion applied to this tensor must be safe on packed bytes
         if converter is None or all(getattr(op, "supports_packed", False) for op in operations):
@@ -100,6 +106,16 @@ def add_gguf_load_ops(mapping: list[WeightTransform], to_unpack: dict[str, int],
     return mapping
 
 
+# The two weights of a stacked expert bank, in the order `GgufExperts` takes their types.
+_EXPERT_PARAMS = ("gate_up_proj", "down_proj")
+
+
+def _row_bytes(ggml_type: int, in_features: int) -> int:
+    """How many bytes one row of `in_features` values occupies, packed as `ggml_type`."""
+    block_elems, block_bytes = GGML_BLOCK[ggml_type]
+    return in_features // block_elems * block_bytes
+
+
 class GgufLinear(nn.Module):
     """`nn.Linear` whose weight stays as GGUF blocks: `(out_features, bytes_per_row)` uint8."""
 
@@ -108,9 +124,9 @@ class GgufLinear(nn.Module):
         self.in_features = in_features
         self.out_features = out_features
         self.ggml_type = ggml_type
-        block_elems, block_bytes = GGML_BLOCK[ggml_type]
-        bytes_per_row = in_features // block_elems * block_bytes
-        self.weight = nn.Parameter(torch.empty((out_features, bytes_per_row), dtype=torch.uint8), requires_grad=False)
+        self.weight = nn.Parameter(
+            torch.empty((out_features, _row_bytes(ggml_type, in_features)), dtype=torch.uint8), requires_grad=False
+        )
         # A GGUF stores a bias as its own f32 tensor, never quantized, so it stays an ordinary
         # parameter and the loader fills it like any other.
         self.bias = None
@@ -151,6 +167,62 @@ class GgufLinear(nn.Module):
         )
 
 
+class GgufExperts(nn.Module):
+    """A MoE expert bank whose weights stay as GGUF blocks: `(n_experts, rows, bytes_per_row)`.
+
+    Worth keeping packed more than anything else in the model: a router hands each token a handful of
+    experts, so the bank is never needed at once, and it is most of the weights -- Qwen3.5-35B-A3B's
+    routed experts are 32B parameters, 60 GB unpacked against 20 GB of blocks. Only the experts a
+    token hits are read, each through the same fused dequant-gemv a `GgufLinear` uses.
+
+    The loop is the model's own: one pass per expert that was hit, over the tokens that chose it.
+    """
+
+    def __init__(self, num_experts, hidden_dim, intermediate_dim, gate_up_type, down_type, act_fn):
+        super().__init__()
+        self.num_experts = num_experts
+        self.hidden_dim = hidden_dim
+        self.intermediate_dim = intermediate_dim
+        self.gate_up_type = gate_up_type
+        self.down_type = down_type
+        self.act_fn = act_fn
+        self.gate_up_proj = nn.Parameter(
+            torch.empty((num_experts, 2 * intermediate_dim, _row_bytes(gate_up_type, hidden_dim)), dtype=torch.uint8),
+            requires_grad=False,
+        )
+        self.down_proj = nn.Parameter(
+            torch.empty((num_experts, hidden_dim, _row_bytes(down_type, intermediate_dim)), dtype=torch.uint8),
+            requires_grad=False,
+        )
+
+    def forward(self, hidden_states, top_k_index, top_k_weights):
+        """The whole bank in two dispatches, rather than two per expert the router picked.
+
+        `mul_mat_id` is ggml's own MoE matmul: it takes the bank as one `(n_experts, rows, bytes)`
+        tensor and the router's choices, and computes every (token, expert) pair in a single grid.
+        The loop this replaces spent its time launching kernels, not running them.
+        """
+        tokens, used = top_k_index.shape
+        ids = top_k_index if top_k_index.dtype == torch.int32 else top_k_index.to(torch.int32)
+
+        # Every slot of a token reads that token's hidden state, so the ids index the weights only.
+        fused = mul_mat_id(self.gate_up_proj, hidden_states, ids, self.gate_up_type, 2 * self.intermediate_dim)
+        gate, up = fused.chunk(2, dim=-1)
+        current = (self.act_fn(gate) * up).reshape(tokens * used, self.intermediate_dim)
+        # Each (token, slot) carries its own vector, so the pair flattens into the token axis.
+        out = mul_mat_id(self.down_proj, current, ids.reshape(-1, 1), self.down_type, self.hidden_dim)
+
+        # The same weighted sum the model's own experts do.
+        out = out.reshape(tokens, used, self.hidden_dim) * top_k_weights.unsqueeze(-1)
+        return out.sum(dim=1).to(hidden_states.dtype)
+
+    def extra_repr(self) -> str:
+        return (
+            f"num_experts={self.num_experts}, hidden_dim={self.hidden_dim}, "
+            f"intermediate_dim={self.intermediate_dim}, ggml_types=({self.gate_up_type}, {self.down_type})"
+        )
+
+
 class GgufEmbedding(nn.Module):
     """`nn.Embedding` whose table stays as GGUF blocks."""
 
@@ -187,6 +259,21 @@ def replace_with_gguf_modules(model, plan: dict[str, int], kernel, dtype=None) -
 
     replaced, unsupported = {}, set()
     for module_name, module in model.named_modules():
+        # An expert bank holds bare parameters, not child `Linear`s, so match by name. Both stay packed
+        # or neither: they are read in one forward.
+        expert_types = [plan.get(f"{module_name}.{name}") for name in _EXPERT_PARAMS]
+        if all(t is not None for t in expert_types):
+            if not all(kernel.supports(t) for t in expert_types):
+                unsupported.update(expert_types)
+                continue
+            new_module = GgufExperts(
+                module.num_experts, module.hidden_dim, module.intermediate_dim, *expert_types, module.act_fn
+            )
+            model.set_submodule(module_name, new_module)
+            for name in _EXPERT_PARAMS:
+                replaced[f"{module_name}.{name}"] = new_module
+            continue
+
         param_name = f"{module_name}.weight"
         ggml_type = plan.get(param_name)
         if ggml_type is None:

--- a/src/transformers/integrations/gguf/utils.py
+++ b/src/transformers/integrations/gguf/utils.py
@@ -20,7 +20,7 @@ from torch import nn
 
 from ...core_model_loading import WeightConverter, WeightRenaming, WeightTransform
 from ...utils import logging
-from .dequant import GGML_BLOCK
+from .dequant import GGML_BLOCK, row_bytes
 from .gguf_conversion_mapping import GGUF_ARCHS, Cast, Dequantize
 from .kernels import DEQUANT_CHUNK_ELEMS, MAX_GEMV_ROWS, dequantize_blocks, mul_mat_id, mul_mat_vec
 from .reader import GgufHeader
@@ -106,16 +106,6 @@ def add_gguf_load_ops(mapping: list[WeightTransform], to_unpack: dict[str, int],
     return mapping
 
 
-# The two weights of a stacked expert bank, in the order `GgufExperts` takes their types.
-_EXPERT_PARAMS = ("gate_up_proj", "down_proj")
-
-
-def _row_bytes(ggml_type: int, in_features: int) -> int:
-    """How many bytes one row of `in_features` values occupies, packed as `ggml_type`."""
-    block_elems, block_bytes = GGML_BLOCK[ggml_type]
-    return in_features // block_elems * block_bytes
-
-
 class GgufLinear(nn.Module):
     """`nn.Linear` whose weight stays as GGUF blocks: `(out_features, bytes_per_row)` uint8."""
 
@@ -125,7 +115,7 @@ class GgufLinear(nn.Module):
         self.out_features = out_features
         self.ggml_type = ggml_type
         self.weight = nn.Parameter(
-            torch.empty((out_features, _row_bytes(ggml_type, in_features)), dtype=torch.uint8), requires_grad=False
+            torch.empty((out_features, row_bytes(ggml_type, in_features)), dtype=torch.uint8), requires_grad=False
         )
         # A GGUF stores a bias as its own f32 tensor, never quantized, so it stays an ordinary
         # parameter and the loader fills it like any other.
@@ -187,11 +177,11 @@ class GgufExperts(nn.Module):
         self.down_type = down_type
         self.act_fn = act_fn
         self.gate_up_proj = nn.Parameter(
-            torch.empty((num_experts, 2 * intermediate_dim, _row_bytes(gate_up_type, hidden_dim)), dtype=torch.uint8),
+            torch.empty((num_experts, 2 * intermediate_dim, row_bytes(gate_up_type, hidden_dim)), dtype=torch.uint8),
             requires_grad=False,
         )
         self.down_proj = nn.Parameter(
-            torch.empty((num_experts, hidden_dim, _row_bytes(down_type, intermediate_dim)), dtype=torch.uint8),
+            torch.empty((num_experts, hidden_dim, row_bytes(down_type, intermediate_dim)), dtype=torch.uint8),
             requires_grad=False,
         )
 
@@ -202,19 +192,21 @@ class GgufExperts(nn.Module):
         tensor and the router's choices, and computes every (token, expert) pair in a single grid.
         The loop this replaces spent its time launching kernels, not running them.
         """
-        tokens, used = top_k_index.shape
-        ids = top_k_index if top_k_index.dtype == torch.int32 else top_k_index.to(torch.int32)
-
-        # Every slot of a token reads that token's hidden state, so the ids index the weights only.
-        fused = mul_mat_id(self.gate_up_proj, hidden_states, ids, self.gate_up_type, 2 * self.intermediate_dim)
-        gate, up = fused.chunk(2, dim=-1)
-        current = (self.act_fn(gate) * up).reshape(tokens * used, self.intermediate_dim)
-        # Each (token, slot) carries its own vector, so the pair flattens into the token axis.
-        out = mul_mat_id(self.down_proj, current, ids.reshape(-1, 1), self.down_type, self.hidden_dim)
-
-        # The same weighted sum the model's own experts do.
-        out = out.reshape(tokens, used, self.hidden_dim) * top_k_weights.unsqueeze(-1)
-        return out.sum(dim=1).to(hidden_states.dtype)
+        num_tokens, top_k = top_k_index.shape
+        # required by mul_mat_id
+        ids = top_k_index.to(torch.int32)
+        gate, up = mul_mat_id(
+            self.gate_up_proj, hidden_states, ids, self.gate_up_type, 2 * self.intermediate_dim
+        ).chunk(2, dim=-1)
+        current_hidden_states = (self.act_fn(gate) * up).reshape(num_tokens * top_k, self.intermediate_dim)
+        # Each (token, top_k_pos) carries its own vector, so the pair flattens into the token axis.
+        current_hidden_states = mul_mat_id(
+            self.down_proj, current_hidden_states, ids.reshape(-1, 1), self.down_type, self.hidden_dim
+        )
+        current_hidden_states = current_hidden_states.reshape(num_tokens, top_k, self.hidden_dim)
+        current_hidden_states = current_hidden_states * top_k_weights.unsqueeze(-1)
+        final_hidden_states = current_hidden_states.sum(dim=1).to(hidden_states.dtype)
+        return final_hidden_states
 
     def extra_repr(self) -> str:
         return (
@@ -232,9 +224,8 @@ class GgufEmbedding(nn.Module):
         self.embedding_dim = embedding_dim
         self.ggml_type = ggml_type
         self.compute_dtype = dtype or torch.get_default_dtype()
-        block_elems, block_bytes = GGML_BLOCK[ggml_type]
         self.weight = nn.Parameter(
-            torch.empty((num_embeddings, embedding_dim // block_elems * block_bytes), dtype=torch.uint8),
+            torch.empty((num_embeddings, row_bytes(ggml_type, embedding_dim)), dtype=torch.uint8),
             requires_grad=False,
         )
 
@@ -259,18 +250,21 @@ def replace_with_gguf_modules(model, plan: dict[str, int], kernel, dtype=None) -
 
     replaced, unsupported = {}, set()
     for module_name, module in model.named_modules():
-        # An expert bank holds bare parameters, not child `Linear`s, so match by name. Both stay packed
-        # or neither: they are read in one forward.
-        expert_types = [plan.get(f"{module_name}.{name}") for name in _EXPERT_PARAMS]
-        if all(t is not None for t in expert_types):
-            if not all(kernel.supports(t) for t in expert_types):
+        # An expert bank holds bare parameters rather than child `Linear`s, so it is swapped whole.
+        if module_name.endswith(".experts"):
+            expert_params = ("gate_up_proj", "down_proj")  # the order `GgufExperts` takes their types
+            expert_types = [plan.get(f"{module_name}.{name}") for name in expert_params]
+            if any(ggml_type is None for ggml_type in expert_types):
+                continue
+            # Both stay packed or neither: they are read in one forward.
+            if not all(kernel.supports(ggml_type) for ggml_type in expert_types):
                 unsupported.update(expert_types)
                 continue
             new_module = GgufExperts(
                 module.num_experts, module.hidden_dim, module.intermediate_dim, *expert_types, module.act_fn
             )
             model.set_submodule(module_name, new_module)
-            for name in _EXPERT_PARAMS:
+            for name in expert_params:
                 replaced[f"{module_name}.{name}"] = new_module
             continue
 

--- a/src/transformers/integrations/gguf/utils.py
+++ b/src/transformers/integrations/gguf/utils.py
@@ -250,7 +250,6 @@ def replace_with_gguf_modules(model, plan: dict[str, int], kernel, dtype=None) -
 
     replaced, unsupported = {}, set()
     for module_name, module in model.named_modules():
-        # An expert bank holds bare parameters rather than child `Linear`s, so it is swapped whole.
         if module_name.endswith(".experts"):
             expert_params = ("gate_up_proj", "down_proj")  # the order `GgufExperts` takes their types
             expert_types = [plan.get(f"{module_name}.{name}") for name in expert_params]

--- a/src/transformers/models/laguna/modeling_laguna.py
+++ b/src/transformers/models/laguna/modeling_laguna.py
@@ -154,6 +154,7 @@ class LagunaMLP(nn.Module):
         return down_proj
 
 
+@use_kernel_forward_from_hub("SoftmaxTopKRouter")
 class LagunaTopKRouter(nn.Module):
     def __init__(self, config):
         super().__init__()

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -879,6 +879,7 @@ class Qwen3_5MoeExperts(nn.Module):
         return final_hidden_states
 
 
+@use_kernel_forward_from_hub("SoftmaxTopKRouter")
 class Qwen3_5MoeTopKRouter(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -920,6 +921,7 @@ class Qwen3_5MoeSparseMoeBlock(nn.Module):
         return expert_output
 
 
+@use_kernel_forward_from_hub("RMSNormZeroCentered")
 class Qwen3_5MoeRMSNorm(nn.Module):
     def __init__(self, dim: int, eps: float = 1e-6):
         super().__init__()

--- a/src/transformers/models/qwen3_5_moe/modular_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modular_qwen3_5_moe.py
@@ -186,6 +186,8 @@ class Qwen3_5MoeExperts(Qwen3NextExperts):
     pass
 
 
+# Not the bare `TopKRouter`: a kernel may reorder softmax and top-k, exact only for a softmax router.
+@use_kernel_forward_from_hub("SoftmaxTopKRouter")
 class Qwen3_5MoeTopKRouter(Qwen3VLMoeTextTopKRouter):
     pass
 
@@ -194,6 +196,8 @@ class Qwen3_5MoeSparseMoeBlock(Qwen3NextSparseMoeBlock):
     pass
 
 
+# Not the plain `RMSNorm`: this weight is zero-centered, so the layer is `x * (1 + w)`.
+@use_kernel_forward_from_hub("RMSNormZeroCentered")
 class Qwen3_5MoeRMSNorm(Qwen3NextRMSNorm):
     pass
 

--- a/src/transformers/models/qwen3_5_moe/modular_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modular_qwen3_5_moe.py
@@ -186,7 +186,6 @@ class Qwen3_5MoeExperts(Qwen3NextExperts):
     pass
 
 
-# Not the bare `TopKRouter`: a kernel may reorder softmax and top-k, exact only for a softmax router.
 @use_kernel_forward_from_hub("SoftmaxTopKRouter")
 class Qwen3_5MoeTopKRouter(Qwen3VLMoeTextTopKRouter):
     pass
@@ -196,7 +195,6 @@ class Qwen3_5MoeSparseMoeBlock(Qwen3NextSparseMoeBlock):
     pass
 
 
-# Not the plain `RMSNorm`: this weight is zero-centered, so the layer is `x * (1 + w)`.
 @use_kernel_forward_from_hub("RMSNormZeroCentered")
 class Qwen3_5MoeRMSNorm(Qwen3NextRMSNorm):
     pass

--- a/src/transformers/quantizers/quantizer_gguf.py
+++ b/src/transformers/quantizers/quantizer_gguf.py
@@ -107,8 +107,6 @@ class GgufHfQuantizer(HfQuantizer):
                 self.dtype = torch.get_default_dtype()
                 return self.dtype
             dtype = self.header.dtype if self.header.dtype is not None else torch.float32
-        # The kernels take f32 activations, so another dtype is cast in and out of every matmul: 9.3
-        # tok/s against 40.7 on Qwen3.5-35B-A3B. The weights are quantized either way.
         if not self.quantization_config.dequantize and dtype != torch.float32:
             logger.warning(
                 f"Loading a GGUF checkpoint with its weights packed is fastest in float32, and this "

--- a/src/transformers/quantizers/quantizer_gguf.py
+++ b/src/transformers/quantizers/quantizer_gguf.py
@@ -107,6 +107,15 @@ class GgufHfQuantizer(HfQuantizer):
                 self.dtype = torch.get_default_dtype()
                 return self.dtype
             dtype = self.header.dtype if self.header.dtype is not None else torch.float32
+        # The kernels take f32 activations, so another dtype is cast in and out of every matmul: 9.3
+        # tok/s against 40.7 on Qwen3.5-35B-A3B. The weights are quantized either way.
+        if not self.quantization_config.dequantize and dtype != torch.float32:
+            logger.warning(
+                f"Loading a GGUF checkpoint with its weights packed is fastest in float32, and this "
+                f"one was asked for in {dtype}. The kernels compute in float32, so every matmul will "
+                f"cast its input and its output. Pass `dtype=torch.float32` to avoid it -- the weights "
+                f"stay quantized regardless, so this costs no extra memory."
+            )
         self.dtype = dtype
         return dtype
 

--- a/tests/quantization/ggml/test_gguf_integration.py
+++ b/tests/quantization/ggml/test_gguf_integration.py
@@ -361,54 +361,8 @@ class Qwen35GgufModelTest(GgufModelIntegrationTesterMixin, unittest.TestCase):
 
 
 @require_torch_accelerator
-class Qwen35MoeGgufModelTest(GgufModelIntegrationTesterMixin, unittest.TestCase):
-    """The MoE architecture, on a purpose-built tiny checkpoint rather than a published one.
-
-    The smallest published Qwen3.5-MoE is 35B-A3B, whose bf16 file and bf16 reference are ~70GB
-    each -- more than this suite can ask of a runner, and the bf16 comparison is the whole point of
-    the mixin. So the fixture is generated instead: a randomly-initialised `Qwen3_5MoeForCausalLM`
-    converted with llama.cpp's own `convert_hf_to_gguf.py`, which makes the reference exact rather
-    than approximate. Every one of its 72 parameters comes back bit-for-bit.
-
-    Its shape is small but not degenerate, and the parts that are not shrunk are the ones that would
-    stop testing anything if they were: the layer stack stays hybrid (three linear-attention layers
-    and a full-attention one), the rope stays interleaved mrope over a quarter of the head, the head
-    dims stay a multiple of 32 so the delta-rule kernel applies rather than its fallback, and every
-    quantized weight's input dim is a multiple of 256 so `llama-quantize` produces the Q4_K it is
-    asked for instead of silently falling back to Q5_0.
-
-    Not `@slow`: at ~150MB it is the one architecture here a normal run can afford.
-    """
-
-    gguf_repo = "marcsun13/tiny-Qwen3_5Moe-GGUF"
-    gguf_file = "tiny-moe-BF16.gguf"
-    quantized_gguf_file = "tiny-moe-Q4_K_M.gguf"
-    reference_repo = "marcsun13/tiny-Qwen3_5Moe"
-    model_class = Qwen3_5MoeForCausalLM
-
-    prompt = "The capital of France is Paris. The capital of Germany is"
-    # Random weights, so this is not language -- it is the same continuation from the bf16 file, the
-    # packed quantized file and the dequantized one, which is what makes it worth asserting.
-    expected_completion = " is is is"
-
-
-@require_torch_accelerator
 @slow
 class Qwen35MoeLargeGgufModelTest(GgufModelIntegrationTesterMixin, unittest.TestCase):
-    """The same architecture on the published checkpoint, for a machine that can hold it.
-
-    The tiny fixture above is what proves the conversion exact, tensor by tensor. This one proves it
-    on the file people actually load, at the shapes they actually load it at -- 40 layers, 256
-    experts, a vocabulary of a quarter of a million tokens -- where a mapping that happens to work at
-    four layers and eight experts can still be wrong.
-
-    Only the quantized file is exercised. The bf16 build of a 35B model is ~70GB and ships split
-    across two shards, which the reader does not read (a GGUF is one memory-mapped file), and the
-    bf16 reference to compare it against would be another 70GB. So `gguf_file` is the Q4_K_M one and
-    the state-dict comparison -- the single test that genuinely needs unquantized weights -- is
-    skipped rather than loosened into something that would pass on a wrong answer.
-    """
-
     gguf_repo = "unsloth/Qwen3.5-35B-A3B-GGUF"
     gguf_file = "Qwen3.5-35B-A3B-Q4_K_M.gguf"
     quantized_gguf_file = "Qwen3.5-35B-A3B-Q4_K_M.gguf"
@@ -418,9 +372,6 @@ class Qwen35MoeLargeGgufModelTest(GgufModelIntegrationTesterMixin, unittest.Test
     prompt = "The capital of France is Paris. The capital of Germany is"
     expected_completion = " Berlin"
 
-    @unittest.skip(
-        "compares against the bf16 checkpoint, which for this model is ~70GB and split across shards "
-        "the reader cannot open; Qwen35MoeGgufModelTest covers it exactly on a tiny checkpoint"
-    )
+    @unittest.skip("the bf16 checkpoint is ~70GB and split across shards the reader cannot open")
     def test_state_dict_matches_transformers(self):
         pass

--- a/tests/quantization/ggml/test_gguf_integration.py
+++ b/tests/quantization/ggml/test_gguf_integration.py
@@ -18,7 +18,14 @@ import tempfile
 import unittest
 import unittest.mock
 
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GgufConfig, Qwen3_5ForCausalLM
+from transformers import (
+    AutoConfig,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    GgufConfig,
+    Qwen3_5ForCausalLM,
+    Qwen3_5MoeForCausalLM,
+)
 from transformers.testing_utils import (
     require_kernels,
     require_torch_accelerator,
@@ -351,3 +358,69 @@ class Qwen35GgufModelTest(GgufModelIntegrationTesterMixin, unittest.TestCase):
     # here is 5.178e-07 in the reference and comes back as 4.768e-07, the nearest `1 + w` can encode.
     # Nothing on load recovers it. Every other parameter matches bit for bit.
     inexact_params = {"norm.weight": 1e-6}
+
+
+@require_torch_accelerator
+class Qwen35MoeGgufModelTest(GgufModelIntegrationTesterMixin, unittest.TestCase):
+    """The MoE architecture, on a purpose-built tiny checkpoint rather than a published one.
+
+    The smallest published Qwen3.5-MoE is 35B-A3B, whose bf16 file and bf16 reference are ~70GB
+    each -- more than this suite can ask of a runner, and the bf16 comparison is the whole point of
+    the mixin. So the fixture is generated instead: a randomly-initialised `Qwen3_5MoeForCausalLM`
+    converted with llama.cpp's own `convert_hf_to_gguf.py`, which makes the reference exact rather
+    than approximate. Every one of its 72 parameters comes back bit-for-bit.
+
+    Its shape is small but not degenerate, and the parts that are not shrunk are the ones that would
+    stop testing anything if they were: the layer stack stays hybrid (three linear-attention layers
+    and a full-attention one), the rope stays interleaved mrope over a quarter of the head, the head
+    dims stay a multiple of 32 so the delta-rule kernel applies rather than its fallback, and every
+    quantized weight's input dim is a multiple of 256 so `llama-quantize` produces the Q4_K it is
+    asked for instead of silently falling back to Q5_0.
+
+    Not `@slow`: at ~150MB it is the one architecture here a normal run can afford.
+    """
+
+    gguf_repo = "marcsun13/tiny-Qwen3_5Moe-GGUF"
+    gguf_file = "tiny-moe-BF16.gguf"
+    quantized_gguf_file = "tiny-moe-Q4_K_M.gguf"
+    reference_repo = "marcsun13/tiny-Qwen3_5Moe"
+    model_class = Qwen3_5MoeForCausalLM
+
+    prompt = "The capital of France is Paris. The capital of Germany is"
+    # Random weights, so this is not language -- it is the same continuation from the bf16 file, the
+    # packed quantized file and the dequantized one, which is what makes it worth asserting.
+    expected_completion = " is is is"
+
+
+@require_torch_accelerator
+@slow
+class Qwen35MoeLargeGgufModelTest(GgufModelIntegrationTesterMixin, unittest.TestCase):
+    """The same architecture on the published checkpoint, for a machine that can hold it.
+
+    The tiny fixture above is what proves the conversion exact, tensor by tensor. This one proves it
+    on the file people actually load, at the shapes they actually load it at -- 40 layers, 256
+    experts, a vocabulary of a quarter of a million tokens -- where a mapping that happens to work at
+    four layers and eight experts can still be wrong.
+
+    Only the quantized file is exercised. The bf16 build of a 35B model is ~70GB and ships split
+    across two shards, which the reader does not read (a GGUF is one memory-mapped file), and the
+    bf16 reference to compare it against would be another 70GB. So `gguf_file` is the Q4_K_M one and
+    the state-dict comparison -- the single test that genuinely needs unquantized weights -- is
+    skipped rather than loosened into something that would pass on a wrong answer.
+    """
+
+    gguf_repo = "unsloth/Qwen3.5-35B-A3B-GGUF"
+    gguf_file = "Qwen3.5-35B-A3B-Q4_K_M.gguf"
+    quantized_gguf_file = "Qwen3.5-35B-A3B-Q4_K_M.gguf"
+    reference_repo = "Qwen/Qwen3.5-35B-A3B"
+    model_class = Qwen3_5MoeForCausalLM
+
+    prompt = "The capital of France is Paris. The capital of Germany is"
+    expected_completion = " Berlin"
+
+    @unittest.skip(
+        "compares against the bf16 checkpoint, which for this model is ~70GB and split across shards "
+        "the reader cannot open; Qwen35MoeGgufModelTest covers it exactly on a tiny checkpoint"
+    )
+    def test_state_dict_matches_transformers(self):
+        pass


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48529&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48529) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48529&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48529)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This PR adds support to MoE in the new gguf integration ! For now, only qwen3.5moe is supported but this opens the door for the other models !

## Performance

Apple Silicon / Metal, Q4_K_M, tg128:

```
  ┌───────────────────────────────────┬────────────┬──────────────┐
  │                                   │ llama.cpp  │ transformers │
  ├───────────────────────────────────┼────────────┼──────────────┤
  │ Qwen3.5-35B-A3B                   │ 59.4 tok/s │ 59.9 tok/s   │
  ├───────────────────────────────────┼────────────┼──────────────┤
  │ Qwen3.5-4B (dense, for reference) │ 73.1 tok/s │ 78.2 tok/s   │
  └───────────────────────────────────┴────────────┴──────────────┘
```