### PR TITLE
fix(integrations): print the base model architecture for PEFT-wrapped models

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -667,7 +667,7 @@ def save_model_architecture_to_file(model: Any, output_dir: str):
         elif is_torch_available() and (
             isinstance(model, (torch.nn.Module, PushToHubMixin)) and hasattr(model, "base_model")
         ):
-            print(model, file=f)
+            print(model.base_model, file=f)
 
 
 class WandbLogModel(str, Enum):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48577&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48577) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48577&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48577)
<!-- ci-dashboard-badge:end -->

### Summary

In `save_model_architecture_to_file` (`src/transformers/integrations/integration_utils.py`), the `elif` branch matches PEFT-wrapped models via `hasattr(model, "base_model")` but its body printed `model` — identical to the plain-model `if` branch, making the branch dead weight and `model_architecture.txt` show the PeftModel wrapper instead of the underlying architecture.

Prints `model.base_model` in that branch so the file actually shows the base architecture the branch was written to reveal.

### Testing

- [x] `python -m py_compile` passes
- [ ] No test asserts the file content (grepped `tests/`); if maintainers prefer collapsing the branches, happy to adapt

Found via an identical if/elif-arm AST scan; the mismatch is long-standing (present at commit 73a9bc3756, checked via the GitHub API).