### PR TITLE
Mirror the registered pytree flatten when building automatic dynamic shapes

### DIFF
--- a/src/transformers/exporters/exporter_dynamo.py
+++ b/src/transformers/exporters/exporter_dynamo.py
@@ -645,8 +645,9 @@ def get_auto_dynamic_shapes(inputs: Any) -> Any:
 
     - Tensors → per-dimension Dim.AUTO spec.
     - Scalars / None → None (no dynamic dims).
-    - Objects with ``__dict__`` (ModelOutput, Cache, …) → flat list of leaf specs,
-      matching the ``TreeSpec(list, …)`` that torch.export produces for these types.
+    - Registered pytree nodes (ModelOutput, Cache, …) → list of one spec per child of the
+      registered flatten, recursed, matching the ``TreeSpec(list, …)`` torch.export compares against.
+    - Other objects with ``__dict__`` → flat list of leaf specs.
     - Lists / tuples → same container type, recursed element-wise.
     - Plain dicts → recursed dict of specs.
     - Everything else → None.
@@ -655,13 +656,21 @@ def get_auto_dynamic_shapes(inputs: Any) -> Any:
         return _auto_dynamic_shape(inputs)
     if inputs is None or isinstance(inputs, (int, float, bool, str)):
         return None
-    if hasattr(inputs, "__dict__"):
-        leaves, _ = _pytree_flatten(inputs)
-        return get_auto_dynamic_shapes(leaves)
     if type(inputs) in (list, tuple, set, frozenset):
         return type(inputs)(get_auto_dynamic_shapes(v) for v in inputs)
     if type(inputs) is dict:
         return {k: get_auto_dynamic_shapes(v) for k, v in inputs.items()}
+    if (node := torch.utils._pytree.SUPPORTED_NODES.get(type(inputs))) is not None:
+        # Registered pytree node (a `ModelOutput`, a `Cache` subclass, ...). Mirror one level of its
+        # registered flatten and recurse, so a field holding a container keeps that container in the
+        # spec. A `Cache` is registered with a flatten that collapses to tensors, so it still yields a
+        # flat list; a `ModelOutput` yields one child per field, which is what `torch.export` compares
+        # against -- flattening it to tensors hands over a flat spec where nested children are expected.
+        children, _ = node.flatten_fn(inputs)
+        return [get_auto_dynamic_shapes(child) for child in children]
+    if hasattr(inputs, "__dict__"):
+        leaves, _ = _pytree_flatten(inputs)
+        return get_auto_dynamic_shapes(leaves)
     return None
 
 

--- a/tests/exporters/test_export.py
+++ b/tests/exporters/test_export.py
@@ -132,6 +132,11 @@ EXPORT_SKIPS: dict[str, dict[str, str]] = {
             "test timeout (12 attention blocks × 3 Q-pool stage transitions on symbolic H/W). Backend-"
             "agnostic — the torch.export step itself overruns, so every backend hits it."
         ),
+        "Sam2VisionModel": (
+            "torch 2.13's constraint solver raises `NotImplementedError` from `solve_univariate_inequality` "
+            "on the Hiera window-partition guard `Eq(s/32 - (s/4)//8, 0)` (a `FloorDiv` in a rational "
+            "equation); tracing itself succeeds. ONNX + ORT also overrun the 1000s timeout at ~7.5 min."
+        ),
         "SeamlessM4TForSpeechToSpeech": (
             "The Conformer speech encoder is non-causal, so `sdpa_attention_forward` evaluates "
             "`q_length > 1 and attention_mask is None and is_causal`; under dynamic shapes `q_length > 1` "
@@ -196,11 +201,6 @@ EXPORT_SKIPS: dict[str, dict[str, str]] = {
         "GroundingDinoForObjectDetection": "Same as `GroundingDinoModel`.",
         "MMGroundingDinoModel": "Same as `GroundingDinoModel`.",
         "MMGroundingDinoForObjectDetection": "Same as `GroundingDinoModel`.",
-        "Sam2VisionModel": (
-            "`torch.export` of the Hiera vision backbone under dynamic shapes takes ~7.5 min "
-            "even after simplifying `window_partition`/`window_unpartition` (12 attention blocks "
-            "× 3 Q-pool stage transitions on symbolic H/W). ONNX + ORT push past 1000s timeout."
-        ),
         "BigBirdModel": ("Lowering exceeds the 10-minute test timeout under dynamic shapes."),
         "BigBirdForCausalLM": "Same `timeout` failure as `BigBirdModel`.",
         "BigBirdForMaskedLM": "Same `timeout` failure as `BigBirdModel`.",
@@ -289,7 +289,6 @@ EXPORT_SKIPS: dict[str, dict[str, str]] = {
         "GroundingDinoForObjectDetection": "Same `timeout` failure as `Mask2FormerModel`.",
         "MMGroundingDinoModel": "Same `timeout` failure as `Mask2FormerModel`.",
         "MMGroundingDinoForObjectDetection": "Same `timeout` failure as `Mask2FormerModel`.",
-        "Sam2VisionModel": "Same `timeout` failure as `Mask2FormerModel`.",
         "Swinv2Model": "Same `timeout` failure as `Mask2FormerModel`.",
         "Swinv2ForImageClassification": "Same `timeout` failure as `Mask2FormerModel`.",
         "Swinv2ForMaskedImageModeling": "Same `timeout` failure as `Mask2FormerModel`.",


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48578&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48578) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48578&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48578)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`get_auto_dynamic_shapes` treated every object with a `__dict__` as flattening to a flat list of tensors, which is true only for the `Cache` subclasses the exporter registers itself. A `ModelOutput` is registered by transformers with the standard dict-like flatten, so `torch.export` expects one child per field -- and a field holding a tuple keeps that tuple in the tree spec.

Passing a `ModelOutput` as a generate kwarg therefore failed with `Node arity mismatch; expected 2, but got 3`. Ask the pytree registry for the flatten instead of assuming one: caches still yield a flat list, outputs keep their nesting.

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.

Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
for reviewers and other users and will almost certainly get you blocked.

For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @molbap @guarin
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @Abdennacer-Badaoui
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @IlyasMoutawwakil 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->