### PR TITLE
Validate hypothesis_template in zero-shot pipelines to prevent unsafe formatting

### DIFF
--- a/src/transformers/pipelines/zero_shot_audio_classification.py
+++ b/src/transformers/pipelines/zero_shot_audio_classification.py
@@ -23,6 +23,7 @@ from ..utils import (
 )
 from .audio_classification import ffmpeg_read
 from .base import Pipeline, build_pipeline_init_args
+from .zero_shot_classification import _validate_hypothesis_template
 
 
 logger = logging.get_logger(__name__)
@@ -102,6 +103,7 @@ class ZeroShotAudioClassificationPipeline(Pipeline):
         return preprocess_params, {}, {}
 
     def preprocess(self, audio, candidate_labels=None, hypothesis_template="This is a sound of {}."):
+        _validate_hypothesis_template(hypothesis_template)
         if isinstance(audio, str):
             if audio.startswith("http://") or audio.startswith("https://"):
                 # We need to actually check for a real protocol, otherwise it's impossible to use a local file
@@ -124,7 +126,7 @@ class ZeroShotAudioClassificationPipeline(Pipeline):
         )
         inputs = inputs.to(self.dtype)
         inputs["candidate_labels"] = candidate_labels
-        sequences = [hypothesis_template.format(x) for x in candidate_labels]
+        sequences = [hypothesis_template.replace("{}", x) for x in candidate_labels]
         text_inputs = self.tokenizer(sequences, return_tensors="pt", padding=True)
         inputs["text_inputs"] = [text_inputs]
         return inputs

--- a/src/transformers/pipelines/zero_shot_classification.py
+++ b/src/transformers/pipelines/zero_shot_classification.py
@@ -1,4 +1,5 @@
 import inspect
+import string
 
 import numpy as np
 
@@ -8,6 +9,36 @@ from .base import ArgumentHandler, ChunkPipeline, build_pipeline_init_args
 
 
 logger = logging.get_logger(__name__)
+
+
+def _validate_hypothesis_template(hypothesis_template: str) -> None:
+    """
+    Validates that the hypothesis template contains exactly one simple {} placeholder.
+    """
+    if not isinstance(hypothesis_template, str):
+        raise AttributeError(f"hypothesis_template must be a string, got {type(hypothesis_template).__name__}")
+
+    formatter = string.Formatter()
+    try:
+        fields = [f for f in formatter.parse(hypothesis_template) if f[1] is not None]
+    except ValueError:
+        raise ValueError(
+            f'The provided hypothesis_template "{hypothesis_template}" was not able to be formatted with the target labels. '
+            "Make sure the passed template includes formatting syntax such as {} where the label should go."
+        )
+
+    if len(fields) != 1:
+        raise ValueError(
+            f'The provided hypothesis_template "{hypothesis_template}" was not able to be formatted with the target labels. '
+            "Make sure the passed template includes formatting syntax such as {} where the label should go."
+        )
+
+    _, field_name, format_spec, conversion = fields[0]
+    if field_name != "" or format_spec != "" or conversion is not None:
+        raise ValueError(
+            f'The provided hypothesis_template "{hypothesis_template}" was not able to be formatted with the target labels. '
+            "Make sure the passed template includes formatting syntax such as {} where the label should go."
+        )
 
 
 class ZeroShotClassificationArgumentHandler(ArgumentHandler):
@@ -24,18 +55,16 @@ class ZeroShotClassificationArgumentHandler(ArgumentHandler):
     def __call__(self, sequences, labels, hypothesis_template):
         if len(labels) == 0 or len(sequences) == 0:
             raise ValueError("You must include at least one label and at least one sequence.")
-        if hypothesis_template.format(labels[0]) == hypothesis_template:
-            raise ValueError(
-                f'The provided hypothesis_template "{hypothesis_template}" was not able to be formatted with the target labels. '
-                "Make sure the passed template includes formatting syntax such as {} where the label should go."
-            )
+
+        _validate_hypothesis_template(hypothesis_template)
+        labels = self._parse_labels(labels)
 
         if isinstance(sequences, str):
             sequences = [sequences]
 
         sequence_pairs = []
         for sequence in sequences:
-            sequence_pairs.extend([[sequence, hypothesis_template.format(label)] for label in labels])
+            sequence_pairs.extend([[sequence, hypothesis_template.replace("{}", label)] for label in labels])
 
         return sequence_pairs, sequences
 

--- a/src/transformers/pipelines/zero_shot_image_classification.py
+++ b/src/transformers/pipelines/zero_shot_image_classification.py
@@ -9,6 +9,7 @@ from ..utils import (
     requires_backends,
 )
 from .base import Pipeline, build_pipeline_init_args
+from .zero_shot_classification import _validate_hypothesis_template
 
 
 if is_vision_available():
@@ -144,11 +145,12 @@ class ZeroShotImageClassificationPipeline(Pipeline):
     ):
         if tokenizer_kwargs is None:
             tokenizer_kwargs = {}
+        _validate_hypothesis_template(hypothesis_template)
         image = load_image(image, timeout=timeout)
         inputs = self.image_processor(images=[image], return_tensors="pt")
         inputs = inputs.to(self.dtype)
         inputs["candidate_labels"] = candidate_labels
-        sequences = [hypothesis_template.format(x) for x in candidate_labels]
+        sequences = [hypothesis_template.replace("{}", x) for x in candidate_labels]
         tokenizer_default_kwargs = {"padding": True}
         if "siglip" in self.model.config.model_type:
             tokenizer_default_kwargs.update(padding="max_length", max_length=64, truncation=True)

--- a/tests/pipelines/test_pipelines_zero_shot.py
+++ b/tests/pipelines/test_pipelines_zero_shot.py
@@ -286,3 +286,41 @@ class ZeroShotClassificationPipelineTests(unittest.TestCase):
                 "scores": [0.817, 0.713, 0.018, 0.018],
             },
         )
+
+    def test_hypothesis_template_validation(self):
+        from transformers.pipelines.zero_shot_classification import ZeroShotClassificationArgumentHandler
+
+        handler = ZeroShotClassificationArgumentHandler()
+        sequences = ["I love this movie"]
+        labels = ["positive", "negative"]
+
+        # Valid templates
+        pairs, _ = handler(sequences, labels, "This movie is {}.")
+        self.assertEqual(len(pairs), 2)
+        self.assertEqual(pairs[0][1], "This movie is positive.")
+        self.assertEqual(pairs[1][1], "This movie is negative.")
+
+        # Safe handling of labels containing formatting characters
+        pairs, _ = handler(sequences, ["{unsafe}"], "This movie is {}.")
+        self.assertEqual(pairs[0][1], "This movie is {unsafe}.")
+
+        # Invalid templates must raise ValueError
+        invalid_templates = [
+            "No placeholder",
+            "{:>10}",
+            "{:>9999999999}",
+            "{0}",
+            "{!r}",
+            "{!s}",
+            "{label}",
+            "{}{}",
+            "This is {0} and {1}",
+            "This is {} and {}",
+        ]
+        for template in invalid_templates:
+            with self.assertRaises(ValueError):
+                handler(sequences, labels, template)
+
+        # None must raise AttributeError
+        with self.assertRaises(AttributeError):
+            handler(sequences, labels, None)

--- a/tests/pipelines/test_pipelines_zero_shot_audio_classification.py
+++ b/tests/pipelines/test_pipelines_zero_shot_audio_classification.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+import numpy as np
 from datasets import load_dataset
 
 from transformers.pipelines import pipeline
@@ -45,6 +46,38 @@ class ZeroShotAudioClassificationPipelineTests(unittest.TestCase):
     @require_torch
     def test_small_model_pt_fp16(self):
         self.test_small_model_pt(dtype="float16")
+
+    @require_torch
+    def test_hypothesis_template_validation(self):
+        audio_classifier = pipeline(
+            task="zero-shot-audio-classification",
+            model="hf-internal-testing/tiny-clap-htsat-unfused",
+        )
+        audio = np.zeros(16000, dtype=np.float32)
+
+        # Valid custom template
+        output = audio_classifier(audio, candidate_labels=["a", "b"], hypothesis_template="This is a sound of {}.")
+        self.assertEqual(len(output), 2)
+
+        # Invalid templates should raise ValueError
+        invalid_templates = [
+            "No placeholder",
+            "{:>10}",
+            "{:>9999999999}",
+            "{0}",
+            "{!r}",
+            "{!s}",
+            "{label}",
+            "{}{}",
+            "This is {} and {}",
+        ]
+        for template in invalid_templates:
+            with self.assertRaises(ValueError):
+                audio_classifier(audio, candidate_labels=["a", "b"], hypothesis_template=template)
+
+        # None should raise AttributeError
+        with self.assertRaises(AttributeError):
+            audio_classifier(audio, candidate_labels=["a", "b"], hypothesis_template=None)
 
     @slow
     @require_torch

--- a/tests/pipelines/test_pipelines_zero_shot_image_classification.py
+++ b/tests/pipelines/test_pipelines_zero_shot_image_classification.py
@@ -137,6 +137,35 @@ class ZeroShotImageClassificationPipelineTests(unittest.TestCase):
     def test_small_model_pt_fp16(self):
         self.test_small_model_pt(dtype="float16")
 
+    @require_torch
+    def test_hypothesis_template_validation(self):
+        image_classifier = pipeline(model="hf-internal-testing/tiny-random-clip-zero-shot-image-classification")
+        image = Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png")
+
+        # Valid custom template
+        output = image_classifier(image, candidate_labels=["a", "b"], hypothesis_template="This is a photo of {}.")
+        self.assertEqual(len(output), 2)
+
+        # Invalid templates should raise ValueError
+        invalid_templates = [
+            "No placeholder",
+            "{:>10}",
+            "{:>9999999999}",
+            "{0}",
+            "{!r}",
+            "{!s}",
+            "{label}",
+            "{}{}",
+            "This is {} and {}",
+        ]
+        for template in invalid_templates:
+            with self.assertRaises(ValueError):
+                image_classifier(image, candidate_labels=["a", "b"], hypothesis_template=template)
+
+        # None should raise AttributeError
+        with self.assertRaises(AttributeError):
+            image_classifier(image, candidate_labels=["a", "b"], hypothesis_template=None)
+
     @slow
     @require_torch
     def test_large_model_pt(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48532&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48532) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48532&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48532)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #35874

### Context & Motivation
In `ZeroShotClassificationArgumentHandler`, `ZeroShotAudioClassificationPipeline`, and `ZeroShotImageClassificationPipeline`, `hypothesis_template` was evaluated directly using `str.format(label)`. Because `hypothesis_template` is exposed as an input parameter (including on remote/hosted zero-shot endpoints), an adversarial input like `"{:>9999999999}"` triggers large memory allocations in Python's format engine before pipeline inference, leading to remote DoS / OOM crashes. Additionally, full format-string evaluation enables access to object attributes and representation conversions.

### Changes
1. Added `_validate_hypothesis_template(hypothesis_template: str)` in `zero_shot_classification.py` using `string.Formatter().parse()` to safely ensure the template contains exactly one empty `{}` placeholder without complex format specifiers, positional indices, or conversions.
2. Replaced `str.format()` with `hypothesis_template.replace("{}", label)` across text, audio, and image zero-shot pipelines as discussed on #35874.
3. Added unit tests for valid templates, escaped characters in candidate labels, and invalid template rejection across all three pipeline test suites (`test_pipelines_zero_shot.py`, `test_pipelines_zero_shot_audio_classification.py`, and `test_pipelines_zero_shot_image_classification.py`).

## Before submitting
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case: https://github.com/huggingface/transformers/issues/35874
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?
@Rocketknight1 @qgallouedec