### PR TITLE
Improve lazy import error messages

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -2509,6 +2509,7 @@ class _LazyModule(ModuleType):
         return result
 
     def __getattr__(self, name: str) -> Any:
+        import_error_message = f"Could not import module '{name}'. Are this object's requirements defined correctly?"
         if name in self._objects:
             return self._objects[name]
         if name in self._object_missing_backend:
@@ -2637,28 +2638,19 @@ class _LazyModule(ModuleType):
                                             setattr(self, lookup_name, value)
                                         setattr(self, name, value)
                                         break
-                            except Exception as e:
-                                logger.debug(f"Could not create tokenizer alias: {e}")
+                            except Exception as alias_error:
+                                logger.debug(f"Could not create tokenizer alias: {alias_error}")
 
                         if value is None:
-                            raise ModuleNotFoundError(
-                                f"Could not import module '{name}'. Are this object's requirements defined correctly? "
-                                f"Original error: {e}"
-                            ) from e
+                            raise ModuleNotFoundError(f"{import_error_message} Original error: {e}") from e
                 else:
-                    raise ModuleNotFoundError(
-                        f"Could not import module '{name}'. Are this object's requirements defined correctly? "
-                        f"Original error: {e}"
-                    ) from e
+                    raise ModuleNotFoundError(f"{import_error_message} Original error: {e}") from e
 
         elif name in self._modules:
             try:
                 value = self._get_module(name)
             except (ModuleNotFoundError, RuntimeError) as e:
-                raise ModuleNotFoundError(
-                    f"Could not import module '{name}'. Are this object's requirements defined correctly? "
-                    f"Original error: {e}"
-                ) from e
+                raise ModuleNotFoundError(f"{import_error_message} Original error: {e}") from e
         else:
             # V5: If a *TokenizerFast symbol is requested but not present in the import structure,
             # try to resolve to the corresponding non-Fast symbol's module if available.

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -2630,11 +2630,13 @@ class _LazyModule(ModuleType):
 
                         if value is None:
                             raise ModuleNotFoundError(
-                                f"Could not import module '{name}'. Are this object's requirements defined correctly?"
+                                f"Could not import module '{name}'. Are this object's requirements defined correctly? "
+                                f"Original error: {e}"
                             ) from e
                 else:
                     raise ModuleNotFoundError(
-                        f"Could not import module '{name}'. Are this object's requirements defined correctly?"
+                        f"Could not import module '{name}'. Are this object's requirements defined correctly? "
+                        f"Original error: {e}"
                     ) from e
 
         elif name in self._modules:
@@ -2642,7 +2644,8 @@ class _LazyModule(ModuleType):
                 value = self._get_module(name)
             except (ModuleNotFoundError, RuntimeError) as e:
                 raise ModuleNotFoundError(
-                    f"Could not import module '{name}'. Are this object's requirements defined correctly?"
+                    f"Could not import module '{name}'. Are this object's requirements defined correctly? "
+                    f"Original error: {e}"
                 ) from e
         else:
             # V5: If a *TokenizerFast symbol is requested but not present in the import structure,

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -9,6 +9,7 @@ from parameterized import parameterized
 from transformers.testing_utils import require_torch, run_test_using_subprocess
 from transformers.utils.import_utils import (
     _is_package_available,
+    _LazyModule,
     clear_import_cache,
     is_flash_attn_2_available,
     is_flash_attn_3_available,
@@ -57,6 +58,25 @@ def test_is_package_available_edge_cases():
             patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
         ):
             assert _is_package_available(pkg_name, return_version=True) == expected
+
+
+def test_lazy_module_error_includes_original_error():
+    lazy_module = _LazyModule(
+        "transformers.test_lazy_module",
+        __file__,
+        {"broken_module": []},
+    )
+
+    original_error = RuntimeError("simulated broken dependency")
+
+    with patch.object(lazy_module, "_get_module", side_effect=original_error):
+        try:
+            lazy_module.broken_module
+        except ModuleNotFoundError as error:
+            assert "Could not import module 'broken_module'" in str(error)
+            assert "Original error: simulated broken dependency" in str(error)
+        else:
+            raise AssertionError("Expected ModuleNotFoundError")
 
 
 @contextmanager

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -65,16 +65,16 @@ def test_lazy_module_error_includes_original_error():
     lazy_module = _LazyModule(
         "transformers.test_lazy_module",
         __file__,
-        {"broken_module": []},
+        {"broken_module": ["BrokenObject"]},
     )
 
     original_error = RuntimeError("simulated broken dependency")
 
     with patch.object(lazy_module, "_get_module", side_effect=original_error):
         try:
-            lazy_module.broken_module
+            lazy_module.BrokenObject
         except ModuleNotFoundError as error:
-            assert "Could not import module 'broken_module'" in str(error)
+            assert "Could not import module 'BrokenObject'" in str(error)
             assert "Original error: simulated broken dependency" in str(error)
         else:
             raise AssertionError("Expected ModuleNotFoundError")


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48602&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48602) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48602&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48602)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Improves `_LazyModule` import errors by including the original exception message in the final `ModuleNotFoundError`.

This keeps the existing optional-dependency availability behavior unchanged, while making failures from broken or incompatible dependencies easier to diagnose.

For example, instead of only reporting:

```text
Could not import module 'AutoImageProcessor'. Are this object's requirements defined correctly?
```

the error now also includes the underlying import failure.

This follows the direction discussed in #48559: avoid adding runtime import probes to availability checks, but preserve the root cause when lazy imports fail.

## Tests

Added a focused regression test for `_LazyModule` that verifies the original exception is included in the user-visible error.

Local validation:

* focused regression test passes
* verified the regression test fails against the previous behavior
* `ruff check` passes for the modified test file
* `ruff format --check` passes for both modified files
* `py_compile` passes for `import_utils.py`
* `git diff --check` passes

The full `tests/utils/test_import_utils.py` suite was also attempted locally, but this environment does not have PyTorch installed, so PyTorch-dependent tests fail during execution.

Fixes/Refs #48559