### PR TITLE
Guard against a None video processor class when the backend is unavailable

### DIFF
--- a/src/transformers/models/auto/video_processing_auto.py
+++ b/src/transformers/models/auto/video_processing_auto.py
@@ -358,10 +358,14 @@ class AutoVideoProcessor:
 
         has_remote_code = video_processor_auto_map is not None
         has_local_code = video_processor_class is not None or type(config) in VIDEO_PROCESSOR_MAPPING
-        explicit_local_code = has_local_code and not (
-            video_processor_class or VIDEO_PROCESSOR_MAPPING[type(config)]
-        ).__module__.startswith("transformers.")
+        explicit_local_code = False
         if has_remote_code:
+            if has_local_code:
+                local_video_processor_class = video_processor_class or VIDEO_PROCESSOR_MAPPING[type(config)]
+                explicit_local_code = (
+                    local_video_processor_class is not None
+                    and not local_video_processor_class.__module__.startswith("transformers.")
+                )
             if "--" in video_processor_auto_map:
                 upstream_repo = video_processor_auto_map.split("--")[0]
             else:

--- a/tests/models/auto/test_video_processing_auto.py
+++ b/tests/models/auto/test_video_processing_auto.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import transformers
 from transformers import (
@@ -24,6 +25,7 @@ from transformers import (
     VIDEO_PROCESSOR_MAPPING,
     AutoConfig,
     AutoVideoProcessor,
+    InternVLConfig,
     LlavaOnevisionConfig,
     LlavaOnevisionVideoProcessor,
 )
@@ -145,6 +147,28 @@ class AutoVideoProcessorTest(unittest.TestCase):
             "Can't load video processor for 'hf-internal-testing/config-no-model'.",
         ):
             _ = AutoVideoProcessor.from_pretrained("hf-internal-testing/config-no-model")
+
+    def test_unavailable_backend_error_mentions_missing_dependency(self):
+        # Without torchvision, `VIDEO_PROCESSOR_MAPPING` resolves to `None` while
+        # `type(config) in VIDEO_PROCESSOR_MAPPING` stays True, so the mapping value must not be
+        # dereferenced unguarded. InternVL is such a case: its image processor is
+        # `GotOCRImageProcessor`, no `GotOCRVideoProcessor` exists to infer from, and the class
+        # stays `None`.
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            with open(Path(tmpdirname) / "preprocessor_config.json", "w") as fp:
+                json.dump({"image_processor_type": "GotOCRImageProcessor"}, fp)
+            with open(Path(tmpdirname) / "config.json", "w") as fp:
+                json.dump({"model_type": "internvl"}, fp)
+
+            with (
+                patch.dict(VIDEO_PROCESSOR_MAPPING._extra_content, {InternVLConfig: None}),
+                patch(
+                    "transformers.models.auto.video_processing_auto.is_torchvision_available",
+                    return_value=False,
+                ),
+            ):
+                with self.assertRaisesRegex(ValueError, "requires `torchvision` to be installed"):
+                    AutoVideoProcessor.from_pretrained(tmpdirname)
 
     def test_from_pretrained_dynamic_video_processor(self):
         # If remote code is not set, we will time out when asking whether to load the model.


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48557&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48557) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48557&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48557)
<!-- ci-dashboard-badge:end -->

Fixes #48556

`AutoProcessor.from_pretrained("OpenGVLab/InternVL3-1B-hf")` without torchvision installed raises `AttributeError: 'NoneType' object has no attribute '__module__'` at `video_processing_auto.py:363`, instead of the "requires torchvision" error added in #44125.

`has_local_code` is true when the config type is a key in `VIDEO_PROCESSOR_MAPPING`, but without torchvision every value in that mapping is `None`. For InternVL `video_processor_class` is also `None` — its image processor is `GotOCRImageProcessor` and no `GotOCRVideoProcessor` exists to infer from, which line 330 already handles — so `(None or None).__module__` raises. `Salesforce/instructblip-vicuna-7b` fails the same way, and InstructBLIP is image-only.

This mirrors `image_processing_auto.py:655-664`, which guards the `None` and computes `explicit_local_code` only inside `if has_remote_code:` — the sole place it is used.

After the change both models reach the intended error:

```
ValueError: OpenGVLab/InternVL3-1B-hf requires `torchvision` to be installed.
```

The test mirrors `test_unavailable_backend_error_mentions_missing_dependency` in `tests/models/auto/test_image_processing_auto.py`. It uses `patch.dict(VIDEO_PROCESSOR_MAPPING._extra_content, ...)` to force the `None` value while torchvision is installed in CI; happy to change that if you prefer a different seam.

### Differentiation from existing PRs

#44125 added the torchvision message at the end of this function but did not guard this earlier path. #45045 fixed a spurious torchvision requirement on PIL-backend *image* processors, a different code path. No open PR touches `explicit_local_code` in `video_processing_auto.py`.

### Tests

```
pytest tests/models/auto/test_video_processing_auto.py
  12 passed

pytest tests/models/auto/test_processing_auto.py tests/models/auto/test_image_processing_auto.py
  41 passed, 5 skipped

pytest tests/models/auto/test_video_processing_auto.py -k unavailable_backend
  before: 1 failed (AttributeError: 'NoneType' object has no attribute '__module__')
  after:  1 passed

ruff check  - All checks passed
ruff format - 2 files already formatted
```

Reproduced on transformers 5.16.1 and `main` @ c93057d, Python 3.11.15, macOS arm64, torchvision not installed.

### AI usage disclosure

Per CONTRIBUTING: this change was made with AI assistance. I hit the defect while loading a Qwen VL processor for a fine-tuning run on a machine without torchvision.

- Drafted and reproduced with Claude Opus 5.
- Reviewed by GLM 5.3 and Muse Spark 1.3 as judges, and by me before submitting.
- Coordination link: #48556
- I have reviewed every changed line, validated the behaviour end to end on both affected models, and run the test commands above.