### PR TITLE
[docs] Add a LiteRT page under community integrations

### DIFF
--- a/docs/source/en/_redirects.yml
+++ b/docs/source/en/_redirects.yml
@@ -15,3 +15,4 @@ performance: optimization_overview
 task_summary: pipeline_tutorial
 model_summary: index
 migration: index
+tflite: community_integrations/litert

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -342,6 +342,8 @@
       title: Candle
     - local: community_integrations/executorch
       title: ExecuTorch
+    - local: community_integrations/litert
+      title: LiteRT
     - local: community_integrations/llama_cpp
       title: llama.cpp
     - local: community_integrations/mlx

--- a/docs/source/en/community_integrations/litert.md
+++ b/docs/source/en/community_integrations/litert.md
@@ -1,0 +1,76 @@
+<!--Copyright 2026 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contains specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# LiteRT
+
+[LiteRT](https://ai.google.dev/edge/litert) (formerly TensorFlow Lite) is Google's runtime for on-device inference. The model format is still `.tflite`, and language models ship as one `.litertlm` file for the [LiteRT-LM](https://ai.google.dev/edge/litert-lm) runtime.
+
+Export a Transformers model with [litert-torch](https://github.com/google-ai-edge/litert-torch) (formerly `ai-edge-torch`). It lowers the [torch.export](https://docs.pytorch.org/docs/stable/export.html) graph to LiteRT directly, without ONNX or TensorFlow.
+
+```bash
+pip install litert-torch
+```
+
+<hfoptions id="export">
+<hfoption id="CLI (LLM)">
+
+`export_hf` loads a text-generation model from the Hub, quantizes the weights to int8 by default, and writes `model.litertlm`.
+
+```bash
+litert-torch export_hf \
+    --model="HuggingFaceTB/SmolLM2-135M-Instruct" \
+    --output_dir="./smollm2_litertlm"
+```
+
+</hfoption>
+<hfoption id="Python (any model)">
+
+`litert_torch.convert` traces a model with sample inputs and exports a `.tflite` file. The returned object also runs it, so the export can be checked in place.
+
+```py
+import litert_torch
+from transformers import AutoModelForMaskedLM, AutoTokenizer
+
+model_id = "google-bert/bert-base-uncased"
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+model = AutoModelForMaskedLM.from_pretrained(model_id).eval()
+inputs = tokenizer("Paris is the [MASK] of France.", return_tensors="pt", padding="max_length", max_length=128)
+
+litert_model = litert_torch.convert(model, sample_kwargs=dict(inputs))
+litert_model.export("bert.tflite")
+
+outputs = litert_model(**{name: tensor.numpy() for name, tensor in inputs.items()})
+mask_index = inputs["input_ids"][0].tolist().index(tokenizer.mask_token_id)
+print(tokenizer.decode(outputs["logits"][0, mask_index].argmax()))  # capital
+```
+
+</hfoption>
+</hfoptions>
+
+## Transformers integration
+
+1. [`~PreTrainedModel.from_pretrained`] loads the model weights in safetensors format.
+2. litert-torch runs [torch.export](https://docs.pytorch.org/docs/stable/export.html) and lowers the graph to LiteRT operators. `export_hf` adds the KV cache, prefill and decode signatures, and int8 quantization.
+3. [`AutoTokenizer`] loads the tokenizer. `export_hf` packs it and the chat template into the `.litertlm` file.
+4. At runtime, `.tflite` runs on LiteRT and `.litertlm` on LiteRT-LM, from Kotlin, Swift, C++, or Python (`ai-edge-litert` and `litert-lm-api`; the older `tflite-runtime` wheels stop at Python 3.11).
+
+> [!NOTE]
+> Transformers v4 documented `optimum-cli export tflite`, which converted through TensorFlow. It was removed with TensorFlow support in v5 ([#40760](https://github.com/huggingface/transformers/pull/40760)) and is not part of Optimum 2.x.
+
+## Resources
+
+- [LiteRT](https://ai.google.dev/edge/litert) and [LiteRT-LM](https://ai.google.dev/edge/litert-lm) docs
+- [Convert PyTorch models](https://ai.google.dev/edge/litert/conversion/pytorch/overview) and [GenAI models](https://ai.google.dev/edge/litert/conversion/pytorch/genai) guides

--- a/docs/source/en/community_integrations/litert.md
+++ b/docs/source/en/community_integrations/litert.md
@@ -16,9 +16,9 @@ rendered properly in your Markdown viewer.
 
 # LiteRT
 
-[LiteRT](https://ai.google.dev/edge/litert) (formerly TensorFlow Lite) is Google's runtime for on-device inference. The model format is still `.tflite`, and language models ship as one `.litertlm` file for the [LiteRT-LM](https://ai.google.dev/edge/litert-lm) runtime.
+[LiteRT](https://ai.google.dev/edge/litert) (formerly TensorFlow Lite) is Google's runtime for on-device inference. The model format is `.tflite` and language models ship as one `.litertlm` file for the [LiteRT-LM](https://ai.google.dev/edge/litert-lm) runtime.
 
-Export a Transformers model with [litert-torch](https://github.com/google-ai-edge/litert-torch) (formerly `ai-edge-torch`). It lowers the [torch.export](https://docs.pytorch.org/docs/stable/export.html) graph to LiteRT directly, without ONNX or TensorFlow.
+Export a Transformers model with [litert-torch](https://github.com/google-ai-edge/litert-torch). It lowers the [torch.export](https://docs.pytorch.org/docs/stable/export.html) graph to LiteRT directly, and not through ONNX or a TensorFlow `SavedModel`.
 
 ```bash
 pip install litert-torch
@@ -27,7 +27,7 @@ pip install litert-torch
 <hfoptions id="export">
 <hfoption id="CLI (LLM)">
 
-`export_hf` loads a text-generation model from the Hub, quantizes the weights to int8 by default, and writes `model.litertlm`.
+`export_hf` loads a language model from the Hub, quantizes the weights to int8 by default, and writes `model.litertlm`.
 
 ```bash
 litert-torch export_hf \
@@ -65,7 +65,7 @@ print(tokenizer.decode(outputs["logits"][0, mask_index].argmax()))  # capital
 1. [`~PreTrainedModel.from_pretrained`] loads the model weights in safetensors format.
 2. litert-torch runs [torch.export](https://docs.pytorch.org/docs/stable/export.html) and lowers the graph to LiteRT operators. `export_hf` adds the KV cache, prefill and decode signatures, and int8 quantization.
 3. [`AutoTokenizer`] loads the tokenizer. `export_hf` packs it and the chat template into the `.litertlm` file.
-4. At runtime, `.tflite` runs on LiteRT and `.litertlm` on LiteRT-LM, from Kotlin, Swift, C++, or Python (`ai-edge-litert` and `litert-lm-api`; the older `tflite-runtime` wheels stop at Python 3.11).
+4. At runtime, `.tflite` runs on LiteRT and `.litertlm` on LiteRT-LM, from Kotlin, Swift, C++, or Python (`ai-edge-litert` and `litert-lm-api`). The older `tflite-runtime` wheels stop at Python 3.11.
 
 > [!NOTE]
 > Transformers v4 documented `optimum-cli export tflite`, which converted through TensorFlow. It was removed with TensorFlow support in v5 ([#40760](https://github.com/huggingface/transformers/pull/40760)) and is not part of Optimum 2.x.


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48540&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48540) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48540&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48540)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Since #40760 removed TensorFlow support, the docs have had no LiteRT page. The v4 page `tflite.md` went with it, because its route (`pip install optimum[exporters-tf]`, `optimum-cli export tflite`) converted through TensorFlow. The gap is still visible today: the v4 text is served at https://huggingface.co/docs/transformers/main/en/tflite, and its command no longer runs with current Optimum (2.3.0; the `exporters-tf` extra is absent from every 2.x release), stopping at `unrecognized arguments: tflite ...`. Meanwhile the conversion itself no longer needs TensorFlow: `litert-torch` converts from `torch.export` directly, which fits a PyTorch-only Transformers. I publish LiteRT conversions of Hub models, so I ran into this from the user side.

This PR adds the replacement page next to the other on-device runtimes (Candle, ExecuTorch, llama.cpp, MLX) under "Local deployment":

- `docs/source/en/community_integrations/litert.md`, laid out like `executorch.md`: a short intro, an `<hfoptions>` block with a CLI example (`litert-torch export_hf`, SmolLM2-135M-Instruct → `model.litertlm`) and a Python example (`litert_torch.convert`, bert-base-uncased → `bert.tflite`), a "Transformers integration" list, and resource links. The renamed packages (TensorFlow Lite → LiteRT, `ai-edge-torch` → `litert-torch`, `tflite-runtime` / `ai-edge-litert`) are named in the text so that searches for the old names land on the current route. The old command gets one note, nothing more.
- the `_toctree.yml` entry.
- `_redirects.yml`: `tflite` → `community_integrations/litert`, so the old URL lands on the new page.

Everything on the page was run as written, in fresh venvs on macOS arm64 with Python 3.12.13 and 3.14.6. `pip install litert-torch` resolves to litert-torch 0.9.4, ai-edge-litert 2.2.0, torch 2.13.0 and transformers 5.16.1, with no TensorFlow or ONNX in the environment. `export_hf` wrote a 136 MiB `model.litertlm` (int8 weights by default) that `litert-lm-api` 0.17.0 loads; the reply to "What is the capital of France?" starts with "The capital of France is Paris." The BERT `.tflite` predicts `capital` for the masked token, with a max logits difference of 9.5e-5 against PyTorch, and the file reloaded from disk with the `ai_edge_litert` Interpreter gives the same output.

Checks: built locally with `doc-builder` (this page plus `executorch.md` as a control); `python utils/check_doc_toc.py` and `python utils/check_doctest_list.py` pass. No code changes.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the forum? No related issue found.
- [x] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary tests? Docs only.

## Who can review?

@stevhliu