### PR TITLE
Add image-text contrastive loss to Blip2ForImageTextRetrieval

### DIFF
--- a/src/transformers/models/blip_2/configuration_blip_2.py
+++ b/src/transformers/models/blip_2/configuration_blip_2.py
@@ -154,6 +154,7 @@ class Blip2Config(PreTrainedConfig):
     text_config: dict | PreTrainedConfig | None = None
     num_query_tokens: int = 32
     image_text_hidden_size: int = 256
+    logit_scale_init_value: float = 2.6592
     image_token_index: int | None = None
     initializer_factor: float = 1.0
     initializer_range: float = 0.02

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -430,6 +430,9 @@ class Blip2PreTrainedModel(PreTrainedModel):
         if isinstance(module, Blip2VisionEmbeddings):
             init.trunc_normal_(module.position_embedding, mean=0.0, std=std)
             init.trunc_normal_(module.class_embedding, mean=0.0, std=std)
+        elif isinstance(module, Blip2ForImageTextRetrieval):
+            init.zeros_(module.query_tokens)
+            init.constant_(module.logit_scale, self.config.logit_scale_init_value)
         elif isinstance(
             module,
             (
@@ -437,7 +440,6 @@ class Blip2PreTrainedModel(PreTrainedModel):
                 Blip2TextModelWithProjection,
                 Blip2VisionModelWithProjection,
                 Blip2ForConditionalGeneration,
-                Blip2ForImageTextRetrieval,
             ),
         ):
             init.zeros_(module.query_tokens)
@@ -1859,6 +1861,8 @@ class Blip2ForImageTextRetrieval(Blip2PreTrainedModel):
         # image text matching head
         self.itm_head = nn.Linear(config.qformer_config.hidden_size, 2)
 
+        self.logit_scale = nn.Parameter(torch.tensor(self.config.logit_scale_init_value))
+
         # Initialize weights and apply final processing
         self.post_init()
 
@@ -1878,6 +1882,7 @@ class Blip2ForImageTextRetrieval(Blip2PreTrainedModel):
         output_attentions: bool | None = None,
         output_hidden_states: bool | None = None,
         return_dict: bool | None = None,
+        return_loss: bool | None = None,
         **kwargs,
     ) -> tuple | Blip2ImageTextMatchingModelOutput:
         r"""
@@ -1890,6 +1895,9 @@ class Blip2ForImageTextRetrieval(Blip2PreTrainedModel):
             [What are input IDs?](../glossary#input-ids)
         use_image_text_matching_head (`bool`, *optional*):
             Whether to return the Image-Text Matching or Contrastive scores.
+        return_loss (`bool`, *optional*):
+            Whether or not to return the image-text contrastive loss. Only supported when
+            `use_image_text_matching_head=False`.
 
         Examples:
 
@@ -1942,6 +1950,10 @@ class Blip2ForImageTextRetrieval(Blip2PreTrainedModel):
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
+
+        if return_loss and use_image_text_matching_head:
+            raise ValueError("`return_loss` is not yet supported with `use_image_text_matching_head=True`.")
+        loss = None
 
         vision_outputs = self.vision_model(
             pixel_values=pixel_values,
@@ -2019,11 +2031,20 @@ class Blip2ForImageTextRetrieval(Blip2PreTrainedModel):
 
             logits_per_text = logits_per_image.t()
 
+            if return_loss:
+                targets = torch.arange(logits_per_image.size(0), device=logits_per_image.device)
+                scale = self.logit_scale.exp()
+                loss = (
+                    nn.functional.cross_entropy(logits_per_image * scale, targets, label_smoothing=0.1)
+                    + nn.functional.cross_entropy(logits_per_text * scale, targets, label_smoothing=0.1)
+                ) / 2
+
         if not return_dict:
             output = (logits_per_image, logits_per_text, text_embeds, image_embeds, text_outputs, vision_outputs)
-            return output
+            return ((loss,) + output) if loss is not None else output
 
         return Blip2ImageTextMatchingModelOutput(
+            loss=loss,
             logits_per_image=logits_per_image,
             logits_per_text=logits_per_text,
             text_embeds=text_embeds,

--- a/tests/models/blip_2/test_modeling_blip_2.py
+++ b/tests/models/blip_2/test_modeling_blip_2.py
@@ -1440,6 +1440,50 @@ class Blip2TextRetrievalModelTest(ModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
+    def test_image_text_contrastive_loss(self):
+        config, input_ids, attention_mask, pixel_values = self.model_tester.prepare_config_and_inputs()
+        model = Blip2ForImageTextRetrieval(config).to(torch_device)
+        model.eval()
+        inputs = {"input_ids": input_ids, "attention_mask": attention_mask, "pixel_values": pixel_values}
+
+        with torch.no_grad():
+            outputs = model(**inputs)
+        self.assertIsNone(outputs.loss)
+
+        with torch.no_grad():
+            outputs_with_loss = model(**inputs, return_loss=True)
+        self.assertIsNotNone(outputs_with_loss.loss)
+        self.assertEqual(outputs_with_loss.loss.shape, torch.Size([]))
+        self.assertTrue(torch.isfinite(outputs_with_loss.loss))
+
+        # returned logits must be unscaled, i.e. identical whether or not the loss is computed
+        torch.testing.assert_close(outputs_with_loss.logits_per_image, outputs.logits_per_image)
+
+    def test_image_text_contrastive_loss_backward(self):
+        config, input_ids, attention_mask, pixel_values = self.model_tester.prepare_config_and_inputs()
+        model = Blip2ForImageTextRetrieval(config).to(torch_device)
+        model.train()
+
+        outputs = model(
+            input_ids=input_ids, attention_mask=attention_mask, pixel_values=pixel_values, return_loss=True
+        )
+        outputs.loss.backward()
+        self.assertIsNotNone(model.logit_scale.grad)
+
+    def test_return_loss_with_matching_head_raises(self):
+        config, input_ids, attention_mask, pixel_values = self.model_tester.prepare_config_and_inputs()
+        model = Blip2ForImageTextRetrieval(config).to(torch_device)
+        model.eval()
+
+        with self.assertRaises(ValueError):
+            model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                pixel_values=pixel_values,
+                use_image_text_matching_head=True,
+                return_loss=True,
+            )
+
     @unittest.skip(reason="Hidden_states is tested in individual model tests")
     def test_hidden_states_output(self):
         pass


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48583&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48583) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48583&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48583)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

`Blip2ForImageTextRetrieval` already computes ITC and ITM logits, but stops there — there's no loss path, so the class can't be used for training or fine-tuning. This adds the contrastive (ITC) half of that, as discussed in #34019.

Two things are needed for a usable ITC loss:

1. **A learnable temperature.** The original LAVIS checkpoints carry a `temp` parameter, but the conversion script drops it. `convert_blip_2_original_to_pytorch.py` L223 asserts it away as an unexpected key, so converted models have no temperature to scale similarities with. This PR adds `logit_scale` as a learnable parameter on the class, constant-initialised from a new `Blip2Config.logit_scale_init_value` (2.6592, matching CLIP). It does not read the LAVIS `temp` value; mapping that through conversion would be a reasonable follow-up.

2. **The loss itself.** A new `return_loss` argument on `forward` computes symmetric cross entropy over `logits_per_image` and `logits_per_text`, each scaled by `logit_scale.exp()`. The two directions are averaged and returned in `Blip2ImageTextMatchingModelOutput.loss` (and in the tuple path when `return_dict=False`).

**Backwards compatible.** `return_loss` defaults to `False`, and the returned logits stay unscaled either way, so existing inference behaviour is unchanged. There's a test for this.

**Scope.** ITC only. `return_loss=True` with `use_image_text_matching_head=True` raises a `ValueError` rather than silently doing the wrong thing. This is deliberately not the full QFormer pretraining recipe from #34019: no hard-negative ITM sampling, no ITG. @qgallouedec noted that's a training recipe rather than a `forward(labels=...)` addition. Partial progress on #34019.

## Test plan

New tests in `tests/models/blip_2/test_modeling_blip_2.py`:

- `loss` is `None` when `return_loss` is not passed
- `return_loss=True` gives a finite scalar loss
- logits are identical with and without the loss computation
- backward reaches `logit_scale.grad`
- ITM head + `return_loss=True` raises `ValueError`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. — #34019
- [x] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@qgallouedec — you offered to look at a scoped draft on this class in #34019.