### PR TITLE
Fix backslash handling in chat generate flags

### DIFF
--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -633,7 +633,10 @@ def parse_generate_flags(generate_flags: list[str] | None) -> dict:
         s = s.removeprefix("-")
         return s.replace(".", "", 1).isdigit()
 
-    generate_flags_as_dict = {k: f'"{v}"' if not is_number(v) else v for k, v in generate_flags_as_dict.items()}
+    generate_flags_as_dict = {
+        k: v if v.startswith("[") and v.endswith("]") else json.dumps(v) if not is_number(v) else v
+        for k, v in generate_flags_as_dict.items()
+    }
     # 2. c. [no processing needed] lists are lists of ints because `generate` doesn't take lists of strings :)
     # We also mention in the help message that we only accept lists of ints for now.
 

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -58,6 +58,24 @@ def test_parse_generate_flags_value_with_equal_sign():
     assert parse_generate_flags(["cache_implementation=a=b"]) == {"cache_implementation": "a=b"}
 
 
+def test_parse_generate_flags_preserves_types_and_quotes():
+    assert parse_generate_flags(['text=a"b', "do_sample=False", "eos_token_id=[1,2]", "watermark=None"]) == {
+        "text": 'a"b',
+        "do_sample": False,
+        "eos_token_id": [1, 2],
+        "watermark": None,
+    }
+
+
+def test_parse_generate_flags_preserves_lists_with_strings():
+    assert parse_generate_flags([r'stop_strings=["a\\b"]']) == {"stop_strings": [r"a\b"]}
+
+
+@pytest.mark.parametrize("value", [r"a\b", r"a\u0041", r"C:\temp", r"a\x"])
+def test_parse_generate_flags_preserves_backslashes(value):
+    assert parse_generate_flags([f"stop_strings={value}"]) == {"stop_strings": value}
+
+
 def test_parse_generate_flags_missing_equal_sign():
     with pytest.raises(typer.BadParameter, match="missing `=` after `do_sample`"):
         parse_generate_flags(["do_sample"])


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48680&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48680) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48680&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48680)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Fixes #48626 by preserving literal backslashes in values passed through `transformers chat --generate`.

Previously, non-numeric generate flag values were wrapped manually in quotes before being parsed as JSON. This caused backslashes such as `\b`, `\u0041`, `\x`, and Windows-style paths like `C:\temp` to be interpreted as JSON escape sequences.

This change uses JSON quoting for scalar string values so that literal backslashes and embedded quotes are preserved correctly.

It also keeps list-shaped values unchanged so existing list parsing behavior is preserved.

## Examples

Values such as:

```text
--generate stop_strings=a\b
--generate stop_strings=a\u0041
--generate path=C:\temp
--generate value=a\x
```

now preserve their literal backslashes instead of allowing JSON parsing to interpret them as escape sequences.

Existing string-list values such as:

```text
stop_strings=["a\\b"]
```

continue to be parsed correctly.

## Tests

Added regression coverage for:

* literal backslashes
* JSON escape-like sequences
* Windows-style paths
* embedded quotes
* string lists containing backslashes
* existing numeric, boolean, `None`, and list parsing behavior

Validation performed:

* `py_compile` ✅
* Ruff lint ✅
* Ruff format check ✅
* `git diff --check` ✅

The focused pytest suite could not be collected locally because of an existing `huggingface_hub` version mismatch (`is_offline_mode` import error). No dependency changes were made.