### PR TITLE
docs: fix broken benchmark/vibevoice links and remove deleted NAT from backbones

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -14,7 +14,7 @@ def run_benchmark(logger: Logger, branch: str, commit_id: str, commit_msg: str, 
 
 `MetricsRecorder` is thread-safe, in the sense of the python [`Thread`](https://docs.python.org/3/library/threading.html#threading.Thread). This means you can start a background thread to do the readings on the device measurements while not blocking the main thread to execute the model measurements.
 
-cf [`llama.py`](./llama.py) to see an example of this in practice.
+cf [`llama.py`](./benches/llama.py) to see an example of this in practice.
 
 ```py
 from benchmarks_entrypoint import MetricsRecorder

--- a/docs/source/en/main_classes/backbones.md
+++ b/docs/source/en/main_classes/backbones.md
@@ -33,7 +33,6 @@ Backbones are supported for the following models:
 * [DINOV2](../model_doc/dinov2)
 * [FocalNet](../model_doc/focalnet)
 * [MaskFormer](../model_doc/maskformer)
-* [NAT](../model_doc/nat)
 * [ResNet](../model_doc/resnet)
 * [Swin Transformer](../model_doc/swin)
 * [Swin Transformer v2](../model_doc/swinv2)

--- a/docs/source/en/model_doc/vibevoice.md
+++ b/docs/source/en/model_doc/vibevoice.md
@@ -40,7 +40,7 @@ This model was contributed by [Eric Bezzam](https://huggingface.co/bezzam).
 </div>
 
 The VibeVoice framework integrates three key components:
-1. **Continuous Speech Tokenizers:** Specialized [acoustic](./vibevoice_acoustic_tokenizer) and [semantic](./vibevoice_semantic_tokenizer) tokenizers, where the acoustic tokenizer uses a $\sigma$-VAE to achieve ultra-low compression (7.5 tokens/sec, 3200x) for scalability and fidelity, and the semantic tokenizer uses an ASR proxy task for content-centric feature extraction.
+1. **Continuous Speech Tokenizers:** Specialized [acoustic](./vibevoice_acoustic_tokenizer) and semantic tokenizers, where the acoustic tokenizer uses a $\sigma$-VAE to achieve ultra-low compression (7.5 tokens/sec, 3200x) for scalability and fidelity, and the semantic tokenizer uses an ASR proxy task for content-centric feature extraction.
 2. **Large Language Model (LLM):** Uses Qwen2.5 (in 1.5B and 7B versions) as its core sequence model.
 3. **Token-Level Diffusion Head:** conditioned on the LLM's hidden state and responsible for predicting the continuous VAE features in a streaming fashion.
 


### PR DESCRIPTION
Three small docs fixes, each verified against the tree:

1. `benchmark/README.md`: `llama.py` lives under `benches/`, not at the benchmark root
2. `docs/source/en/model_doc/vibevoice.md`: linked a `vibevoice_semantic_tokenizer` doc page that was never created; dropped the dead link, kept plain text
3. `docs/source/en/main_classes/backbones.md`: NAT model was deleted in 9f311047; removed the stale bullet from the backbone types list