### PR TITLE
[CI] Deduplicate Nvidia/AMD CI reply comments and add headers

### DIFF
--- a/.github/workflows/self-comment-ci-amd.yml
+++ b/.github/workflows/self-comment-ci-amd.yml
@@ -408,6 +408,21 @@ jobs:
             fi
           } > comment_body.txt
 
+          # Delete previous "CI Results (AMD)" comments before posting a new one
+          existing_comment_ids=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${github_repository}/issues/${pr_number}/comments" \
+            --paginate \
+            --jq '.[] | select(.body | startswith("## CI Results (AMD)")) | .id')
+          for comment_id in $existing_comment_ids; do
+            gh api \
+              --method DELETE \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/${github_repository}/issues/comments/${comment_id}"
+          done
+
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/self-comment-ci-amd.yml
+++ b/.github/workflows/self-comment-ci-amd.yml
@@ -143,7 +143,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "repos/${github_repository}/issues/${pr_number}/comments" \
             --paginate \
-            --jq '.[] | select(.body | startswith("## Nvidia CI") or startswith("## AMD CI")) | .id')
+            --jq '.[] | select(.body | startswith("## AMD CI")) | .id')
           for comment_id in $existing_comment_ids; do
             gh api \
               --method DELETE \

--- a/.github/workflows/self-comment-ci-amd.yml
+++ b/.github/workflows/self-comment-ci-amd.yml
@@ -131,12 +131,27 @@ jobs:
       - name: Reply to the comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PREFIX: '[Workflow Run ⚙️](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+          PREFIX: '## AMD CI\n\n[Workflow Run ⚙️](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
           INFO: '\n\nThis comment contains `run-slow`, running the specified jobs on AMD'
           BODY: '\n\nmodels: ${{ needs.get-tests.outputs.models }}'
           github_repository: ${{ github.repository }}
           pr_number: ${{ needs.get-pr-number.outputs.PR_NUMBER }}
         run: |
+          # Delete previous Nvidia CI and AMD CI comments before posting
+          existing_comment_ids=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${github_repository}/issues/${pr_number}/comments" \
+            --paginate \
+            --jq '.[] | select(.body | startswith("## Nvidia CI") or startswith("## AMD CI")) | .id')
+          for comment_id in $existing_comment_ids; do
+            gh api \
+              --method DELETE \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/${github_repository}/issues/comments/${comment_id}"
+          done
+
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/self-comment-ci.yml
+++ b/.github/workflows/self-comment-ci.yml
@@ -137,12 +137,27 @@ jobs:
       - name: Reply to the comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PREFIX: '[Workflow Run ⚙️](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
-          INFO: '\n\nThis comment contains `run-slow`, running the specified jobs'
+          PREFIX: '## Nvidia CI\n\n[Workflow Run ⚙️](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+          INFO: '\n\nThis comment contains `run-slow`, running the specified jobs on Nvidia'
           BODY: '\n\nmodels: ${{ needs.get-tests.outputs.models }}\nquantizations: ${{ needs.get-tests.outputs.quantizations }}'
           github_repository: ${{ github.repository }}
           pr_number: ${{ needs.get-pr-number.outputs.PR_NUMBER }}
         run: |
+          # Delete previous Nvidia CI and AMD CI comments before posting
+          existing_comment_ids=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${github_repository}/issues/${pr_number}/comments" \
+            --paginate \
+            --jq '.[] | select(.body | startswith("## Nvidia CI") or startswith("## AMD CI")) | .id')
+          for comment_id in $existing_comment_ids; do
+            gh api \
+              --method DELETE \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/${github_repository}/issues/comments/${comment_id}"
+          done
+
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
@@ -390,7 +405,7 @@ jobs:
           main_commit_link="[${main_commit:0:8}](https://github.com/${github_repository}/commit/${main_commit})"
 
           {
-            echo '## CI Results'
+            echo '## CI Results (Nvidia)'
             echo "[Workflow Run ⚙️]($GITHUB_RUN_URL)"
             echo ''
 
@@ -457,6 +472,21 @@ jobs:
               echo '✅ No failing test specific to this PR 🎉 👏 !'
             fi
           } > comment_body.txt
+
+          # Delete previous "CI Results (Nvidia)" comments before posting a new one
+          existing_comment_ids=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${github_repository}/issues/${pr_number}/comments" \
+            --paginate \
+            --jq '.[] | select(.body | startswith("## CI Results (Nvidia)")) | .id')
+          for comment_id in $existing_comment_ids; do
+            gh api \
+              --method DELETE \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/${github_repository}/issues/comments/${comment_id}"
+          done
 
           gh api \
             --method POST \

--- a/.github/workflows/self-comment-ci.yml
+++ b/.github/workflows/self-comment-ci.yml
@@ -149,7 +149,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "repos/${github_repository}/issues/${pr_number}/comments" \
             --paginate \
-            --jq '.[] | select(.body | startswith("## Nvidia CI") or startswith("## AMD CI")) | .id')
+            --jq '.[] | select(.body | startswith("## Nvidia CI")) | .id')
           for comment_id in $existing_comment_ids; do
             gh api \
               --method DELETE \


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48655&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48655) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48655&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48655)
<!-- ci-dashboard-badge:end -->

## Summary

- **`self-comment-ci.yml` (Nvidia)**:
  - `reply_to_comment` now posts `## Nvidia CI` as the header and adds "on Nvidia" to the message body; deletes any existing `## Nvidia CI` comment before posting.
  - `report` job comment header changed from `## CI Results` → `## CI Results (Nvidia)`; deletes any existing `## CI Results (Nvidia)` comment before posting.
- **`self-comment-ci-amd.yml` (AMD)**:
  - `reply_to_comment` now posts `## AMD CI` as the header; deletes any existing `## AMD CI` comment before posting.
  - `report` job already used `## CI Results (AMD)`; now also deletes any existing `## CI Results (AMD)` comment before posting.

Each workflow only touches its own comments — Nvidia does not delete AMD comments and vice versa.

**Result**: re-triggering `run-slow` on a PR replaces the previous acknowledgment/result comment instead of accumulating duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)