### PR TITLE
[fix] Remove vision-encoder-decoder from MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -416,7 +416,6 @@ MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS: set[str] = {
     "cohere_asr",
     "camembertv2-base",
     "smolvlm",
-    "vision-encoder-decoder",
 }
 
 for model_type in MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48628&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48628) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48628&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48628)
<!-- ci-dashboard-badge:end -->

## What broke

PR #46091 added `"vision-encoder-decoder"` to `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS`. A loop in `tokenization_auto.py` then injected `"vision-encoder-decoder" → TokenizersBackend` into `TOKENIZER_MAPPING_NAMES` (for any model type in that set not already registered). This caused `AutoTokenizer.from_pretrained` to route all `VisionEncoderDecoder` checkpoints through `TokenizersBackend`, which fails with:

```
ValueError: Couldn't instantiate the backend tokenizer from one of:
```

for checkpoints like `microsoft/trocr-base-printed` / `microsoft/trocr-base-handwritten`, because those use an `XLMRobertaTokenizer` (slow tokenizer only — no `tokenizer.json`).

## Why the fix is safe

`MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS` is designed for specific model types (e.g. `qwen2`, `phi3`) where the Hub `tokenizer_class` field is stale and the tokenizer.json works fine with `TokenizersBackend`. `"vision-encoder-decoder"` is a meta model type covering many heterogeneous architectures (TrOCR, Donut, …) — each checkpoint uses its own decoder's tokenizer, none of them have a universally wrong Hub class. Removing it restores the previous behaviour of trusting the Hub `tokenizer_class` for these models.

## Tests

```
TrOCRModelIntegrationTest::test_inference_handwritten  PASSED
TrOCRModelIntegrationTest::test_inference_printed      PASSED
```

Fixes the regression introduced by #46091.

## Note on CI failures

Please ignore the 2 failing `NougatModelIntegrationTest` tests. They were already failing on `main` with the same tokenizer error (same root cause as TrOCR — all `VisionEncoderDecoder` models were routed to `TokenizersBackend`). After this PR fixes the tokenizer issue, those tests now get past tokenizer loading but fail on a separate pre-existing problem: a 404 when downloading the `nougat_pdf.png` test fixture from the Hub. This artifact issue will be fixed in a follow-up PR (#48637).