### PR TITLE
Fix Whisper beam_indices so compute_transition_scores does not select the beam twice

### DIFF
--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -1206,6 +1206,14 @@ class WhisperGenerationMixin(GenerationMixin):
         for key in seek_outputs[0]:
             if key in ["sequences", "beam_indices", "token_timestamps"]:
                 outputs[key] = torch.stack([v[key] for v in seek_outputs], dim=0).to(device)
+                if key == "beam_indices" and "scores" in seek_outputs[0]:
+                    # `split_by_batch_index` already gathered `scores` from the beam each step was generated on,
+                    # so the stacked scores hold one row per returned sequence instead of one row per beam. Point
+                    # `beam_indices` at those rows, otherwise `compute_transition_scores` selects the beam a second
+                    # time and gathers out of bounds. `-1` marks steps past the end of a sequence and is kept.
+                    beam_indices = outputs[key]
+                    rows = torch.arange(beam_indices.shape[0], device=device).unsqueeze(1).expand_as(beam_indices)
+                    outputs[key] = torch.where(beam_indices == -1, beam_indices, rows)
             elif key in ["scores", "encoder_attentions", "encoder_hidden_states", "logits"]:
                 outputs[key] = tuple(
                     torch.stack([v[key][i] for v in seek_outputs]).to(device) for i in range(len(seek_outputs[0][key]))

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -506,6 +506,34 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         self.assertEqual(output.beam_indices.shape[0], input_features.shape[0] * 3)
         self.assertEqual(output.sequences_scores.shape[0], input_features.shape[0] * 3)
 
+    def test_beam_search_transition_scores(self):
+        config, input_dict = self.model_tester.prepare_config_and_inputs()
+        model = WhisperForConditionalGeneration(config).to(torch_device).eval()
+
+        input_features = input_dict["input_features"]
+
+        output = model.generate(
+            input_features,
+            num_beams=3,
+            num_return_sequences=3,
+            return_dict_in_generate=True,
+            output_scores=True,
+            length_penalty=0.0,
+        )
+
+        transition_scores = model.compute_transition_scores(output.sequences, output.scores, output.beam_indices)
+
+        # `scores` are gathered from the beam each step was generated on, so every transition score has to come
+        # from the row of the sequence it belongs to
+        cut_idx = output.sequences.shape[-1] - transition_scores.shape[-1]
+        for seq_idx in range(output.sequences.shape[0]):
+            for step, token_id in enumerate(output.sequences[seq_idx, cut_idx:]):
+                if output.beam_indices[seq_idx, step] < 0:
+                    continue
+                self.assertEqual(transition_scores[seq_idx, step], output.scores[step][seq_idx, token_id])
+
+        torch.testing.assert_close(transition_scores.sum(dim=-1), output.sequences_scores, atol=1e-3, rtol=1e-3)
+
     @unittest.skip(reason="This module does not support standalone training")
     def test_training(self):
         pass

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -20,6 +20,7 @@ import re
 import tempfile
 import time
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -512,14 +513,26 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
 
         input_features = input_dict["input_features"]
 
-        output = model.generate(
-            input_features,
-            num_beams=3,
-            num_return_sequences=3,
-            return_dict_in_generate=True,
-            output_scores=True,
-            length_penalty=0.0,
-        )
+        ancestry = []
+        stack_split_outputs = model._stack_split_outputs
+
+        def capture_ancestry(seek_outputs, *args, **kwargs):
+            ancestry.extend(output["beam_indices"] for output in seek_outputs)
+            return stack_split_outputs(seek_outputs, *args, **kwargs)
+
+        with patch.object(model, "_stack_split_outputs", capture_ancestry):
+            output = model.generate(
+                input_features,
+                num_beams=3,
+                num_return_sequences=3,
+                return_dict_in_generate=True,
+                output_scores=True,
+                length_penalty=0.0,
+            )
+
+        # a run whose ancestry never leaves beam 0 gathers in bounds either way, so it would
+        # pass on unpatched code too
+        self.assertTrue(any((indices > 0).any() for indices in ancestry))
 
         transition_scores = model.compute_transition_scores(output.sequences, output.scores, output.beam_indices)
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48623&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48623) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48623&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48623)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48621.

`compute_transition_scores()` raises for Whisper with `num_beams > 1`:

```
RuntimeError: index 156073 is out of bounds for dimension 0 with size 51865
```

The beam axis is selected twice.

`_postprocess_outputs` already gathers `scores` from the beam each step was generated on ([added in #32336](https://github.com/huggingface/transformers/pull/32336), fixing #32246):

```python
if beam_indices is not None and key == "scores":
    return [v[beam_idx].cpu() for (v, beam_idx) in zip(values, beam_indices[batch_idx][: len(values)])]
```

So the stacked `scores[t]` hold one row per **returned sequence**, not one row per beam. The returned `beam_indices` still carried the beam ancestry, and `compute_transition_scores` multiplies it by `vocab_size` to index into the flattened scores — reaching rows that no longer exist.

It only raises when the winning beam's ancestry passes through a beam other than 0. Sequences that stayed on beam 0 gather `0 * vocab_size + token`, which is in range, and return plausible-looking but arbitrary scores. That is what made this look data-dependent.

## Fix

Point `beam_indices` at the rows of the `scores` that are actually returned, so the two outputs agree. `-1` is preserved, so steps past the end of a sequence are still masked by `compute_transition_scores`.

With this, the usual beam-search invariant holds again — `transition_scores.sum(-1)` reproduces `sequences_scores` exactly:

```
sum              tensor([-40.0329, -40.0329, -40.0329, -40.0325, -40.0325, -40.0325])
sequences_scores tensor([-40.0329, -40.0329, -40.0329, -40.0325, -40.0325, -40.0325])
```

The remap is guarded on `scores` being present, so `output_scores=False` still returns the raw ancestry.

## On the alternative

@vasqu noted on the issue that the general rule is to follow what core `generate` does. The other way to fix this is to stop gathering `scores` by beam in `_postprocess_outputs` and return the plain `(batch_size * num_beams, vocab_size)` rows that core beam search returns, which would make `beam_indices` correct as-is.

I did not go that way because it reverts the deliberate behaviour from #32336 and changes what `outputs.scores` means for every Whisper user since v4.45 — that felt like a call for maintainers rather than a drive-by fix. Happy to redo it that way if you prefer the core semantics.

## Tests

`tests/models/whisper/test_modeling_whisper.py::WhisperModelTest::test_beam_search_transition_scores` asserts that each transition score comes from the row of its own sequence, and that the scores sum back to `sequences_scores`. On `main` it fails with the reported `RuntimeError`.

`tests/models/whisper/test_modeling_whisper.py` passes: 370 passed, 346 skipped.

## Who can review?

@eustlb @vasqu (Whisper / generation)