### PR TITLE
[GLM 5.3 Flash] Preserve original names when saving text checkpoints

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -102,6 +102,7 @@ _MODEL_TO_CONVERSION_PATTERN = {
     "granitemoeshared": "granitemoe",
     "granitemoehybrid": "granitemoe",
     "gemma3n_text": "qwen3_5_text",
+    "glm5_next_text": "glm5_next",
     "qwen3_5_moe_text": "qwen3_5_text",
     "llava_next_video": "llava_next",
     "llava_onevision": "llava_next",

--- a/tests/models/glm5_next/test_modeling_glm5_next.py
+++ b/tests/models/glm5_next/test_modeling_glm5_next.py
@@ -14,14 +14,17 @@
 """Testing suite for the PyTorch Glm5Next model."""
 
 import copy
+import tempfile
 import unittest
 
 import pytest
+from safetensors.torch import load_file
 
 from transformers import (
     Glm5NextConfig,
     Glm5NextForConditionalGeneration,
     Glm5NextModel,
+    Glm5NextTextModel,
     Glm5NextVisionConfig,
     is_torch_available,
     logging,
@@ -170,6 +173,26 @@ class Glm5NextModelTest(VLMModelTest, unittest.TestCase):
     model_split_percents = [0.5, 0.8, 0.9]
     # FIXME: export is very sensitive to any shape changes
     test_torch_exportable = False
+
+    def test_text_model_save_uses_original_weight_names(self):
+        """Keep text-only saves in the released layout expected by SGLang (sgl-project/sglang#38618)."""
+        config = self.model_tester.get_text_config()
+        model = Glm5NextTextModel(config)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            model.save_pretrained(tmpdirname)
+            saved_keys = set(load_file(f"{tmpdirname}/model.safetensors"))
+
+        expected_keys = {
+            "layers.0.hc_attn_fn",
+            "layers.0.hc_ffn_fn",
+            "layers.0.self_attn.f_a_proj.weight",
+            "layers.0.self_attn.q_conv1d.weight",
+            "layers.1.mlp.experts.0.gate_proj.weight",
+            "layers.1.mlp.experts.0.up_proj.weight",
+            "layers.1.mlp.experts.0.down_proj.weight",
+        }
+        self.assertTrue(expected_keys.issubset(saved_keys))
 
     @staticmethod
     def _prepare_config_headdim(config, requested_dim):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48676&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48676) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48676&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48676)
<!-- ci-dashboard-badge:end -->

# Summary                                                                               
                                                                                          
Fixes GLM-5.3-Flash text checkpoints saved with `save_pretrained()` using Transformers-internal weight names instead of the released checkpoint layout.                        
                                                                                          
`Glm5NextTextModel` uses the `glm5_next_text` model type, while its weight conversion rules were only registered for `glm5_next`. As a result, the reverse conversion was not applied when saving the standalone text model.                                          
                                                                                          
This PR makes `glm5_next_text` reuse the existing `glm5_next` conversion mapping. The standard `save_pretrained(save_original_format=True)` path can then restore the released names and layouts for:                                                                  
                                                                                          
  - mHC attention and FFN parameters                                                      
  - KDA forget-gate parameters                                                            
  - packed KDA q/k/v convolution weights                                                  
  - packed routed MoE expert weights                                                      
                                                                                          
The vision tower requires no additional mapping because its saved weight names already match the released checkpoint.                                                          
                                                                                          
Related issue: https://github.com/sgl-project/sglang/issues/38618                          
                                                                                          
 # Changes

  - Register `glm5_next_text` as an alias of the existing `glm5_next` conversion mapping.
  - Add regression coverage verifying that standalone text models save mHC, KDA,
  convolution, and routed expert weights with their original released names.
  - Preserve the existing full multimodal model and native Transformers checkpoint round
  trips.

  # Root cause
`save_pretrained()` already supports reversing complete weight conversions, including renaming, splitting concatenated tensors, and unpacking expert tensors.

However, the reverse conversion lookup returned no GLM5 mapping for `Glm5NextTextModel` because its model type is `glm5_next_text`. The model therefore serialized its internal packed layout unchanged.