### PR TITLE
docs: fix dead in-page anchors across guides

### DIFF
--- a/docs/source/en/conversations.md
+++ b/docs/source/en/conversations.md
@@ -52,7 +52,7 @@ The chat is implemented on top of the [AutoClass](./model_doc/auto), using tooli
 
 ## TextGenerationPipeline
 
-[`TextGenerationPipeline`] is a high-level text generation class with a "chat mode". Chat mode is enabled when a conversational model is detected and the chat prompt is [properly formatted](./llm_tutorial#wrong-prompt-format).
+[`TextGenerationPipeline`] is a high-level text generation class with a "chat mode". Chat mode is enabled when a conversational model is detected and the chat prompt is [properly formatted](./llm_tutorial#prompt-format).
 
 Chat models accept a list of messages (the chat history) as the input. Each message is a dictionary with `role` and `content` keys.
 To start the chat, add a single `user` message. You can also optionally include a `system` message to give the model directions on how to behave.
@@ -113,7 +113,7 @@ pipeline = pipeline(task="text-generation", model="meta-llama/Meta-Llama-3-8B-In
 In general, model size and performance are directly correlated. Larger models are slower in addition to requiring more memory because each active parameter must be read from memory for every generated token.
 This is a bottleneck for LLM text generation and the main options for improving generation speed are to either quantize a model or use hardware with higher memory bandwidth. Adding more compute power doesn't meaningfully help.
 
-You can also try techniques like [speculative decoding](./generation_strategies#speculative-decoding), where a smaller model generates candidate tokens that are verified by the larger model. If the candidate tokens are correct, the larger model can generate more than one token at a time. This significantly alleviates the bandwidth bottleneck and improves generation speed.
+You can also try techniques like [speculative decoding](./generation_strategies#greedy-search), where a smaller model generates candidate tokens that are verified by the larger model. If the candidate tokens are correct, the larger model can generate more than one token at a time. This significantly alleviates the bandwidth bottleneck and improves generation speed.
 
 > [!TIP]
 Mixture-of-Expert (MoE) models such as [Mixtral](./model_doc/mixtral), [Qwen2MoE](./model_doc/qwen2_moe), and [GPT-OSS](./model_doc/gpt_oss) have lots of parameters, but only "activate" a small fraction of them to generate each token. As a result, MoE models generally have much lower memory bandwidth requirements and can be faster than a regular LLM of the same size. However, techniques like speculative decoding are ineffective with MoE models because more parameters become activated with each new speculated token.

--- a/docs/source/en/custom_models.md
+++ b/docs/source/en/custom_models.md
@@ -97,7 +97,7 @@ You'll create two ResNet models, a barebones ResNet model that outputs the hidde
 Define a mapping between the block types and classes. Everything else is created by passing the configuration class to the ResNet model class.
 
 > [!TIP]
-> Add `config_class` to the model class to enable [AutoClass](#autoclass-support) support.
+> Add `config_class` to the model class to enable [AutoClass](#autoclass) support.
 
 ```py
 from transformers import PreTrainedModel
@@ -134,7 +134,7 @@ class ResnetModel(PreTrainedModel):
 The `forward` method needs to be rewritten to calculate the loss for each logit if labels are available. Otherwise, the ResNet model class is the same.
 
 > [!TIP]
-> Add `config_class` to the model class to enable [AutoClass](#autoclass-support) support.
+> Add `config_class` to the model class to enable [AutoClass](#autoclass) support.
 
 ```py
 import torch

--- a/docs/source/en/quicktour.md
+++ b/docs/source/en/quicktour.md
@@ -144,7 +144,7 @@ tokenizer.batch_decode(generated_ids)[0]
 ```
 
 > [!TIP]
-> Skip ahead to the [Trainer](#trainer-api) section to learn how to fine-tune a model.
+> Skip ahead to the [Trainer](#trainer) section to learn how to fine-tune a model.
 
 ## Pipeline
 

--- a/docs/source/en/tasks/prompting.md
+++ b/docs/source/en/tasks/prompting.md
@@ -18,7 +18,7 @@ rendered properly in your Markdown viewer.
 
 [[open-in-colab]]
 
-Prompt engineering or prompting, uses natural language to improve large language model (LLM) performance on a variety of tasks. A prompt can steer the model towards generating a desired output. In many cases, you don't even need a [fine-tuned](#finetuning) model for a task. You just need a good prompt.
+Prompt engineering or prompting, uses natural language to improve large language model (LLM) performance on a variety of tasks. A prompt can steer the model towards generating a desired output. In many cases, you don't even need a [fine-tuned](#fine-tuning) model for a task. You just need a good prompt.
 
 Try prompting a LLM to classify some text. When you create a prompt, it's important to provide very specific instructions about the task and what the result should look like.
 
@@ -66,7 +66,7 @@ This guide covers prompt engineering best practices, techniques, and examples fo
 
 7. Lead the model to generate the correct output by writing the first word or even the first sentence.
 
-8. Try other techniques like [few-shot](#few-shot) and [chain-of-thought](#chain-of-thought) to improve results.
+8. Try other techniques like [few-shot](#few-shot-prompting) and [chain-of-thought](#chain-of-thought) to improve results.
 
 9. Test your prompts with different models to assess their robustness.
 
@@ -166,7 +166,7 @@ If you eat 6 muffins, how many are left?
 Answer: 6
 ```
 
-Like [few-shot](#few-shot) prompting, the downside of CoT is that it requires more effort to design a series of prompts that help the model reason through a complex task and prompt length increases latency.
+Like [few-shot](#few-shot-prompting) prompting, the downside of CoT is that it requires more effort to design a series of prompts that help the model reason through a complex task and prompt length increases latency.
 
 ## Fine-tuning
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48573&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48573) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48573&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48573)
<!-- ci-dashboard-badge:end -->

Fixes in-page anchors that match no heading in their target files, each verified against the actual heading slugs:

1. `docs/source/en/quicktour.md`: `#trainer-api` → `#trainer` (the heading is `## Trainer`)
2. `docs/source/en/tasks/prompting.md`: `#finetuning` → `#fine-tuning` and `#few-shot` → `#few-shot-prompting` (headings: `## Fine-tuning`, `### Few-shot prompting`)