### PR TITLE
[Fix] yolos offload issue

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -976,6 +976,9 @@ def _build_checkpoint_conversion_mapping():
         ],
         "dinov3_convnext": [WeightRenaming(r"(?<!model\.)stages", r"model.stages")],
         "dinov3_vit": [WeightRenaming(r"(?<!model\.)layer.", r"model.layer.")],
+        "yolos": [
+            WeightRenaming(r"encoder.mid_position_embeddings", r"encoder.interpolation.mid_position_embeddings")
+        ],
         "timesfm2_5": [
             WeightRenaming("ff0", "fc1"),
             WeightRenaming("ff1", "fc2"),

--- a/src/transformers/models/yolos/convert_yolos_to_pytorch.py
+++ b/src/transformers/models/yolos/convert_yolos_to_pytorch.py
@@ -93,7 +93,7 @@ def rename_key(name: str) -> str:
     if "det_token" in name:
         name = name.replace("det_token", "embeddings.detection_tokens")
     if "mid_pos_embed" in name:
-        name = name.replace("mid_pos_embed", "encoder.mid_position_embeddings")
+        name = name.replace("mid_pos_embed", "encoder.interpolation.mid_position_embeddings")
     if "pos_embed" in name:
         name = name.replace("pos_embed", "embeddings.position_embeddings")
     if "patch_embed.proj" in name:

--- a/src/transformers/models/yolos/modeling_yolos.py
+++ b/src/transformers/models/yolos/modeling_yolos.py
@@ -148,8 +148,15 @@ class InterpolateMidPositionEmbeddings(nn.Module):
     def __init__(self, config) -> None:
         super().__init__()
         self.config = config
+        seq_length = (
+            1 + (config.image_size[0] * config.image_size[1] // config.patch_size**2) + config.num_detection_tokens
+        )
+        self.mid_position_embeddings = nn.Parameter(
+            torch.zeros(config.num_hidden_layers - 1, 1, seq_length, config.hidden_size)
+        )
 
-    def forward(self, pos_embed, img_size=(800, 1344)) -> torch.Tensor:
+    def forward(self, img_size=(800, 1344)) -> torch.Tensor:
+        pos_embed = self.mid_position_embeddings
         cls_pos_embed = pos_embed[:, :, 0, :]
         cls_pos_embed = cls_pos_embed[:, None]
         det_pos_embed = pos_embed[:, :, -self.config.num_detection_tokens :, :]
@@ -401,23 +408,6 @@ class YolosEncoder(nn.Module):
         self.config = config
         self.layer = nn.ModuleList([YolosLayer(config) for _ in range(config.num_hidden_layers)])
         self.gradient_checkpointing = False
-
-        seq_length = (
-            1 + (config.image_size[0] * config.image_size[1] // config.patch_size**2) + config.num_detection_tokens
-        )
-        self.mid_position_embeddings = (
-            nn.Parameter(
-                torch.zeros(
-                    config.num_hidden_layers - 1,
-                    1,
-                    seq_length,
-                    config.hidden_size,
-                )
-            )
-            if config.use_mid_position_embeddings
-            else None
-        )
-
         self.interpolation = InterpolateMidPositionEmbeddings(config) if config.use_mid_position_embeddings else None
 
     def forward(
@@ -427,14 +417,14 @@ class YolosEncoder(nn.Module):
         width: int,
     ) -> BaseModelOutput:
         if self.config.use_mid_position_embeddings:
-            interpolated_mid_position_embeddings = self.interpolation(self.mid_position_embeddings, (height, width))
+            interpolated_mid_position_embeddings = self.interpolation((height, width))
 
         for i, layer_module in enumerate(self.layer):
             hidden_states = layer_module(hidden_states)
 
             if self.config.use_mid_position_embeddings:
                 if i < (self.config.num_hidden_layers - 1):
-                    hidden_states = hidden_states + interpolated_mid_position_embeddings[i]
+                    hidden_states = hidden_states + interpolated_mid_position_embeddings[i].to(hidden_states.device)
 
         return BaseModelOutput(last_hidden_state=hidden_states)
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48688&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48688) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48688&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48688)
<!-- ci-dashboard-badge:end -->

# What does this PR do?
Fixes the yolos disk offload tests broken by #46886: accelerate can't hook `nn.Parameter` on a container module, so `mid_position_embeddings` moves into `InterpolateMidPositionEmbeddings`  and the mid-embedding residual gets a `.to(hidden_states.device)` for sharded layers

Note that the slow CI was passing for this, but tests are currently not fired when they need a GPU but are not `slow` , but @ydshieh is aware :muscle: