### PR TITLE
Fallback for unsupported grouped_mm tensor layouts

### DIFF
--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -257,6 +257,19 @@ if is_torch_available():
     )
 
 
+def _has_valid_grouped_mm_strides(tensor: torch.Tensor) -> bool:
+    """Return whether the last two tensor dimensions satisfy grouped_mm's 16-byte stride requirements."""
+    strides = tensor.stride()
+    sizes = tensor.size()
+    alignment = 16 // tensor.element_size()
+
+    if strides[-2] == 1 and strides[-1] >= max(1, sizes[-2]):
+        return strides[-1] % alignment == 0
+    if strides[-1] == 1 and strides[-2] >= max(1, sizes[-1]):
+        return strides[-2] % alignment == 0
+    return False
+
+
 def _can_use_grouped_mm(input: torch.Tensor, weight: torch.Tensor, offs: torch.Tensor) -> bool:
     """
     Check if torch.nn.functional.grouped_mm or torch._grouped_mm can be used based on availability and compatibility with torch.compile.
@@ -271,6 +284,9 @@ def _can_use_grouped_mm(input: torch.Tensor, weight: torch.Tensor, offs: torch.T
     Returns:
         `bool`: True if grouped_mm can be used, False otherwise.
     """
+    if not _has_valid_grouped_mm_strides(input) or not _has_valid_grouped_mm_strides(weight):
+        return False
+
     # accept_dev=True is necessary for "+cpu"/"+xpu" etc.
     if (
         (is_torchdynamo_compiling() and weight.dtype != torch.bfloat16)

--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -257,22 +257,14 @@ if is_torch_available():
     )
 
 
-def _has_valid_grouped_mm_strides(tensor: torch.Tensor) -> bool:
-    """Return whether the last two tensor dimensions satisfy grouped_mm's 16-byte stride requirements."""
-    strides = tensor.stride()
-    sizes = tensor.size()
+def _has_valid_grouped_mm_layout(tensor: torch.Tensor) -> bool:
+    """Check grouped_mm's 16-byte stride and non-CPU pointer alignment requirements."""
+    strides, sizes = tensor.stride(), tensor.size()
     alignment = 16 // tensor.element_size()
-
-    if strides[-2] == 1 and strides[-1] >= max(1, sizes[-2]):
-        return strides[-1] % alignment == 0
-    if strides[-1] == 1 and strides[-2] >= max(1, sizes[-1]):
-        return strides[-2] % alignment == 0
-    return False
-
-
-def _has_valid_grouped_mm_data_ptr(tensor: torch.Tensor) -> bool:
-    """Return whether grouped_mm accepts the tensor's storage start address."""
-    return tensor.device.type == "cpu" or tensor.data_ptr() % 16 == 0
+    stride_ok = (strides[-2] == 1 and strides[-1] >= max(1, sizes[-2]) and strides[-1] % alignment == 0) or (
+        strides[-1] == 1 and strides[-2] >= max(1, sizes[-1]) and strides[-2] % alignment == 0
+    )
+    return stride_ok and (tensor.device.type == "cpu" or tensor.data_ptr() % 16 == 0)
 
 
 def _can_use_grouped_mm(input: torch.Tensor, weight: torch.Tensor, offs: torch.Tensor) -> bool:
@@ -289,12 +281,7 @@ def _can_use_grouped_mm(input: torch.Tensor, weight: torch.Tensor, offs: torch.T
     Returns:
         `bool`: True if grouped_mm can be used, False otherwise.
     """
-    if (
-        not _has_valid_grouped_mm_strides(input)
-        or not _has_valid_grouped_mm_strides(weight)
-        or not _has_valid_grouped_mm_data_ptr(input)
-        or not _has_valid_grouped_mm_data_ptr(weight)
-    ):
+    if not all(_has_valid_grouped_mm_layout(tensor) for tensor in (input, weight)):
         return False
 
     # accept_dev=True is necessary for "+cpu"/"+xpu" etc.

--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -270,6 +270,11 @@ def _has_valid_grouped_mm_strides(tensor: torch.Tensor) -> bool:
     return False
 
 
+def _has_valid_grouped_mm_data_ptr(tensor: torch.Tensor) -> bool:
+    """Return whether grouped_mm accepts the tensor's storage start address."""
+    return tensor.device.type == "cpu" or tensor.data_ptr() % 16 == 0
+
+
 def _can_use_grouped_mm(input: torch.Tensor, weight: torch.Tensor, offs: torch.Tensor) -> bool:
     """
     Check if torch.nn.functional.grouped_mm or torch._grouped_mm can be used based on availability and compatibility with torch.compile.
@@ -284,7 +289,12 @@ def _can_use_grouped_mm(input: torch.Tensor, weight: torch.Tensor, offs: torch.T
     Returns:
         `bool`: True if grouped_mm can be used, False otherwise.
     """
-    if not _has_valid_grouped_mm_strides(input) or not _has_valid_grouped_mm_strides(weight):
+    if (
+        not _has_valid_grouped_mm_strides(input)
+        or not _has_valid_grouped_mm_strides(weight)
+        or not _has_valid_grouped_mm_data_ptr(input)
+        or not _has_valid_grouped_mm_data_ptr(weight)
+    ):
         return False
 
     # accept_dev=True is necessary for "+cpu"/"+xpu" etc.

--- a/tests/integrations/test_moe.py
+++ b/tests/integrations/test_moe.py
@@ -1,0 +1,50 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+
+from transformers.integrations.moe import _can_use_grouped_mm, _grouped_mm, _has_valid_grouped_mm_strides
+from transformers.testing_utils import require_torch
+
+
+@require_torch
+class GroupedMmCompatibilityTest(unittest.TestCase):
+    def test_rejects_unaligned_transposed_weight_stride(self):
+        inputs = torch.empty(8, 1025, dtype=torch.bfloat16)
+        weights = torch.empty(4, 512, 1025, dtype=torch.bfloat16).transpose(-2, -1)
+        offsets = torch.tensor([2, 4, 6, 8], dtype=torch.int32)
+
+        self.assertFalse(_has_valid_grouped_mm_strides(weights))
+        self.assertFalse(_can_use_grouped_mm(inputs, weights, offsets))
+
+    def test_accepts_aligned_transposed_weight_stride(self):
+        weights = torch.empty(4, 512, 1024, dtype=torch.bfloat16).transpose(-2, -1)
+
+        self.assertTrue(_has_valid_grouped_mm_strides(weights))
+
+    def test_unaligned_stride_uses_fallback(self):
+        inputs = torch.randn(4, 5)
+        weights = torch.randn(2, 4, 5).transpose(-2, -1)
+        offsets = torch.tensor([2, 4], dtype=torch.int32)
+
+        result = _grouped_mm(inputs, weights, offsets)
+        expected = torch.cat([inputs[:2] @ weights[0], inputs[2:] @ weights[1]])
+
+        torch.testing.assert_close(result, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integrations/test_moe.py
+++ b/tests/integrations/test_moe.py
@@ -16,19 +16,12 @@ import unittest
 
 import torch
 
-from transformers.integrations.moe import _can_use_grouped_mm, _grouped_mm, _has_valid_grouped_mm_layout
+from transformers.integrations.moe import _can_use_grouped_mm, _grouped_mm
 from transformers.testing_utils import require_torch, require_torch_accelerator, torch_device
 
 
 @require_torch
 class GroupedMmCompatibilityTest(unittest.TestCase):
-    def test_stride_alignment(self):
-        aligned = torch.empty(4, 512, 1024, dtype=torch.bfloat16).transpose(-2, -1)
-        unaligned = torch.empty(4, 512, 1025, dtype=torch.bfloat16).transpose(-2, -1)
-
-        self.assertTrue(_has_valid_grouped_mm_layout(aligned))
-        self.assertFalse(_has_valid_grouped_mm_layout(unaligned))
-
     @require_torch_accelerator
     def test_misaligned_weight_data_ptr_uses_fallback(self):
         inputs = torch.randn(8, 16, dtype=torch.bfloat16, device=torch_device)

--- a/tests/integrations/test_moe.py
+++ b/tests/integrations/test_moe.py
@@ -16,8 +16,13 @@ import unittest
 
 import torch
 
-from transformers.integrations.moe import _can_use_grouped_mm, _grouped_mm, _has_valid_grouped_mm_strides
-from transformers.testing_utils import require_torch
+from transformers.integrations.moe import (
+    _can_use_grouped_mm,
+    _grouped_mm,
+    _has_valid_grouped_mm_data_ptr,
+    _has_valid_grouped_mm_strides,
+)
+from transformers.testing_utils import require_torch, require_torch_accelerator, torch_device
 
 
 @require_torch
@@ -34,6 +39,22 @@ class GroupedMmCompatibilityTest(unittest.TestCase):
         weights = torch.empty(4, 512, 1024, dtype=torch.bfloat16).transpose(-2, -1)
 
         self.assertTrue(_has_valid_grouped_mm_strides(weights))
+
+    @require_torch_accelerator
+    def test_misaligned_weight_data_ptr_uses_fallback(self):
+        inputs = torch.randn(8, 16, dtype=torch.bfloat16, device=torch_device)
+        weight_storage = torch.randn(4 * 16 * 16 + 1, dtype=torch.bfloat16, device=torch_device)
+        weights = weight_storage[1:].view(4, 16, 16)
+        offsets = torch.tensor([2, 4, 6, 8], dtype=torch.int32, device=torch_device)
+
+        self.assertEqual(weights.stride(), (256, 16, 1))
+        self.assertNotEqual(weights.data_ptr() % 16, 0)
+        self.assertFalse(_has_valid_grouped_mm_data_ptr(weights))
+        self.assertFalse(_can_use_grouped_mm(inputs, weights, offsets))
+
+        result = _grouped_mm(inputs, weights, offsets)
+        expected = torch.cat([inputs[i * 2 : (i + 1) * 2] @ weights[i] for i in range(4)])
+        torch.testing.assert_close(result, expected)
 
     def test_unaligned_stride_uses_fallback(self):
         inputs = torch.randn(4, 5)

--- a/tests/integrations/test_moe.py
+++ b/tests/integrations/test_moe.py
@@ -16,29 +16,18 @@ import unittest
 
 import torch
 
-from transformers.integrations.moe import (
-    _can_use_grouped_mm,
-    _grouped_mm,
-    _has_valid_grouped_mm_data_ptr,
-    _has_valid_grouped_mm_strides,
-)
+from transformers.integrations.moe import _can_use_grouped_mm, _grouped_mm, _has_valid_grouped_mm_layout
 from transformers.testing_utils import require_torch, require_torch_accelerator, torch_device
 
 
 @require_torch
 class GroupedMmCompatibilityTest(unittest.TestCase):
-    def test_rejects_unaligned_transposed_weight_stride(self):
-        inputs = torch.empty(8, 1025, dtype=torch.bfloat16)
-        weights = torch.empty(4, 512, 1025, dtype=torch.bfloat16).transpose(-2, -1)
-        offsets = torch.tensor([2, 4, 6, 8], dtype=torch.int32)
+    def test_stride_alignment(self):
+        aligned = torch.empty(4, 512, 1024, dtype=torch.bfloat16).transpose(-2, -1)
+        unaligned = torch.empty(4, 512, 1025, dtype=torch.bfloat16).transpose(-2, -1)
 
-        self.assertFalse(_has_valid_grouped_mm_strides(weights))
-        self.assertFalse(_can_use_grouped_mm(inputs, weights, offsets))
-
-    def test_accepts_aligned_transposed_weight_stride(self):
-        weights = torch.empty(4, 512, 1024, dtype=torch.bfloat16).transpose(-2, -1)
-
-        self.assertTrue(_has_valid_grouped_mm_strides(weights))
+        self.assertTrue(_has_valid_grouped_mm_layout(aligned))
+        self.assertFalse(_has_valid_grouped_mm_layout(unaligned))
 
     @require_torch_accelerator
     def test_misaligned_weight_data_ptr_uses_fallback(self):
@@ -49,7 +38,6 @@ class GroupedMmCompatibilityTest(unittest.TestCase):
 
         self.assertEqual(weights.stride(), (256, 16, 1))
         self.assertNotEqual(weights.data_ptr() % 16, 0)
-        self.assertFalse(_has_valid_grouped_mm_data_ptr(weights))
         self.assertFalse(_can_use_grouped_mm(inputs, weights, offsets))
 
         result = _grouped_mm(inputs, weights, offsets)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48645&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48645) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48645&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48645)
<!-- ci-dashboard-badge:end -->

## Summary

This PR narrows the implementation changes to the concrete MoE `grouped_mm` runtime compatibility issue in #48644, preventing dispatch for tensor layouts that the optimized kernel cannot accept.

## Changes

- reject input/weight layouts whose matrix strides do not satisfy the kernel's 16-byte alignment requirement
- reject non-CPU tensors whose `data_ptr()` is not 16-byte aligned
- use the existing grouped-mm fallback for unsupported layouts
- add focused regression tests for aligned and unaligned strides, fallback correctness, and misaligned accelerator storage offsets

## Related issues

Closes #48101
Closes #48169
Closes #48643
Closes #48644
Closes #48648
Closes #48659