### PR TITLE
[Kernels] Enable rotary_pos_emb hub kernel dispatch for partial RoPE models (GPT-NeoX, Qwen3-Next)

### DIFF
--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -12,6 +12,7 @@ from torch import nn
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
+from ...integrations import use_kernel_forward_from_hub, use_kernelized_func
 from ...masking_utils import create_causal_mask
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import GradientCheckpointingLayer
@@ -115,6 +116,7 @@ def rotate_half(x):
     return torch.cat((-x2, x1), dim=-1)
 
 
+@use_kernel_forward_from_hub("rotary_pos_emb")
 def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
     """Applies Rotary Position Embedding to the query and key tensors.
 
@@ -177,6 +179,7 @@ def eager_attention_forward(
     return attn_output, attn_weights
 
 
+@use_kernelized_func(apply_rotary_pos_emb)
 class GPTNeoXAttention(nn.Module):
     def __init__(self, config, layer_idx=None):
         super().__init__()

--- a/src/transformers/models/gpt_neox/modular_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modular_gpt_neox.py
@@ -6,6 +6,7 @@ from torch import nn
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
+from ...integrations import use_kernel_forward_from_hub, use_kernelized_func
 from ...masking_utils import create_causal_mask
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import GradientCheckpointingLayer
@@ -64,6 +65,7 @@ class GPTNeoXRotaryEmbedding(LlamaRotaryEmbedding):
         return inv_freq.to(device), attention_factor
 
 
+@use_kernel_forward_from_hub("rotary_pos_emb")
 def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
     """Applies Rotary Position Embedding to the query and key tensors.
 
@@ -126,6 +128,7 @@ def eager_attention_forward(
     return attn_output, attn_weights
 
 
+@use_kernelized_func(apply_rotary_pos_emb)
 class GPTNeoXAttention(nn.Module):
     def __init__(self, config, layer_idx=None):
         super().__init__()

--- a/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modeling_qwen3_next.py
@@ -159,6 +159,7 @@ def rotate_half(x):
 
 
 # Adapted from transformers.models.glm.modular_glm.apply_rotary_pos_emb
+@use_kernel_forward_from_hub("rotary_pos_emb")
 def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
     """Applies Rotary Position Embedding to the query and key tensors.
 
@@ -234,6 +235,7 @@ def eager_attention_forward(
     return attn_output, attn_weights
 
 
+@use_kernelized_func(apply_rotary_pos_emb)
 class Qwen3NextAttention(nn.Module):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
 

--- a/src/transformers/models/qwen3_next/modular_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modular_qwen3_next.py
@@ -102,6 +102,7 @@ class Qwen3NextRMSNorm(Gemma3RMSNorm):
 
 
 @no_inherit_decorator
+@use_kernelized_func(apply_rotary_pos_emb)
 class Qwen3NextAttention(Qwen3MoeAttention):
     def __init__(self, config: Qwen3NextConfig, layer_idx: int):
         super().__init__(config, layer_idx)

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -273,6 +273,16 @@ class TestHubKernels(TestCasePlus):
 
         del model
 
+    def test_partial_rope_kernels_registration(self):
+        # Verify that models with partial RoPE (such as GPT-NeoX) register rotary_pos_emb
+        model = AutoModelForCausalLM.from_pretrained(
+            "EleutherAI/gpt-neox-20b", use_kernels=True, device_map=torch_device
+        )
+        self.assertIn("rotary_pos_emb", model.kernel_config.registered_layer_names.values())
+        self.assertTrue(any(name.endswith(".rotary_pos_emb") for name in model.kernel_config.registered_layer_names))
+        del model
+
+
     def test_kernels_mapping_no_inherit(self):
         kernel_config = KernelConfig(
             kernel_mapping={


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48662&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48662) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48662&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48662)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Enables `@use_kernel_forward_from_hub("rotary_pos_emb")` and `@use_kernelized_func(apply_rotary_pos_emb)` for models using partial RoPE (`rotary_dim < head_dim`), specifically **GPT-NeoX** and **Qwen3-Next**.

Related to #48622.
Pairs with kernel update: huggingface/kernels-community#1143

## Details

Following discussion with @vasqu in #48622, `rotary` kernel support for partial dimensions is handled in `apply_rotary_transformers` (huggingface/kernels-community#1143). With that in place, models with partial rotary factors can now leverage the `rotary_pos_emb` kernel dispatch cleanly without needing model-level changes or special kernel names.

## Changes
- `src/transformers/models/gpt_neox/modular_gpt_neox.py` and `modeling_gpt_neox.py`: add `@use_kernel_forward_from_hub("rotary_pos_emb")` to `apply_rotary_pos_emb` and `@use_kernelized_func(apply_rotary_pos_emb)` to `GPTNeoXAttention`.
- `src/transformers/models/qwen3_next/modular_qwen3_next.py` and `modeling_qwen3_next.py`: add `@use_kernel_forward_from_hub("rotary_pos_emb")` and `@use_kernelized_func`.
- `tests/kernels/test_kernels.py`: add `test_partial_rope_kernels_registration` sanity check.

## Verification
- Tested E2E on GPU across various partial RoPE dimensions and configurations.