### PR TITLE
fix(luke): set post-processor to add <s></s> special tokens in plain-text encoding

### DIFF
--- a/src/transformers/models/luke/tokenization_luke.py
+++ b/src/transformers/models/luke/tokenization_luke.py
@@ -18,7 +18,7 @@ import json
 from collections.abc import Mapping
 
 import numpy as np
-from tokenizers import Tokenizer, decoders, pre_tokenizers
+from tokenizers import Tokenizer, decoders, pre_tokenizers, processors
 from tokenizers.models import BPE
 
 from ...tokenization_python import PreTrainedTokenizer
@@ -383,6 +383,16 @@ class LukeTokenizer(TokenizersBackend):
             entity_vocab=entity_vocab if entity_vocab_file is None else None,  # Only store if it was passed as data
             **kwargs,
         )
+
+        # Set post-processor to add <s> </s> special tokens, matching RoBERTa behavior.
+        # This is needed because __init__ builds a raw BPE tokenizer without a post-processor,
+        # whereas the slow tokenizer path used build_inputs_with_special_tokens.
+        if self.cls_token_id is not None and self.sep_token_id is not None:
+            self._tokenizer.post_processor = processors.RobertaProcessing(
+                (str(sep_token), self.sep_token_id),
+                (str(cls_token), self.cls_token_id),
+                True,  # add_prefix_space
+            )
 
     def build_inputs_with_special_tokens(
         self, token_ids_0: list[int], token_ids_1: list[int] | None = None


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48555&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48555) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48555&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48555)
<!-- ci-dashboard-badge:end -->

## Summary

Fixes [LukeTokenizer dropping `<s></s>` special tokens when encoding plain text](https://github.com/huggingface/transformers/issues/48544).

### Problem

`LukeTokenizer` was returning `[31414, 232]` instead of the expected `[0, 31414, 232, 2]` for plain text input:

```python
tok("Hello world")["input_ids"]
# Before:  [31414, 232]
# After:   [0, 31414, 232, 2]  ✓
```

The `add_special_tokens=False` flag was also being ignored, and `special_tokens_mask` was returning `[0, 0]` instead of `[1, 0, 0, 1]`.

### Root Cause

`LukeTokenizer.__init__` builds a raw BPE tokenizer with a pre-tokenizer and decoder but **no post-processor**. After [#40936](https://github.com/huggingface/transformers/pull/40936) switched to the `tokenizers` backend, plain-text calls no longer route through `build_inputs_with_special_tokens`. LUKE is the only tokenizer that defines `build_inputs_with_special_tokens` without a post-processor set.

### Fix

After `super().__init__()`, set the `RobertaProcessing` post-processor (if `cls`/`sep` token IDs are available), matching how `RobertaTokenizer` handles this:

```python
if self.cls_token_id is not None and self.sep_token_id is not None:
    self._tokenizer.post_processor = processors.RobertaProcessing(
        (str(sep_token), self.sep_token_id),
        (str(cls_token), self.cls_token_id),
        True,  # add_prefix_space
    )
```

### Testing

- `RUN_SLOW=1 pytest tests/models/luke/test_tokenization_luke.py::LukeTokenizerTest::test_sequence_builders` — previously failing, now passes
- All 52 non-slow LUKE tokenizer tests pass (5 skipped, 14 deselected)
- No regressions to entity_spans, entity_position_ids, or offset mappings