### PR TITLE
fix incorrect hub tokenizer class

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -394,6 +394,7 @@ MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS: set[str] = {
     "minicpmv",
     "minimax_m2",
     "modernbert",
+    "modernbert-decoder",
     "molmo",
     "molmo2",
     "nemotron",
@@ -411,7 +412,6 @@ MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS: set[str] = {
     "cohere_asr",
     "camembertv2-base",
     "smolvlm",
-    "vision-encoder-decoder",
 }
 
 for model_type in MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS:
@@ -427,6 +427,7 @@ MODEL_IDS_TO_TOKENIZERS_BACKEND = [
     "deepseek-ai/deepseek-coder-*",
     "allenai/dolma2-tokenizer",
     "google/umt5-small",
+    "naver-clova-ix/donut-*",
     "salesforce/blip2-opt-*",
     "salesforce/blip2-flan-t5-*",
     "salesforce/instructblip-flan-t5-*",

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -1035,8 +1035,8 @@ class NopConfig(PreTrainedConfig):
         tokenizer_auto = AutoTokenizer.from_pretrained(repo_id)
         tokenizer_tok = TokenizersBackend.from_pretrained(repo_id)
 
-        auto_ids = tokenizer_auto.encode(TOKENIZERS_BACKEND_AUTO_MAPPING_SHARED_TEXT)
-        tok_ids = tokenizer_tok.encode(TOKENIZERS_BACKEND_AUTO_MAPPING_SHARED_TEXT)
+        auto_ids = tokenizer_auto.encode(TOKENIZERS_BACKEND_AUTO_MAPPING_SHARED_TEXT, add_special_tokens=False)
+        tok_ids = tokenizer_tok.encode(TOKENIZERS_BACKEND_AUTO_MAPPING_SHARED_TEXT, add_special_tokens=False)
 
         self.assertEqual(auto_ids, tok_ids)
         self.assertEqual(

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -1020,6 +1020,7 @@ class NopConfig(PreTrainedConfig):
         "google/rembert",
         "facebook/xglm-564M",
         "xlnet/xlnet-base-cased",
+        "allenai/OLMo-7B-hf",
     ]
 
     @slow
@@ -1051,6 +1052,7 @@ class NopConfig(PreTrainedConfig):
         "allenai/OLMo-2-0425-1B",
         "stabilityai/tiny-random-stablelm-2",
         "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+        "naver-clova-ix/donut-base-finetuned-docvqa",
     ]
 
     @slow


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48641&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48641) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48641&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48641)
<!-- ci-dashboard-badge:end -->

fixes:  https://github.com/huggingface/transformers/pull/48628 , https://github.com/huggingface/transformers/pull/48535

see v5 migration guide --> in v5 if a checkpoint on the hub maps to a specific tokenizer class, **then we load that specific tokenizer class** . we did not enforce this in v4. if a model starts tokenizing differently in v5, then the hub checkpoint always mapped to an incorrect class (that we never enforced in v4!) so we put it in the list of shame in `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS` (for all models using this `model_type`) or `MODEL_IDS_TO_TOKENIZERS_BACKEND` (to use a specific checkpoint). Alternatively, you can open a PR on the 🤗 Hub to fix the `tokenizer_class` mapping in `tokenization_config.json`

please see https://github.com/huggingface/transformers/pull/44255 for the repots, may need to go back a couple commits to see the removed .html files)