### PR TITLE
[VLM] Support shift_labels in Qwen3-VL, Qwen3-VL-MoE, and Gemma3 loss computation

### DIFF
--- a/src/transformers/models/cosmos3_omni/modeling_cosmos3_omni.py
+++ b/src/transformers/models/cosmos3_omni/modeling_cosmos3_omni.py
@@ -617,7 +617,9 @@ class Cosmos3OmniForConditionalGeneration(Cosmos3OmniPreTrainedModel, Generation
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return Cosmos3OmniCausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -1028,25 +1028,9 @@ class Gemma3ForConditionalGeneration(Gemma3PreTrainedModel, GenerationMixin):
 
         loss = None
         if labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            shift_logits = logits[..., :-1, :]
-            shift_labels = labels[..., 1:]
-            if attention_mask is not None:
-                # we use the input attention mask to shift the logits and labels, because it is 2D.
-                # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-                shift_attention_mask = attention_mask[:, -shift_logits.shape[1] :].to(logits.device)
-                shift_logits = shift_logits[shift_attention_mask.to(logits.device) != 0].contiguous()
-                shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
-            else:
-                shift_logits = shift_logits.contiguous()
-                shift_labels = shift_labels.contiguous()
-            # Flatten the tokens
-            loss_fct = nn.CrossEntropyLoss()
-
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
-            flat_labels = shift_labels.view(-1).to(shift_logits.device)
-            loss = loss_fct(flat_logits, flat_labels)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **lm_kwargs
+            )
 
         return Gemma3CausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -857,25 +857,9 @@ class Gemma3ForConditionalGeneration(PaliGemmaForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            shift_logits = logits[..., :-1, :]
-            shift_labels = labels[..., 1:]
-            if attention_mask is not None:
-                # we use the input attention mask to shift the logits and labels, because it is 2D.
-                # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-                shift_attention_mask = attention_mask[:, -shift_logits.shape[1] :].to(logits.device)
-                shift_logits = shift_logits[shift_attention_mask.to(logits.device) != 0].contiguous()
-                shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
-            else:
-                shift_logits = shift_logits.contiguous()
-                shift_labels = shift_labels.contiguous()
-            # Flatten the tokens
-            loss_fct = nn.CrossEntropyLoss()
-
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
-            flat_labels = shift_labels.view(-1).to(shift_logits.device)
-            loss = loss_fct(flat_logits, flat_labels)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **lm_kwargs
+            )
 
         return Gemma3CausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -1872,7 +1872,9 @@ class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return Qwen3_5CausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -2062,7 +2062,9 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMi
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         aux_loss = None
         if kwargs.get("output_router_logits", False):

--- a/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -1378,7 +1378,9 @@ class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return Qwen3VLCausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -864,7 +864,9 @@ class Qwen3VLForConditionalGeneration(Qwen2_5_VLForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return Qwen3VLCausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -1553,7 +1553,9 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMi
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         aux_loss = None
         if kwargs.get("output_router_logits", False):

--- a/src/transformers/models/qwen3_vl_moe/modular_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modular_qwen3_vl_moe.py
@@ -416,7 +416,9 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         aux_loss = None
         if kwargs.get("output_router_logits", False):

--- a/src/transformers/models/qwen4_exp/modeling_qwen4_exp.py
+++ b/src/transformers/models/qwen4_exp/modeling_qwen4_exp.py
@@ -2519,7 +2519,9 @@ class Qwen4ExpForConditionalGeneration(Qwen4ExpPreTrainedModel, GenerationMixin)
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         aux_loss = None
         if kwargs.get("output_router_logits", False):

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -242,6 +242,25 @@ class Gemma3Vision2TextModelTest(VLMModelTest, unittest.TestCase):
         loss = model(**inputs).loss
         loss.backward()
 
+    def test_shift_labels_respected(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        config.return_dict = True
+
+        model = Gemma3ForConditionalGeneration(config).to(torch_device).eval()
+        inputs = self._prepare_for_class(inputs_dict, Gemma3ForConditionalGeneration, return_labels=True)
+
+        # Default forward with labels computes valid loss
+        out_normal = model(**inputs)
+        self.assertIsNotNone(out_normal.loss)
+        self.assertFalse(torch.isnan(out_normal.loss))
+
+        # Explicit shift_labels with all -100 must produce nan loss,
+        # confirming shift_labels is forwarded to loss_function.
+        shift_labels = torch.full_like(inputs["labels"], -100)
+        out_shifted = model(**inputs, shift_labels=shift_labels)
+        self.assertIsNotNone(out_shifted.loss)
+        self.assertTrue(torch.isnan(out_shifted.loss))
+
     @unittest.skip("Gemma3 applies key/query norm which doesn't work with packing")
     def test_flash_attention_2_padding_matches_padding_free_with_position_ids(self):
         pass

--- a/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
@@ -397,6 +397,25 @@ class Qwen3VLModelTest(VLMModelTest, unittest.TestCase):
             )
             self.assertIsNotNone(outputs)
 
+    def test_shift_labels_respected(self):
+        config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        model = Qwen3VLForConditionalGeneration(config).to(torch_device).eval()
+
+        input_ids = input_dict["input_ids"]
+        labels = input_ids.clone()
+
+        # Default forward with labels computes valid loss
+        out_normal = model(**input_dict, labels=labels)
+        self.assertIsNotNone(out_normal.loss)
+        self.assertFalse(torch.isnan(out_normal.loss))
+
+        # Explicit shift_labels with all -100 must produce nan loss,
+        # confirming shift_labels is forwarded to loss_function.
+        shift_labels = torch.full_like(labels, -100)
+        out_shifted = model(**input_dict, labels=labels, shift_labels=shift_labels)
+        self.assertIsNotNone(out_shifted.loss)
+        self.assertTrue(torch.isnan(out_shifted.loss))
+
 
 @require_torch
 class Qwen3VLTextModelPositionIdsTest(unittest.TestCase):

--- a/tests/models/qwen3_vl_moe/test_modeling_qwen3_vl_moe.py
+++ b/tests/models/qwen3_vl_moe/test_modeling_qwen3_vl_moe.py
@@ -342,6 +342,25 @@ class Qwen3VLMoeModelTest(VLMModelTest, unittest.TestCase):
     def test_reverse_loading_mapping(self, check_keys_were_modified=False):
         super().test_reverse_loading_mapping(check_keys_were_modified)
 
+    def test_shift_labels_respected(self):
+        config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        model = Qwen3VLMoeForConditionalGeneration(config).to(torch_device).eval()
+
+        input_ids = input_dict["input_ids"]
+        labels = input_ids.clone()
+
+        # Default forward with labels computes valid loss
+        out_normal = model(**input_dict, labels=labels)
+        self.assertIsNotNone(out_normal.loss)
+        self.assertFalse(torch.isnan(out_normal.loss))
+
+        # Explicit shift_labels with all -100 must produce nan loss,
+        # confirming shift_labels is forwarded to loss_function.
+        shift_labels = torch.full_like(labels, -100)
+        out_shifted = model(**input_dict, labels=labels, shift_labels=shift_labels)
+        self.assertIsNotNone(out_shifted.loss)
+        self.assertTrue(torch.isnan(out_shifted.loss))
+
 
 @require_torch
 class Qwen3VLMoeIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48563&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48563) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48563&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48563)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48491.

In distributed, context-parallel, and sequence-parallel training setups (such as Ulysses SP, Accelerate Context Parallel, DeepSpeed ALST), the token sequence is sharded across ranks. Shifting labels per-rank breaks label alignment across rank boundaries; instead, frameworks pre-compute globally shifted labels and pass them explicitly as shift_labels into orward(..., labels=labels, shift_labels=shift_labels).

Previously, Qwen3-VL, Qwen3-VL-MoE, and Gemma3 ignored user-supplied shift_labels:
1. Qwen3-VL and Qwen3-VL-MoE called self.loss_function(logits=logits, labels=labels, vocab_size=...) without forwarding **kwargs, completely dropping shift_labels.
2. Gemma3 (Gemma3ForConditionalGeneration) bypassed self.loss_function entirely with hardcoded shift_logits = logits[..., :-1, :], shift_labels = labels[..., 1:], and 
n.CrossEntropyLoss(), ignoring both shift_labels and any custom self.loss_function.

This PR:
- Passes **kwargs / **lm_kwargs to self.loss_function in Qwen3-VL and Qwen3-VL-MoE (both modeling_*.py and modular_*.py).
- Refactors Gemma3ForConditionalGeneration to delegate to self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **lm_kwargs) (both modeling_gemma3.py and modular_gemma3.py), matching PaliGemma and Qwen2.5-VL.
- Adds regression unit tests in 	ests/models/qwen3_vl/test_modeling_qwen3_vl.py, 	ests/models/qwen3_vl_moe/test_modeling_qwen3_vl_moe.py, and 	ests/models/gemma3/test_modeling_gemma3.py verifying that passing shift_labels (e.g. all -100) produces NaN loss as expected when all targets are masked, and normal valid loss when omitted.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?
@ArthurZucker @amyeroberts @SunMarc