### PR TITLE
Experts implementations: per-row post-expert hook

### DIFF
--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -523,8 +523,15 @@ def _default_apply_gate(self, gate_up_out: torch.Tensor) -> torch.Tensor:
 
 
 def _default_apply_post_expert(self, proj_out: torch.Tensor) -> torch.Tensor:
-    """Per-row transform applied to the experts' output before the routing weights: the identity unless the experts
-    class defines `_apply_post_expert` (e.g. a per-expert output norm)."""
+    """
+    Default post-expert transform: the identity. An experts class overrides `_apply_post_expert` when its output goes
+    through a per-row transform before the routing weights, such as a per-expert output norm.
+    Args:
+        proj_out (`torch.Tensor`):
+            The output tensor from the down projection of shape (S, hidden_dim).
+    Returns:
+        `torch.Tensor`: The transformed output tensor of shape (S, hidden_dim).
+    """
     return proj_out
 
 

--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -160,6 +160,7 @@ def batched_mm_experts_forward(
     proj_out = _batched_linear(
         proj_out, selected_weights, bias=selected_biases, is_transposed=self.is_transposed
     )  # (S, hidden_dim)
+    proj_out = self._apply_post_expert(proj_out)
 
     # Apply routing weights
     weighted_out = proj_out * sample_weights.unsqueeze(-1)  # (S, hidden_dim)
@@ -458,11 +459,12 @@ def grouped_mm_experts_forward(
         proj_out, selected_weights, offsets, bias=selected_biases, is_transposed=self.is_transposed
     )  # (S, hidden_dim)
 
+    # Post-mask (fwd path): the sentinel rows are uninitialized kernel output, zeroed before anything reads them.
+    proj_out.masked_fill_(sentinel_mask, 0.0)
+    proj_out = self._apply_post_expert(proj_out)
+
     # Apply routing weights
     weighted_out = proj_out * sample_weights_g.unsqueeze(-1)  # (S, hidden_dim)
-
-    # Post-mask (fwd path).
-    weighted_out.masked_fill_(sentinel_mask, 0.0)
 
     # Restore original order
     inv_perm = torch.empty_like(perm)
@@ -520,6 +522,12 @@ def _default_apply_gate(self, gate_up_out: torch.Tensor) -> torch.Tensor:
     return self.act_fn(gate) * up  # (S, intermediate_dim)
 
 
+def _default_apply_post_expert(self, proj_out: torch.Tensor) -> torch.Tensor:
+    """Per-row transform applied to the experts' output before the routing weights: the identity unless the experts
+    class defines `_apply_post_expert` (e.g. a per-expert output norm)."""
+    return proj_out
+
+
 def use_experts_implementation(
     experts_class: type[torch.nn.Module] | None = None,
     *,
@@ -571,6 +579,8 @@ def use_experts_implementation(
 
         if not hasattr(experts_class, "_apply_gate"):
             experts_class._apply_gate = _default_apply_gate
+        if not hasattr(experts_class, "_apply_post_expert"):
+            experts_class._apply_post_expert = _default_apply_post_expert
 
         experts_class.__init__ = __init__
         experts_class.forward = forward

--- a/tests/utils/test_experts_implementations.py
+++ b/tests/utils/test_experts_implementations.py
@@ -1,0 +1,108 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from torch import nn
+
+from transformers import PreTrainedConfig
+from transformers.integrations.moe import (
+    batched_mm_experts_forward,
+    grouped_mm_experts_forward,
+    use_experts_implementation,
+)
+from transformers.testing_utils import require_torch
+
+
+class RowNorm(nn.Module):
+    """A per-row norm with a weight, the shape of a per-expert output norm."""
+
+    def __init__(self, dim):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-6) * self.weight
+
+
+@use_experts_implementation
+class ExpertsWithPostNorm(nn.Module):
+    """Gated experts whose output goes through a per-row norm before the routing weights."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.num_experts = config.num_experts
+        self.hidden_dim = config.hidden_size
+        self.intermediate_dim = config.intermediate_size
+        self.gate_up_proj = nn.Parameter(torch.randn(self.num_experts, 2 * self.intermediate_dim, self.hidden_dim))
+        self.down_proj = nn.Parameter(torch.randn(self.num_experts, self.hidden_dim, self.intermediate_dim))
+        self.act_fn = nn.SiLU()
+        self.post_expert_norm = RowNorm(self.hidden_dim)
+
+    def _apply_post_expert(self, proj_out):
+        return self.post_expert_norm(proj_out)
+
+    def forward(self, hidden_states, top_k_index, top_k_weights):
+        # The eager reference: one expert at a time, the norm on each expert's rows
+        final_hidden_states = torch.zeros_like(hidden_states)
+        for expert_idx in range(self.num_experts):
+            top_k_pos, token_idx = torch.where(top_k_index.T == expert_idx)
+            if token_idx.numel() == 0:
+                continue
+            gate, up = nn.functional.linear(hidden_states[token_idx], self.gate_up_proj[expert_idx]).chunk(2, dim=-1)
+            out = nn.functional.linear(self.act_fn(gate) * up, self.down_proj[expert_idx])
+            out = self.post_expert_norm(out) * top_k_weights[token_idx, top_k_pos, None]
+            final_hidden_states.index_add_(0, token_idx, out)
+        return final_hidden_states
+
+
+@use_experts_implementation
+class PlainExperts(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.num_experts = config.num_experts
+        self.gate_up_proj = nn.Parameter(
+            torch.randn(self.num_experts, 2 * config.intermediate_size, config.hidden_size)
+        )
+        self.down_proj = nn.Parameter(torch.randn(self.num_experts, config.hidden_size, config.intermediate_size))
+        self.act_fn = nn.SiLU()
+
+    def forward(self, hidden_states, top_k_index, top_k_weights):
+        raise NotImplementedError
+
+
+@require_torch
+class ExpertsImplementationsTest(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        self.config = PreTrainedConfig(
+            num_experts=8, hidden_size=16, intermediate_size=12, _experts_implementation="eager"
+        )
+        num_tokens, top_k = 10, 2
+        self.hidden_states = torch.randn(num_tokens, self.config.hidden_size)
+        self.top_k_index = torch.stack([torch.randperm(self.config.num_experts)[:top_k] for _ in range(num_tokens)])
+        self.top_k_weights = torch.softmax(torch.randn(num_tokens, top_k), dim=-1)
+
+    def test_post_expert_hook_matches_the_eager_loop(self):
+        experts = ExpertsWithPostNorm(self.config)
+        expected = experts(self.hidden_states, self.top_k_index, self.top_k_weights)
+        for forward in (batched_mm_experts_forward, grouped_mm_experts_forward):
+            out = forward(experts, self.hidden_states, self.top_k_index, self.top_k_weights)
+            torch.testing.assert_close(out, expected, atol=1e-5, rtol=1e-5)
+
+    def test_default_hook_is_the_identity(self):
+        experts = PlainExperts(self.config)
+        x = torch.randn(3, self.config.hidden_size)
+        self.assertIs(experts._apply_post_expert(x), x)

--- a/tests/utils/test_experts_implementations.py
+++ b/tests/utils/test_experts_implementations.py
@@ -58,7 +58,7 @@ class ExpertsWithPostNorm(nn.Module):
         # The eager reference: one expert at a time, the norm on each expert's rows
         final_hidden_states = torch.zeros_like(hidden_states)
         for expert_idx in range(self.num_experts):
-            top_k_pos, token_idx = torch.where(top_k_index.T == expert_idx)
+            top_k_pos, token_idx = torch.where(expert_idx == top_k_index.T)
             if token_idx.numel() == 0:
                 continue
             gate, up = nn.functional.linear(hidden_states[token_idx], self.gate_up_proj[expert_idx]).chunk(2, dim=-1)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48539&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48539) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48539&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48539)
<!-- ci-dashboard-badge:end -->

Some MoE models apply a norm to each expert's output before the routing weights (per (token, expert) row, so it cannot move after the combine or fold into `down_proj`).
Today such a model cannot use `@use_experts_implementation`: it keeps a hand-written per-expert loop, which means no `grouped_mm`, no EP sentinel handling, and under EP a norm called once per hit expert, a per-rank count that breaks the `replicated_with_grad_allreduce` hook.

This PR adds `_apply_post_expert(self, proj_out)` next to `_apply_gate`.

Identity by default, called by `batched_mm_experts_forward` and `grouped_mm_experts_forward` right after the down projection and before the routing weights.