### PR TITLE
Fix AttributeError in gradient_checkpointing_enable(offload=True)

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3108,7 +3108,9 @@ class PreTrainedModel(
             gradient_checkpointing_kwargs = {"use_reentrant": False}
 
         if offload:
-            device_type = torch.accelerator.current_accelerator().type
+            # `current_accelerator()` is None when no accelerator is available, in which case the
+            # activations already live on the host and there is nothing to copy off a device.
+            device_type = (torch.accelerator.current_accelerator() or torch.device("cpu")).type
 
             def checkpoint_func(function, *args, **kwargs):
                 with save_on_cpu(pin_memory=True, device_type=device_type):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48590&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48590) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48590&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48590)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`torch.accelerator.current_accelerator()` returns `None` when no accelerator is available, so `.type` raised `AttributeError: 'NoneType' object has no attribute 'type'` on CPU-only machines. Fall back to `torch.device("cpu")`, matching the idiom already used in `quantizers/quantizer_mxfp4.py`.