### PR TITLE
Fall back to model type for unresolvable image processor names

### DIFF
--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -649,6 +649,15 @@ class AutoImageProcessor:
         if base_class_name is not None:
             image_processor_class = _load_backend_class(base_class_name, backend, is_legacy_fast)
 
+            if image_processor_class is None and image_processor_auto_map is None:
+                try:
+                    if not isinstance(config, PreTrainedConfig):
+                        config = AutoConfig.from_pretrained(
+                            pretrained_model_name_or_path, trust_remote_code=trust_remote_code, **kwargs
+                        )
+                except (OSError, ValueError):
+                    pass
+
         # Handle remote code
         has_remote_code = image_processor_auto_map is not None
         has_local_code = image_processor_class is not None or type(config) in IMAGE_PROCESSOR_MAPPING

--- a/tests/models/auto/test_image_processing_auto.py
+++ b/tests/models/auto/test_image_processing_auto.py
@@ -45,6 +45,37 @@ class AutoImageProcessorTest(unittest.TestCase):
         transformers.dynamic_module_utils.TIME_OUT_REMOTE_CODE = 0
 
     @require_torchvision
+    def test_qwen3_vl_checkpoint_resolves_to_qwen2_vl_image_processor(self):
+        from transformers import Qwen2VLImageProcessor
+
+        preprocessor_dict = {
+            "image_mean": [0.5, 0.5, 0.5],
+            "image_std": [0.5, 0.5, 0.5],
+            "patch_size": 16,
+            "merge_size": 2,
+            "temporal_patch_size": 2,
+            "processor_class": "Qwen3VLProcessor",
+        }
+        for model_type, text_model_type, vision_model_type in [
+            ("qwen3_vl", "qwen3_vl_text", "qwen3_vl"),
+            ("qwen3_5", "qwen3_5_text", "qwen3_5_vision"),
+        ]:
+            config_dict = {
+                "model_type": model_type,
+                "text_config": {"model_type": text_model_type},
+                "vision_config": {"model_type": vision_model_type},
+            }
+            for image_processor_type in ["Qwen2VLImageProcessorFast", "Qwen3VLImageProcessor"]:
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    with open(Path(tmpdirname) / "preprocessor_config.json", "w") as fp:
+                        json.dump({**preprocessor_dict, "image_processor_type": image_processor_type}, fp)
+                    with open(Path(tmpdirname) / "config.json", "w") as fp:
+                        json.dump(config_dict, fp)
+
+                    image_processor = AutoImageProcessor.from_pretrained(tmpdirname)
+                    self.assertIsInstance(image_processor, Qwen2VLImageProcessor)
+
+    @require_torchvision
     def test_image_processor_from_model_shortcut(self):
         config = AutoImageProcessor.from_pretrained("openai/clip-vit-base-patch32")
         self.assertIsInstance(config, CLIPImageProcessor)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48547&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48547) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48547&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48547)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Some Qwen3-VL and Qwen3.5 checkpoints contain legacy or unavailable `image_processor_type` values even though their model configuration maps to the compatible Qwen2-VL image processor.

When the explicit image processor name cannot be resolved, fall back to the processor mapping for the checkpoint's model type before raising the unrecognized processor error.

Fixes #48511

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?
@molbap @guarin @CyrilVallez

## Code Agent Policy

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent


