### PR TITLE
feat(hf_argparser): support dict-typed dataclass fields from CLI (#48030)

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -46,6 +46,34 @@ def string_to_bool(v):
         )
 
 
+def string_to_dict(v):
+    if isinstance(v, dict):
+        return v
+    try:
+        val = json.loads(v)
+        if isinstance(val, dict):
+            return val
+        raise ArgumentTypeError(f"Expected a dict/JSON object, but got {type(val).__name__}: {v!r}")
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    try:
+        if os.path.isfile(v):
+            try:
+                with open(v, "r", encoding="utf-8") as f:
+                    val = json.load(f)
+                if isinstance(val, dict):
+                    return val
+                raise ArgumentTypeError(f"Expected a dict from file '{v}', but got {type(val).__name__}")
+            except Exception as e:
+                raise ArgumentTypeError(f"Failed to load JSON file '{v}': {e}")
+    except OSError:
+        pass
+
+    raise ArgumentTypeError(f"Invalid dict value: {v!r}. Expected a valid JSON object string or path to a JSON file.")
+
+
+
 def make_choice_type_function(choices: list) -> Callable[[str], Any]:
     """
     Creates a mapping function from each choices string representation to the actual value. Used to support multiple
@@ -223,6 +251,14 @@ class HfArgumentParser(ArgumentParser):
             if field.default_factory is not dataclasses.MISSING:
                 kwargs["default"] = field.default_factory()
             elif field.default is dataclasses.MISSING:
+                kwargs["required"] = True
+        elif isclass(origin_type) and issubclass(origin_type, dict):
+            kwargs["type"] = string_to_dict
+            if field.default is not dataclasses.MISSING:
+                kwargs["default"] = field.default
+            elif field.default_factory is not dataclasses.MISSING:
+                kwargs["default"] = field.default_factory()
+            else:
                 kwargs["required"] = True
         else:
             kwargs["type"] = field.type

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -73,7 +73,6 @@ def string_to_dict(v):
     raise ArgumentTypeError(f"Invalid dict value: {v!r}. Expected a valid JSON object string or path to a JSON file.")
 
 
-
 def make_choice_type_function(choices: list) -> Callable[[str], Any]:
     """
     Creates a mapping function from each choices string representation to the actual value. Used to support multiple

--- a/tests/utils/test_hf_argparser.py
+++ b/tests/utils/test_hf_argparser.py
@@ -28,7 +28,7 @@ from unittest.mock import patch
 import yaml
 
 from transformers import HfArgumentParser, TrainingArguments
-from transformers.hf_argparser import make_choice_type_function, string_to_bool
+from transformers.hf_argparser import make_choice_type_function, string_to_bool, string_to_dict
 from transformers.testing_utils import require_torch
 
 
@@ -104,6 +104,15 @@ class ListExample:
     bar_int: list[int] = list_field(default=[1, 2, 3])
     foo_str: list[str] = list_field(default=["Hallo", "Bonjour", "Hello"])
     foo_float: list[float] = list_field(default=[0.1, 0.2, 0.3])
+
+
+@dataclass
+class DictExample:
+    foo_dict: dict = field(default_factory=dict)
+    bar_dict: dict[str, int] = field(default_factory=lambda: {"a": 1, "b": 2})
+    foo_str_dict: dict[str, str] = field(default_factory=lambda: {"hello": "world"})
+    opt_dict: dict | None = None
+
 
 
 @dataclass
@@ -292,6 +301,68 @@ class HfArgumentParserTest(unittest.TestCase):
 
         args = parser.parse_args("--foo-int 1 --bar-int 2 3 --foo-str a b c --foo-float 0.1 0.7".split())
         self.assertEqual(args, Namespace(foo_int=[1], bar_int=[2, 3], foo_str=["a", "b", "c"], foo_float=[0.1, 0.7]))
+
+    def test_05_with_dict(self):
+        parser = HfArgumentParser(DictExample)
+
+        expected = argparse.ArgumentParser()
+        expected.add_argument("--foo_dict", "--foo-dict", default={}, type=string_to_dict)
+        expected.add_argument("--bar_dict", "--bar-dict", default={"a": 1, "b": 2}, type=string_to_dict)
+        expected.add_argument("--foo_str_dict", "--foo-str-dict", default={"hello": "world"}, type=string_to_dict)
+        expected.add_argument("--opt_dict", "--opt-dict", default=None, type=string_to_dict)
+
+        self.argparsersEqual(parser, expected)
+
+        args = parser.parse_args([])
+        self.assertEqual(
+            args,
+            Namespace(foo_dict={}, bar_dict={"a": 1, "b": 2}, foo_str_dict={"hello": "world"}, opt_dict=None),
+        )
+
+        args = parser.parse_args(
+            [
+                "--foo_dict",
+                '{"custom": true, "count": 10}',
+                "--bar_dict",
+                '{"x": 99}',
+                "--foo-str-dict",
+                '{"lang": "fr"}',
+                "--opt_dict",
+                '{"nested": {"val": 1}}',
+            ]
+        )
+        self.assertEqual(
+            args,
+            Namespace(
+                foo_dict={"custom": True, "count": 10},
+                bar_dict={"x": 99},
+                foo_str_dict={"lang": "fr"},
+                opt_dict={"nested": {"val": 1}},
+            ),
+        )
+
+        (example,) = parser.parse_args_into_dataclasses(
+            ["--foo-dict", '{"k": "v"}', "--opt-dict", '{"flag": false}']
+        )
+        self.assertEqual(example.foo_dict, {"k": "v"})
+        self.assertEqual(example.opt_dict, {"flag": False})
+        self.assertEqual(example.bar_dict, {"a": 1, "b": 2})
+
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as f:
+            f.write('{"file_key": 42}')
+            tmp_json_path = f.name
+        try:
+            (example_from_file,) = parser.parse_args_into_dataclasses(["--foo-dict", tmp_json_path])
+            self.assertEqual(example_from_file.foo_dict, {"file_key": 42})
+        finally:
+            if os.path.exists(tmp_json_path):
+                os.remove(tmp_json_path)
+
+        with patch("sys.stderr"):
+            with self.assertRaises(SystemExit):
+                parser.parse_args(["--foo_dict", "not_a_valid_json"])
+            with self.assertRaises(SystemExit):
+                parser.parse_args(["--foo_dict", "[1, 2, 3]"])
 
     def test_06_with_optional(self):
         expected = argparse.ArgumentParser()

--- a/tests/utils/test_hf_argparser.py
+++ b/tests/utils/test_hf_argparser.py
@@ -114,7 +114,6 @@ class DictExample:
     opt_dict: dict | None = None
 
 
-
 @dataclass
 class RequiredExample:
     required_list: list[int] = field()
@@ -341,9 +340,7 @@ class HfArgumentParserTest(unittest.TestCase):
             ),
         )
 
-        (example,) = parser.parse_args_into_dataclasses(
-            ["--foo-dict", '{"k": "v"}', "--opt-dict", '{"flag": false}']
-        )
+        (example,) = parser.parse_args_into_dataclasses(["--foo-dict", '{"k": "v"}', "--opt-dict", '{"flag": false}'])
         self.assertEqual(example.foo_dict, {"k": "v"})
         self.assertEqual(example.opt_dict, {"flag": False})
         self.assertEqual(example.bar_dict, {"a": 1, "b": 2})


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48549&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48549) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48549&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48549)
<!-- ci-dashboard-badge:end -->

Fixes #48030

`HfArgumentParser` fails when parsing `dict`-typed dataclass fields from CLI arguments because `_parse_dataclass_field` falls through to the generic type constructor, raising an invalid dict value error.

This adds a `string_to_dict` parser supporting JSON strings and file paths, matching the existing list-handling pattern in `_parse_dataclass_field`.