### PR TITLE
[Bug] Preserve MoE router auxiliary loss weighting in Trainer DDP

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2130,7 +2130,24 @@ class Trainer:
             loss_scale = self.accelerator.num_processes
             if (pc := getattr(self.accelerator, "parallelism_config", None)) is not None:
                 loss_scale //= pc.tp_size
-            loss *= loss_scale if self.args.n_gpu <= 1 else self.args.n_gpu
+            loss_scale = loss_scale if self.args.n_gpu <= 1 else self.args.n_gpu
+            loss *= loss_scale
+
+            if loss_scale != 1 and self.compute_loss_func is None and labels is None:
+                unwrapped_model = self.accelerator.unwrap_model(model)
+                router_aux_loss_coef = getattr(unwrapped_model, "router_aux_loss_coef", 0.0)
+                if router_aux_loss_coef:
+                    if isinstance(outputs, dict):
+                        aux_loss = outputs.get("aux_loss")
+                    else:
+                        output_router_logits = inputs.get("output_router_logits")
+                        if output_router_logits is None:
+                            output_router_logits = unwrapped_model.config.output_router_logits
+                        aux_loss = outputs[1] if output_router_logits else None
+                    if aux_loss is not None:
+                        # The model's router loss is a local mean, not divided by
+                        # num_items_in_batch. DDP already averages it across ranks.
+                        loss -= (loss_scale - 1) * router_aux_loss_coef * aux_loss.to(loss.device)
 
         return (loss, outputs) if return_outputs else loss
 

--- a/tests/trainer/distributed/scripts/moe_aux_loss.py
+++ b/tests/trainer/distributed/scripts/moe_aux_loss.py
@@ -1,0 +1,92 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compare native Qwen3-MoE Trainer gradients across DDP world sizes, without downloads."""
+
+import argparse
+from pathlib import Path
+
+import torch
+
+from transformers import Qwen3MoeConfig, Qwen3MoeForCausalLM, Trainer, TrainingArguments, set_seed
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--use_cpu", action="store_true")
+    args = parser.parse_args()
+    set_seed(17)
+    if torch.cuda.is_available():
+        torch.backends.cuda.matmul.allow_tf32 = False
+        torch.backends.cudnn.allow_tf32 = False
+
+    config = Qwen3MoeConfig(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        moe_intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_experts=4,
+        num_experts_per_tok=1,
+        max_position_embeddings=128,
+        router_aux_loss_coef=0.01,
+        output_router_logits=True,
+        use_cache=False,
+        pad_token_id=0,
+    )
+    model = Qwen3MoeForCausalLM(config)
+    trainer = Trainer(
+        model=model,
+        args=TrainingArguments(
+            output_dir=args.output_dir,
+            use_cpu=args.use_cpu,
+            average_tokens_across_devices=True,
+            ddp_find_unused_parameters=True,
+            report_to="none",
+        ),
+    )
+    accelerator = trainer.accelerator
+    model = accelerator.prepare(model)
+
+    # Repeat every sequence once per rank. Each rank then sees the same token
+    # and routing distribution as the full batch used by the single-rank run.
+    rows = [(torch.arange(9) * (3 + i) + 92 + i * 11) % 125 + 3 for i in range(4)]
+    input_ids = torch.stack(rows).to(trainer.args.device)
+    if accelerator.num_processes == 1:
+        input_ids = input_ids.repeat_interleave(2, dim=0)
+    batch = {"input_ids": input_ids, "labels": input_ids.clone(), "attention_mask": torch.ones_like(input_ids)}
+    num_items = trainer._get_num_items_in_batch([batch], trainer.args.device)
+    trainer.current_gradient_accumulation_steps = 1
+    loss = trainer.training_step(model, batch, num_items_in_batch=num_items)
+    loss = accelerator.reduce(loss, reduction="mean")
+
+    if accelerator.is_main_process:
+        gradients = {
+            name: parameter.grad.detach().cpu()
+            for name, parameter in accelerator.unwrap_model(model).named_parameters()
+            if parameter.grad is not None
+        }
+        result = {"loss": loss.cpu(), "gradients": gradients}
+        Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+        torch.save(result, Path(args.output_dir) / "result.pt")
+    accelerator.wait_for_everyone()
+    accelerator.end_training()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/trainer/distributed/test_trainer_distributed_ddp.py
+++ b/tests/trainer/distributed/test_trainer_distributed_ddp.py
@@ -20,6 +20,7 @@ import json
 import os
 import re
 
+import torch
 from parameterized import parameterized
 
 from transformers.testing_utils import (
@@ -99,6 +100,22 @@ class DDPCommandsMixin:
 @slow
 @require_torch_multi_accelerator
 class TestTrainerDistributedDDP(DDPCommandsMixin, TestCasePlus):
+    def test_moe_aux_loss_averaging(self):
+        output_dir = self.get_auto_remove_tmp_dir()
+        script = os.path.join(SCRIPTS_DIR, "moe_aux_loss.py")
+        results = []
+        for num_processes in (1, 2):
+            run_dir = os.path.join(output_dir, str(num_processes))
+            cmd = self.get_torchrun_cmd(script, ["--output_dir", run_dir], num_processes=num_processes)
+            execute_subprocess_async(cmd, env=self.get_env())
+            results.append(torch.load(os.path.join(run_dir, "result.pt"), weights_only=True))
+
+        torch.testing.assert_close(results[0]["loss"], results[1]["loss"])
+        self.assertEqual(results[0]["gradients"].keys(), results[1]["gradients"].keys())
+        for name, gradient in results[0]["gradients"].items():
+            with self.subTest(parameter=name):
+                torch.testing.assert_close(gradient, results[1]["gradients"][name], atol=1e-6, rtol=1e-4)
+
     # -----------------------------------------------------------------------
     # accelerate launch tests
     # -----------------------------------------------------------------------

--- a/tests/trainer/test_trainer_moe_loss.py
+++ b/tests/trainer/test_trainer_moe_loss.py
@@ -1,0 +1,136 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from parameterized import parameterized
+
+from transformers import LlamaConfig, LlamaForCausalLM, Qwen3MoeConfig, Qwen3MoeForCausalLM, Trainer, TrainingArguments
+from transformers.loss.loss_utils import ForCausalLMLoss
+from transformers.testing_utils import TestCasePlus, require_torch
+
+
+@require_torch
+class TrainerMoELossTest(TestCasePlus):
+    def get_trainer(self, *, dense=False, compute_loss_func=None, **args):
+        torch.manual_seed(17)
+        config_args = {
+            "vocab_size": 128,
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 16,
+            "max_position_embeddings": 128,
+            "use_cache": False,
+            "pad_token_id": 0,
+        }
+        if dense:
+            model = LlamaForCausalLM(LlamaConfig(**config_args))
+        else:
+            model = Qwen3MoeForCausalLM(
+                Qwen3MoeConfig(
+                    **config_args,
+                    moe_intermediate_size=64,
+                    num_experts=4,
+                    num_experts_per_tok=1,
+                    router_aux_loss_coef=0.01,
+                    output_router_logits=True,
+                )
+            )
+        return Trainer(
+            model=model,
+            args=TrainingArguments(output_dir=self.get_auto_remove_tmp_dir(), use_cpu=True, report_to="none", **args),
+            compute_loss_func=compute_loss_func,
+        )
+
+    def check_partitioned_loss(self, trainer, *, tp_size=1, **forward_kwargs):
+        # Each half has the same routing distribution, so the local auxiliary
+        # losses should match the full batch without any distributed reduction.
+        rows = [(torch.arange(9) * (3 + i) + 92 + i * 11) % 125 + 3 for i in range(4)]
+        input_ids = torch.stack(rows).repeat_interleave(2, dim=0)
+        batch = {"input_ids": input_ids, "labels": input_ids.clone(), "attention_mask": torch.ones_like(input_ids)}
+
+        def loss_and_gradients(world_size):
+            trainer.model.zero_grad(set_to_none=True)
+            inputs = {key: value[::world_size] for key, value in batch.items()}
+            with patch.object(trainer.accelerator.state, "num_processes", world_size * tp_size):
+                loss = trainer.compute_loss(trainer.model, {**inputs, **forward_kwargs}, num_items_in_batch=64)
+            loss.backward()
+            gradients = {
+                name: parameter.grad.detach().clone()
+                for name, parameter in trainer.model.named_parameters()
+                if parameter.grad is not None
+            }
+            return loss.detach(), gradients
+
+        full_loss, full_gradients = loss_and_gradients(1)
+        local_loss, local_gradients = loss_and_gradients(2)
+        torch.testing.assert_close(local_loss, full_loss)
+        self.assertEqual(local_gradients.keys(), full_gradients.keys())
+        for name in full_gradients:
+            with self.subTest(parameter=name):
+                torch.testing.assert_close(local_gradients[name], full_gradients[name], atol=1e-6, rtol=1e-4)
+
+    @parameterized.expand(
+        [
+            ("model_output", {}),
+            ("tuple", {"return_dict": False}),
+            ("tuple_default_router_flag", {"return_dict": False, "output_router_logits": None}),
+            ("router_disabled", {"output_router_logits": False}),
+            ("tuple_router_disabled", {"return_dict": False, "output_router_logits": False}),
+        ]
+    )
+    def test_model_loss_matches_full_batch(self, _, forward_kwargs):
+        self.check_partitioned_loss(self.get_trainer(), **forward_kwargs)
+
+    @parameterized.expand([(0.0,), (0.07,)])
+    def test_uses_model_auxiliary_coefficient(self, coefficient):
+        trainer = self.get_trainer()
+        trainer.model.router_aux_loss_coef = coefficient
+        self.check_partitioned_loss(trainer)
+
+    def test_custom_loss(self):
+        def compute_loss(outputs, labels, num_items_in_batch):
+            return ForCausalLMLoss(outputs.logits, labels, vocab_size=128, num_items_in_batch=num_items_in_batch)
+
+        self.check_partitioned_loss(self.get_trainer(compute_loss_func=compute_loss))
+
+    def test_label_smoothing(self):
+        self.check_partitioned_loss(self.get_trainer(label_smoothing_factor=0.1))
+
+    def test_dense_model(self):
+        self.check_partitioned_loss(self.get_trainer(dense=True))
+
+    def test_tensor_parallel_ranks_do_not_increase_loss_scale(self):
+        trainer = self.get_trainer()
+        parallelism_config = SimpleNamespace(tp_size=2, sp_backend=None)
+        with patch.object(trainer.accelerator.state, "parallelism_config", parallelism_config):
+            self.check_partitioned_loss(trainer, tp_size=2)
+
+    @parameterized.expand([("averaging_disabled", False, 64), ("no_token_count", True, None)])
+    def test_unscaled_model_loss(self, _, average_tokens, num_items):
+        trainer = self.get_trainer(average_tokens_across_devices=average_tokens)
+        input_ids = torch.arange(18).reshape(2, 9) + 3
+        inputs = {"input_ids": input_ids, "labels": input_ids.clone(), "attention_mask": torch.ones_like(input_ids)}
+        expected = trainer.model(**inputs, num_items_in_batch=num_items).loss
+        with patch.object(trainer.accelerator.state, "num_processes", 2):
+            loss, outputs = trainer.compute_loss(
+                trainer.model, inputs, return_outputs=True, num_items_in_batch=num_items
+            )
+        torch.testing.assert_close(loss, expected)
+        torch.testing.assert_close(outputs.loss, expected)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48691&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48691) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48691&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48691)
<!-- ci-dashboard-badge:end -->

## Summary

With `average_tokens_across_devices=True`, `Trainer` multiplies the model loss by the data-parallel world size to compensate for DDP's gradient averaging. Qwen3-MoE has already added its rank-local router auxiliary loss to the token-normalized cross-entropy, so that multiplication also increases the auxiliary loss weight.

This keeps the cross-entropy scaling and removes the extra scaling of the built-in router loss. Fixes #48690.

## Changes

- Use the coefficient from the unwrapped model, matching the value used in its forward pass.
- Handle both model-output and tuple returns, including an explicitly disabled `output_router_logits` flag.
- Apply the correction only to the native model loss. Custom loss functions and label smoothing keep their existing behavior.
- Add small, randomly initialized Qwen3-MoE regressions and a two-rank DDP test. The DDP fixture gives both ranks the same routing distribution to isolate the scaling error.

## Validation

Tested against `c6947074832360a35cb8d26d1255b2b517fa9097` with Python 3.11.15, PyTorch 2.13.0+cpu and Accelerate 1.14.0.

The 13 new unit tests give **5 failures before the fix and 13 passes after it**. With the adjacent Trainer tests, the result is **26 passed, 2 skipped**; both skips require multiple accelerators.

```bash
OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 RUN_SLOW=1 python -m pytest -q \
  tests/trainer/test_trainer_moe_loss.py \
  tests/trainer/test_trainer_data.py::TrainerLabelSmoothingTest \
  tests/trainer/test_trainer.py::TrainerDDPKwargsTest \
  tests/trainer/test_trainer.py::TrainerGradientAccumulationTest \
  tests/trainer/distributed/test_trainer_distributed_ddp.py::TestTrainerDistributedDDP::test_moe_aux_loss_averaging
```

The DDP worker was also run directly on CPU/Gloo with one and two processes:

```bash
OMP_NUM_THREADS=1 python -m torch.distributed.run --standalone --nproc_per_node=1 \
  tests/trainer/distributed/scripts/moe_aux_loss.py --use_cpu --output_dir /tmp/moe-aux-1
OMP_NUM_THREADS=1 python -m torch.distributed.run --standalone --nproc_per_node=2 \
  tests/trainer/distributed/scripts/moe_aux_loss.py --use_cpu --output_dir /tmp/moe-aux-2
```

| One-rank vs. two-rank comparison | Before | After |
| --- | ---: | ---: |
| Router gradient relative L2 error, using the one-rank norm | 0.6182 | 2.31e-7 |
| Absolute loss difference | 0.0102444 | 4.77e-7 |

All parameter gradients pass `torch.testing.assert_close(atol=1e-6, rtol=1e-4)` after the fix. These are fresh CPU results; the new GPU DDP test has not been run locally.

`make fix-repo` (17 checks) and `make check-repo` (26 checks) passed. `utils/tests_fetcher.py` selects the full CI suite for the Trainer dependency graph; the local test scope is the loss-related command above.

## AI assistance

The implementation and tests were prepared with OpenAI Codex at the issue author's request. I have personally reviewed every changed line. The local tests reported above were run by Codex. The first-contribution declaration below is left unchecked because the code and description were prepared with an agent.

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent