### PR TITLE
[fix] Update stale expected strings in HunYuanVL integration tests

### DIFF
--- a/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
+++ b/tests/models/hunyuan_vl/test_modeling_hunyuan_vl.py
@@ -445,7 +445,7 @@ class HunYuanVLForConditionalGenerationIntegrationTest(unittest.TestCase):
 
         expected_texts = Expectations(
             {
-                ("cuda", None): "The image is a radar chart that compares the performance of four different models or methods across various benchmarks. The chart is labeled with the names of the benchmarks on the axes, and each model is represented by a different colored line. The models are labeled as BLIP-2, InstructBLIP, Qwen-VL",
+                ("cuda", None): "To determine what is shown in the image, we analyze the visual elements:  \n\n1. **Chart Type**: A radar chart (also called a spider chart) is used to compare multiple quantitative metrics across different categories.  \n2. **Axes & Categories**: The chart has 12 axes, each representing a different",
                 ("xpu", 5): "To determine what is shown in the image, we analyze the visual elements:  \n\n1. **Chart Type**: A radar chart (also called a spider chart) is used to compare multiple datasets.  \n2. **Axes and Data**: The chart has 12 axes, each representing a dataset: *VQ",
             }
         )  # fmt: skip
@@ -464,8 +464,8 @@ class HunYuanVLForConditionalGenerationIntegrationTest(unittest.TestCase):
         expected_texts = Expectations(
             {
                 ("cuda", None): [
-                    "The image is a radar chart that compares the performance of four different models or methods across various benchmarks. The chart is labeled with the names of the benchmarks on the axes, and each model is represented by a different colored line. The models are labeled as BLIP-2, InstructBLIP, Qwen-VL",
-                    "To determine the animal on the candy, observe the image: there are two candies—one teal and one orange. The teal candy has a black silhouette of a bird (a type of bird in the family **passerina**). The orange candy also has a black silhouette of a bird, but",
+                    "To determine what is shown in the image, we analyze the context of the radar chart. A radar chart is a graphical representation of multivariate data, where each axis represents a different variable (here, different models or tasks).  \n\nIn the image, the axes are labeled with model names (e.g., VQAv",
+                    "To determine the animal on the candy, observe the image: there are two green candies with black designs. The animal in the green candies is a **turtle** (a type of reptile with a shell and a tail).",
                 ],
                 ("xpu", 5): [
                     "To determine what is shown in the image, we analyze the context of the radar chart. A radar chart is a graphical representation of multivariate data, where each axis represents a different variable (here, different models or tasks).  \n\nIn the image, the axes are labeled with model names (e.g., VQAv",
@@ -483,7 +483,7 @@ class HunYuanVLForConditionalGenerationIntegrationTest(unittest.TestCase):
 
         expected_texts = Expectations(
             {
-                ("cuda", None): "To determine the answer, we analyze the radar chart:  \n\n1. **First image**: The first image shows a hand with multiple colored candy beads. The top - most bead is teal, and the second bead from the top is green. The third bead from the top is orange. The fourth bead from the",
+                ("cuda", None): "To determine the answers, let’s analyze the radar chart:  \n\n1. **First Image**: The first image shows a radar chart with multiple colored candy beads. The first candy bead is a **green** one. The animal on this green bead is a **turtle** (a small aquatic creature with a",
                 ("xpu", 5): "To determine the answers, let’s analyze the radar chart:  \n\n1. **First Image**: The first image shows a radar chart with multiple colored candy beads. The first candy bead is a **green** one. The animal on this green bead is a **turtle** (a small aquatic creature with a",
             }
         )  # fmt: skip
@@ -503,9 +503,9 @@ class HunYuanVLForConditionalGenerationIntegrationTest(unittest.TestCase):
         expected_texts = Expectations(
             {
                 ("cuda", None): [
-                    "OCR (Optical Character Recognition) is a computer technology that uses **Optical Character Recognition (OCR)** to extract text from images or documents. It is a powerful tool for automating tasks like text extraction, image analysis, and document processing.\n\n### Brief Explanation:\n1. **Purpose**: OCR is used to recognize and extract",
-                    "To determine the answer, we analyze the radar chart:  \n\n1. **First image**: The first image shows a hand with multiple colored candy beads. The top - most bead is teal, and the second bead from the top is green. The third bead from the top is orange. The fourth bead from the",
-                    "The image is a radar chart that compares the performance of four different models or methods across various benchmarks. The chart is labeled with the names of the benchmarks on the axes, and each model is represented by a different colored line. The models are labeled as BLIP-2, InstructBLIP, Qwen-VL",
+                    "It is a software tool that allows you to extract text from a document.",
+                    "To determine the answers, let’s analyze the radar chart:  \n\n1. **First Image**: The first image shows a radar chart with multiple colored candy beads. The first candy bead is a **green** one. The animal on this green bead is a **turtle** (a small aquatic creature with a",
+                    "To determine what is shown in the image, we analyze the visual elements:  \n\n1. **Chart Type**: A radar chart (also called a spider chart) is used to compare multiple datasets.  \n2. **Axes and Data**: The chart has 12 axes, each representing a dataset: *VQ",
                 ],
                 ("xpu", 5): [
                     "It is a software tool that allows you to extract text from a document.",
@@ -530,8 +530,8 @@ class HunYuanVLForConditionalGenerationIntegrationTest(unittest.TestCase):
         expected_texts = Expectations(
             {
                 ("cuda", None): [
-                    "STEALTH CAM 07:59 AM 09/01/15 69 F FRONT CBN",
-                    "To determine the animal on the candy, observe the image: there are two candies—one teal and one orange. The teal candy has a black silhouette of a bird (a type of bird in the family **passerina**). The orange candy also has a black silhouette of a bird, but",
+                    "STEALTH CAM\n07:59 AM 09/01/15 69 F \nFRONT CBN",
+                    "To determine the animal on the candy, observe the image: there are two green candies with black designs. The animal in the green candies is a **turtle** (a type of reptile with a shell and a tail).",
                 ],
                 ("xpu", 5): [
                     "STEALTH CAM\n07:59 AM 09/01/15 69 F \nFRONT CBN",
@@ -554,8 +554,8 @@ class HunYuanVLForConditionalGenerationIntegrationTest(unittest.TestCase):
         expected_texts_batch = Expectations(
             {
                 ("cuda", None): [
-                    "STEALTH CAM 07:59 AM 09/01/15 69 F FRONT CBN",
-                    "To determine the animal on the candy, observe the image: there are two candies—one teal and one orange. The teal candy has a black silhouette of a bird (a type of bird in the family **passerina**). The orange candy also has a black silhouette of a bird, but",
+                    "STEALTH CAM\n07:59 AM 09/01/15 69 F \nFRONT CBN",
+                    "To determine the animal on the candy, observe the image: there are two green candies with black designs. The animal in the green candies is a **turtle** (a type of reptile with a shell and a tail).",
                 ],
                 ("xpu", 5): [
                     "STEALTH CAM\n07:59 AM 09/01/15 69 F \nFRONT CBN",
@@ -565,7 +565,7 @@ class HunYuanVLForConditionalGenerationIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_texts_single = Expectations(
             {
-                ("cuda", None): "STEALTH CAM 07:59 AM 09/01/15 69 F FRONT CBN",
+                ("cuda", None): "STEALTH CAM\n07:59 AM 09/01/15 69 F \nFRONT CBN",
                 ("xpu", 5): "STEALTH CAM\n07:59 AM 09/01/15 69 F \nFRONT CBN",
             }
         )  # fmt: skip


### PR DESCRIPTION
## Summary

All 6 `HunYuanVLForConditionalGenerationIntegrationTest` integration tests were failing due to stale golden strings. This PR updates the expected outputs for the `("cuda", None)` device across all test cases, verified on a single-GPU runner.

## Root Cause

**`tencent/HunyuanOCR` was upgraded from v1.0 to v1.5 on 2026-07-06** (HF Hub commit `01b3ec86`: *"Add HunyuanOCR-1.5 (target at root, DFlash under dflash/, archive 1.0 under v1.0/)"*). The new v1.5 weights replaced the root of the repo, while v1.0 was archived under `v1.0/`. This is a **model-side change**, not a transformers regression.

To confirm, we checked out the two commits surrounding the first failure (`b70d02fc` = last-good, `5204b4fe` = first-failure) and ran the model on both. Both produced identical outputs to current main — the transformers code never changed anything affecting HunYuanVL. The commit that landed between those two (`5204b4fe`: *"fix mask return-type contract regression"*) only touched `masking_utils.py`, `deepseek_v32`, and `glm_moe_dsa` — nothing related to HunYuanVL.

## CI History

Tests first broke on **2026-07-06** (4 tests) and **2026-07-07** (2 more), with **59 consecutive failures** by the time this PR was written. The CI system flagged `bad_commit: null` (flaky) — consistent with a model-side update rather than a code regression. The error timeline:

| Date | Error type |
|---|---|
| 2026-07-05 | Last pass (HunyuanOCR v1.0) |
| 2026-07-06 | `AssertionError`: stale expected strings (HunyuanOCR v1.5 pushed to Hub) |
| 2026-07-07 | `OSError`: `tencent/HunyuanOCR` temporarily unavailable on HF Hub |
| 2026-07-08 | Back to `AssertionError` (persistent, unfixed) |
| 2026-07-17 | `PIL.UnidentifiedImageError`: external `4.img-dpreview.com` URL returned an invalid image |
| 2026-07-18+ | Back to `AssertionError` (59 consecutive failures) |

## Why not PR #47606?

[PR #47606](https://github.com/huggingface/transformers/pull/47606) (opened 2026-07-28 by serge) was the right action at the time — it correctly identified and updated stale expected strings. However it only fixed **2 of the 6 failing tests** with 2 line changes, and left the other 4 untouched. Furthermore, the values it wrote in late July had already drifted again by September (the model outputs on the current Hub are different from what serge measured), so even those 2 tests would still fail today with that patch. This PR fixes all 6 tests from a fresh run against the current HunyuanOCR v1.5 weights.

## Changes

- `test_small_model_integration_test`: updated radar chart description
- `test_small_model_integration_test_batch`: updated radar + candy strings
- `test_small_model_integration_test_batch_different_resolutions`: fixed STEALTH CAM format (spaces → `\n`) and candy/turtle description
- `test_small_model_integration_test_batch_matches_single`: same STEALTH CAM + candy fixes
- `test_small_model_integration_test_multi_image`: updated combined radar+candy string; fixed curly apostrophe U+2019 (`let's` → `let\u2019s`)
- `test_small_model_integration_test_multi_image_nested`: fixed nested[1] apostrophe + nested[2] standalone radar text

All 6 tests verified passing on a single-GPU runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)