### PR TITLE
Support converting the unified Parakeet checkpoints (nvidia/parakeet-unified-en-0.6b)

### DIFF
--- a/src/transformers/models/parakeet/convert_nemo_to_hf.py
+++ b/src/transformers/models/parakeet/convert_nemo_to_hf.py
@@ -236,6 +236,11 @@ def convert_encoder_config(nemo_config):
     """Convert NeMo encoder config to HF encoder config."""
     encoder_keys_to_ignore = [
         "att_context_size",
+        # Streaming-only knobs of the unified (offline + streaming) FastConformer checkpoints. They select the
+        # chunked attention masks and dynamic chunk convolution used in streaming mode; the offline path this
+        # conversion targets runs with full context, where they have no effect on the forward pass.
+        "att_chunk_context_size",
+        "conv_context_style",
         "causal_downsampling",
         "stochastic_depth_start_layer",
         "feat_out",


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48686&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48686) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48686&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48686)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`nvidia/parakeet-unified-en-0.6b` is a unified offline + streaming FastConformer-RNN-T
(`EncDecRNNTBPEModel`). Its NeMo encoder config carries two keys the converter does not know about,
`att_chunk_context_size` and `conv_context_style`. `convert_encoder_config()` raises on any unmapped
key, so `--model_type rnnt` fails outright on this checkpoint.

Both keys are streaming-only and have no effect on the offline graph this conversion targets:

- the checkpoint ships `att_context_size: [-1, -1]`, i.e. full context;
- NeMo 3.0.0 stores `conv_context_style` on the encoder but never reads it in the forward pass
  (`nemo/collections/asr/modules/conformer_encoder.py` assigns `self.conv_context_style` and nothing
  else references it), so the depthwise conv keeps the symmetric non-causal default
  `conv_context_size = (kernel_size - 1) // 2`.

Adding them to `encoder_keys_to_ignore` is therefore enough; the existing `rnnt` path handles the rest
unchanged. Streaming inference is not addressed here.

## Verification

Converted checkpoint: https://huggingface.co/extraordinarylab/parakeet-unified-en-0.6b

Compared against NeMo 3.0.0 running the original `.nemo` on the same audio (CPU, fp32, greedy):

| Check | Result |
| --- | --- |
| `load_state_dict(strict=True)` | 0 missing / 0 unexpected keys |
| Transcripts on LibriSpeech dummy validation (73 utterances, 481 s of real speech) | **73/73 character-identical** |
| Transcripts on 3 additional real recordings | identical |
| Mel features | max abs diff 2.1e-05 |
| Encoder output | max abs diff 5.4e-07 |
| WER vs LibriSpeech references | 2.348% both sides |

Repo checks: `make fix-repo` passes all 17 checks with no resulting diff.

## Relation to existing PRs

#47891 also touches `convert_nemo_to_hf.py`, but in `write_processor` / `convert_tdt_config` (TDT
checkpoints without a `<pad>` token). This PR only touches `convert_encoder_config`; the two do not
overlap.

## Who can review?

@eustlb (added Parakeet-RNN-T) and @nithinraok (added Parakeet; NVIDIA NeMo)