### PR TITLE
DO NOT MERGE: verify the quality gate lets tests run on a New model PR

### DIFF
--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -20,5 +20,9 @@ permissions:
 jobs:
   pr-ci:
     # DON'T use commit sha here before the CI migration is finished
-    uses: huggingface/transformers-ci/.github/workflows/pr-ci_dynamic_caller_example.yml@main # main
+    #
+    # TEMPORARY — DO NOT MERGE. Points at the branch under test so the quality-gate
+    # fix can be exercised on a real PR. Revert to `@main` before this branch is
+    # considered for anything.
+    uses: huggingface/transformers-ci/.github/workflows/pr-ci_dynamic_caller_example.yml@tarek/quality-gate-if-status-function
 

--- a/tests/utils/test_activations.py
+++ b/tests/utils/test_activations.py
@@ -24,6 +24,13 @@ if is_torch_available():
     from transformers.activations import gelu_new, gelu_python, get_activation
 
 
+# TEMPORARY — DO NOT MERGE. Two jobs at once: touching a test file gives
+# tests_fetcher a non-empty tests_non_model list, and the deliberate spacing below
+# is a `ruff format` violation, so check_code_quality fails. That is the exact
+# combination the quality gate is supposed to survive on a `New model` PR.
+_QUALITY_GATE_PROBE  =  True
+
+
 @require_torch
 class TestActivations(unittest.TestCase):
     def test_gelu_versions(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48600&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48600) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48600&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48600)
<!-- ci-dashboard-badge:end -->

Points pr-ci-caller at transformers-ci@tarek/quality-gate-if-status-function and adds a deliberate ruff format violation in a test file, so check_code_quality fails while tests_non_model has a non-empty list.