### PR TITLE
Fix deepspeed ci

### DIFF
--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -1,22 +1,46 @@
-# https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-24-08.html
-FROM nvcr.io/nvidia/pytorch:24.08-py3
+# Plain CUDA base, like `transformers-all-latest-gpu`, but deliberately held on CUDA 12.x rather
+# than following that image to 13.0.
+#
+# DeepSpeed pre-compiles its CUDA ops here, and `op_builder/builder.py` picks the architectures to
+# cross-compile for in `get_default_compute_capabilities()`, which only has branches for CUDA 11 and
+# CUDA 12. On CUDA 13 neither matches, so the list stays at the `DEFAULT_COMPUTE_CAPABILITIES` of
+# `6.0;6.1;7.0` -- every one of which CUDA 13 dropped -- and the build dies on
+# `nvcc fatal: Unsupported gpu architecture 'compute_60'`. This is still the case on DeepSpeed
+# master and in the latest release (0.19.6).
+#
+# So: bump this to a CUDA 13 base and `cu130` torch once DeepSpeed knows about CUDA 13, and keep the
+# toolkit here matching `$CUDA` in the meantime -- `assert_no_cuda_mismatch()` compares them exactly
+# and refuses to compile when they differ.
+FROM nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
 LABEL maintainer="Hugging Face"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PYTORCH='2.8.0'
+# Torch version is kept in sync with `transformers-all-latest-gpu`; `CUDA` is not, see above.
+ARG PYTORCH='2.13.0'
 # Example: `cu102`, `cu113`, etc.
 ARG CUDA='cu126'
 
-RUN apt -y update
-RUN apt install -y libaio-dev
+RUN apt update
+# On top of what the general test image installs: `libaio-dev` for DeepSpeed's async I/O, and
+# `python-is-python3` because DeepSpeed's `zero_to_fp32.py` is executed directly and its shebang is
+# `#!/usr/bin/env python`, which Ubuntu does not provide (the previous `nvcr.io` base image did).
+RUN apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3 python3-pip ffmpeg git-lfs libaio-dev python-is-python3
+RUN git lfs install
 RUN python3 -m pip install --no-cache-dir --upgrade pip
+
+# The DeepSpeed CI job passes `working-directory-prefix: /workspace` and so expects the clone at
+# `/workspace/transformers`. The previous `nvcr.io` base image set this as its `WORKDIR`, the plain
+# CUDA one does not.
+WORKDIR /workspace
 
 ARG REF=main
 RUN git clone https://github.com/huggingface/transformers && cd transformers && git checkout $REF
 
-# `datasets` requires pandas, pandas has some modules compiled with numpy=1.x causing errors
-RUN python3 -m pip install --no-cache-dir './transformers[deepspeed-testing]' 'pandas<2' 'numpy<2'
+# `sklearn` on top of `deepspeed-testing`: the model zoo tests drive the example scripts, which
+# compute metrics with scikit-learn (and scipy, which it pulls in). `transformers-all-latest-gpu`
+# gets these through `[dev]`, and the previous `nvcr.io` base image happened to preinstall them.
+RUN python3 -m pip install --no-cache-dir './transformers[deepspeed-testing,sklearn]'
 
 # Install latest release PyTorch
 # (PyTorch must be installed before pre-compiling any DeepSpeed c++/cuda ops.)
@@ -25,23 +49,10 @@ RUN python3 -m pip uninstall -y torch torchvision torchaudio torchcodec && pytho
 
 RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/accelerate@main#egg=accelerate
 
-# Uninstall `transformer-engine` shipped with the base image
-RUN python3 -m pip uninstall -y transformer-engine
-
-# Uninstall `torch-tensorrt` shipped with the base image
-RUN python3 -m pip uninstall -y torch-tensorrt
-
-# Uninstall outdated `nvtx` (0.2.5 from /rapids/) shipped with the base image:
-# DeepSpeed calls `nvtx.get_domain` (added in 0.2.12) and will crash otherwise.
-# DeepSpeed falls back to `torch.cuda.nvtx` when the standalone package is absent.
-RUN python3 -m pip uninstall -y nvtx
-
-# recompile apex
-RUN python3 -m pip uninstall -y apex
-# RUN git clone https://github.com/NVIDIA/apex
-#  `MAX_JOBS=1` disables parallel building to avoid cpu memory OOM when building image on GitHub Action (standard) runners
-# TODO: check if there is alternative way to install latest apex
-# RUN cd apex && MAX_JOBS=1 python3 -m pip install --global-option="--cpp_ext" --global-option="--cuda_ext" --no-cache -v --disable-pip-version-check .
+# Narrow DeepSpeed's cross-compile list to the architectures the CI runners actually use, instead of
+# the `6.0;6.1;7.0;8.0;8.6;9.0` default -- the old entries are dead weight in the op build, which is
+# repeated inside every GPU VM. `TORCH_CUDA_ARCH_LIST` takes priority over the default list.
+ENV TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0"
 
 # Pre-build **latest** DeepSpeed, so it would be ready for testing (otherwise, the 1st deepspeed test will timeout)
 RUN python3 -m pip uninstall -y deepspeed
@@ -57,6 +68,4 @@ RUN python3 -m pip uninstall -y kernels
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop
 
-# The base image ships with `pydantic==1.8.2` which is not working - i.e. the next command fails
-RUN python3 -m pip install -U --no-cache-dir "pydantic>=2.0.0"
 RUN python3 -c "from deepspeed.launcher.runner import main"

--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -244,9 +244,11 @@ class HfTrainerDeepSpeedConfig(HfDeepSpeedConfig):
             num_training_steps,
             "num_training_steps (calculated)",
         )
+        # `deepspeed>=0.19.6` rejects a non-positive `warmup_num_steps`, while older versions silently
+        # clamped it to 2. Keep the auto-filled value positive so that no-warmup runs still work.
         self.fill_match(
             "scheduler.params.warmup_num_steps",
-            args.get_warmup_steps(num_training_steps),
+            max(1, args.get_warmup_steps(num_training_steps)),
             "warmup_steps",
         )
 

--- a/tests/trainer/distributed/scripts/train.py
+++ b/tests/trainer/distributed/scripts/train.py
@@ -42,6 +42,27 @@ DTYPE_MAP = {"fp32": torch.float32, "bf16": torch.bfloat16, "fp16": torch.float1
 PADDING_CHOICES = ("max_length", "do_not_pad")
 
 
+class DataCollatorWithPositionIds:
+    """Wrap a collator so every batch carries `position_ids`.
+
+    DeepSpeed's Ulysses sequence parallelism requires them, because a token has to keep its global
+    position once the sequence is sharded across ranks (see `deepspeed/runtime/sequence_parallel/
+    ulysses_sp.py`). These samples are not packed, so a plain `arange` per sample is the correct
+    value -- and it is also what the model derives internally when `position_ids` is not passed, so
+    adding it does not change the non-SP runs this test compares against.
+    """
+
+    def __init__(self, inner):
+        self.inner = inner
+
+    def __call__(self, features):
+        batch = self.inner(features)
+        if "position_ids" not in batch:
+            batch_size, seq_len = batch["input_ids"].shape
+            batch["position_ids"] = torch.arange(seq_len).expand(batch_size, seq_len).clone()
+        return batch
+
+
 def _pop_custom_arg(name):
     """Pop a custom --name value arg from sys.argv before HfArgumentParser sees it."""
     if name in sys.argv:
@@ -120,7 +141,9 @@ def main():
         args=training_args,
         train_dataset=train_dataset,
         eval_dataset=eval_dataset,
-        data_collator=DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False, **collator_kwargs),
+        data_collator=DataCollatorWithPositionIds(
+            DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False, **collator_kwargs)
+        ),
     )
 
     if training_args.do_train:

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -223,6 +223,7 @@ class TrainerGradientAccumulationTest(TestCasePlus, TrainerIntegrationCommon):
         gas_batch_size,
         gas_steps,
         loss_tolerance,
+        grad_norm_tolerance=0.1,
         model_accepts_loss_kwargs=True,
         compute_loss_func=None,
         label_smoothing_factor=0.0,
@@ -267,7 +268,10 @@ class TrainerGradientAccumulationTest(TestCasePlus, TrainerIntegrationCommon):
         for step, (base_gn, gas_gn) in enumerate(zip(base_grad_norms, gas_grad_norms)):
             ratio = gas_gn / base_gn if base_gn > 0 else float("inf")
             self.assertAlmostEqual(
-                ratio, 1.0, delta=0.1, msg=f"Step {step}: grad_norm ratio {ratio:.2f} — GAS leak suspected"
+                ratio,
+                1.0,
+                delta=grad_norm_tolerance,
+                msg=f"Step {step}: grad_norm ratio {ratio:.2f} — GAS leak suspected",
             )
         loss_diff = [abs(b - g) for b, g in zip(base_callback.losses, gas_callback.losses)]
         self.assertLess(max(loss_diff), loss_tolerance, f"Loss difference {max(loss_diff)} exceeds {loss_tolerance}")
@@ -288,13 +292,17 @@ class TrainerGradientAccumulationTest(TestCasePlus, TrainerIntegrationCommon):
         itself. Grad norms and losses must still match between a large-batch
         baseline and an equivalent GAS run.
         """
-        # Looser tolerance: without num_items_in_batch each micro-batch is independently
-        # mean-reduced, so losses won't match as tightly.
+        # Looser tolerances: without num_items_in_batch each micro-batch is independently
+        # mean-reduced over its own valid label count, so regrouping the same samples into
+        # smaller micro-batches shifts both the loss and the grad norm. `DataParallel` splits
+        # every micro-batch again across replicas, which regroups them more finely still and
+        # pushes the grad norm ratio to ~1.11. A real GAS leak shows a ratio near `gas_steps`.
         self._check_gradient_accumulation(
             base_batch_size=8,
             gas_batch_size=4,
             gas_steps=2,
             loss_tolerance=0.1,
+            grad_norm_tolerance=0.2,
             model_accepts_loss_kwargs=False,
         )
 

--- a/tests/trainer/test_trainer_checkpointing.py
+++ b/tests/trainer/test_trainer_checkpointing.py
@@ -61,7 +61,9 @@ from transformers.testing_utils import (
     backend_device_count,
     evaluate_side_effect_factory,
     get_steps_per_epoch,
+    get_torch_dist_unique_port,
     is_staging_test,
+    mockenv_context,
     require_accelerate,
     require_deepspeed,
     require_non_hpu,
@@ -690,8 +692,18 @@ class TrainerAutoBatchSizeTest(TestCasePlus, TrainerIntegrationCommon):
             auto_find_batch_size=True,
             deepspeed=deepspeed,
         )
-        trainer = Trainer(model, args, train_dataset=train_dataset, callbacks=[MockCudaOOMCallback()])
-        trainer.train()
+        # DeepSpeed refuses to initialize without a rank in the environment, and this test runs
+        # in-process rather than under `accelerate launch`, so stand in for the launcher.
+        dist_env_1_gpu = {
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": str(get_torch_dist_unique_port()),
+            "RANK": "0",
+            "LOCAL_RANK": "0",
+            "WORLD_SIZE": "1",
+        }
+        with mockenv_context(**dist_env_1_gpu):
+            trainer = Trainer(model, args, train_dataset=train_dataset, callbacks=[MockCudaOOMCallback()])
+            trainer.train()
         self.assertEqual(trainer._train_batch_size, 14)
 
     def test_auto_batch_size_with_resume_from_checkpoint(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48640&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48640) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48640&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48640)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This PR fixes the deepseed Ci tests that have been broken for a while due to the dockerfile. Also we fix some training tests.