### PR TITLE
Test AMD PR CI

### DIFF
--- a/tests/models/vit/test_modeling_vit.py
+++ b/tests/models/vit/test_modeling_vit.py
@@ -229,6 +229,9 @@ class ViTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
+    def test_dummy_failing(self):
+        assert 1 == 2
+
     def test_for_masked_image_modeling(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_masked_image_modeling(*config_and_inputs)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48596&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48596) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48596&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48596)
<!-- ci-dashboard-badge:end -->

Dummy PR to verify AMD PR comment CI (`run-slow` trigger on AMD MI300 runners).

Contains a deliberately failing test (`test_dummy_failing` in `tests/models/vit/test_modeling_vit.py`) to confirm the CI picks it up.