### PR TITLE
fix: preserve backslashes in generate flag values

### DIFF
--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -633,7 +633,7 @@ def parse_generate_flags(generate_flags: list[str] | None) -> dict:
         s = s.removeprefix("-")
         return s.replace(".", "", 1).isdigit()
 
-    generate_flags_as_dict = {k: f'"{v}"' if not is_number(v) else v for k, v in generate_flags_as_dict.items()}
+    generate_flags_as_dict = {k: json.dumps(v) if not is_number(v) else v for k, v in generate_flags_as_dict.items()}
     # 2. c. [no processing needed] lists are lists of ints because `generate` doesn't take lists of strings :)
     # We also mention in the help message that we only accept lists of ints for now.
 

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -68,6 +68,21 @@ def test_parse_generate_flags_invalid_json_error_message():
         parse_generate_flags(["stop_strings=[a]"])
 
 
+def test_parse_generate_flags_backslash_escaping():
+    # Backslashes in flag values should be preserved literally, not interpreted as JSON escapes
+    # See: https://github.com/huggingface/transformers/issues/48626
+    parsed = parse_generate_flags([r"stop_strings=a\b"])
+    assert parsed["stop_strings"] == r"a\b"
+
+    # \uXXXX should not be interpreted as a unicode escape
+    parsed = parse_generate_flags([r"stop_strings=a\u0041"])
+    assert parsed["stop_strings"] == r"a\u0041"
+
+    # Windows-style paths should be preserved
+    parsed = parse_generate_flags([r"stop_strings=C:\temp"])
+    assert parsed["stop_strings"] == r"C:\temp"
+
+
 def test_get_service_root_url():
     assert get_service_root_url("http://localhost:8000/v1") == "http://localhost:8000"
     assert get_service_root_url("http://localhost:8000/v1/") == "http://localhost:8000"


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48674&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48674) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48674&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48674)
<!-- ci-dashboard-badge:end -->

Fixes #48626

`parse_generate_flags` used `f'{v}'` to quote string values, which doesn't
escape backslashes. This caused backslash escape sequences (like \\n, \\b,
\\u0041) to be interpreted as JSON escapes during `json.loads`, producing
unexpected output or ValueError.

Fix: use `json.dumps(v)` instead, which properly escapes special characters.

Verified:
- `stop_strings=a\\b` → preserved as `a\\b` (not `a\\x08`)
- `stop_strings=a\\u0041` → preserved as `a\\u0041` (not `aA`)
- `stop_strings=C:\\temp` → preserved as `C:\\temp` (not `C:\\temp`)
- `stop_strings=a\\x` → no ValueError (not a JSON parser error)
- Normal values (numbers, booleans, None, lists) still work correctly