### PR TITLE
[KimiLinear] Fix test_cpu_offload: set num_local_experts=4 in model tester

### DIFF
--- a/tests/models/kimi_linear/test_modeling_kimi_linear.py
+++ b/tests/models/kimi_linear/test_modeling_kimi_linear.py
@@ -69,6 +69,7 @@ class KimiLinearModelTester(CausalLMModelTester):
         self.v_head_dim = 32
         # MoE
         self.moe_intermediate_size = 16
+        self.num_local_experts = 4
         self.n_routed_experts = 8
         self.n_shared_experts = 1
         self.num_experts_per_tok = 2

--- a/tests/models/kimi_linear/test_modeling_kimi_linear.py
+++ b/tests/models/kimi_linear/test_modeling_kimi_linear.py
@@ -73,7 +73,6 @@ class KimiLinearModelTester(CausalLMModelTester):
         # dominates ~94% of model size, making accelerate unable to split it across GPU/CPU in
         # test_cpu_offload (infer_auto_device_map puts everything on CPU → no dispatch → no hf_device_map).
         self.num_local_experts = 4
-        self.n_routed_experts = 8
         self.n_shared_experts = 1
         self.num_experts_per_tok = 2
         self.n_group = 1

--- a/tests/models/kimi_linear/test_modeling_kimi_linear.py
+++ b/tests/models/kimi_linear/test_modeling_kimi_linear.py
@@ -69,6 +69,9 @@ class KimiLinearModelTester(CausalLMModelTester):
         self.v_head_dim = 32
         # MoE
         self.moe_intermediate_size = 16
+        # Must override the config default (256) with a small value: with 256 experts the MoE layer
+        # dominates ~94% of model size, making accelerate unable to split it across GPU/CPU in
+        # test_cpu_offload (infer_auto_device_map puts everything on CPU → no dispatch → no hf_device_map).
         self.num_local_experts = 4
         self.n_routed_experts = 8
         self.n_shared_experts = 1


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48624&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48624) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48624&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48624)
<!-- ci-dashboard-badge:end -->

## Summary

**Root cause**: `KimiLinearConfig` defaults to `num_local_experts=256`. The model tester only set `self.n_routed_experts=8`, which is the wrong attribute name (`KimiLinearConfig` uses `num_local_experts`, not `n_routed_experts`) and was silently ignored. As a general rule, model testers should not rely on large default config values — they must explicitly override them with small values suitable for unit tests.

With 256 experts, `layers.1` (the MoE decoder layer) accounts for ~94% of total model size. Since `_no_split_modules=["KimiLinearDecoderLayer"]` makes it atomic, `infer_auto_device_map` cannot fit it within any reasonable GPU budget fraction — it puts everything on CPU (single device). `dispatch_model` is then never called, `hf_device_map` is never set, and `test_cpu_offload` raises `AttributeError: 'KimiLinearModel' object has no attribute 'hf_device_map'`.

**Fix**:
- Set `self.num_local_experts = 4` in the model tester so the config receives a small expert count, making the MoE layer a proportionate fraction of the model and allowing accelerate to correctly split it across GPU and CPU
- Remove the dead `self.n_routed_experts = 8` attribute which had no effect on the config

## Test plan
- [x] `KimiLinearModelTest::test_cpu_offload` passes
- [x] Full `KimiLinearModelTest` suite: 148 passed, 147 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)