### PR TITLE
Add a DevLab Dispatch connectivity probe

### DIFF
--- a/.github/workflows/devlab-dispatch-probe.yml
+++ b/.github/workflows/devlab-dispatch-probe.yml
@@ -1,0 +1,44 @@
+# Connectivity probe for the AMD Ryzen DevLab DISPATCH ephemeral runner pool.
+#
+# This is deliberately the smallest thing that proves the route works. It is
+# dispatch-only: nothing here fires on push or pull_request, so it cannot run
+# on untrusted code and costs nothing until someone asks for it.
+name: DevLab Dispatch probe
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Hello from the DevLab pool
+    # `devlab-dispatch` is the opt-in token for the pool. A runner is built for
+    # this job alone and destroyed when it finishes, so nothing persists between
+    # runs and no state is shared with any other job.
+    runs-on: [self-hosted, Linux, devlab-dispatch]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Report the machine
+        run: |
+          echo "runner   : ${RUNNER_NAME:-unknown}"
+          echo "kernel   : $(uname -srm)"
+          echo "distro   : $(. /etc/os-release && echo "$PRETTY_NAME")"
+          echo "cpu      : $(grep -m1 '^model name' /proc/cpuinfo | cut -d: -f2- | xargs)"
+          echo "cores    : $(nproc)"
+          echo "memory   : $(free -h | awk '/^Mem:/ {print $2}')"
+          echo "disk free: $(df -h . | awk 'NR==2 {print $4}')"
+
+      - name: Report the AMD stack
+        # Informational only. A missing tool prints a line and does not fail the
+        # job -- the point of this run is the route, not the toolchain.
+        run: |
+          command -v rocminfo   >/dev/null && rocminfo | grep -m1 'Marketing Name' || echo "rocminfo  : not installed"
+          command -v xrt-smi    >/dev/null && xrt-smi examine | head -20         || echo "xrt-smi   : not installed"
+          command -v python3    >/dev/null && python3 -VV                        || echo "python3   : not installed"
+
+      - name: Done
+        run: echo "Job ran on the DevLab DISPATCH pool."


### PR DESCRIPTION
Adds one dispatch-only workflow that runs a job on the AMD Ryzen DevLab DISPATCH ephemeral runner pool and prints what it landed on. No existing workflow is touched.

The DevLab-Dispatch GitHub App is installed on this organisation, and the pool has been watching this repo since today. Nothing here can reach it yet, and the reason is worth stating: the AMD CI in this repo routes by runner **group** (`runner_group: amd-mi300`, and siblings for mi250 and mi355), not by label. The pool only answers jobs that name `devlab-dispatch` in `runs-on`, so this is the smallest change that proves the route end to end without altering how any existing job is scheduled.

**What the runners are.** AMD Strix Halo (Ryzen AI Max+ 395), 128 GB unified memory, NPU present. These are client APUs and not a substitute for the MI250/MI300/MI355 fleet -- different silicon for a different purpose. A runner is built for one job and destroyed when it finishes, so nothing persists between runs and no state is shared with any other job or repo.

**Trigger is `workflow_dispatch` only** — deliberately, and it matters more here than in a small repo. It cannot fire on a push or a pull request, so it never runs untrusted code on a self-hosted machine, and it adds nothing to the CI load on this repo's PR volume. Run it from the Actions tab once merged.

The probe checks out the repo, prints kernel, CPU, cores, memory and free disk, then reports whether `rocminfo`, `xrt-smi` and `python3` are present. The AMD stack step is informational and cannot fail the job, since the point of this run is the route rather than the toolchain.

Happy to narrow, rename or drop this if a concrete workflow would be a more useful thing to point at the pool instead.