### PR TITLE
[fix] Fix GlmOcr integration tests: wrong token IDs and image token decode bug

### DIFF
--- a/tests/models/glm_ocr/test_modeling_glm_ocr.py
+++ b/tests/models/glm_ocr/test_modeling_glm_ocr.py
@@ -481,9 +481,11 @@ class GlmOcrIntegrationTest(unittest.TestCase):
         torch.manual_seed(42)
 
         output = model.generate(**inputs, max_new_tokens=30)
-        EXPECTED_DECODED_TEXT = "This is a Pallas cat, a small wild cat native to the mountainous regions of Central Asia."
+        EXPECTED_DECODED_TEXT = (
+            "This is a Pallas cat, a small wild cat native to the mountainous regions of Central Asia."
+        )
         self.assertEqual(
-            self.processor.decode(output[0][inputs.input_ids.shape[1]:], skip_special_tokens=True),
+            self.processor.decode(output[0][inputs.input_ids.shape[1] :], skip_special_tokens=True),
             EXPECTED_DECODED_TEXT,
         )
 
@@ -506,7 +508,7 @@ class GlmOcrIntegrationTest(unittest.TestCase):
             "This is a Pallas cat, a small wild cat native to the mountainous regions of Central Asia.",
         ]  # fmt: skip
         self.assertEqual(
-            self.processor.batch_decode(output[:, inputs.input_ids.shape[1]:], skip_special_tokens=True),
+            self.processor.batch_decode(output[:, inputs.input_ids.shape[1] :], skip_special_tokens=True),
             EXPECTED_DECODED_TEXT,
         )
 
@@ -544,7 +546,7 @@ class GlmOcrIntegrationTest(unittest.TestCase):
         EXPECTED_DECODED_TEXT = ["A tennis player is preparing to hit the ball on a tennis court."]  # fmt: skip
 
         self.assertEqual(
-            processor.batch_decode(output[:, inputs.input_ids.shape[1]:], skip_special_tokens=True),
+            processor.batch_decode(output[:, inputs.input_ids.shape[1] :], skip_special_tokens=True),
             EXPECTED_DECODED_TEXT,
         )
 
@@ -575,7 +577,7 @@ class GlmOcrIntegrationTest(unittest.TestCase):
         # fmt: on
         EXPECTED_DECODED_TEXT = EXPECTED_DECODED_TEXTS.get_expectation()
 
-        decoded_text = self.processor.batch_decode(output[:, inputs.input_ids.shape[1]:], skip_special_tokens=True)
+        decoded_text = self.processor.batch_decode(output[:, inputs.input_ids.shape[1] :], skip_special_tokens=True)
         self.assertEqual(decoded_text, EXPECTED_DECODED_TEXT)
 
     @slow
@@ -605,7 +607,7 @@ class GlmOcrIntegrationTest(unittest.TestCase):
             "I'm a humanoid robot named Ai.",
         ]  # fmt: skip
         self.assertEqual(
-            self.processor.batch_decode(output[:, inputs.input_ids.shape[1]:], skip_special_tokens=True),
+            self.processor.batch_decode(output[:, inputs.input_ids.shape[1] :], skip_special_tokens=True),
             EXPECTED_DECODED_TEXT,
         )
 
@@ -633,7 +635,7 @@ class GlmOcrIntegrationTest(unittest.TestCase):
             "This is cat.",
         ]  # fmt: skip
         self.assertEqual(
-            self.processor.batch_decode(output[:, inputs.input_ids.shape[1]:], skip_special_tokens=True),
+            self.processor.batch_decode(output[:, inputs.input_ids.shape[1] :], skip_special_tokens=True),
             EXPECTED_DECODED_TEXT,
         )
 

--- a/tests/models/glm_ocr/test_modeling_glm_ocr.py
+++ b/tests/models/glm_ocr/test_modeling_glm_ocr.py
@@ -457,7 +457,7 @@ class GlmOcrIntegrationTest(unittest.TestCase):
         inputs = self.processor.apply_chat_template(
             self.message, tokenize=True, add_generation_prompt=True, return_dict=True, return_tensors="pt"
         )
-        expected_input_ids = [151331, 151333, 151336, 198, 151339, 151343, 151343, 151343, 151343, 151343, 151343, 151343, 151343, 151343, 151343, 151343, 151343]  # fmt: skip
+        expected_input_ids = [59248, 59250, 59253, 10, 59256, 59280, 59280, 59280, 59280, 59280, 59280, 59280, 59280, 59280, 59280, 59280, 59280]  # fmt: skip
         assert expected_input_ids == inputs.input_ids[0].tolist()[:17]
 
         expected_pixel_slice = torch.tensor(
@@ -481,9 +481,9 @@ class GlmOcrIntegrationTest(unittest.TestCase):
         torch.manual_seed(42)
 
         output = model.generate(**inputs, max_new_tokens=30)
-        EXPECTED_DECODED_TEXT = "\nWhat kind of dog is this?\n<think>Got it, let's look at the image. The animal in the picture doesn't look like a dog; it's actually a cat. Specifically"
+        EXPECTED_DECODED_TEXT = "This is a Pallas cat, a small wild cat native to the mountainous regions of Central Asia."
         self.assertEqual(
-            self.processor.decode(output[0], skip_special_tokens=True),
+            self.processor.decode(output[0][inputs.input_ids.shape[1]:], skip_special_tokens=True),
             EXPECTED_DECODED_TEXT,
         )
 
@@ -502,11 +502,11 @@ class GlmOcrIntegrationTest(unittest.TestCase):
         output = model.generate(**inputs, max_new_tokens=30)
 
         EXPECTED_DECODED_TEXT = [
-            "\nWhat kind of dog is this?\n<think>Got it, let's look at the image. The animal in the picture doesn't look like a dog; it's actually a cat. Specifically",
-            "\nWhat kind of dog is this?\n<think>Got it, let's look at the image. The animal in the picture has a stocky body, thick fur, and a face that's"
+            "This is a Pallas cat, a small wild cat native to the mountainous regions of Central Asia.",
+            "This is a Pallas cat, a small wild cat native to the mountainous regions of Central Asia.",
         ]  # fmt: skip
         self.assertEqual(
-            self.processor.batch_decode(output, skip_special_tokens=True),
+            self.processor.batch_decode(output[:, inputs.input_ids.shape[1]:], skip_special_tokens=True),
             EXPECTED_DECODED_TEXT,
         )
 
@@ -541,10 +541,10 @@ class GlmOcrIntegrationTest(unittest.TestCase):
         torch.manual_seed(42)
 
         output = model.generate(**inputs, max_new_tokens=30)
-        EXPECTED_DECODED_TEXT = ["\n012345Describe this video.\n<think>Got it, let's analyze the video. First, the scene is an indoor tennis court. There are two players: one in a white shirt"]  # fmt: skip
+        EXPECTED_DECODED_TEXT = ["A tennis player is preparing to hit the ball on a tennis court."]  # fmt: skip
 
         self.assertEqual(
-            processor.batch_decode(output, skip_special_tokens=True),
+            processor.batch_decode(output[:, inputs.input_ids.shape[1]:], skip_special_tokens=True),
             EXPECTED_DECODED_TEXT,
         )
 
@@ -564,9 +564,8 @@ class GlmOcrIntegrationTest(unittest.TestCase):
         # fmt: off
         EXPECTED_DECODED_TEXTS = Expectations(
             {
-
-                (None, None): ["\nWhat kind of dog is this?\n<think>Got it, let's look at the image. The animal in the picture doesn't look like a dog; it's actually a cat. Specifically",
-                               "\nWhat kind of dog is this?\n<think>Got it, let's look at the image. The animal in the picture doesn't look like a dog; it's actually a cat, specifically"
+                (None, None): ["This is a Pallas cat, also known as the Pallasian cat. It is a medium-sized wild cat with a thick fur coat and a",
+                               "This is a Pallas cat, also known as the Pallasian cat. It is a medium-sized carnivorous mammal with a thick fur"
                               ],
                 ("xpu", None): ["\nWhat kind of dog is this?\n<think>Got it, let's look at the image. The animal in the picture is not a dog; it's a cat. Specifically, it looks",
                                 "\nWhat kind of dog is this?\n<think>Got it, let's look at the image. The animal in the picture is not a dog; it's a cat, specifically a Pallas"
@@ -576,7 +575,7 @@ class GlmOcrIntegrationTest(unittest.TestCase):
         # fmt: on
         EXPECTED_DECODED_TEXT = EXPECTED_DECODED_TEXTS.get_expectation()
 
-        decoded_text = self.processor.batch_decode(output, skip_special_tokens=True)
+        decoded_text = self.processor.batch_decode(output[:, inputs.input_ids.shape[1]:], skip_special_tokens=True)
         self.assertEqual(decoded_text, EXPECTED_DECODED_TEXT)
 
     @slow
@@ -602,11 +601,11 @@ class GlmOcrIntegrationTest(unittest.TestCase):
         output = model.generate(**inputs, max_new_tokens=30)
 
         EXPECTED_DECODED_TEXT = [
-            "\nWhat kind of dog is this?\n<think>Got it, let's look at the image. The animal in the picture doesn't look like a dog; it's actually a cat. Specifically",
-            "\nWho are you?\n<think>Got it, let's look at the user's question: \"Who are you?\" This is a common question when someone is just starting a conversation"
+            "This is a Pallas cat, a small wild cat native to the mountainous regions of Central Asia.",
+            "I'm a humanoid robot named Ai.",
         ]  # fmt: skip
         self.assertEqual(
-            self.processor.batch_decode(output, skip_special_tokens=True),
+            self.processor.batch_decode(output[:, inputs.input_ids.shape[1]:], skip_special_tokens=True),
             EXPECTED_DECODED_TEXT,
         )
 
@@ -630,11 +629,11 @@ class GlmOcrIntegrationTest(unittest.TestCase):
         output = model.generate(**inputs, max_new_tokens=30)
 
         EXPECTED_DECODED_TEXT = [
-            "\nWhat kind of dog is this?\n<think>Got it, let's look at the image. The animal in the picture doesn't look like a dog; it's actually a cat. Specifically",
-            "\nWhat kind of dog is this?\n<think>Got it, let's look at the image. Wait, the animals here are cats, not dogs. The question is about a dog, but",
+            "This is a Pallas cat, a small wild cat native to the mountainous regions of Central Asia.",
+            "This is cat.",
         ]  # fmt: skip
         self.assertEqual(
-            self.processor.batch_decode(output, skip_special_tokens=True),
+            self.processor.batch_decode(output[:, inputs.input_ids.shape[1]:], skip_special_tokens=True),
             EXPECTED_DECODED_TEXT,
         )
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48650&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48650) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48650&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48650)
<!-- ci-dashboard-badge:end -->

## Summary

All 6 `GlmOcrIntegrationTest` integration tests were failing from day one — they **never passed on CI** (`last_pass: null`). Two distinct bugs were found and fixed.

## Root Cause Analysis

### Bug 1 — Wrong expected `input_ids` in `test_small_model_integration_test`

The test was written with hardcoded IDs in the **151K range** (Qwen2.5-style vocabulary) but `zai-org/GLM-OCR` uses a **GLM-4 tokenizer with 59K vocab**. The actual processor returns IDs in the 59K range (e.g. `<|image|>` = 59280, not 151343). The pixel values assertion was already correct.

### Bug 2 — `<|image|>` tokens leaking into decoded output (all 6 tests)

All tests call `batch_decode(output, skip_special_tokens=True)` which decodes the **full output tensor including the input prompt**. The input contains hundreds of `<|image|>` tokens (ID 59280). Despite `<|image|>` appearing in `tokenizer.all_special_tokens`, its `added_tokens_decoder` entry has `special=False` in the Rust (`TokenizersBackend`) side — so `skip_special_tokens=True` does **not** filter it. This caused the decoded text to start with hundreds of literal `<|image|>` characters instead of the expected response.

**Fix**: decode only the newly generated tokens — `output[:, inputs.input_ids.shape[1]:]` — which is the semantically correct thing to test anyway (what the model generates, not what was in the prompt).

See issue #48658 for the question of whether `special=True` should be set for `<|image|>` in `zai-org/GLM-OCR`'s tokenizer on the Hub. **If the Hub repo is updated to fix this, the test file will need to be updated** (the new-tokens-only decode workaround could be reverted, and expected strings re-captured).

### Why tests were never caught

The model `zai-org/GLM-OCR` was unavailable on the Hub when the tests were first merged (Jan 2026), causing `OSError`. By the time it became available (Feb 2026), both bugs caused immediate failures.

## Verification

All 6 tests verified passing on a single-GPU runner. The generated outputs are coherent — the model correctly identifies the cat image as a Pallas cat, answers text-only prompts, and describes the tennis video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)