### PR TITLE
fix: check GPU architecture before enabling GQA in SDPA on CUDA

### DIFF
--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -29,10 +29,17 @@ def use_gqa_in_sdpa(attention_mask: torch.Tensor | None, key: torch.Tensor, valu
     # 1.cuda or Ascend NPU
     #   - attention_mask is None (otherwise it will fall back to the math kernel)
     #   - key head_dim == value head_dim <= 256 (otherwise it will fall back to the math kernel)
+    #   - On CUDA: GPU must be sm80+ (FlashAttention). On pre-sm80 GPUs
+    #     (e.g. sm75/T4), enabling GQA removes the EFFICIENT_ATTENTION candidate,
+    #     leaving only the slow MATH backend (up to 28% slower decode).
     # 2.xpu
     #   - torch version >= 2.8
     if _is_torch_xpu_available:
         return _is_torch_greater_or_equal_than_2_8
+    if torch.cuda.is_available():
+        major, _ = torch.cuda.get_device_capability()
+        if major < 8:
+            return False
     return attention_mask is None and key.shape[-1] == value.shape[-1] <= 256
 
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -3046,6 +3046,35 @@ class TestAttentionImplementation(unittest.TestCase):
             )
         self.assertTrue("the package for FlashAttention2 doesn't seem to be installed." in str(cm.exception))
 
+    def test_use_gqa_in_sdpa_pre_sm80_gpu_returns_false(self):
+        """On pre-sm80 GPUs (e.g. T4/sm75), GQA should be disabled because the
+        FlashAttention kernel is unavailable and enabling GQA removes the
+        EFFICIENT_ATTENTION candidate, leaving only the slow MATH backend.
+
+        See: https://github.com/huggingface/transformers/issues/48633
+        """
+        from transformers.integrations.sdpa_attention import use_gqa_in_sdpa
+
+        key = torch.randn(1, 2, 16, 128)
+        value = torch.randn(1, 2, 16, 128)
+
+        with patch.object(torch.cuda, "is_available", return_value=True), patch.object(
+            torch.cuda, "get_device_capability", return_value=(7, 5)
+        ):
+            self.assertFalse(use_gqa_in_sdpa(None, key, value))
+
+    def test_use_gqa_in_sdpa_sm80_gpu_allows_gqa(self):
+        """On sm80+ GPUs, GQA should still be enabled per existing conditions."""
+        from transformers.integrations.sdpa_attention import use_gqa_in_sdpa
+
+        key = torch.randn(1, 2, 16, 128)
+        value = torch.randn(1, 2, 16, 128)
+
+        with patch.object(torch.cuda, "is_available", return_value=True), patch.object(
+            torch.cuda, "get_device_capability", return_value=(8, 0)
+        ):
+            self.assertTrue(use_gqa_in_sdpa(None, key, value))
+    
     @parameterized.expand(
         [
             # (key head_dim, value head_dim, use_mask, GQA kept, expected backend): GQA is kept only for matched


### PR DESCRIPTION
## Problem
On pre-sm80 GPUs (e.g. T4/sm75), FlashAttention is unavailable. When `use_gqa_in_sdpa()` returns `True`, it removes the `EFFICIENT_ATTENTION` candidate because the key/value head counts no longer match what the efficient kernel expects. With FlashAttention also unavailable, the only remaining backend is the slow `MATH` kernel, causing up to **28% slower decode** on T4.

## Fix
Check CUDA compute capability in `use_gqa_in_sdpa()`. On pre-sm80 GPUs, return `False` so the `EFFICIENT_ATTENTION` path is preserved.

## Testing
- Added `test_use_gqa_in_sdpa_pre_sm80_gpu_returns_false` — verifies GQA disabled on sm75
- Added `test_use_gqa_in_sdpa_sm80_gpu_allows_gqa` — verifies GQA still works on sm80+

Fixes #48633