### PR TITLE
Fix static cache per layer head shapes

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1845,6 +1845,27 @@ class DynamicCache(Cache):
             yield layer.keys, layer.values, getattr(layer, "_sliding_window_tensor", None)
 
 
+def get_head_shapes(config) -> tuple[int | list[int], int | list[int]]:
+    """Returns a tuple `(num_heads, head_dim)`, each of them either a single int for all layers, or a list of int with
+    the value for each layer."""
+    # Some models (e.g. Gemma4) have different head_dim and num_heads depending on layer type
+    per_layer_attributes = config.per_layer_attributes or ()
+    # Layers sharing kv states have no kv cache of their own, so they are excluded.
+    layers = range(config.num_hidden_layers - getattr(config, "num_kv_shared_layers", 0))
+
+    if "head_dim" in per_layer_attributes:
+        head_dim = [config.per_layer_config[layer].head_dim for layer in layers]
+    else:
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+
+    if "num_key_value_heads" in per_layer_attributes:
+        num_heads = [config.per_layer_config[layer].num_key_value_heads for layer in layers]
+    else:
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+
+    return num_heads, head_dim
+
+
 class StaticCache(Cache):
     """
     Static Cache class to be used with `torch.compile(model)` and `torch.export()`. It will check the `config`

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -33,6 +33,7 @@ from ..cache_utils import (
     EncoderDecoderCache,
     QuantizedCache,
     StaticCache,
+    get_head_shapes,
 )
 from ..distributed.fsdp import is_fsdp_managed_module
 from ..distributed.utils import _get_torch_distributed_world_size
@@ -1957,25 +1958,30 @@ class GenerationMixin(ContinuousMixin):
 
         return generation_config, model_kwargs
 
-    def _get_static_cache_init_shape(self: "GenerativePreTrainedModel") -> tuple[int, int] | None:
+    def _get_static_cache_init_shape(
+        self: "GenerativePreTrainedModel",
+    ) -> tuple[int | list[int], int | list[int]] | None:
         """
         Returns the per-rank `(num_heads, head_dim)` to eagerly initialize a `StaticCache`, with the head count sharded
-        for tensor parallelism. Returns `None` when the cache cannot be early initialized.
+        for tensor parallelism. Either of them is a list with a value per layer if the layers differ in it. Returns
+        `None` when the cache cannot be early initialized.
         """
         if hasattr(self, "hf_device_map") and len(set(self.hf_device_map.values())) > 1:
             # The model layers are on different devices
             return None
         text_config = self.config.get_text_config(decoder=True)
-        tp_size = getattr(self, "_tp_size", None) or 1
-        num_key_value_heads = getattr(text_config, "num_key_value_heads", None) or text_config.num_attention_heads
-        if num_key_value_heads % tp_size != 0:
-            # The model cannot be evenly sharded by head
-            return None
         if getattr(text_config, "qk_head_dim", None) is not None:
             # MLA models have distinct key (`qk_head_dim`) and value (`v_head_dim`) sizes.
             return None
-        head_dim = getattr(text_config, "head_dim", None) or text_config.hidden_size // text_config.num_attention_heads
-        return num_key_value_heads // tp_size, head_dim
+        num_heads, head_dim = get_head_shapes(text_config)
+        tp_size = getattr(self, "_tp_size", None) or 1
+        if tp_size > 1:
+            layer_heads = [num_heads] if isinstance(num_heads, int) else num_heads
+            if any(heads % tp_size for heads in layer_heads):
+                # The model cannot be evenly sharded by head
+                return None
+            num_heads = num_heads // tp_size if isinstance(num_heads, int) else [h // tp_size for h in layer_heads]
+        return num_heads, head_dim
 
     def _prepare_static_cache(
         self: "GenerativePreTrainedModel",

--- a/src/transformers/integrations/executorch.py
+++ b/src/transformers/integrations/executorch.py
@@ -23,6 +23,7 @@ from ..cache_utils import (
     StaticCache,
     StaticLayer,
     StaticSlidingWindowLayer,
+    get_head_shapes,
 )
 from ..generation.configuration_utils import GenerationConfig
 from ..modeling_utils import PreTrainedModel
@@ -442,27 +443,6 @@ class TorchExportableModuleForDecoderOnlyLM(torch.nn.Module):
 
         # Decode the generated text
         return tokenizer.decode(generated_ids[0], skip_special_tokens=True)
-
-
-def get_head_shapes(config) -> tuple[int | list[int], int | list[int]]:
-    """Returns a tuple `(num_heads, head_dim)` containing either 2 ints, or a list of int with the value for each
-    layer."""
-    # Some models (e.g. Gemma4) have different head_dim and num_heads depending on layer type
-    per_layer_attributes = config.per_layer_attributes or ()
-    # Layers sharing kv states have no kv cache of their own, so they are excluded.
-    layers = range(config.num_hidden_layers - getattr(config, "num_kv_shared_layers", 0))
-
-    if "head_dim" in per_layer_attributes:
-        head_dim = [config.per_layer_config[layer].head_dim for layer in layers]
-    else:
-        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
-
-    if "num_key_value_heads" in per_layer_attributes:
-        num_heads = [config.per_layer_config[layer].num_key_value_heads for layer in layers]
-    else:
-        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
-
-    return num_heads, head_dim
 
 
 class TorchExportableModuleWithStaticCache(torch.nn.Module):

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -50,6 +50,8 @@ if is_torch_available():
         Cache,
         DynamicCache,
         Gemma2Config,
+        Gemma4ForCausalLM,
+        Gemma4TextConfig,
         GenerationConfig,
         LlamaConfig,
         QuantizedCache,
@@ -67,6 +69,9 @@ if is_torch_available():
         StaticLayer,
     )
     from transformers.integrations.executorch import export_with_dynamic_cache, register_dynamic_cache_export_support
+    from transformers.integrations.heterogeneity.configuration_utils import (
+        AmbiguousGlobalPerLayerAttributeError,
+    )
 
 
 # FIXME: offloaded cache is skipped becase it needs `offload_only_non_sliding=False`
@@ -188,6 +193,44 @@ class CacheTest(unittest.TestCase):
         for layer_idx in attention_indices:
             keys, _ = cache.update(*_kv(1), layer_idx)
             self.assertEqual(keys.device.type, torch.device(torch_device).type)
+
+    def test_chunked_prefill_static_cache_per_layer_head_shapes(self):
+        """
+        Regression test for heterogeneous models with per-layer head shapes. The static cache is eagerly initialized
+        for a chunked prefill, and `generate` derives the head shapes of the static cache. Models such as Gemma4 use
+        a different `head_dim` depending on the layer, and reading a single global one raises on them, so the shapes
+        must be derived per layer.
+        """
+        config = Gemma4TextConfig(
+            hidden_size=32,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=8,
+            num_hidden_layers=4,
+            intermediate_size=64,
+            vocab_size=99,
+            layer_types=["sliding_attention", "full_attention", "sliding_attention", "full_attention"],
+            per_layer_config={1: {"head_dim": 16}, 3: {"head_dim": 16}},
+        )
+        # On such a config there is no global `head_dim` to read, not even a default one
+        with self.assertRaises(AmbiguousGlobalPerLayerAttributeError):
+            getattr(config.get_text_config(decoder=True), "head_dim", None)
+
+        model = Gemma4ForCausalLM(config).to(torch_device).eval()
+        inputs = torch.tensor([[1, 2, 3, 4]], device=torch_device)
+        out = model.generate(
+            inputs,
+            max_new_tokens=2,
+            do_sample=False,
+            cache_implementation="static",
+            prefill_chunk_size=2,
+            return_dict_in_generate=True,
+        )
+
+        # Each layer must be allocated with its own `head_dim`, instead of all of them sharing the global one
+        cache = out.past_key_values
+        self.assertIsInstance(cache, StaticCache)
+        self.assertEqual([layer.keys.shape[-1] for layer in cache.layers], [8, 16, 8, 16])
 
 
 def _skip_on_failed_cache_prerequisites(test, cache_implementation):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48619&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48619) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48619&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48619)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`cache_implementation="static"` together with `prefill_chunk_size` raises on any model whose layers have different head shapes like Gemma 4, because the static cache is initialized early and wrongly assumes all layers use the same head dim.

Fixes #48501

## Before submitting
- [X] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

@Cyrilvallez @vasqu @ArthurZucker