### PR TITLE
[fix] Update stale golden values and fix expected_logits shape in FlavaForPreTraining integration tests

### DIFF
--- a/tests/models/flava/test_modeling_flava.py
+++ b/tests/models/flava/test_modeling_flava.py
@@ -1168,9 +1168,9 @@ class FlavaForPreTrainingIntegrationTest(unittest.TestCase):
 
         expected_logits = torch.tensor([[16.1291, 8.4033], [16.1291, 8.4033]], device=torch_device)
         torch.testing.assert_close(outputs.contrastive_logits_per_image, expected_logits, rtol=1e-3, atol=1e-3)
-        self.assertAlmostEqual(outputs.loss_info.mmm_text.item(), 2.0727925, places=4)
-        self.assertAlmostEqual(outputs.loss_info.mmm_image.item(), 7.0282096, places=4)
-        self.assertAlmostEqual(outputs.loss.item(), 11.3792324, places=4)
+        self.assertAlmostEqual(outputs.loss_info.mmm_text.item(), 2.0732639, places=4)
+        self.assertAlmostEqual(outputs.loss_info.mmm_image.item(), 7.0149107, places=4)
+        self.assertAlmostEqual(outputs.loss.item(), 11.3664246, places=4)
 
     @slow
     def test_inference_with_itm_labels(self):
@@ -1217,8 +1217,8 @@ class FlavaForPreTrainingIntegrationTest(unittest.TestCase):
             torch.Size((torch.count_nonzero(inputs["itm_labels"]).item(), inputs.pixel_values.shape[0])),
         )
 
-        expected_logits = torch.tensor([[16.1291, 8.4033], [16.1291, 8.4033]], device=torch_device)
+        expected_logits = torch.tensor([[16.1291, 8.4033]], device=torch_device)
         torch.testing.assert_close(outputs.contrastive_logits_per_image, expected_logits, rtol=1e-3, atol=1e-3)
-        self.assertAlmostEqual(outputs.loss_info.mmm_text.item(), 2.0727925, places=4)
-        self.assertAlmostEqual(outputs.loss_info.mmm_image.item(), 6.8965902, places=4)
-        self.assertAlmostEqual(outputs.loss.item(), 9.6084213, places=4)
+        self.assertAlmostEqual(outputs.loss_info.mmm_text.item(), 2.0732639, places=4)
+        self.assertAlmostEqual(outputs.loss_info.mmm_image.item(), 6.8857641, places=4)
+        self.assertAlmostEqual(outputs.loss.item(), 9.5979137, places=4)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48639&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48639) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48639&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48639)
<!-- ci-dashboard-badge:end -->

## What

Fixes two `FlavaForPreTrainingIntegrationTest` tests that have been failing since 2025-01-25 (when PR #35659 replaced `torch.allclose` with `torch.testing.assert_close`).

### `test_inference`
- Stale golden values for `mmm_text`, `mmm_image`, and `loss` — small numerical drift from accumulated env changes (torch/CUDA updates)

### `test_inference_with_itm_labels`
- **Root cause**: `expected_logits` had shape `[2, 2]` but the model correctly returns shape `[1, 2]` when `itm_labels=[1, 0]` (only 1 positive pair → only 1 row in contrastive logits). The shape assertion on the line above already correctly expected `(1, 2)`, making the test internally inconsistent.
- **Why it passed before**: `torch.allclose` silently broadcasts — `[1, 2]` expanded to match `[2, 2]` where both rows were identical, so it returned `True`. `torch.testing.assert_close` does strict shape checking and caught the mismatch.
- **Fix**: remove the duplicate row from `expected_logits` (`[[a, b], [a, b]]` → `[[a, b]]`), consistent with the shape assertion above it. Also update stale loss golden values.

## Test

Both tests now pass on the CI runner.