### PR TITLE
Fix TextGenerationPipeline missing tokenizer for stop_strings

### DIFF
--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -399,7 +399,6 @@ class TextGenerationPipeline(Pipeline):
         # User-defined `generation_config` passed to the pipeline call take precedence
         if "generation_config" not in generate_kwargs:
             generate_kwargs["generation_config"] = self.generation_config
-
         generate_kwargs.setdefault("tokenizer", self.tokenizer)
 
         output = self.model.generate(input_ids=input_ids, attention_mask=attention_mask, **generate_kwargs)

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -399,6 +399,8 @@ class TextGenerationPipeline(Pipeline):
         # User-defined `generation_config` passed to the pipeline call take precedence
         if "generation_config" not in generate_kwargs:
             generate_kwargs["generation_config"] = self.generation_config
+        
+        generate_kwargs.setdefault("tokenizer", self.tokenizer)
 
         output = self.model.generate(input_ids=input_ids, attention_mask=attention_mask, **generate_kwargs)
 

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -399,7 +399,7 @@ class TextGenerationPipeline(Pipeline):
         # User-defined `generation_config` passed to the pipeline call take precedence
         if "generation_config" not in generate_kwargs:
             generate_kwargs["generation_config"] = self.generation_config
-        
+
         generate_kwargs.setdefault("tokenizer", self.tokenizer)
 
         output = self.model.generate(input_ids=input_ids, attention_mask=attention_mask, **generate_kwargs)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48564&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48564) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48564&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48564)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This PR fixes a bug where `TextGenerationPipeline` fails to forward its internal tokenizer down to `model.generate()`. 

When running a high-level `pipeline("text-generation", ...)`, the pipeline already holds the required tokenizer object internally. However, it was not being forwarded down during the generation pass. Because of this, any model checkpoint that specifies default `stop_strings` inside its `generation_config.json` immediately crashes with a `ValueError` (tokenizer not found) when a user tries to run it through the standard pipeline.

Following the maintainer's suggestion, this fix introduces `generate_kwargs.setdefault("tokenizer", self.tokenizer)` in `text_generation.py` right before the generation call. This ensures the tokenizer is safely present for evaluating stop sequences while properly maintaining any explicit user-passed tokenizers.


Fixes #34571


## Code Agent Policy

- [x] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

Based on the reviewer guide, tagging the pipeline and generation maintainers who were active in the issue:
@Rocketknight1 @qgallouedec @zucchini-nlp