### PR TITLE
[higgs_audio_v2] Fix: use config.num_codebooks in audio labels tensor (Simple Fix!)

### DIFF
--- a/src/transformers/models/higgs_audio_v2/modeling_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/modeling_higgs_audio_v2.py
@@ -753,7 +753,7 @@ class HiggsAudioV2ForConditionalGeneration(HiggsAudioV2PreTrainedModel, HiggsAud
         loss = None
         if audio_labels is not None:
             audio_logits = logits.reshape(*logits.shape[:2], self.config.num_codebooks, self.config.codebook_size)
-            audio_labels_expanded = input_ids.new_ones((*input_ids.shape[:2], 8)) * -100
+            audio_labels_expanded = input_ids.new_ones((*input_ids.shape[:2], self.config.num_codebooks)) * -100
             audio_token_mask = self.model.get_placeholder_mask(input_ids, inputs_embeds, audio_input_ids_mask)
             audio_labels_expanded[audio_token_mask] = audio_labels[audio_input_ids_mask]
 

--- a/src/transformers/models/higgs_audio_v2/modular_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/modular_higgs_audio_v2.py
@@ -535,7 +535,7 @@ class HiggsAudioV2ForConditionalGeneration(HiggsAudioV2PreTrainedModel, HiggsAud
         loss = None
         if audio_labels is not None:
             audio_logits = logits.reshape(*logits.shape[:2], self.config.num_codebooks, self.config.codebook_size)
-            audio_labels_expanded = input_ids.new_ones((*input_ids.shape[:2], 8)) * -100
+            audio_labels_expanded = input_ids.new_ones((*input_ids.shape[:2], self.config.num_codebooks)) * -100
             audio_token_mask = self.model.get_placeholder_mask(input_ids, inputs_embeds, audio_input_ids_mask)
             audio_labels_expanded[audio_token_mask] = audio_labels[audio_input_ids_mask]
 

--- a/tests/models/higgs_audio_v2/test_modeling_higgs_audio_v2.py
+++ b/tests/models/higgs_audio_v2/test_modeling_higgs_audio_v2.py
@@ -355,6 +355,20 @@ class HiggsAudioV2ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Te
             # Assert the last tokens are actually the same (except for the natural fluctuation due to order of FP ops)
             torch.testing.assert_close(all_logits[:, -1:, :], last_token_logits, rtol=1e-5, atol=1e-5)
 
+    def test_forward_with_audio_labels(self):
+        """The audio loss must be computed reflecting the `num_codebooks` in the config."""
+        config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
+        model = HiggsAudioV2ForConditionalGeneration(config).to(torch_device).eval()
+
+        # `audio_labels` has the same shape as `audio_input_ids`: (batch, audio_seq_len, num_codebooks)
+        inputs["audio_labels"] = ids_tensor(list(inputs["audio_input_ids"].shape), self.model_tester.codebook_size)
+
+        outputs = model(**inputs)
+
+        self.assertIsNotNone(outputs.loss)
+        self.assertEqual(outputs.loss.shape, torch.Size([]))
+        self.assertTrue(torch.isfinite(outputs.loss))
+
     @pytest.mark.generate
     def test_generate_continue_from_past_key_values(self):
         # Tests that we can continue generating from past key values, returned from a previous `generate` call


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48560&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48560) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48560&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48560)
<!-- ci-dashboard-badge:end -->

Hello, I'm a TTS researcher who heavily relies on transformers library for my research work.
Recently, I found a simple but somewhat critical bug for model researcher while I using Higgs Audio V2 model.

So, I'd like to report and PR this fix (without Issue).
Below is the content what I am reporting:

`HiggsAudioV2ForConditionalGeneration.forward` allocated the expanded audio label tensor with a hardcoded last dimension of 8:

    audio_labels_expanded = input_ids.new_ones((*input_ids.shape[:2], 8)) * -100

while every surrounding computation is driven by
`self.config.num_codebooks`: `audio_logits` is reshaped to `(..., num_codebooks, codebook_size)` and the per-codebook loss loop iterates over `range(self.config.num_codebooks)`.

`8` is just the default of `HiggsAudioV2Config.num_codebooks`, so the two only agree by coincidence. With any other value the next line fails to broadcast:

    RuntimeError: shape mismatch: value tensor of shape [20, 2] cannot be broadcast to indexing result of shape [20, 8]

This happens for any `num_codebooks != 8`, smaller or larger, the loss loop is never reached.

Replace the literal with `self.config.num_codebooks`.
Applied to `modular_higgs_audio_v2.py` and regenerated into `modeling_higgs_audio_v2.py`.

`audio_labels` is not passed anywhere in `tests/`, so this branch was dead code in CI. I added `test_forward_with_audio_labels`; the tester already uses `num_codebooks=2`, so it fails on the current code and passes with the fix.


# What does this PR do?

## Code Agent Policy

- [x] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Models:
- audio models: @eustlb @ebezzam