### PR TITLE
Fix LukeTokenizer dropping <s>/</s> on the plain-text path

### DIFF
--- a/src/transformers/models/luke/tokenization_luke.py
+++ b/src/transformers/models/luke/tokenization_luke.py
@@ -18,7 +18,7 @@ import json
 from collections.abc import Mapping
 
 import numpy as np
-from tokenizers import Tokenizer, decoders, pre_tokenizers
+from tokenizers import Tokenizer, decoders, pre_tokenizers, processors
 from tokenizers.models import BPE
 
 from ...tokenization_python import PreTrainedTokenizer
@@ -382,6 +382,11 @@ class LukeTokenizer(TokenizersBackend):
             entity_mask2_token=entity_mask2_token,
             entity_vocab=entity_vocab if entity_vocab_file is None else None,  # Only store if it was passed as data
             **kwargs,
+        )
+        self._tokenizer.post_processor = processors.RobertaProcessing(
+            sep=(str(sep_token), self.sep_token_id),
+            cls=(str(cls_token), self.cls_token_id),
+            add_prefix_space=add_prefix_space,
         )
 
     def build_inputs_with_special_tokens(

--- a/tests/models/luke/test_tokenization_luke.py
+++ b/tests/models/luke/test_tokenization_luke.py
@@ -55,6 +55,30 @@ class LukeTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertEqual(encoded_sentence, encoded_text_from_decode)
         self.assertEqual(encoded_pair, encoded_pair_from_decode)
 
+    def test_special_tokens_added_on_plain_text(self):
+        tokenizer = self.get_tokenizer()
+
+        encoded = tokenizer("Hello world", return_special_tokens_mask=True)
+        self.assertEqual(encoded["input_ids"], [tokenizer.cls_token_id, 31414, 232, tokenizer.eos_token_id])
+        self.assertEqual(encoded["special_tokens_mask"], [1, 0, 0, 1])
+
+        encoded_pair = tokenizer("Hello world", "Second")
+        self.assertEqual(
+            encoded_pair["input_ids"],
+            [
+                tokenizer.cls_token_id,
+                31414,
+                232,
+                tokenizer.eos_token_id,
+                tokenizer.eos_token_id,
+                32703,
+                tokenizer.eos_token_id,
+            ],
+        )
+
+        encoded_no_special = tokenizer("Hello world", add_special_tokens=False)
+        self.assertEqual(encoded_no_special["input_ids"], [31414, 232])
+
     def get_clean_sequence(self, tokenizer, max_length=20) -> tuple[str, list]:
         txt = "Beyonce lives in Los Angeles"
         ids = tokenizer.encode(txt, add_special_tokens=False)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48545&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48545) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48545&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48545)
<!-- ci-dashboard-badge:end -->

Fixes #48544

### What's wrong

`LukeTokenizer` builds its backend tokenizer with a pre-tokenizer and decoder but no post-processor, unlike `RobertaTokenizer` (`tokenization_roberta.py:170-175`). As a result, on the plain-text path the special tokens are never added:

```python
tok = LukeTokenizer.from_pretrained("studio-ousia/luke-base")
tok("Hello world")["input_ids"]             # was [31414, 232], expected [0, 31414, 232, 2]
tok("Hello world", "Second")["input_ids"]   # was [31414, 232, 32703], no separator between the two
```

`add_special_tokens=False` returned the same ids (flag did nothing), `return_special_tokens_mask=True` came back as `[0, 0]`, and `LukeTokenizerTest::test_sequence_builders` was red on `main` (but `@slow`, so CI never ran it).

### Fix

Set the post-processor at the end of `__init__`, the same way RoBERTa does:

```python
self._tokenizer.post_processor = processors.RobertaProcessing(
    sep=(str(sep_token), self.sep_token_id),
    cls=(str(cls_token), self.cls_token_id),
    add_prefix_space=add_prefix_space,
)
```

This restores `<s> A </s>` for a single sequence and `<s> A </s></s> B </s>` for a pair, matching the docstring, `build_inputs_with_special_tokens`, and the `special_tokens_pattern="cls_double_sep"` LUKE declares. `entity_spans` ids and `entity_position_ids` come out unchanged.

### Test

Added `test_special_tokens_added_on_plain_text` (non-slow) covering:
- single sequence gets `<s>`/`</s>` and correct `special_tokens_mask`
- pair gets the double separator
- `add_special_tokens=False` leaves them out

The previously-failing slow `test_sequence_builders` now passes (`RUN_SLOW=1`).