### PR TITLE
Add an FP8 backend to `QuantizedCache`

### DIFF
--- a/benchmark_v2/benchmark_scripts/quantized_cache.py
+++ b/benchmark_v2/benchmark_scripts/quantized_cache.py
@@ -1,0 +1,104 @@
+"""
+Quantized cache benchmark.
+
+Compares the backends of `QuantizedCache` against the default bf16 `DynamicCache`, on the size of the KV cache,
+the peak device memory, the latency of `generate`, and how much the generation drifts from the bf16 one.
+"""
+
+import argparse
+import gc
+import statistics
+import time
+
+import torch
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+# The additional options of the group-wise integer backends, which do not apply to `fp8`
+BACKEND_CACHE_CONFIGS = {
+    "quanto": {"backend": "quanto", "nbits": 4, "axis_key": 0, "axis_value": 0},
+    "hqq": {"backend": "hqq", "nbits": 4, "axis_key": 1, "axis_value": 1},
+    "fp8": {"backend": "fp8"},
+}
+
+PROMPT = "The French Revolution was a period of political and societal change in France that began in 1789. "
+
+
+def cache_memory(cache) -> int:
+    """Number of bytes held by the key and value states of `cache`, whether they are quantized or not."""
+    states = ("keys", "values", "_quantized_keys", "_quantized_values")
+    tensors = (getattr(layer, name, None) for layer in cache.layers for name in states)
+    return sum(t.numel() * t.element_size() for t in tensors if isinstance(t, torch.Tensor))
+
+
+def run(model, inputs, generation_kwargs, warmup: int, iterations: int) -> dict:
+    """Time `generate` and collect the memory used by the cache it returns."""
+    gc.collect()
+    torch.accelerator.empty_cache()
+    torch.accelerator.reset_peak_memory_stats()
+
+    latencies = []
+    for i in range(warmup + iterations):
+        torch.accelerator.synchronize()
+        start = time.perf_counter()
+        outputs = model.generate(**inputs, **generation_kwargs)
+        torch.accelerator.synchronize()
+        if i >= warmup:
+            latencies.append(time.perf_counter() - start)
+
+    return {
+        "latency": statistics.median(latencies) * 1e3,
+        "cache_memory": cache_memory(outputs.past_key_values) / 2**20,
+        "peak_memory": torch.accelerator.max_memory_allocated() / 2**20,
+        "sequences": outputs.sequences,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-id", type=str, default="Qwen/Qwen3-4B-Instruct-2507")
+    parser.add_argument("--backends", type=str, nargs="+", default=list(BACKEND_CACHE_CONFIGS))
+    parser.add_argument("--sequence-length", "-s", type=int, default=1024)
+    parser.add_argument("--num-tokens-to-generate", "-n", type=int, default=256)
+    parser.add_argument("--warmup", "-w", type=int, default=1)
+    parser.add_argument("--iterations", "-i", type=int, default=3)
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_id)
+    model = AutoModelForCausalLM.from_pretrained(args.model_id, dtype=torch.bfloat16, device_map="auto")
+
+    prompt = PROMPT * (args.sequence_length // len(tokenizer(PROMPT).input_ids) + 1)
+    inputs = tokenizer(
+        [prompt], return_tensors="pt", max_length=args.sequence_length, truncation=True, return_attention_mask=True
+    ).to(model.device)
+    generation_kwargs = {
+        "do_sample": False,
+        "max_new_tokens": args.num_tokens_to_generate,
+        "return_dict_in_generate": True,
+        "disable_compile": True,
+    }
+
+    print(f"\n{args.model_id}, {args.sequence_length} prompt tokens, {args.num_tokens_to_generate} generated tokens\n")
+    header = f"{'cache':>10} | {'kv cache':>10} | {'peak memory':>12} | {'latency':>10} | {'matching tokens':>16}"
+    print(header + "\n" + "-" * len(header))
+
+    # The bf16 `DynamicCache` is the baseline that the quantized backends are compared against
+    baseline = run(model, inputs, generation_kwargs, args.warmup, args.iterations)
+    results = {"bf16": baseline}
+    for backend in args.backends:
+        cache_kwargs = {"cache_implementation": "quantized", "cache_config": BACKEND_CACHE_CONFIGS[backend]}
+        results[backend] = run(model, inputs, generation_kwargs | cache_kwargs, args.warmup, args.iterations)
+
+    for name, result in results.items():
+        # Quantizing the cache changes the numerics, so the greedy generations eventually diverge from the bf16 one
+        matching_tokens = (result["sequences"] == baseline["sequences"]).int().cumprod(dim=-1).sum()
+        print(
+            f"{name:>10} | {result['cache_memory']:7.1f} MiB | {result['peak_memory']:9.1f} MiB "
+            f"| {result['latency']:7.1f} ms | {matching_tokens - inputs.input_ids.numel():6d} "
+            f"/ {args.num_tokens_to_generate:<7d}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/en/internal/generation_utils.md
+++ b/docs/source/en/internal/generation_utils.md
@@ -240,6 +240,10 @@ A [`StoppingCriteria`] can be used to change when to stop generation (other than
     - update
     - lazy_initialization
 
+[[autodoc]] Fp8QuantizedLayer
+    - update
+    - lazy_initialization
+
 [[autodoc]] Cache
     - update
     - early_initialization

--- a/docs/source/en/kv_cache.md
+++ b/docs/source/en/kv_cache.md
@@ -176,10 +176,11 @@ responses = tokenizer.batch_decode(out[:,-28:], skip_special_tokens=True)
 
 ## Quantized cache
 
-The [`QuantizedCache`] reduces memory requirements by quantizing the KV values to a lower precision. [`QuantizedCache`] currently supports two quantization backends:
+The [`QuantizedCache`] reduces memory requirements by quantizing the KV values to a lower precision. [`QuantizedCache`] currently supports three quantization backends:
 
 - `hqq` supports int2, int4, and int8 datatypes.
 - `quanto` supports int2 and int4 datatypes. This is the default quantization backend.
+- `fp8` stores the KV values in 8-bit floating point (`float8_e4m3fn`). It requires no extra dependency, and quantizes per-tensor rather than per-group, so `nbits`, `axis_key`, `axis_value`, `q_group_size` and `residual_length` do not apply to it.
 
 > [!WARNING]
 > Quantizing the cache can harm latency if the context length is short and there is enough GPU memory available for generation without enabling cache quantization. Try to find a balance between memory efficiency and latency.
@@ -216,6 +217,21 @@ inputs = tokenizer("I like rock music because", return_tensors="pt").to(model.de
 out = model.generate(**inputs, do_sample=False, max_new_tokens=20, cache_implementation="quantized", cache_config={"nbits": 4, "backend": "quanto"})
 print(tokenizer.batch_decode(out, skip_special_tokens=True)[0])
 I like rock music because it's loud and energetic. It's a great way to express myself and rel
+```
+
+The `fp8` backend does not take any additional parameter.
+
+```py
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B-Instruct-2507")
+model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-4B-Instruct-2507", dtype=torch.float16, device_map="auto")
+inputs = tokenizer("I like rock music because", return_tensors="pt").to(model.device)
+
+out = model.generate(**inputs, do_sample=False, max_new_tokens=20, cache_implementation="quantized", cache_config={"backend": "fp8"})
+print(tokenizer.batch_decode(out, skip_special_tokens=True)[0])
+I like rock music because it is powerful and emotional. I also like classical music because it is elegant and sophisticated. I enjoy
 ```
 
 ## Encoder-decoder cache

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -373,6 +373,7 @@ else:
         "DynamicIndexedLayer",
         "DynamicLayer",
         "EncoderDecoderCache",
+        "Fp8QuantizedLayer",
         "HQQQuantizedLayer",
         "QuantizedCache",
         "QuantoQuantizedLayer",
@@ -498,6 +499,7 @@ if TYPE_CHECKING:
     from .cache_utils import DynamicIndexedLayer as DynamicIndexedLayer
     from .cache_utils import DynamicLayer as DynamicLayer
     from .cache_utils import EncoderDecoderCache as EncoderDecoderCache
+    from .cache_utils import Fp8QuantizedLayer as Fp8QuantizedLayer
     from .cache_utils import HQQQuantizedLayer as HQQQuantizedLayer
     from .cache_utils import QuantizedCache as QuantizedCache
     from .cache_utils import QuantoQuantizedLayer as QuantoQuantizedLayer

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -702,6 +702,11 @@ class StaticIndexedLayer(StaticLayer):
             self.indexer_keys = self.indexer_keys.index_select(0, beam_idx.to(self.indexer_keys.device))
 
 
+def _cat_fp8(tensor: torch.Tensor, other: torch.Tensor, dim: int = -2) -> torch.Tensor:
+    """Concatenate two FP8 tensors, as `torch.cat` is not implemented for FP8 dtypes on all backends."""
+    return torch.cat([tensor.view(torch.uint8), other.view(torch.uint8)], dim=dim).view(tensor.dtype)
+
+
 class QuantizedLayer(DynamicLayer):
     """
     A quantized layer similar to what is described in the [KIVI: A Tuning-Free Asymmetric 2bit Quantization for KV Cache paper](https://huggingface.co/papers/2402.02750).
@@ -888,6 +893,76 @@ class HQQQuantizedLayer(QuantizedLayer):
         quant_tensor, meta = qtensor
         tensor = self.quantizer.dequantize(quant_tensor, meta)
         return tensor
+
+
+class Fp8QuantizedLayer(QuantizedLayer):
+    """
+    A quantized layer storing the key and value states in 8-bit floating point.
+
+    Contrary to the integer backends, FP8 uses a single scale per tensor, which allows new tokens to be
+    appended to the quantized states directly. This layer therefore needs neither a full-precision residual
+    cache, nor a re-quantization of the whole cache every `residual_length` tokens. The scale is calibrated
+    during the first `update` call and then kept fixed.
+
+    The states are dequantized in `update`, i.e. before attention is computed, so that every attention
+    implementation keeps working unchanged. They are nonetheless stored as a single contiguous FP8 tensor, so
+    that attention backends supporting FP8 inputs can later consume them directly.
+    """
+
+    fp8_dtype = torch.float8_e4m3fn
+
+    def __init__(self):
+        # The base class options are all specific to group-wise integer quantization, so they are left to
+        # their default values and unused (`nbits` is only informative here).
+        super().__init__(nbits=8, residual_length=0)
+
+        self._fp8_max = torch.finfo(self.fp8_dtype).max
+        # Calibrated on the first `update` call, then frozen
+        self._key_scale = None
+        self._value_scale = None
+
+    def _quantize(self, tensor, axis=None, scale=None):
+        """Quantize `tensor` to FP8, calibrating the scale on its amplitude if it is not provided. The `axis`
+        argument is unused, as the scale is per-tensor."""
+        if scale is None:
+            # `clamp` guards against an all-zeros tensor, which would give a null scale
+            scale = (tensor.abs().amax().float() / self._fp8_max).clamp(min=torch.finfo(torch.float32).tiny)
+        return (tensor.float() / scale).to(self.fp8_dtype), scale
+
+    def _dequantize(self, qtensor):
+        quant_tensor, scale = qtensor
+        return (quant_tensor.float() * scale).to(self.dtype)
+
+    def update(
+        self, key_states: torch.Tensor, value_states: torch.Tensor, *args, **kwargs
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Update the key and value caches in-place, and return the necessary keys and value states.
+
+        Args:
+            key_states (`torch.Tensor`): The new key states to cache.
+            value_states (`torch.Tensor`): The new value states to cache.
+
+        Returns:
+            tuple[`torch.Tensor`, `torch.Tensor`]: The key and value states.
+        """
+        self.cumulative_length += key_states.shape[-2]
+
+        # Lazy initialization, which is also where the scales are calibrated
+        if not self.is_initialized:
+            self.lazy_initialization(key_states, value_states)
+            self._quantized_keys, self._key_scale = self._quantize(key_states.contiguous())
+            self._quantized_values, self._value_scale = self._quantize(value_states.contiguous())
+            return key_states, value_states
+
+        new_keys, _ = self._quantize(key_states.contiguous(), scale=self._key_scale)
+        new_values, _ = self._quantize(value_states.contiguous(), scale=self._value_scale)
+        self._quantized_keys = _cat_fp8(self._quantized_keys, new_keys)
+        self._quantized_values = _cat_fp8(self._quantized_values, new_values)
+
+        keys_to_return = self._dequantize((self._quantized_keys, self._key_scale))
+        values_to_return = self._dequantize((self._quantized_values, self._value_scale))
+        return keys_to_return, values_to_return
 
 
 class LinearAttentionCacheLayerMixin(ABC):
@@ -1916,7 +1991,7 @@ class QuantizedCache(Cache):
 
     Args:
         backend (`str`):
-            The quantization backend to use. One of `("quanto", "hqq").
+            The quantization backend to use. One of `("quanto", "hqq", "fp8")`.
         config (`PreTrainedConfig`):
             The config of the model for which this Cache will be used.
         nbits (`int`, *optional*, defaults to 4):
@@ -1928,7 +2003,9 @@ class QuantizedCache(Cache):
         q_group_size (`int`, *optional*, defaults to 64):
             Quantization is done per-channel according to a set `q_group_size` for both keys and values.
         residual_length (`int`, *optional*, defaults to 128):
-            Maximum capacity for the original precision cache
+            Maximum capacity for the original precision cache.
+
+    The last five arguments are specific to the group-wise integer backends, and unused by `fp8`.
     """
 
     def __init__(
@@ -1945,8 +2022,21 @@ class QuantizedCache(Cache):
             layer_class = QuantoQuantizedLayer
         elif backend == "hqq":
             layer_class = HQQQuantizedLayer
+        elif backend == "fp8":
+            layer_class = Fp8QuantizedLayer
         else:
             raise ValueError(f"Unknown quantization backend `{backend}`")
+
+        # The `fp8` backend quantizes per-tensor, so it does not use any of the group-wise options
+        layer_kwargs = {}
+        if backend != "fp8":
+            layer_kwargs = {
+                "nbits": nbits,
+                "axis_key": axis_key,
+                "axis_value": axis_value,
+                "q_group_size": q_group_size,
+                "residual_length": residual_length,
+            }
 
         config = config.get_text_config(decoder=True)
         layer_types, _ = get_layer_types_and_kwargs(config)
@@ -1956,10 +2046,7 @@ class QuantizedCache(Cache):
                 "`QuantizedCache` is only supported for models with only full attention layers. We found the following invalid layer "
                 f"types: {invalid_layer_types}"
             )
-        layers = [
-            layer_class(nbits, axis_key, axis_value, q_group_size, residual_length)
-            for _ in range(config.num_hidden_layers)
-        ]
+        layers = [layer_class(**layer_kwargs) for _ in range(config.num_hidden_layers)]
         super().__init__(layers=layers)
 
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -964,6 +964,14 @@ class Fp8QuantizedLayer(QuantizedLayer):
         values_to_return = self._dequantize((self._quantized_values, self._value_scale))
         return keys_to_return, values_to_return
 
+    def reorder_cache(self, beam_idx: torch.LongTensor) -> None:
+        """Reorders this layer's cache for beam search. The scale being per-tensor, the FP8 states can be
+        reordered as-is, without any dequantization."""
+        if self.is_initialized:
+            beam_idx = beam_idx.to(self._quantized_keys.device)
+            self._quantized_keys = self._quantized_keys.index_select(0, beam_idx)
+            self._quantized_values = self._quantized_values.index_select(0, beam_idx)
+
 
 class LinearAttentionCacheLayerMixin(ABC):
     """Base, abstract class for a linear attention single layer's cache."""

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -967,10 +967,12 @@ class Fp8QuantizedLayer(QuantizedLayer):
     def reorder_cache(self, beam_idx: torch.LongTensor) -> None:
         """Reorders this layer's cache for beam search. The scale being per-tensor, the FP8 states can be
         reordered as-is, without any dequantization."""
-        if self.is_initialized:
-            beam_idx = beam_idx.to(self._quantized_keys.device)
-            self._quantized_keys = self._quantized_keys.index_select(0, beam_idx)
-            self._quantized_values = self._quantized_values.index_select(0, beam_idx)
+        if not self.is_initialized:
+            return
+
+        beam_idx = beam_idx.to(self._quantized_keys.device)
+        self._quantized_keys = self._quantized_keys.index_select(0, beam_idx)
+        self._quantized_values = self._quantized_values.index_select(0, beam_idx)
 
 
 class LinearAttentionCacheLayerMixin(ABC):

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -61,6 +61,7 @@ if is_torch_available():
         DynamicIndexedLayer,
         DynamicLayer,
         DynamicSlidingWindowLayer,
+        Fp8QuantizedLayer,
         LinearAttentionAndFullAttentionLayer,
         LinearAttentionAndSlidingWindowAttentionLayer,
         LinearAttentionLayer,
@@ -118,6 +119,28 @@ class CacheTest(unittest.TestCase):
         cached_keys, cached_values = mqa_static_cache.update(*_random_kvs(mqa_config), 0)
         self.assertTrue(cached_keys.shape == (1, 1, 10, 128))
         self.assertTrue(cached_values.shape == (1, 1, 10, 128))
+
+    def test_fp8_quantized_layer(self):
+        """
+        Tests that `Fp8QuantizedLayer` appends new tokens to a single contiguous FP8 tensor, using the scale
+        calibrated on the states of the first `update` call.
+        """
+        layer = Fp8QuantizedLayer()
+
+        keys, values = torch.randn(1, 2, 5, 8), torch.randn(1, 2, 5, 8)
+        layer.update(keys, values)
+        self.assertEqual(layer._quantized_keys.dtype, torch.float8_e4m3fn)
+        self.assertEqual(layer._quantized_keys.shape, keys.shape)
+        calibrated_scale = layer._key_scale.clone()
+
+        # Even states with a much larger amplitude do not change the scale, which is frozen after calibration
+        cached_keys, _ = layer.update(torch.randn(1, 2, 1, 8) * 100, torch.randn(1, 2, 1, 8))
+        self.assertEqual(cached_keys.shape, (1, 2, 6, 8))
+        self.assertEqual(cached_keys.dtype, keys.dtype)
+        self.assertTrue(torch.equal(layer._key_scale, calibrated_scale))
+        # The quantized states are stored contiguously, so that they can be consumed by FP8 attention kernels
+        self.assertTrue(layer._quantized_keys.is_contiguous())
+        self.assertEqual(layer._quantized_keys.shape, (1, 2, 6, 8))
 
     def test_early_initialization_does_not_corrupt_linear_attention_layers(self):
         """
@@ -280,20 +303,25 @@ class CacheIntegrationTest(unittest.TestCase):
         decoded = self.tokenizer.decode(gen_out.sequences, skip_special_tokens=True)
         self.assertListEqual(decoded, EXPECTED_GENERATION)
 
-    @parameterized.expand([("quanto"), ("HQQ")])
+    @parameterized.expand([("quanto"), ("HQQ"), ("fp8")])
     def test_quantized_cache_generation(self, backend):
-        """Tests that QuantizedCache works as expected for both `quanto` and `hqq` backends."""
+        """Tests that QuantizedCache works as expected for the `quanto`, `hqq` and `fp8` backends."""
+        # The group-wise integer backends share the same options, while `fp8` quantizes per-tensor
+        cache_config = {"backend": backend, "nbits": 4, "q_group_size": 16, "residual_length": 4}
         if backend == "quanto":
             if not is_optimum_quanto_available():
                 self.skipTest("Quanto is not available")
-            axis_key, axis_value = 0, 0
+            cache_config.update({"axis_key": 0, "axis_value": 0})
             # This output is taken from a run with the same parameters, and is known to be correct
             expected_generation = ["The cat's whiskers are also a sign of anxiety."]
         elif backend == "HQQ":
             if not is_hqq_available():
                 self.skipTest("HQQ is not available")
-            axis_key, axis_value = 1, 1
+            cache_config.update({"axis_key": 1, "axis_value": 1})
             # HQQ has slightly different numerics
+            expected_generation = ["The cat's whiskers are also a sign of anxiety."]
+        elif backend == "fp8":
+            cache_config = {"backend": backend}
             expected_generation = ["The cat's whiskers are also a sign of anxiety."]
         else:
             return
@@ -306,14 +334,7 @@ class CacheIntegrationTest(unittest.TestCase):
             max_new_tokens=10,
             return_dict_in_generate=True,
             cache_implementation="quantized",
-            cache_config={
-                "backend": backend,
-                "nbits": 4,
-                "q_group_size": 16,
-                "residual_length": 4,
-                "axis_key": axis_key,
-                "axis_value": axis_value,
-            },
+            cache_config=cache_config,
             disable_compile=True,
         )
 


### PR DESCRIPTION
## What does this PR do?

Adds a third backend to `QuantizedCache`, next to `quanto` and `hqq`, that stores the KV states in `torch.float8_e4m3fn`:

```py
model.generate(**inputs, cache_implementation="quantized", cache_config={"backend": "fp8"})
```

Unlike the integer backends, FP8 uses a single scale per tensor. New tokens can therefore be appended to the quantized states directly, so the layer needs neither a full-precision residual cache nor a periodic re-quantization of the whole cache. The scale is calibrated on the first `update` and then kept fixed.

The states are dequantized in `update`, i.e. before attention is computed, so every attention implementation keeps working unchanged. They are nonetheless kept as a single contiguous FP8 tensor, so that a follow-up PR can let FP8-capable attention backends consume them directly.

It also requires no extra dependency, contrary to `quanto` and `hqq`.

## Results

Qwen3-4B-Instruct-2507, 1024-token prompt + 256 generated tokens, A100 80GB, measured with the benchmark script added in this PR (`benchmark_v2/benchmark_scripts/quantized_cache.py`):

| cache | KV cache | peak memory | latency | matching tokens |
| --- | --- | --- | --- | --- |
| bf16 | 175.2 MiB | 8098.9 MiB | 8396.0 ms | 256 / 256 |
| fp8 | 87.6 MiB | 7917.4 MiB | 9723.7 ms | 256 / 256 |

The KV cache is exactly 2x smaller, and greedy generation is bit-for-bit identical to the bf16 baseline on this prompt.

Latency is 16% higher and peak memory barely moves, because the whole cache is dequantized to bf16 at every decoding step. Both are addressed by the follow-up PR consuming the FP8 states directly in the attention kernels; this PR is deliberately kept to the cache backend alone to stay easy to review.

## Changes

- `Fp8QuantizedLayer` in `cache_utils.py`, selected by `cache_config={"backend": "fp8"}`
- Exported from the top-level package and documented in `kv_cache.md` / `internal/generation_utils.md`
- `test_fp8_quantized_layer` unit test, and `fp8` added to the `test_quantized_cache_generation` parameterization
- `benchmark_v2/benchmark_scripts/quantized_cache.py`, comparing the backends against a bf16 `DynamicCache`
