### PR TITLE
Keep user-typed multimodal placeholders literal

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -45,6 +45,8 @@ from .tokenization_utils_base import (
     PreTrainedTokenizerBase,
     TextInput,
     TruncationStrategy,
+    can_escape_literal_text,
+    escape_literal_text,
 )
 from .utils import (
     AUDIO_TOKENIZER_NAME,
@@ -1978,6 +1980,46 @@ class ProcessorMixin(PushToHubMixin):
 
         return unused_kwargs, valid_kwargs
 
+    def _escape_literal_multimodal_tokens(self, conversations: list[list[dict]]) -> list[list[dict]]:
+        """
+        Escape the multimodal placeholder tokens (`<image>`, `<video>`, ...) that a user typed inside the text blocks
+        of a conversation.
+
+        The images, videos and audio of a conversation are passed as their own content blocks, so a placeholder token
+        found in a `"text"` block is text the user meant literally, not a reference to some media. It must not be
+        expanded by the processor nor tokenized as a special token, but the rendered chat template is a plain string
+        in which both are spelled the exact same way. Escaping the user-typed ones keeps them distinguishable all the
+        way down to the tokenizer, which turns them back into plain text (see [`escape_literal_text`]).
+
+        Conversations are copied on write, so the caller's messages are left untouched.
+        """
+        mm_tokens = [token for token in self.all_special_multimodal_tokens if can_escape_literal_text(token)]
+        if not mm_tokens:
+            return conversations
+
+        mm_tokens_regex = re.compile("|".join(re.escape(token) for token in sorted(mm_tokens, key=len, reverse=True)))
+        escaped_conversations = []
+        for conversation in conversations:
+            escaped_conversation = []
+            for message in conversation:
+                content = message.get("content") if isinstance(message, dict) else None
+                if isinstance(content, list):
+                    escaped_content = []
+                    is_escaped = False
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text" and "text" in block:
+                            text = block["text"]
+                            if isinstance(text, str) and mm_tokens_regex.search(text):
+                                escaped_text = mm_tokens_regex.sub(lambda m: escape_literal_text(m.group()), text)
+                                block = {**block, "text": escaped_text}
+                                is_escaped = True
+                        escaped_content.append(block)
+                    if is_escaped:
+                        message = {**message, "content": escaped_content}
+                escaped_conversation.append(message)
+            escaped_conversations.append(escaped_conversation)
+        return escaped_conversations
+
     def apply_chat_template(
         self,
         conversation: list[dict[str, str]] | list[list[dict[str, str]]],
@@ -2173,6 +2215,9 @@ class ProcessorMixin(PushToHubMixin):
                 # So we'll make a batched list of images and let the processor handle it
                 batch_images.append(images)
                 batch_videos.append(videos)
+
+        if tokenize:
+            conversations = self._escape_literal_multimodal_tokens(conversations)
 
         # `kwargs` overwrite special tokens if both are present
         template_kwargs = {**self.tokenizer.special_tokens_map, **kwargs}

--- a/src/transformers/tokenization_python.py
+++ b/src/transformers/tokenization_python.py
@@ -30,6 +30,8 @@ from .tokenization_utils_base import (
     PreTrainedTokenizerBase,
     TextInput,
     TruncationStrategy,
+    has_escaped_literal_text,
+    split_escaped_literal_text,
 )
 from .utils import PaddingStrategy, TensorType, add_end_docstrings, logging
 
@@ -634,6 +636,17 @@ class PythonBackend(PreTrainedTokenizerBase):
             The list of tokens.
         """
         split_special_tokens = kwargs.pop("split_special_tokens", self.split_special_tokens)
+
+        if has_escaped_literal_text(text):
+            tokens = []
+            for chunk, is_literal in split_escaped_literal_text(text):
+                if not chunk:
+                    continue
+                tokens.extend(
+                    self.tokenize(chunk, split_special_tokens=is_literal or split_special_tokens, **kwargs)
+                )
+            return tokens
+
         text, kwargs = self.prepare_for_tokenization(text, **kwargs)
 
         if split_special_tokens:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -141,6 +141,62 @@ EncodedInputPair = tuple[list[int], list[int]]
 # Define type aliases for text-related non-text modalities
 AudioInput = Union[np.ndarray, "torch.Tensor", list[np.ndarray], list["torch.Tensor"]]
 
+# Once a chat template has been rendered to a plain string, a multimodal placeholder such as `<image>` that the
+# template emitted for an actual image is indistinguishable from the very same characters typed by a user inside a
+# text message. To keep them apart, `ProcessorMixin.apply_chat_template` rewrites the characters of user-typed
+# occurrences into the reserved Private Use Area block below before rendering, and tokenizers turn those spans back
+# into plain text when encoding, so they never map to a special token id. The mapping is per-character, so it is
+# length-preserving and character offsets into the rendered prompt stay valid.
+LITERAL_TEXT_ESCAPE_BASE = 0xF0000
+_re_escaped_literal_text = re.compile(f"[{chr(LITERAL_TEXT_ESCAPE_BASE)}-{chr(LITERAL_TEXT_ESCAPE_BASE + 0xFFFF)}]+")
+
+
+def can_escape_literal_text(text: str) -> bool:
+    """Whether `text` only contains characters that [`escape_literal_text`] is able to map."""
+    return all(ord(char) <= 0xFFFF for char in text)
+
+
+def escape_literal_text(text: str) -> str:
+    """
+    Map every character of `text` into a reserved Private Use Area block, so that the result no longer matches any
+    special token but keeps the exact same length.
+    """
+    return "".join(chr(LITERAL_TEXT_ESCAPE_BASE + ord(char)) for char in text)
+
+
+def unescape_literal_text(text: str) -> str:
+    """Inverse of [`escape_literal_text`]."""
+    return "".join(chr(ord(char) - LITERAL_TEXT_ESCAPE_BASE) for char in text)
+
+
+def has_escaped_literal_text(text) -> bool:
+    """Whether `text`, a string or an arbitrarily nested list of strings, holds any escaped span."""
+    if isinstance(text, str):
+        # Escaped characters are never ASCII, and `str.isascii` is O(1), so texts don't pay for the scan below
+        return not text.isascii() and _re_escaped_literal_text.search(text) is not None
+    if isinstance(text, (list, tuple)):
+        return any(has_escaped_literal_text(item) for item in text)
+    return False
+
+
+def split_escaped_literal_text(text: str) -> list[tuple[str, bool]]:
+    """
+    Split `text` into `(chunk, is_literal)` pairs. Escaped chunks are returned unescaped and have to be encoded as
+    plain text (i.e. with `split_special_tokens=True`), the other ones are encoded as usual.
+    """
+    chunks = []
+    last_end = 0
+    for match in _re_escaped_literal_text.finditer(text):
+        start, end = match.span()
+        if start > last_end:
+            chunks.append((text[last_end:start], False))
+        chunks.append((unescape_literal_text(match.group()), True))
+        last_end = end
+    if last_end < len(text):
+        chunks.append((text[last_end:], False))
+    return chunks
+
+
 # Slow tokenizers used to be saved in three separated files
 SPECIAL_TOKENS_MAP_FILE = "special_tokens_map.json"
 ADDED_TOKENS_FILE = "added_tokens.json"

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -47,6 +47,8 @@ from .tokenization_utils_base import (
     TextInput,
     TruncationStrategy,
     generate_merges,
+    has_escaped_literal_text,
+    split_escaped_literal_text,
 )
 from .utils import PaddingStrategy, add_end_docstrings, hf_api, logging
 
@@ -969,6 +971,81 @@ class TokenizersBackend(PreTrainedTokenizerBase):
             if _padding != target:
                 self._tokenizer.enable_padding(**target)
 
+    def _encode_batch_with_literal_text(
+        self,
+        batch_text: list[TextInput],
+        add_special_tokens: bool,
+        padding_strategy: PaddingStrategy,
+        max_length: int | None,
+        pad_to_multiple_of: int | None,
+        padding_side: str | None,
+    ) -> list[EncodingFast]:
+        """
+        Encode a batch of texts holding escaped literal spans (see [`~tokenization_utils_base.escape_literal_text`]).
+
+        Such a span is text that a user typed themselves and which collides with a special token, in practice a
+        multimodal placeholder such as `<image>`. It is encoded as plain text while the rest of the sequence is
+        encoded as usual, so that only the placeholders that a chat template emitted for actual media end up as
+        special token ids.
+        """
+        if not all(isinstance(text, str) for text in batch_text):
+            raise ValueError(
+                "Text pairs and pretokenized inputs are not supported for text holding literal special tokens."
+            )
+
+        truncation, padding = self._tokenizer.truncation, self._tokenizer.padding
+        split_special_tokens = self._tokenizer.encode_special_tokens
+        self._tokenizer.no_truncation()
+        self._tokenizer.no_padding()
+
+        try:
+            batch_chunk_encodings = []
+            for text in batch_text:
+                chunk_encodings = []
+                for chunk, is_literal in split_escaped_literal_text(text):
+                    if not chunk:
+                        continue
+                    self._tokenizer.encode_special_tokens = is_literal or split_special_tokens
+                    chunk_encodings.append(self._tokenizer.encode(chunk, add_special_tokens=False))
+                if not chunk_encodings:
+                    chunk_encodings.append(self._tokenizer.encode("", add_special_tokens=False))
+                batch_chunk_encodings.append(chunk_encodings)
+
+            if truncation is not None:
+                self._tokenizer.enable_truncation(**truncation)
+            encodings = [
+                self._tokenizer.post_process(
+                    EncodingFast.merge(chunk_encodings), add_special_tokens=add_special_tokens
+                )
+                for chunk_encodings in batch_chunk_encodings
+            ]
+        finally:
+            self._tokenizer.encode_special_tokens = split_special_tokens
+            if truncation is None:
+                self._tokenizer.no_truncation()
+            else:
+                self._tokenizer.enable_truncation(**truncation)
+            if padding is None:
+                self._tokenizer.no_padding()
+            else:
+                self._tokenizer.enable_padding(**padding)
+
+        if padding_strategy != PaddingStrategy.DO_NOT_PAD:
+            length = max_length if padding_strategy == PaddingStrategy.MAX_LENGTH and max_length else None
+            length = length if length is not None else max(len(encoding.ids) for encoding in encodings)
+            if pad_to_multiple_of is not None and length % pad_to_multiple_of != 0:
+                length = ((length // pad_to_multiple_of) + 1) * pad_to_multiple_of
+            for encoding in encodings:
+                encoding.pad(
+                    length,
+                    direction=padding_side if padding_side is not None else self.padding_side,
+                    pad_id=self.pad_token_id,
+                    pad_token=self.pad_token,
+                    pad_type_id=self.pad_token_type_id,
+                )
+
+        return encodings
+
     def _encode_plus(
         self,
         text: TextInput | PreTokenizedInput | list[TextInput] | list[PreTokenizedInput],
@@ -1070,12 +1147,21 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         if self._tokenizer.encode_special_tokens != split_special_tokens:
             self._tokenizer.encode_special_tokens = split_special_tokens
 
-        # Direct rust backend call
-        encodings = self._tokenizer.encode_batch(
-            batch_text_or_text_pairs,
-            add_special_tokens=add_special_tokens,
-            is_pretokenized=is_split_into_words,
-        )
+        if not is_split_into_words and has_escaped_literal_text(batch_text_or_text_pairs):
+            encodings = self._encode_batch_with_literal_text(
+                batch_text_or_text_pairs,
+                add_special_tokens=add_special_tokens,
+                padding_strategy=padding_strategy,
+                max_length=max_length,
+                pad_to_multiple_of=pad_to_multiple_of,
+                padding_side=padding_side,
+            )
+        else:
+            encodings = self._tokenizer.encode_batch(
+                batch_text_or_text_pairs,
+                add_special_tokens=add_special_tokens,
+                is_pretokenized=is_split_into_words,
+            )
 
         # Convert encodings to BatchEncoding format
         tokens_and_encodings = [

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -1525,6 +1525,32 @@ class ProcessorTesterMixin:
         expected_prompt = "You are a helpful assistant.<|special_start|>user\nWhich of these animals is making the sound?<|special_end|>\nYou are a helpful assistant.<|special_start|>assistant\nIt is a cow.<|special_end|>\n"
         self.assertEqual(formatted_prompt, expected_prompt)
 
+    @require_torch
+    @require_vision
+    def test_apply_chat_template_literal_image_token(self):
+        processor = self.get_processor()
+        if processor.chat_template is None or "image_processor" not in self.processor_class.get_attributes():
+            self.skipTest("Processor does not support image chat templates")
+
+        image_token = getattr(processor, "image_token", None)
+        if image_token is None:
+            self.skipTest("Processor has no image token")
+
+        messages = [
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": f"Describe the {image_token} in this image."},
+                        {"type": "image", "url": MODALITY_INPUT_DATA["images"][0]},
+                    ],
+                }
+            ]
+        ]
+        inputs = processor.apply_chat_template(messages, tokenize=True, return_dict=True, return_tensors="pt")
+        image_token_id = processor.tokenizer.convert_tokens_to_ids(image_token)
+        self.assertEqual(inputs["input_ids"][0].tolist().count(image_token_id), 1)
+
     def test_apply_chat_template_assistant_mask(self):
         processor = self.get_processor()
 

--- a/tests/utils/test_tokenization_utils.py
+++ b/tests/utils/test_tokenization_utils.py
@@ -24,6 +24,7 @@ import httpx
 from transformers import AutoTokenizer, BertTokenizer, BertTokenizerFast, GPT2TokenizerFast, is_tokenizers_available
 from transformers.testing_utils import TOKEN, TemporaryHubRepo, is_staging_test, require_tokenizers
 from transformers.tokenization_python import ExtensionsTrie, Trie
+from transformers.tokenization_utils_base import escape_literal_text, unescape_literal_text
 
 
 sys.path.append(str(Path(__file__).parent.parent.parent / "utils"))
@@ -216,6 +217,66 @@ class TokenizersBackendTest(unittest.TestCase):
         # With BPE guard, cleanup=True also preserves the text
         decoded_with_cleanup = tokenizer.decode(token_ids, clean_up_tokenization_spaces=True)
         self.assertEqual(decoded_with_cleanup, text)
+
+
+class LiteralTextEscapingTest(unittest.TestCase):
+    """
+    Tests for the escaping of text that a user typed themselves and which collides with a special token, in practice
+    a multimodal placeholder such as `<image>`. Such text must never be tokenized as the special token. See #47217.
+    """
+
+    def test_escaping_round_trip(self):
+        for token in ["<image>", "<|image_pad|>", "<img><IMG_CONTEXT></img>", "<image_soft_token>", "<图像>"]:
+            escaped = escape_literal_text(token)
+            # Escaping is length-preserving, so character offsets into a rendered prompt stay valid
+            self.assertEqual(len(escaped), len(token))
+            # ... and the token no longer appears as such, so it can't be matched by a processor or a tokenizer
+            self.assertNotIn(token, escaped)
+            self.assertEqual(unescape_literal_text(escaped), token)
+
+    @require_tokenizers
+    def test_fast_tokenizer_encodes_escaped_text_as_plain_text(self):
+        tokenizer = GPT2TokenizerFast.from_pretrained("openai-community/gpt2")
+        tokenizer.add_special_tokens({"additional_special_tokens": ["<image>"]})
+        image_token_id = tokenizer.convert_tokens_to_ids("<image>")
+
+        placeholder_ids = tokenizer("an <image> here", add_special_tokens=False).input_ids
+        literal_ids = tokenizer(f"an {escape_literal_text('<image>')} here", add_special_tokens=False).input_ids
+
+        # A placeholder is the special token, the same characters escaped are plain text spelling it out
+        self.assertIn(image_token_id, placeholder_ids)
+        self.assertNotIn(image_token_id, literal_ids)
+        self.assertEqual(tokenizer.decode(literal_ids), "an <image> here")
+
+    @require_tokenizers
+    def test_fast_tokenizer_pads_and_truncates_escaped_text(self):
+        tokenizer = GPT2TokenizerFast.from_pretrained("openai-community/gpt2")
+        tokenizer.add_special_tokens({"additional_special_tokens": ["<image>"]})
+        tokenizer.pad_token = tokenizer.eos_token
+        texts = [f"an {escape_literal_text('<image>')} here", "much shorter"]
+
+        padded = tokenizer(texts, padding=True, add_special_tokens=False)
+        self.assertEqual(len(padded.input_ids[0]), len(padded.input_ids[1]))
+        for input_ids, attention_mask in zip(padded.input_ids, padded.attention_mask):
+            self.assertEqual(len(input_ids), len(attention_mask))
+
+        truncated = tokenizer(texts, padding="max_length", truncation=True, max_length=4, add_special_tokens=False)
+        self.assertTrue(all(len(input_ids) == 4 for input_ids in truncated.input_ids))
+
+    def test_python_tokenizer_encodes_escaped_text_as_plain_text(self):
+        tokenizer = BertTokenizer.from_pretrained("hf-internal-testing/tiny-random-bert")
+        tokenizer.add_special_tokens({"additional_special_tokens": ["<image>"]})
+        image_token_id = tokenizer.convert_tokens_to_ids("<image>")
+
+        placeholder_ids = tokenizer("an <image> here", add_special_tokens=False).input_ids
+        literal_ids = tokenizer(f"an {escape_literal_text('<image>')} here", add_special_tokens=False).input_ids
+
+        self.assertIn(image_token_id, placeholder_ids)
+        self.assertNotIn(image_token_id, literal_ids)
+        self.assertEqual(
+            tokenizer.tokenize(escape_literal_text("<image>")),
+            tokenizer.tokenize("<image>", split_special_tokens=True),
+        )
 
 
 class TrieTest(unittest.TestCase):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48546&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48546) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48546&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48546)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Fixes #47217.

A multimodal placeholder such as `<image>` inside a structured text content block is user text, but processor chat templating previously rendered it indistinguishably from the placeholder emitted for an actual image. This caused the processor to count and expand the literal text as an additional image.

This change escapes user-typed multimodal placeholders before rendering and teaches both tokenizer backends to encode the escaped spans as ordinary text, while preserving actual media placeholders as special tokens.