### PR TITLE
Fix GPT-NeoX family tokenization when config flags and serialized post-processor disagree

### DIFF
--- a/src/transformers/models/gpt_neox/tokenization_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/tokenization_gpt_neox.py
@@ -139,12 +139,10 @@ class GPTNeoXTokenizer(TokenizersBackend):
             trim_offsets=trim_offsets,
             **kwargs,
         )
-        # See https://github.com/huggingface/transformers/pull/47988 for more details.
-        # `_from_pretrained` strips `add_bos_token`/`add_eos_token` from init_kwargs when a
-        # tokenizer.json is present (assuming the post_processor is authoritative). But GPTNeoX
-        # rebuilds its backend tokenizer from scratch, so the post_processor baked into
-        # tokenizer.json may not match the desired add_bos/eos settings. Call
-        # update_post_processor() here to ensure they stay in sync.
+        # GPTNeoX rebuilds its backend tokenizer above, so the post_processor serialized in
+        # tokenizer.json only reaches it through the post_processor kwarg handled by the base
+        # class. Re-apply it here so it always matches the add_bos_token/add_eos_token settings
+        # this tokenizer was loaded with. See https://github.com/huggingface/transformers/pull/47988.
         self.update_post_processor()
 
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1776,9 +1776,12 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         else:
             init_kwargs = init_configuration
 
-        if resolved_vocab_files.get("tokenizer_file", None) is not None:
-            init_kwargs.pop("add_bos_token", None)
-            init_kwargs.pop("add_eos_token", None)
+        # `add_bos_token` / `add_eos_token` from the tokenizer config are kept here on purpose.
+        # Classes that rebuild their backend tokenizer (e.g. GPTNeoXTokenizer) use them to fix up
+        # the post-processor serialized in `tokenizer.json`: a declared flag takes precedence over
+        # the matching serialized side, while undeclared sides keep the serialized behavior.
+        # Stripping them here silently broke checkpoints whose flags disagree with their serialized
+        # post-processor (e.g. allenai/OLMo-7B-hf), which is what #47988 addressed on the class side.
 
         # If independent chat template file(s) exist, they take priority over template entries in the tokenizer config
         chat_templates = {}

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -17,6 +17,7 @@ see tokenization_utils.py
 """
 
 import copy
+import inspect
 import json
 import os
 from collections import defaultdict
@@ -85,6 +86,37 @@ VOCAB_FILES_NAMES = {"tokenizer_file": TOKENIZER_FILE, "vocab_file": TIKTOKEN_VO
 
 
 @add_end_docstrings(INIT_TOKENIZER_DOCSTRING)
+def _extract_template_sides(tokenizer_json):
+    """
+    Return the special tokens a serialized ``TemplateProcessing`` post-processor prepends and
+    appends, as ``{"prefix": token, "suffix": token}``, or ``None`` when it is not a
+    ``TemplateProcessing`` or its template does not cleanly split into prefix/suffix sides.
+    """
+    post_processor = tokenizer_json.get("post_processor")
+    if not isinstance(post_processor, dict) or post_processor.get("type") != "TemplateProcessing":
+        return None
+
+    def template_sides(side):
+        template = post_processor.get(side)
+        if not isinstance(template, list) or not template:
+            return (None, None)
+        first = template[0] if isinstance(template[0], dict) else None
+        last = template[-1] if len(template) > 1 and isinstance(template[-1], dict) else None
+        prefix = next(iter(first.values())).get("id") if first is not None and "SpecialToken" in first else None
+        suffix = next(iter(last.values())).get("id") if last is not None and "SpecialToken" in last else None
+        return (prefix, suffix)
+
+    sides = {}
+    for position, index in (("prefix", 0), ("suffix", 1)):
+        candidates = {info[index] for info in map(template_sides, ("single", "pair")) if info[index] is not None}
+        if len(candidates) > 1:
+            # single and pair templates disagree on this side: fall back to a full rebuild
+            return None
+        if candidates:
+            sides[position] = candidates.pop()
+    return sides or None
+
+
 class TokenizersBackend(PreTrainedTokenizerBase):
     """
     Base class for all fast tokenizers (wrapping HuggingFace tokenizers library).
@@ -117,6 +149,20 @@ class TokenizersBackend(PreTrainedTokenizerBase):
             and os.path.isfile(fast_tokenizer_file)
             and (cls is TokenizersBackend or "__init__" not in cls.__dict__ or trust_remote_code)
         ):
+            # When flags are declared, update_post_processor reconciles against the serialized
+            # template: carry its sides so undeclared sides keep the serialized behavior. Only
+            # pass them when __init__ tolerates extra kwargs (remote-code classes may be rigid).
+            if "add_bos_token" in local_kwargs or "add_eos_token" in local_kwargs:
+                try:
+                    with open(fast_tokenizer_file, encoding="utf-8") as tokenizer_handle:
+                        serialized_pp_sides = _extract_template_sides(json.load(tokenizer_handle))
+                except (OSError, json.JSONDecodeError):
+                    serialized_pp_sides = None
+                accepts_extra_kwargs = any(
+                    param.kind is param.VAR_KEYWORD for param in inspect.signature(cls.__init__).parameters.values()
+                )
+                if serialized_pp_sides and accepts_extra_kwargs:
+                    local_kwargs["_serialized_pp_sides"] = serialized_pp_sides
             local_kwargs["tokenizer_object"] = TokenizerFast.from_file(fast_tokenizer_file)
             return local_kwargs
         elif fast_tokenizer_file is not None and os.path.isfile(fast_tokenizer_file):
@@ -124,6 +170,13 @@ class TokenizersBackend(PreTrainedTokenizerBase):
             # from the file so the reconstructed tokenizer matches the tokenizer.json
             with open(fast_tokenizer_file, encoding="utf-8") as tokenizer_handle:
                 tokenizer_json = json.load(tokenizer_handle)
+
+            # Classes with a custom __init__ rebuild their backend tokenizer, so the serialized
+            # post-processor only survives through this kwarg. Carry which sides it adds so
+            # update_post_processor can keep the ones the add_bos/eos flags do not declare.
+            serialized_pp_sides = _extract_template_sides(tokenizer_json)
+            if serialized_pp_sides:
+                local_kwargs["_serialized_pp_sides"] = serialized_pp_sides
 
             # Build a minimal tokenizer (empty vocab/merges) to cheaply extract post_processor,
             # padding and truncation as Rust objects — avoids parsing the full vocab via from_file.
@@ -464,8 +517,13 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         explicit_bos_eos_in_kwargs = "add_bos_token" in kwargs or "add_eos_token" in kwargs
         self._add_bos_token = kwargs.get("add_bos_token", False)
         self._add_eos_token = kwargs.get("add_eos_token", False)
+        # Whether each flag was explicitly provided (from tokenizer_config.json or by the caller).
+        # Undeclared sides leave a serialized post-processor untouched in update_post_processor.
+        self._add_bos_token_declared = "add_bos_token" in kwargs
+        self._add_eos_token_declared = "add_eos_token" in kwargs
         if post_processor := kwargs.pop("post_processor", None):  # most reliable way to get the post-processor
             self._tokenizer.post_processor = post_processor
+        self._serialized_pp_sides = kwargs.pop("_serialized_pp_sides", None)
         self._should_update_post_processor = explicit_bos_eos_in_kwargs or self._tokenizer.post_processor is None
         # We call this after having initialized the backend tokenizer because we update it.
         super().__init__(**kwargs)
@@ -648,14 +706,32 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         if eos is None and self.add_eos_token:
             self.add_eos_token = False
 
-        single = f"{(bos + ':0 ') if self.add_bos_token else ''}$A:0{(' ' + eos + ':0') if self.add_eos_token else ''}"
-        pair = f"{single}{(' ' + bos + ':1') if self.add_bos_token else ''} $B:1{(' ' + eos + ':1') if self.add_eos_token else ''}"
+        # Each side defaults to the add_bos_token/add_eos_token settings. When the backend
+        # tokenizer was rebuilt from a tokenizer.json (classes with a custom __init__, e.g.
+        # GPTNeoXTokenizer), a side not covered by an explicitly-declared flag keeps the behavior
+        # of the serialized post-processor instead (e.g. the [CLS]/[SEP] template of
+        # blab-jhu/test-32m-dec next to its add_bos_token: true). Idempotent: this method runs
+        # again from _post_init and from the property setters.
+        add_bos, bos_side, bos_side_id = self.add_bos_token, bos, bos_token_id
+        add_eos, eos_side, eos_side_id = self.add_eos_token, eos, eos_token_id
+        serialized_sides = self._serialized_pp_sides or {}
+        if not self._add_bos_token_declared:
+            serialized_prefix = serialized_sides.get("prefix")
+            if serialized_prefix is not None:
+                add_bos, bos_side, bos_side_id = True, serialized_prefix, self.convert_tokens_to_ids(serialized_prefix)
+        if not self._add_eos_token_declared:
+            serialized_suffix = serialized_sides.get("suffix")
+            if serialized_suffix is not None:
+                add_eos, eos_side, eos_side_id = True, serialized_suffix, self.convert_tokens_to_ids(serialized_suffix)
+
+        single = f"{(bos_side + ':0 ') if add_bos else ''}$A:0{(' ' + eos_side + ':0') if add_eos else ''}"
+        pair = f"{single}{(' ' + bos_side + ':1') if add_bos else ''} $B:1{(' ' + eos_side + ':1') if add_eos else ''}"
 
         special_tokens = []
-        if self.add_bos_token:
-            special_tokens.append((bos, bos_token_id))
-        if self.add_eos_token:
-            special_tokens.append((eos, eos_token_id))
+        if add_bos:
+            special_tokens.append((bos_side, bos_side_id))
+        if add_eos:
+            special_tokens.append((eos_side, eos_side_id))
         self._tokenizer.post_processor = processors.TemplateProcessing(
             single=single, pair=pair, special_tokens=special_tokens
         )
@@ -671,11 +747,13 @@ class TokenizersBackend(PreTrainedTokenizerBase):
     @add_eos_token.setter
     def add_eos_token(self, value):
         object.__setattr__(self, "_add_eos_token", value)
+        self._add_eos_token_declared = True
         self.update_post_processor()
 
     @add_bos_token.setter
     def add_bos_token(self, value):
         object.__setattr__(self, "_add_bos_token", value)
+        self._add_bos_token_declared = True
         self.update_post_processor()
 
     def _post_init(self):

--- a/tests/models/gpt_neox/test_tokenization_gpt_neox.py
+++ b/tests/models/gpt_neox/test_tokenization_gpt_neox.py
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
+import tempfile
 import unittest
 
-from transformers import GPTNeoXTokenizer
+from tokenizers import Tokenizer, decoders, normalizers, pre_tokenizers, processors
+from tokenizers.models import BPE
+
+from transformers import GPTNeoXTokenizer, TokenizersBackend
 from transformers.testing_utils import require_tokenizers
 
 from ...test_tokenization_common import TokenizerTesterMixin
@@ -24,8 +30,149 @@ from ...test_tokenization_common import TokenizerTesterMixin
 class GPTNeoXTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     from_pretrained_id = "EleutherAI/gpt-neox-20b"
     tokenizer_class = GPTNeoXTokenizer
-
     integration_expected_tokens = ['This', 'Ġis', 'Ġa', 'Ġtest', 'ĠðŁĺ', 'Ĭ', 'Ċ', 'I', 'Ġwas', 'Ġborn', 'Ġin', 'Ġ9', '2000', ',', 'Ġand', 'Ġthis', 'Ġis', 'Ġfals', 'Ã©', '.', 'Ċ', 'çĶŁ', 'æ´»', 'çļĦ', 'çľŁ', 'è°', 'Ľ', 'æĺ¯', 'Ċ', 'Hi', '  ', 'Hello', 'Ċ', 'Hi', '   ', 'Hello', 'ĊĊĠĊ', '  ', 'Ċ', 'ĠHello', 'Ċ', '<', 's', '>', 'Ċ', 'hi', '<', 's', '>', 'there', 'Ċ', 'The', 'Ġfollowing', 'Ġstring', 'Ġshould', 'Ġbe', 'Ġproperly', 'Ġencoded', ':', 'ĠHello', '.', 'Ċ', 'But', 'Ġ', 'ird', 'Ġand', 'Ġ', 'à¸', 'Ľ', 'à¸µ', '   ', 'ird', '   ', 'à¸Ķ', 'Ċ', 'Hey', 'Ġhow', 'Ġare', 'Ġyou', 'Ġdoing']  # fmt: skip
     integration_expected_token_ids = [1552, 310, 247, 1071, 49042, 221, 187, 42, 369, 5686, 275, 898, 6914, 13, 285, 436, 310, 21649, 860, 15, 187, 20025, 46549, 5225, 48561, 33656, 238, 12105, 187, 12764, 50276, 12092, 187, 12764, 50275, 12092, 46603, 50276, 187, 24387, 187, 29, 84, 31, 187, 5801, 29, 84, 31, 9088, 187, 510, 1563, 2876, 943, 320, 6283, 16202, 27, 24387, 15, 187, 1989, 209, 1817, 285, 209, 2869, 238, 26863, 50275, 1817, 50275, 35071, 187, 8262, 849, 403, 368, 2509]  # fmt: skip
     expected_tokens_from_ids = ['This', 'Ġis', 'Ġa', 'Ġtest', 'ĠðŁĺ', 'Ĭ', 'Ċ', 'I', 'Ġwas', 'Ġborn', 'Ġin', 'Ġ9', '2000', ',', 'Ġand', 'Ġthis', 'Ġis', 'Ġfals', 'Ã©', '.', 'Ċ', 'çĶŁ', 'æ´»', 'çļĦ', 'çľŁ', 'è°', 'Ľ', 'æĺ¯', 'Ċ', 'Hi', '  ', 'Hello', 'Ċ', 'Hi', '   ', 'Hello', 'ĊĊĠĊ', '  ', 'Ċ', 'ĠHello', 'Ċ', '<', 's', '>', 'Ċ', 'hi', '<', 's', '>', 'there', 'Ċ', 'The', 'Ġfollowing', 'Ġstring', 'Ġshould', 'Ġbe', 'Ġproperly', 'Ġencoded', ':', 'ĠHello', '.', 'Ċ', 'But', 'Ġ', 'ird', 'Ġand', 'Ġ', 'à¸', 'Ľ', 'à¸µ', '   ', 'ird', '   ', 'à¸Ķ', 'Ċ', 'Hey', 'Ġhow', 'Ġare', 'Ġyou', 'Ġdoing']  # fmt: skip
     integration_expected_decoded_text = "This is a test 😊\nI was born in 92000, and this is falsé.\n生活的真谛是\nHi  Hello\nHi   Hello\n\n \n  \n Hello\n<s>\nhi<s>there\nThe following string should be properly encoded: Hello.\nBut ird and ปี   ird   ด\nHey how are you doing"
+
+
+@require_tokenizers
+class GPTNeoXTokenizerConfigFlagsTest(unittest.TestCase):
+    """
+    GPTNeoXTokenizer rebuilds its backend post-processor from the add_bos_token/
+    add_eos_token settings (see #47988). Flags explicitly declared in tokenizer_config.json
+    replace the matching side of a post-processor serialized in tokenizer.json; sides the
+    flags do not declare keep the serialized behavior. Hub checkpoints exist in either
+    polarity: blab-jhu/test-32m-dec declares add_bos_token: true next to a [CLS]/[SEP]
+    template, while allenai/OLMo-7B-hf declares add_eos_token: false next to a template that
+    appends EOS. When no flags are declared at all, the serialized template applies as-is.
+    """
+
+    @staticmethod
+    def _prepare_tokenizer_dir(
+        tmpdirname, tokenizer_config, add_eos_post_processor=False, add_bos_post_processor=False
+    ):
+        alphabet = sorted(pre_tokenizers.ByteLevel.alphabet())
+        vocab = {char: i for i, char in enumerate(alphabet)}
+        eos_id = len(vocab)
+        vocab["<|endoftext|>"] = eos_id
+        vocab["<|padding|>"] = len(vocab)
+
+        backend = Tokenizer(
+            BPE(
+                vocab=vocab,
+                merges=[],
+                dropout=None,
+                continuing_subword_prefix="",
+                end_of_word_suffix="",
+                fuse_unk=False,
+            )
+        )
+        backend.normalizer = normalizers.NFC()
+        backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False, trim_offsets=True)
+        backend.decoder = decoders.ByteLevel()
+
+        if add_eos_post_processor or add_bos_post_processor:
+            prefix = "<|padding|>" if add_bos_post_processor else None
+            suffix = "<|endoftext|>" if add_eos_post_processor else None
+            single = "".join(
+                part
+                for part in (
+                    f"{prefix} $A" if prefix else "$A",
+                    f" {suffix}" if suffix else "",
+                )
+                if part
+            )
+            pair = "".join(
+                part
+                for part in (
+                    f"{prefix} $A" if prefix else "$A",
+                    f" {prefix} $B" if prefix else " $B",
+                    f" {suffix}" if suffix else "",
+                )
+                if part
+            )
+            special_tokens = []
+            if prefix:
+                special_tokens.append((prefix, vocab[prefix]))
+            if suffix:
+                special_tokens.append((suffix, vocab[suffix]))
+            backend.post_processor = processors.TemplateProcessing(
+                single=single,
+                pair=pair,
+                special_tokens=special_tokens,
+            )
+
+        backend.save(os.path.join(tmpdirname, "tokenizer.json"))
+        with open(os.path.join(tmpdirname, "tokenizer_config.json"), "w", encoding="utf-8") as config_file:
+            json.dump(tokenizer_config, config_file)
+        return vocab
+
+    def test_config_add_eos_false_wins_over_stale_post_processor(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            vocab = self._prepare_tokenizer_dir(
+                tmpdirname,
+                {"add_bos_token": False, "add_eos_token": False},
+                add_eos_post_processor=True,
+            )
+            tokenizer = GPTNeoXTokenizer.from_pretrained(tmpdirname)
+
+        input_ids = tokenizer("hello world")["input_ids"]
+        self.assertNotIn(vocab["<|endoftext|>"], input_ids[1:])
+        self.assertFalse(tokenizer.add_eos_token)
+
+    def test_declared_bos_applies_while_undeclared_eos_side_is_kept(self):
+        # blab-jhu/test-32m-dec case: config declares add_bos_token: true next to a serialized
+        # template that also appends a special token; the eos side stays serialized (no
+        # add_eos_token is declared), so both the bos prefix and the eos suffix are applied.
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            vocab = self._prepare_tokenizer_dir(
+                tmpdirname,
+                {"bos_token": "<|padding|>", "add_bos_token": True},
+                add_bos_post_processor=True,
+                add_eos_post_processor=True,
+            )
+            tokenizer = GPTNeoXTokenizer.from_pretrained(tmpdirname)
+
+        input_ids = tokenizer("hello world")["input_ids"]
+        self.assertEqual(input_ids[0], vocab["<|padding|>"])
+        self.assertEqual(input_ids[-1], vocab["<|endoftext|>"])
+        self.assertTrue(tokenizer.add_bos_token)
+
+    def test_serialized_sides_apply_when_flags_absent(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            vocab = self._prepare_tokenizer_dir(
+                tmpdirname,
+                {},
+                add_eos_post_processor=True,
+            )
+            tokenizer = GPTNeoXTokenizer.from_pretrained(tmpdirname)
+
+        input_ids = tokenizer("hello world")["input_ids"]
+        self.assertEqual(input_ids[-1], vocab["<|endoftext|>"])
+        self.assertFalse(tokenizer.add_eos_token)
+
+    def test_undeclared_sides_kept_on_tokenizer_object_path(self):
+        # Classes without a custom __init__ load their backend through tokenizer_object instead
+        # of rebuilding it; the serialized template's undeclared sides must be honored there too.
+        class PlainBackend(TokenizersBackend):
+            model = BPE
+            vocab_files_names = {"tokenizer_file": "tokenizer.json"}
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            vocab = self._prepare_tokenizer_dir(
+                tmpdirname,
+                {"bos_token": "<|padding|>", "add_bos_token": True},
+                add_bos_post_processor=True,
+                add_eos_post_processor=True,
+            )
+            tokenizer = PlainBackend.from_pretrained(tmpdirname)
+
+        input_ids = tokenizer("hello world")["input_ids"]
+        self.assertEqual(input_ids[0], vocab["<|padding|>"])
+        self.assertEqual(input_ids[-1], vocab["<|endoftext|>"])
+        self.assertTrue(tokenizer.add_bos_token)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48542&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48542) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48542&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48542)
<!-- ci-dashboard-badge:end -->

## Summary

Restores the tokenization contract for checkpoints whose `tokenizer_config.json` declares `add_bos_token`/`add_eos_token` alongside a `tokenizer.json` post-processor that disagrees with (or only partially describes) those flags. Fixes the `modernbert_decoder` integration-test regressions that the CI triage ([#48514](https://github.com/huggingface/transformers/issues/48514)) attributes to #47988 and that could not be resolved automatically.

## Problem

#42563 added a strip in `PreTrainedTokenizerBase._from_pretrained` that drops `add_bos_token`/`add_eos_token` from the init kwargs whenever a `tokenizer.json` exists (treating the serialized post-processor as authoritative). #47988 then restored GPT-NeoX's unconditional `update_post_processor()` call to fix `allenai/OLMo-7B-hf` garbage generation — correct, since OLMo-7B-hf *declares* `add_eos_token: false` next to a stale EOS-appending template.

The combination breaks checkpoints of the opposite polarity. `blab-jhu/test-32m-dec` (ModernBERT Decoder) declares `add_bos_token: true` next to a `[CLS] … [SEP]` `TemplateProcessing` template. With the flags stripped, the unconditional rebuild produced bare input ids (no `[CLS]`), shifting every recorded integration expectation — `ModernBertDecoderIntegrationTest::test_inference_causal_lm` and `::test_inference_no_head` have been failing on `main` since #47988 (4 occurrences in the 2026-08-28 → 09-03 window), and the failing tests are the reason the model card for this checkpoint cannot be validated.

## Root cause

The strip makes "declared flags win" and "serialized post-processor wins" mutually exclusive, but both are needed:

- `allenai/OLMo-7B-hf`: flags (`add_bos_token: false`, `add_eos_token: false`) contradict the serialized template → flags must win.
- `blab-jhu/test-32m-dec`: `add_bos_token: true` agrees with the template's `[CLS]` prefix, while the `[SEP]` suffix is described *only* by the template → the template must win on undeclared sides.

## Solution

1. `_from_pretrained` no longer strips the flags; config-declared values reach the tokenizer.
2. `TokenizersBackend.update_post_processor()` now reconciles per side instead of replacing wholesale:
   - a side whose flag is **explicitly declared** follows the flag (OLMo-7B-hf: `add_eos_token: false` removes the stale EOS);
   - a side **not declared** keeps the serialized behavior (blab-jhu keeps `[CLS]` and `[SEP]`);
   - with no serialized `TemplateProcessing`, the rebuild is unchanged.
3. `GPTNeoXTokenizer` keeps its re-apply call from #47988 (now harmless — the rebuild is reconciled).
4. The save-side behavior is intentionally untouched: `save_pretrained` still does not persist `add_bos_token`/`add_eos_token` in `tokenizer_config.json`, so the serialized post-processor remains the sole carrier for freshly saved tokenizers (and it is saved in its reconciled form, making the repair persistent across save/load cycles).

Behavior after the change, verified against real checkpoints:

| checkpoint | before | after |
|---|---|---|
| `blab-jhu/test-32m-dec` | bare ids, integration tests fail (logit diff 6.63) | `[CLS] … [SEP]`, tests pass (diff 0.0000) |
| `allenai/OLMo-7B-hf` | no spurious EOS (fixed by #47988) | unchanged — no spurious EOS |
| `NousResearch/Llama-2-7b-hf`, `mistralai/Mistral-7B-v0.1` | `[1, …]` (serialized BOS) | unchanged |
| `EleutherAI/pythia-410m`, `EleutherAI/gpt-neox-20b` | bare | unchanged |
| `allenai/OLMo-2-0425-1B` | no trailing EOS | unchanged (v4-identical ids) |

## Testing

- New `GPTNeoXTokenizerConfigFlagsTest` (offline fixtures): declared `add_eos_token: false` beats a stale EOS template; declared `add_bos_token: true` applies BOS while an undeclared EOS side is kept; with no flags the serialized template applies as-is; and the same reconcile holds on the `tokenizer_object` load path for classes without a custom `__init__`. Two of the four fail on `main` without the fix.
- `ModernBertDecoderIntegrationTest`: 5/5 pass (2 were failing on `main`).
- `tests/models/gpt_neox`: 55 passed, 32 subtests; `gpt2`, `code_llama`, `splinter`, `modernbert_decoder` suites: no new failures (remaining failures reproduce on pristine `main`: gated `meta-llama` downloads, Windows `torch.compile` env issues).
- `ruff check` / `ruff format --check` clean on all touched files.

Closes the `modernbert_decoder` failures tracked in #48514 (the only dispatched group marked "🚫 no fix"). No dedicated issue exists for this regression yet — happy to file one if maintainers prefer.