### PR TITLE
Validate DeepSeek-V3 grouped router topology

### DIFF
--- a/src/transformers/models/axk1/configuration_axk1.py
+++ b/src/transformers/models/axk1/configuration_axk1.py
@@ -121,5 +121,37 @@ class AXK1Config(PreTrainedConfig):
         self.head_dim = self.qk_rope_head_dim
         super().__post_init__(**kwargs)
 
+    def validate_architecture(self):
+        super().validate_architecture()
+
+        n_routed_experts = getattr(self, "n_routed_experts", None)
+        if n_routed_experts is None:
+            return
+
+        n_group = getattr(self, "n_group", None)
+        topk_group = getattr(self, "topk_group", None)
+        num_experts_per_tok = getattr(self, "num_experts_per_tok", None)
+        if n_group is None or n_group <= 0:
+            raise ValueError(f"`n_group` must be a positive integer, got {n_group}.")
+        if topk_group is None or topk_group <= 0:
+            raise ValueError(f"`topk_group` must be a positive integer, got {topk_group}.")
+        if n_routed_experts % n_group != 0:
+            raise ValueError(f"`n_routed_experts` ({n_routed_experts}) must be divisible by `n_group` ({n_group}).")
+        experts_per_group = n_routed_experts // n_group
+        if experts_per_group < 2:
+            raise ValueError(
+                f"DeepSeek-V3 grouped routing requires at least 2 routed experts per group, got {experts_per_group}."
+            )
+        if topk_group > n_group:
+            raise ValueError(f"`topk_group` ({topk_group}) cannot exceed `n_group` ({n_group}).")
+        routing_capacity = topk_group * experts_per_group
+        if num_experts_per_tok is None or num_experts_per_tok <= 0:
+            raise ValueError(f"`num_experts_per_tok` must be a positive integer, got {num_experts_per_tok}.")
+        if num_experts_per_tok > routing_capacity:
+            raise ValueError(
+                f"`num_experts_per_tok` ({num_experts_per_tok}) cannot exceed the {routing_capacity} experts "
+                "available in the selected expert groups."
+            )
+
 
 __all__ = ["AXK1Config"]

--- a/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
@@ -124,5 +124,37 @@ class DeepseekV3Config(PreTrainedConfig):
         self.head_dim = self.qk_rope_head_dim
         super().__post_init__(**kwargs)
 
+    def validate_architecture(self):
+        super().validate_architecture()
+
+        n_routed_experts = getattr(self, "n_routed_experts", None)
+        if n_routed_experts is None:
+            return
+
+        n_group = getattr(self, "n_group", None)
+        topk_group = getattr(self, "topk_group", None)
+        num_experts_per_tok = getattr(self, "num_experts_per_tok", None)
+        if n_group is None or n_group <= 0:
+            raise ValueError(f"`n_group` must be a positive integer, got {n_group}.")
+        if topk_group is None or topk_group <= 0:
+            raise ValueError(f"`topk_group` must be a positive integer, got {topk_group}.")
+        if n_routed_experts % n_group != 0:
+            raise ValueError(f"`n_routed_experts` ({n_routed_experts}) must be divisible by `n_group` ({n_group}).")
+        experts_per_group = n_routed_experts // n_group
+        if experts_per_group < 2:
+            raise ValueError(
+                f"DeepSeek-V3 grouped routing requires at least 2 routed experts per group, got {experts_per_group}."
+            )
+        if topk_group > n_group:
+            raise ValueError(f"`topk_group` ({topk_group}) cannot exceed `n_group` ({n_group}).")
+        routing_capacity = topk_group * experts_per_group
+        if num_experts_per_tok is None or num_experts_per_tok <= 0:
+            raise ValueError(f"`num_experts_per_tok` must be a positive integer, got {num_experts_per_tok}.")
+        if num_experts_per_tok > routing_capacity:
+            raise ValueError(
+                f"`num_experts_per_tok` ({num_experts_per_tok}) cannot exceed the {routing_capacity} experts "
+                "available in the selected expert groups."
+            )
+
 
 __all__ = ["DeepseekV3Config"]

--- a/src/transformers/models/kimi_linear/configuration_kimi_linear.py
+++ b/src/transformers/models/kimi_linear/configuration_kimi_linear.py
@@ -146,5 +146,37 @@ class KimiLinearConfig(PreTrainedConfig):
                 "dense" if i < first_k_dense_replace else "sparse" for i in range(self.num_hidden_layers)
             ]
 
+    def validate_architecture(self):
+        super().validate_architecture()
+
+        n_routed_experts = getattr(self, "n_routed_experts", None)
+        if n_routed_experts is None:
+            return
+
+        n_group = getattr(self, "n_group", None)
+        topk_group = getattr(self, "topk_group", None)
+        num_experts_per_tok = getattr(self, "num_experts_per_tok", None)
+        if n_group is None or n_group <= 0:
+            raise ValueError(f"`n_group` must be a positive integer, got {n_group}.")
+        if topk_group is None or topk_group <= 0:
+            raise ValueError(f"`topk_group` must be a positive integer, got {topk_group}.")
+        if n_routed_experts % n_group != 0:
+            raise ValueError(f"`n_routed_experts` ({n_routed_experts}) must be divisible by `n_group` ({n_group}).")
+        experts_per_group = n_routed_experts // n_group
+        if experts_per_group < 2:
+            raise ValueError(
+                f"DeepSeek-V3 grouped routing requires at least 2 routed experts per group, got {experts_per_group}."
+            )
+        if topk_group > n_group:
+            raise ValueError(f"`topk_group` ({topk_group}) cannot exceed `n_group` ({n_group}).")
+        routing_capacity = topk_group * experts_per_group
+        if num_experts_per_tok is None or num_experts_per_tok <= 0:
+            raise ValueError(f"`num_experts_per_tok` must be a positive integer, got {num_experts_per_tok}.")
+        if num_experts_per_tok > routing_capacity:
+            raise ValueError(
+                f"`num_experts_per_tok` ({num_experts_per_tok}) cannot exceed the {routing_capacity} experts "
+                "available in the selected expert groups."
+            )
+
 
 __all__ = ["KimiLinearConfig"]

--- a/src/transformers/models/youtu/configuration_youtu.py
+++ b/src/transformers/models/youtu/configuration_youtu.py
@@ -109,5 +109,37 @@ class YoutuConfig(PreTrainedConfig):
         self.head_dim = self.qk_rope_head_dim
         super().__post_init__(**kwargs)
 
+    def validate_architecture(self):
+        super().validate_architecture()
+
+        n_routed_experts = getattr(self, "n_routed_experts", None)
+        if n_routed_experts is None:
+            return
+
+        n_group = getattr(self, "n_group", None)
+        topk_group = getattr(self, "topk_group", None)
+        num_experts_per_tok = getattr(self, "num_experts_per_tok", None)
+        if n_group is None or n_group <= 0:
+            raise ValueError(f"`n_group` must be a positive integer, got {n_group}.")
+        if topk_group is None or topk_group <= 0:
+            raise ValueError(f"`topk_group` must be a positive integer, got {topk_group}.")
+        if n_routed_experts % n_group != 0:
+            raise ValueError(f"`n_routed_experts` ({n_routed_experts}) must be divisible by `n_group` ({n_group}).")
+        experts_per_group = n_routed_experts // n_group
+        if experts_per_group < 2:
+            raise ValueError(
+                f"DeepSeek-V3 grouped routing requires at least 2 routed experts per group, got {experts_per_group}."
+            )
+        if topk_group > n_group:
+            raise ValueError(f"`topk_group` ({topk_group}) cannot exceed `n_group` ({n_group}).")
+        routing_capacity = topk_group * experts_per_group
+        if num_experts_per_tok is None or num_experts_per_tok <= 0:
+            raise ValueError(f"`num_experts_per_tok` must be a positive integer, got {num_experts_per_tok}.")
+        if num_experts_per_tok > routing_capacity:
+            raise ValueError(
+                f"`num_experts_per_tok` ({num_experts_per_tok}) cannot exceed the {routing_capacity} experts "
+                "available in the selected expert groups."
+            )
+
 
 __all__ = ["YoutuConfig"]

--- a/tests/models/deepseek_v3/test_configuration_deepseek_v3.py
+++ b/tests/models/deepseek_v3/test_configuration_deepseek_v3.py
@@ -1,0 +1,38 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from huggingface_hub.errors import StrictDataclassClassValidationError
+
+from transformers import DeepseekV3Config
+
+
+class DeepseekV3ConfigValidationTest(unittest.TestCase):
+    def test_rejects_invalid_group_topology(self):
+        with self.assertRaisesRegex(StrictDataclassClassValidationError, "at least 2 routed experts per group"):
+            DeepseekV3Config(n_routed_experts=8, n_group=8, topk_group=1, num_experts_per_tok=2)
+
+        with self.assertRaisesRegex(StrictDataclassClassValidationError, "must be divisible by"):
+            DeepseekV3Config(n_routed_experts=10, n_group=4, topk_group=1, num_experts_per_tok=2)
+
+    def test_rejects_routing_topk_beyond_selected_group_capacity(self):
+        with self.assertRaisesRegex(StrictDataclassClassValidationError, "cannot exceed the 2 experts available"):
+            DeepseekV3Config(n_routed_experts=8, n_group=4, topk_group=1, num_experts_per_tok=5)
+
+        DeepseekV3Config(n_routed_experts=8, n_group=4, topk_group=1, num_experts_per_tok=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
+++ b/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
@@ -75,7 +75,7 @@ class DeepseekV3ModelTester:
         v_head_dim=32,
         qk_nope_head_dim=32,
         n_group=2,
-        topk_group=1,
+        topk_group=2,
         num_experts_per_tok=8,
         first_k_dense_replace=1,
         norm_topk_prob=True,

--- a/tests/models/kimi_k25/test_modeling_kimi_k25.py
+++ b/tests/models/kimi_k25/test_modeling_kimi_k25.py
@@ -81,7 +81,7 @@ class Kimi_K25VisionText2TextModelTester(VLMModelTester):
         # `first_k_dense_replace` enables MoEs after `layer=0`
         kwargs.setdefault("first_k_dense_replace", 1)
         kwargs.setdefault("n_group", 2)
-        kwargs.setdefault("topk_group", 1)
+        kwargs.setdefault("topk_group", 2)
         kwargs.setdefault("num_experts_per_tok", 8)
         kwargs.setdefault("n_shared_experts", 1)
         kwargs.setdefault("n_routed_experts", 8)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48649&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48649) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48649&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48649)
<!-- ci-dashboard-badge:end -->

## Summary

Draft/WIP fix for #48647.

`DeepseekV3MoE.route_tokens_to_experts()` assumes a structurally valid grouped-routing topology, but `DeepseekV3Config` previously accepted configurations that could either crash in `topk()` or reshape router scores across token rows.

This change validates the router invariants before model construction:

- `n_group` and `topk_group` must be positive
- `n_routed_experts` must be divisible by `n_group`
- each group must contain at least two experts because group scoring uses `topk(2)`
- `topk_group` cannot exceed `n_group`
- `num_experts_per_tok` cannot exceed the expert capacity of the selected groups

The tiny DeepSeek-V3 and Kimi-K2.5 (DeepSeek-V3-backbone) test configurations are adjusted to satisfy the same routing-capacity invariant, and focused regression tests cover the invalid topologies reported in #48647.

## Validation

- focused configuration regression tests: 2 passed
- Python compile checks
- `git diff --check`
