### PR TITLE
Honor shift_labels in Qwen3-VL, Qwen3-VL-MoE, and Gemma3 VLM losses

### DIFF
--- a/src/transformers/models/cosmos3_omni/modeling_cosmos3_omni.py
+++ b/src/transformers/models/cosmos3_omni/modeling_cosmos3_omni.py
@@ -617,7 +617,9 @@ class Cosmos3OmniForConditionalGeneration(Cosmos3OmniPreTrainedModel, Generation
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return Cosmos3OmniCausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -1028,25 +1028,11 @@ class Gemma3ForConditionalGeneration(Gemma3PreTrainedModel, GenerationMixin):
 
         loss = None
         if labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            shift_logits = logits[..., :-1, :]
-            shift_labels = labels[..., 1:]
-            if attention_mask is not None:
-                # we use the input attention mask to shift the logits and labels, because it is 2D.
-                # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-                shift_attention_mask = attention_mask[:, -shift_logits.shape[1] :].to(logits.device)
-                shift_logits = shift_logits[shift_attention_mask.to(logits.device) != 0].contiguous()
-                shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
-            else:
-                shift_logits = shift_logits.contiguous()
-                shift_labels = shift_labels.contiguous()
-            # Flatten the tokens
-            loss_fct = nn.CrossEntropyLoss()
-
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
-            flat_labels = shift_labels.view(-1).to(shift_logits.device)
-            loss = loss_fct(flat_logits, flat_labels)
+            # we are filtering the logits/labels so we shouldn't divide the loss based on num_items_in_batch
+            # Fix: https://github.com/huggingface/transformers/issues/40564
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **lm_kwargs
+            )
 
         return Gemma3CausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -857,25 +857,9 @@ class Gemma3ForConditionalGeneration(PaliGemmaForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            shift_logits = logits[..., :-1, :]
-            shift_labels = labels[..., 1:]
-            if attention_mask is not None:
-                # we use the input attention mask to shift the logits and labels, because it is 2D.
-                # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-                shift_attention_mask = attention_mask[:, -shift_logits.shape[1] :].to(logits.device)
-                shift_logits = shift_logits[shift_attention_mask.to(logits.device) != 0].contiguous()
-                shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
-            else:
-                shift_logits = shift_logits.contiguous()
-                shift_labels = shift_labels.contiguous()
-            # Flatten the tokens
-            loss_fct = nn.CrossEntropyLoss()
-
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
-            flat_labels = shift_labels.view(-1).to(shift_logits.device)
-            loss = loss_fct(flat_logits, flat_labels)
+            # we are filtering the logits/labels so we shouldn't divide the loss based on num_items_in_batch
+            # Fix: https://github.com/huggingface/transformers/issues/40564
+            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **lm_kwargs)
 
         return Gemma3CausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -859,7 +859,9 @@ class Gemma3ForConditionalGeneration(PaliGemmaForConditionalGeneration):
         if labels is not None:
             # we are filtering the logits/labels so we shouldn't divide the loss based on num_items_in_batch
             # Fix: https://github.com/huggingface/transformers/issues/40564
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **lm_kwargs)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **lm_kwargs
+            )
 
         return Gemma3CausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -1872,7 +1872,9 @@ class Qwen3_5ForConditionalGeneration(Qwen3_5PreTrainedModel, GenerationMixin):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return Qwen3_5CausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -2062,7 +2062,9 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMi
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         aux_loss = None
         if kwargs.get("output_router_logits", False):

--- a/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -1378,7 +1378,9 @@ class Qwen3VLForConditionalGeneration(Qwen3VLPreTrainedModel, GenerationMixin):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return Qwen3VLCausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -864,7 +864,9 @@ class Qwen3VLForConditionalGeneration(Qwen2_5_VLForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         return Qwen3VLCausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -864,7 +864,7 @@ class Qwen3VLForConditionalGeneration(Qwen2_5_VLForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs)
 
         return Qwen3VLCausalLMOutputWithPast(
             loss=loss,

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -1553,7 +1553,9 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLMoePreTrainedModel, GenerationMi
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         aux_loss = None
         if kwargs.get("output_router_logits", False):

--- a/src/transformers/models/qwen3_vl_moe/modular_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modular_qwen3_vl_moe.py
@@ -416,7 +416,7 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs)
 
         aux_loss = None
         if kwargs.get("output_router_logits", False):

--- a/src/transformers/models/qwen3_vl_moe/modular_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modular_qwen3_vl_moe.py
@@ -416,7 +416,9 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         aux_loss = None
         if kwargs.get("output_router_logits", False):

--- a/src/transformers/models/qwen4_exp/modeling_qwen4_exp.py
+++ b/src/transformers/models/qwen4_exp/modeling_qwen4_exp.py
@@ -2519,7 +2519,9 @@ class Qwen4ExpForConditionalGeneration(Qwen4ExpPreTrainedModel, GenerationMixin)
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs
+            )
 
         aux_loss = None
         if kwargs.get("output_router_logits", False):

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -224,6 +224,25 @@ class Gemma3Vision2TextModelTest(VLMModelTest, unittest.TestCase):
     test_disk_offload_safetensors = False
     test_disk_offload_bin = False
 
+    def test_shift_labels_are_used(self):
+        # Caller-supplied `shift_labels` must reach the loss function instead of being
+        # silently dropped, so masking every target yields a nan loss.
+        # See https://github.com/huggingface/transformers/issues/48491
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        model = Gemma3ForConditionalGeneration(config).to(torch_device)
+        model.eval()
+        inputs = self._prepare_for_class(inputs_dict, Gemma3ForConditionalGeneration, return_labels=True)
+        input_ids = inputs["input_ids"]
+        ignore_all = torch.full_like(input_ids, -100)
+        with torch.no_grad():
+            loss = model(**inputs, shift_labels=ignore_all).loss
+        self.assertTrue(torch.isnan(loss).all())
+
+        # With no caller-supplied shift labels the derived loss is finite
+        with torch.no_grad():
+            loss = model(**inputs).loss
+        self.assertTrue(torch.isfinite(loss).all())
+
     def test_training(self):
         # Overwrite to test training with text-only samples, should not raise errors
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
@@ -205,6 +205,24 @@ class Qwen3VLModelTest(VLMModelTest, unittest.TestCase):
         self.assertListEqual(list(position_ids.shape), [3, 1, 27])
         self.assertListEqual(position_ids.tolist(), expected_positions.tolist())
 
+    def test_shift_labels_are_used(self):
+        # Caller-supplied `shift_labels` must reach the loss function instead of being
+        # silently dropped, so masking every target yields a nan loss.
+        # See https://github.com/huggingface/transformers/issues/48491
+        config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        model = Qwen3VLForConditionalGeneration(config).to(torch_device)
+        model.eval()
+        input_ids = input_dict["input_ids"]
+        ignore_all = torch.full_like(input_ids, -100)
+        with torch.no_grad():
+            loss = model(input_ids=input_ids, labels=input_ids, shift_labels=ignore_all).loss
+        self.assertTrue(torch.isnan(loss).all())
+
+        # With no caller-supplied shift labels the derived loss is finite
+        with torch.no_grad():
+            loss = model(input_ids=input_ids, labels=input_ids).loss
+        self.assertTrue(torch.isfinite(loss).all())
+
     def test_mismatching_num_image_tokens(self):
         # Override the base test because we need to slice image_grid_thw too
         config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48570&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48570) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48570&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48570)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`Qwen3VLForConditionalGeneration` and `Qwen3VLMoeForConditionalGeneration` called `self.loss_function(logits=logits, labels=labels, vocab_size=...)` without `**kwargs`, so caller-supplied `shift_labels` were silently dropped and the loss re-derived its own shift from `labels`. `Gemma3ForConditionalGeneration` used a hand-rolled cross-entropy that could not accept `shift_labels` at all.

This matters for sequence/context parallel training (accelerate CP, Ulysses SP, DeepSpeed ALST), where the pre-shifted labels are the only correct ones: with the old code, each shard's last token silently gets no target.

Changes:

- `Qwen3VLForConditionalGeneration` / `Qwen3VLMoeForConditionalGeneration`: pass `**kwargs` to `self.loss_function` (same as `Qwen2_5_VLForConditionalGeneration`). The `Qwen3_5`, `Qwen3_5_moe` and `Qwen4_exp` generated files inherit this forward and were regenerated via `utils/check_modular_conversion.py`.
- `Gemma3ForConditionalGeneration`: replace the hand-rolled loss with `self.loss_function(logits=logits, labels=labels, vocab_size=..., **lm_kwargs)`, matching its parent `PaliGemmaForConditionalGeneration`. `accepts_loss_kwargs = False` is kept, so the `num_items_in_batch` semantics from #40564 are unchanged. One behavioral difference: the old hand-rolled path filtered logits/labels by the attention mask before the CE reduction; the shared loss function relies on `-100` ignore indices instead, exactly like the parent class and `Gemma3ForCausalLM`.

## Before / After

```python
for name in ["trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration",
             "trl-internal-testing/tiny-Gemma3ForConditionalGeneration"]:
    model = AutoModelForImageTextToText.from_pretrained(name)
    input_ids = torch.randint(10, 100, (1, 16))
    ignore_all = torch.full_like(input_ids, -100)
    print(model(input_ids=input_ids, labels=input_ids, shift_labels=ignore_all).loss.item())
```

Before (main `c93057d`):

```
Qwen2_5_VLForConditionalGeneration nan
Qwen3VLForConditionalGeneration 11.929235458374023
Gemma3ForConditionalGeneration 12.473801612854004
```

After (this PR):

```
Qwen2_5_VLForConditionalGeneration nan
Qwen3VLForConditionalGeneration nan
Gemma3ForConditionalGeneration nan
```

Fixes #48491

## Who can review?

@zucchini-nlp

## Testing

- Added `test_shift_labels_are_used` to `Qwen3VLModelTest` and `Gemma3Vision2TextModelTest`: asserts a `nan` loss when every `shift_label` is `-100` (fails on main, passes with this patch) and a finite loss without `shift_labels`.
- `pytest tests/models/qwen3_vl/test_modeling_qwen3_vl.py::Qwen3VLModelTest tests/models/gemma3/test_modeling_gemma3.py::Gemma3Vision2TextModelTest`: 282 passed, 251 skipped, 3 xfailed, 3 xpassed on CPU.
- `ruff check` on all touched files: clean.
- `utils/check_copies.py`, `utils/check_inits.py`, `utils/check_repo.py`: all pass.