### PR TITLE
Fix `generate_flags` parsing in `transformers chat`

### DIFF
--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -323,7 +323,7 @@ class Chat:
                 help=(
                     "Flags to pass to `generate`, using a space as a separator between flags. Accepts booleans, numbers, "
                     "and lists of integers, more advanced parameterization should be set through --generation-config. "
-                    "Example: `transformers chat <base_url> <model_id> max_new_tokens=100 do_sample=False eos_token_id=[1,2]`. "
+                    "Example: `transformers chat <model_id> <base_url> max_new_tokens=100 do_sample=False eos_token_id=[1,2]`. "
                     "If you're a new user, check this basic flag guide: "
                     "https://huggingface.co/docs/transformers/llm_tutorial#common-options"
                 )
@@ -608,10 +608,17 @@ def parse_generate_flags(generate_flags: list[str] | None) -> dict:
     if generate_flags is None or len(generate_flags) == 0:
         return {}
 
+    for flag in generate_flags:
+        if "=" not in flag:
+            raise typer.BadParameter(
+                f"Invalid flag format, missing `=` after `{flag}`. Please use the format "
+                "`arg_1=value_1 arg_2=value_2 ...`."
+            )
+
     # Assumption: `generate_flags` is a list of strings, each string being a `flag=value` pair, that can be parsed
     # into a json string if we:
     # 1. Add quotes around each flag name
-    generate_flags_as_dict = {'"' + flag.split("=")[0] + '"': flag.split("=")[1] for flag in generate_flags}
+    generate_flags_as_dict = {'"' + flag.split("=", 1)[0] + '"': flag.split("=", 1)[1] for flag in generate_flags}
 
     # 2. Handle types:
     # 2. a. booleans should be lowercase, None should be null
@@ -643,16 +650,13 @@ def parse_generate_flags(generate_flags: list[str] | None) -> dict:
     generate_flags_string = generate_flags_string.replace('"[', "[")
     generate_flags_string = generate_flags_string.replace(']"', "]")
 
-    # 6. Replace the `=` with `:`
-    generate_flags_string = generate_flags_string.replace("=", ":")
-
     try:
         processed_generate_flags = json.loads(generate_flags_string)
     except json.JSONDecodeError:
         raise ValueError(
             "Failed to convert `generate_flags` into a valid JSON object."
-            "\n`generate_flags` = {generate_flags}"
-            "\nConverted JSON string = {generate_flags_string}"
+            f"\n`generate_flags` = {generate_flags}"
+            f"\nConverted JSON string = {generate_flags_string}"
         )
     return processed_generate_flags
 

--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -608,12 +608,12 @@ def parse_generate_flags(generate_flags: list[str] | None) -> dict:
     if generate_flags is None or len(generate_flags) == 0:
         return {}
 
-    for flag in generate_flags:
-        if "=" not in flag:
-            raise typer.BadParameter(
-                f"Invalid flag format, missing `=` after `{flag}`. Please use the format "
-                "`arg_1=value_1 arg_2=value_2 ...`."
-            )
+    invalid_flags = [flag for flag in generate_flags if "=" not in flag]
+    if invalid_flags:
+        raise typer.BadParameter(
+            f"Invalid flag format, missing `=` after `{'`, `'.join(invalid_flags)}`. Please use the format "
+            "`arg_1=value_1 arg_2=value_2 ...`."
+        )
 
     # Assumption: `generate_flags` is a list of strings, each string being a `flag=value` pair, that can be parsed
     # into a json string if we:

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -15,6 +15,9 @@ import json
 import os
 import tempfile
 
+import pytest
+import typer
+
 from transformers.cli.chat import (
     get_service_root_url,
     new_chat_history,
@@ -49,6 +52,20 @@ def test_parse_generate_flags():
     parsed = parse_generate_flags(["temperature=0.5", "max_new_tokens=10"])
     assert parsed["temperature"] == 0.5
     assert parsed["max_new_tokens"] == 10
+
+
+def test_parse_generate_flags_value_with_equal_sign():
+    assert parse_generate_flags(["cache_implementation=a=b"]) == {"cache_implementation": "a=b"}
+
+
+def test_parse_generate_flags_missing_equal_sign():
+    with pytest.raises(typer.BadParameter, match="missing `=` after `do_sample`"):
+        parse_generate_flags(["do_sample"])
+
+
+def test_parse_generate_flags_invalid_json_error_message():
+    with pytest.raises(ValueError, match=r"Converted JSON string = \{\"stop_strings\": \[a\]\}"):
+        parse_generate_flags(["stop_strings=[a]"])
 
 
 def test_get_service_root_url():


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48597&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48597) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48597&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48597)
<!-- ci-dashboard-badge:end -->

# What does this PR do ? 

This PR fixes the bugs in `parse_generate_flags`, reported in #48588. We make sure that we parse `generate_flags` correctly: 
- a flag passed without = now fails with a clean CLI error instead of an IndexError
- a value containing = is no longer truncated at the first one

Fixes #48588