### PR TITLE
Skip symlinked hub-cache test when the platform cannot create symlinks

### DIFF
--- a/tests/utils/test_dynamic_module_utils.py
+++ b/tests/utils/test_dynamic_module_utils.py
@@ -222,6 +222,18 @@ def test_get_cached_module_file_local_cache_key_includes_transitive_import_sourc
     assert cached_a != cached_b
 
 
+def _skip_if_symlinks_unsupported(directory: Path):
+    # Building the hub-cache layout below requires creating symlinks, which
+    # Windows denies without Developer Mode or elevation (OSError WinError
+    # 1314) and some restricted filesystems deny on any platform.
+    target = directory / "symlink_capability_target.txt"
+    target.touch()
+    try:
+        (directory / "symlink_capability_link").symlink_to(target)
+    except OSError as e:
+        pytest.skip(f"Platform/filesystem cannot create symlinks ({e})")
+
+
 def _build_symlinked_hub_cache(repo_root: Path, files: dict[str, str], revision: str = "abc123") -> Path:
     blobs = repo_root / "blobs"
     snapshot = repo_root / "snapshots" / revision
@@ -239,6 +251,7 @@ def test_get_cached_module_file_local_handles_symlinked_hub_cache(monkeypatch, t
     # In a real hub cache the snapshot files are symlinks into a content-addressed ``blobs/`` dir,
     # so relative-import discovery must follow the named ``*.py`` symlinks in the snapshot dir rather
     # than their opaque blob targets
+    _skip_if_symlinks_unsupported(tmp_path)
     modules_cache = tmp_path / "hf_modules_cache"
     monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", str(modules_cache))
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48530&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48530) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48530&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48530)
<!-- ci-dashboard-badge:end -->

Body:

Fixes #48527

## What does this PR do?

`test_get_cached_module_file_local_handles_symlinked_hub_cache` builds a
hub-cache layout whose snapshot files are symlinks into a content-addressed
`blobs/` dir. Creating those symlinks is unconditional, so on Windows
without Developer Mode or elevation the test fails with
`OSError: [WinError 1314] A required privilege is not held by the client`
(1 failed, 15 passed on the reporter's setup) instead of being recognized
as an environment limitation.

This adds a small capability probe (`_skip_if_symlinks_unsupported`) that
tries to create a throwaway symlink in `tmp_path` and calls `pytest.skip`
with the underlying `OSError` when it is denied. Platforms/filesystems that
can create symlinks are unaffected: the probe succeeds, the test runs
exactly as before.

The probe is runtime-based rather than `sys.platform`-keyed so it also
covers restricted filesystems on any OS that deny symlink creation.

## Verification

- On a symlink-capable platform (macOS): `pytest tests/utils/test_dynamic_module_utils.py` → 16 passed (the test still runs, does not skip)
- Simulated `OSError 1314` from `Path.symlink_to` → the helper raises a
  clean `pytest.skip("Platform/filesystem cannot create symlinks (...)")`
- `ruff format --check` and `ruff check` pass on the touched file

## Related

`tests/utils/test_modeling_utils.py` (`test_transformers_weights`, around
line 923) creates a symlink unconditionally too and would hit the same
WinError 1314 on that setup. It is a `unittest.TestCase` method living in a
torch-dependent file, so I left it out of this PR to keep the change
focused — happy to follow up with the same guard there (using
`self.skipTest`) if wanted.