### PR TITLE
[perf] Qwen3.5-9B full fine-tuning with FSDP2 on 8x B200: 0.60 s to 0.48 s per step, mostly from the unfused fp32 RMSNorm passes

### DIFF
--- a/examples/pytorch/language-modeling/requirements.txt
+++ b/examples/pytorch/language-modeling/requirements.txt
@@ -6,3 +6,4 @@ protobuf
 evaluate
 scikit-learn
 flash-linear-attention==0.5.2  # perf campaign: Triton chunk_gated_delta_rule for Qwen3.5 linear-attention layers
+causal-conv1d==1.7.0  # perf campaign: fused causal depthwise conv + silu for Qwen3.5 linear-attention layers (built from source against CUDA 12.8; no wheel for torch 2.11)

--- a/examples/pytorch/language-modeling/requirements.txt
+++ b/examples/pytorch/language-modeling/requirements.txt
@@ -5,5 +5,3 @@ sentencepiece != 0.1.92
 protobuf
 evaluate
 scikit-learn
-flash-linear-attention==0.5.2  # perf campaign: Triton chunk_gated_delta_rule for Qwen3.5 linear-attention layers
-causal-conv1d==1.7.0  # perf campaign: fused causal depthwise conv + silu for Qwen3.5 linear-attention layers (built from source against CUDA 12.8; no wheel for torch 2.11)

--- a/examples/pytorch/language-modeling/requirements.txt
+++ b/examples/pytorch/language-modeling/requirements.txt
@@ -5,3 +5,4 @@ sentencepiece != 0.1.92
 protobuf
 evaluate
 scikit-learn
+flash-linear-attention==0.5.2  # perf campaign: Triton chunk_gated_delta_rule for Qwen3.5 linear-attention layers

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -43,6 +43,10 @@ except Exception:  # fla missing or broken: keep the reference path
     _fla_rms_norm_gated = None
 
 
+# perf: fla's chunk_gated_delta_rule handles grouped value heads (HV > H) itself, see Qwen3_5GatedDeltaNet.forward
+_FLA_GDN_GVA = _fla_rms_norm is not None
+
+
 def _use_fla_norm(x: torch.Tensor) -> bool:
     return _fla_rms_norm is not None and x.is_cuda and not is_torchdynamo_exporting()
 from ...integrations.accelerate import force_accelerate_hooks
@@ -633,7 +637,15 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         beta = b.sigmoid()
         # If the model is loaded in fp16, without the .float() here, A might be -inf
         g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
-        if self.num_v_heads // self.num_k_heads > 1:
+        # perf: fla's chunk kernel applies grouped value attention itself when num_v_heads > num_k_heads
+        # (`HV % H == 0`), so the query/key repeat (and its backward reduction) is only needed on the torch path.
+        fla_gva = (
+            _FLA_GDN_GVA  # flash-linear-attention importable: the chunk kernel below resolves to fla
+            and query.is_cuda
+            and not is_torchdynamo_exporting()
+            and not (use_precomputed_states and seq_len == 1)
+        )
+        if self.num_v_heads // self.num_k_heads > 1 and not fla_gva:
             query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -865,8 +865,9 @@ class Qwen3_5RMSNorm(nn.Module):
 
     def forward(self, x):
         if _use_fla_norm(x):
-            # fused: fp32 rms-norm * (1 + weight), cast back to x.dtype; one Triton kernel each way
-            return _fla_rms_norm(x, 1.0 + self.weight, None, eps=self.eps)
+            # fused: fp32 rms-norm * (1 + weight), cast back to x.dtype; one Triton kernel each way.
+            # The add is done in fp32 like the reference: in bf16 it would round every channel scale by up to 0.4%.
+            return _fla_rms_norm(x, 1.0 + self.weight.float(), None, eps=self.eps)
         output = self._norm(x.float())
         # Llama does x.to(float16) * w whilst Qwen3_5 is (x * w).to(float16)
         # See https://github.com/huggingface/transformers/pull/29402

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -32,23 +32,6 @@ from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
 from ...integrations import use_kernel_forward_from_hub, use_kernel_func_from_hub_with_fallback, use_kernelized_func
-
-# perf: fused Triton RMSNorm kernels from flash-linear-attention, when the package is installed. The reference
-# forward below runs 6 unfused fp32 element-wise passes (plus ~10 in backward) per norm; the fused kernel does one.
-try:
-    from fla.modules.fused_norm_gate import rms_norm_gated as _fla_rms_norm_gated
-    from fla.modules.layernorm import rms_norm as _fla_rms_norm
-except Exception:  # fla missing or broken: keep the reference path
-    _fla_rms_norm = None
-    _fla_rms_norm_gated = None
-
-
-# perf: fla's chunk_gated_delta_rule handles grouped value heads (HV > H) itself, see Qwen3_5GatedDeltaNet.forward
-_FLA_GDN_GVA = _fla_rms_norm is not None
-
-
-def _use_fla_norm(x: torch.Tensor) -> bool:
-    return _fla_rms_norm is not None and x.is_cuda and not is_torchdynamo_exporting()
 from ...integrations.accelerate import force_accelerate_hooks
 from ...masking_utils import create_causal_mask, create_recurrent_attention_mask
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
@@ -70,6 +53,7 @@ from ...utils import (
     TransformersKwargs,
     auto_docstring,
     can_return_tuple,
+    is_flash_linear_attention_available,
     is_torchdynamo_exporting,
     torch_compilable_check,
 )
@@ -226,32 +210,6 @@ class Qwen3_5TextRotaryEmbedding(nn.Module):
             idx = slice(offset, length, 3)
             freqs_thw[..., idx] = freq[dim, ..., idx]
         return torch.cat((freqs_thw, freqs_thw), dim=-1)
-
-
-# NOTE: the FLA package does not re-cast to `input_dtype` in its implementation, maybe we should do the same
-@use_kernel_forward_from_hub("RMSNormGated")
-class Qwen3_5RMSNormGated(nn.Module):
-    def __init__(self, hidden_size: int, eps: float = 1e-6, **kwargs) -> None:
-        super().__init__()
-        self.weight = nn.Parameter(torch.ones(hidden_size))
-        self.variance_epsilon = eps
-        self.activation = "silu"
-
-    def forward(self, hidden_states: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
-        if _use_fla_norm(hidden_states):
-            # fused: fp32 rms-norm, * weight, * silu(gate), cast back; one Triton kernel each way
-            return _fla_rms_norm_gated(
-                hidden_states, gate, self.weight, None, activation="swish", eps=self.variance_epsilon
-            )
-        input_dtype = hidden_states.dtype
-        hidden_states = hidden_states.to(torch.float32)
-        variance = hidden_states.pow(2).mean(-1, keepdim=True)
-        # Norm before gate
-        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
-        hidden_states = self.weight * hidden_states.to(input_dtype)
-        hidden_states = hidden_states * ACT2FN[self.activation](gate.to(torch.float32))
-
-        return hidden_states.to(input_dtype)
 
 
 def apply_mask_to_padding_states(hidden_states, attention_mask):
@@ -640,7 +598,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         # perf: fla's chunk kernel applies grouped value attention itself when num_v_heads > num_k_heads
         # (`HV % H == 0`), so the query/key repeat (and its backward reduction) is only needed on the torch path.
         fla_gva = (
-            _FLA_GDN_GVA  # flash-linear-attention importable: the chunk kernel below resolves to fla
+            is_flash_linear_attention_available()  # the chunk kernel below resolves to fla
             and query.is_cuda
             and not is_torchdynamo_exporting()
             and not (use_precomputed_states and seq_len == 1)
@@ -865,6 +823,40 @@ class Qwen3_5MLP(nn.Module):
         return down_proj
 
 
+def _use_fla_norm(x: torch.Tensor) -> bool:
+    # perf: fused Triton RMSNorm kernels from flash-linear-attention, when the package is installed. The reference
+    # forwards run 6 unfused fp32 element-wise passes (plus ~10 in backward) per norm; the fused kernel does one.
+    return is_flash_linear_attention_available() and x.is_cuda and not is_torchdynamo_exporting()
+
+
+# NOTE: the FLA package does not re-cast to `input_dtype` in its implementation, maybe we should do the same
+@use_kernel_forward_from_hub("RMSNormGated")
+class Qwen3_5RMSNormGated(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6, **kwargs) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+        self.activation = "silu"
+
+    def forward(self, hidden_states: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+        if _use_fla_norm(hidden_states):
+            # fused: fp32 rms-norm, * weight, * silu(gate), cast back; one Triton kernel each way
+            from fla.modules.fused_norm_gate import rms_norm_gated
+
+            return rms_norm_gated(
+                hidden_states, gate, self.weight, None, activation="swish", eps=self.variance_epsilon
+            )
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        # Norm before gate
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        hidden_states = self.weight * hidden_states.to(input_dtype)
+        hidden_states = hidden_states * ACT2FN[self.activation](gate.to(torch.float32))
+
+        return hidden_states.to(input_dtype)
+
+
 @use_kernel_forward_from_hub("RMSNormZeroCentered")
 class Qwen3_5RMSNorm(nn.Module):
     def __init__(self, dim: int, eps: float = 1e-6):
@@ -879,7 +871,9 @@ class Qwen3_5RMSNorm(nn.Module):
         if _use_fla_norm(x):
             # fused: fp32 rms-norm * (1 + weight), cast back to x.dtype; one Triton kernel each way.
             # The add is done in fp32 like the reference: in bf16 it would round every channel scale by up to 0.4%.
-            return _fla_rms_norm(x, 1.0 + self.weight.float(), None, eps=self.eps)
+            from fla.modules.layernorm import rms_norm
+
+            return rms_norm(x, 1.0 + self.weight.float(), None, eps=self.eps)
         output = self._norm(x.float())
         # Llama does x.to(float16) * w whilst Qwen3_5 is (x * w).to(float16)
         # See https://github.com/huggingface/transformers/pull/29402

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -32,6 +32,19 @@ from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
 from ...integrations import use_kernel_forward_from_hub, use_kernel_func_from_hub_with_fallback, use_kernelized_func
+
+# perf: fused Triton RMSNorm kernels from flash-linear-attention, when the package is installed. The reference
+# forward below runs 6 unfused fp32 element-wise passes (plus ~10 in backward) per norm; the fused kernel does one.
+try:
+    from fla.modules.fused_norm_gate import rms_norm_gated as _fla_rms_norm_gated
+    from fla.modules.layernorm import rms_norm as _fla_rms_norm
+except Exception:  # fla missing or broken: keep the reference path
+    _fla_rms_norm = None
+    _fla_rms_norm_gated = None
+
+
+def _use_fla_norm(x: torch.Tensor) -> bool:
+    return _fla_rms_norm is not None and x.is_cuda and not is_torchdynamo_exporting()
 from ...integrations.accelerate import force_accelerate_hooks
 from ...masking_utils import create_causal_mask, create_recurrent_attention_mask
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
@@ -221,6 +234,11 @@ class Qwen3_5RMSNormGated(nn.Module):
         self.activation = "silu"
 
     def forward(self, hidden_states: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+        if _use_fla_norm(hidden_states):
+            # fused: fp32 rms-norm, * weight, * silu(gate), cast back; one Triton kernel each way
+            return _fla_rms_norm_gated(
+                hidden_states, gate, self.weight, None, activation="swish", eps=self.variance_epsilon
+            )
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)
         variance = hidden_states.pow(2).mean(-1, keepdim=True)
@@ -846,6 +864,9 @@ class Qwen3_5RMSNorm(nn.Module):
         return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
 
     def forward(self, x):
+        if _use_fla_norm(x):
+            # fused: fp32 rms-norm * (1 + weight), cast back to x.dtype; one Triton kernel each way
+            return _fla_rms_norm(x, 1.0 + self.weight, None, eps=self.eps)
         output = self._norm(x.float())
         # Llama does x.to(float16) * w whilst Qwen3_5 is (x * w).to(float16)
         # See https://github.com/huggingface/transformers/pull/29402

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -19,6 +19,7 @@ from huggingface_hub.dataclasses import strict
 from torch import nn
 
 from ... import initialization as init
+from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...integrations import use_kernel_forward_from_hub, use_kernelized_func
 from ...masking_utils import create_causal_mask, create_recurrent_attention_mask
@@ -30,7 +31,14 @@ from ...modeling_layers import (
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling, SequenceClassifierOutputWithPast
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
-from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
+from ...utils import (
+    TransformersKwargs,
+    auto_docstring,
+    can_return_tuple,
+    is_flash_linear_attention_available,
+    is_torchdynamo_exporting,
+    logging,
+)
 from ...utils.generic import accepts_precomputed_kwargs, merge_with_config_defaults
 from ...utils.output_capturing import capture_outputs
 from ...vision_utils import (
@@ -47,6 +55,7 @@ from ..qwen3_next.modeling_qwen3_next import (
     Qwen3NextModel,
     Qwen3NextPreTrainedModel,
     Qwen3NextRMSNorm,
+    Qwen3NextRMSNormGated,
     apply_mask_to_padding_states,
     causal_conv1d_fn,
     causal_conv1d_update,
@@ -62,6 +71,12 @@ from ..qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLVisionModel,
     Qwen3VLVisionRotaryEmbedding,
 )
+
+
+def _use_fla_norm(x: torch.Tensor) -> bool:
+    # perf: fused Triton RMSNorm kernels from flash-linear-attention, when the package is installed. The reference
+    # forwards run 6 unfused fp32 element-wise passes (plus ~10 in backward) per norm; the fused kernel does one.
+    return is_flash_linear_attention_available() and x.is_cuda and not is_torchdynamo_exporting()
 
 
 logger = logging.get_logger(__name__)
@@ -291,7 +306,15 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
         beta = b.sigmoid()
         # If the model is loaded in fp16, without the .float() here, A might be -inf
         g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
-        if self.num_v_heads // self.num_k_heads > 1:
+        # perf: fla's chunk kernel applies grouped value attention itself when num_v_heads > num_k_heads
+        # (`HV % H == 0`), so the query/key repeat (and its backward reduction) is only needed on the torch path.
+        fla_gva = (
+            is_flash_linear_attention_available()  # the chunk kernel below resolves to fla
+            and query.is_cuda
+            and not is_torchdynamo_exporting()
+            and not (use_precomputed_states and seq_len == 1)
+        )
+        if self.num_v_heads // self.num_k_heads > 1 and not fla_gva:
             query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
@@ -347,9 +370,40 @@ class Qwen3_5MLP(Qwen3NextMLP):
         self.intermediate_size = intermediate_size
 
 
+class Qwen3_5RMSNormGated(Qwen3NextRMSNormGated):
+    def forward(self, hidden_states: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+        if _use_fla_norm(hidden_states):
+            # fused: fp32 rms-norm, * weight, * silu(gate), cast back; one Triton kernel each way
+            from fla.modules.fused_norm_gate import rms_norm_gated
+
+            return rms_norm_gated(
+                hidden_states, gate, self.weight, None, activation="swish", eps=self.variance_epsilon
+            )
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        # Norm before gate
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        hidden_states = self.weight * hidden_states.to(input_dtype)
+        hidden_states = hidden_states * ACT2FN[self.activation](gate.to(torch.float32))
+
+        return hidden_states.to(input_dtype)
+
+
 @use_kernel_forward_from_hub("RMSNormZeroCentered")
 class Qwen3_5RMSNorm(Qwen3NextRMSNorm):
-    pass
+    def forward(self, x):
+        if _use_fla_norm(x):
+            # fused: fp32 rms-norm * (1 + weight), cast back to x.dtype; one Triton kernel each way.
+            # The add is done in fp32 like the reference: in bf16 it would round every channel scale by up to 0.4%.
+            from fla.modules.layernorm import rms_norm
+
+            return rms_norm(x, 1.0 + self.weight.float(), None, eps=self.eps)
+        output = self._norm(x.float())
+        # Llama does x.to(float16) * w whilst Qwen3_5 is (x * w).to(float16)
+        # See https://github.com/huggingface/transformers/pull/29402
+        output = output * (1.0 + self.weight.float())
+        return output.type_as(x)
 
 
 class Qwen3_5DecoderLayer(GradientCheckpointingLayer):

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -55,6 +55,7 @@ from ...utils import (
     TransformersKwargs,
     auto_docstring,
     can_return_tuple,
+    is_flash_linear_attention_available,
     is_torchdynamo_exporting,
     torch_compilable_check,
 )
@@ -213,6 +214,12 @@ class Qwen3_5MoeTextRotaryEmbedding(nn.Module):
         return torch.cat((freqs_thw, freqs_thw), dim=-1)
 
 
+def _use_fla_norm(x: torch.Tensor) -> bool:
+    # perf: fused Triton RMSNorm kernels from flash-linear-attention, when the package is installed. The reference
+    # forwards run 6 unfused fp32 element-wise passes (plus ~10 in backward) per norm; the fused kernel does one.
+    return is_flash_linear_attention_available() and x.is_cuda and not is_torchdynamo_exporting()
+
+
 # NOTE: the FLA package does not re-cast to `input_dtype` in its implementation, maybe we should do the same
 @use_kernel_forward_from_hub("RMSNormGated")
 class Qwen3_5MoeRMSNormGated(nn.Module):
@@ -223,6 +230,13 @@ class Qwen3_5MoeRMSNormGated(nn.Module):
         self.activation = "silu"
 
     def forward(self, hidden_states: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+        if _use_fla_norm(hidden_states):
+            # fused: fp32 rms-norm, * weight, * silu(gate), cast back; one Triton kernel each way
+            from fla.modules.fused_norm_gate import rms_norm_gated
+
+            return rms_norm_gated(
+                hidden_states, gate, self.weight, None, activation="swish", eps=self.variance_epsilon
+            )
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)
         variance = hidden_states.pow(2).mean(-1, keepdim=True)
@@ -617,7 +631,15 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         beta = b.sigmoid()
         # If the model is loaded in fp16, without the .float() here, A might be -inf
         g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
-        if self.num_v_heads // self.num_k_heads > 1:
+        # perf: fla's chunk kernel applies grouped value attention itself when num_v_heads > num_k_heads
+        # (`HV % H == 0`), so the query/key repeat (and its backward reduction) is only needed on the torch path.
+        fla_gva = (
+            is_flash_linear_attention_available()  # the chunk kernel below resolves to fla
+            and query.is_cuda
+            and not is_torchdynamo_exporting()
+            and not (use_precomputed_states and seq_len == 1)
+        )
+        if self.num_v_heads // self.num_k_heads > 1 and not fla_gva:
             query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 

--- a/src/transformers/models/qwen4_exp/modeling_qwen4_exp.py
+++ b/src/transformers/models/qwen4_exp/modeling_qwen4_exp.py
@@ -55,6 +55,7 @@ from ...utils import (
     TransformersKwargs,
     auto_docstring,
     can_return_tuple,
+    is_flash_linear_attention_available,
     is_torchdynamo_exporting,
     torch_compilable_check,
 )
@@ -147,6 +148,12 @@ class Qwen4ExpTextRotaryEmbedding(nn.Module):
         return torch.cat((freqs_thw, freqs_thw), dim=-1)
 
 
+def _use_fla_norm(x: torch.Tensor) -> bool:
+    # perf: fused Triton RMSNorm kernels from flash-linear-attention, when the package is installed. The reference
+    # forwards run 6 unfused fp32 element-wise passes (plus ~10 in backward) per norm; the fused kernel does one.
+    return is_flash_linear_attention_available() and x.is_cuda and not is_torchdynamo_exporting()
+
+
 class Qwen4ExpTextRMSNorm(nn.Module):
     def __init__(self, dim: int, group_size: int | None = None, eps: float = 1e-6):
         super().__init__()
@@ -163,6 +170,12 @@ class Qwen4ExpTextRMSNorm(nn.Module):
         return out.flatten(-2) if self.group_size is not None else out
 
     def forward(self, x):
+        if _use_fla_norm(x):
+            # fused: fp32 rms-norm * (1 + weight), cast back to x.dtype; one Triton kernel each way.
+            # The add is done in fp32 like the reference: in bf16 it would round every channel scale by up to 0.4%.
+            from fla.modules.layernorm import rms_norm
+
+            return rms_norm(x, 1.0 + self.weight.float(), None, eps=self.eps)
         output = self._norm(x.float())
         # Llama does x.to(float16) * w whilst Qwen4ExpText is (x * w).to(float16)
         # See https://github.com/huggingface/transformers/pull/29402
@@ -577,7 +590,15 @@ class Qwen4ExpTextGatedDeltaNet(nn.Module):
         beta = b.sigmoid()
         # If the model is loaded in fp16, without the .float() here, A might be -inf
         g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
-        if self.num_v_heads // self.num_k_heads > 1:
+        # perf: fla's chunk kernel applies grouped value attention itself when num_v_heads > num_k_heads
+        # (`HV % H == 0`), so the query/key repeat (and its backward reduction) is only needed on the torch path.
+        fla_gva = (
+            is_flash_linear_attention_available()  # the chunk kernel below resolves to fla
+            and query.is_cuda
+            and not is_torchdynamo_exporting()
+            and not (use_precomputed_states and seq_len == 1)
+        )
+        if self.num_v_heads // self.num_k_heads > 1 and not fla_gva:
             query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1841,18 +1841,17 @@ class Trainer:
                 with sync_context():
                     tr_loss_step = self.training_step(model, inputs, num_items_in_batch)
 
-                if (
-                    self.args.logging_nan_inf_filter
-                    and not is_torch_xla_available()
-                    and (torch.isnan(tr_loss_step) or torch.isinf(tr_loss_step))
-                ):
-                    # if loss is nan or inf simply add the average of previous logged losses
-                    self._tr_loss += self._tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
+                if self._tr_loss.device != tr_loss_step.device:
+                    raise ValueError(
+                        f"Calculated loss must be on the original device: {self._tr_loss.device} but device in use is {tr_loss_step.device}"
+                    )
+                if self.args.logging_nan_inf_filter and not is_torch_xla_available():
+                    # if loss is nan or inf simply add the average of previous logged losses. Done on the device
+                    # (perf): `torch.isnan(...) or ...` forced a host sync right after backward, which left the GPU
+                    # idle for every CPU-bound launch in grad clipping and the optimizer step that followed.
+                    fallback = self._tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
+                    self._tr_loss += torch.where(torch.isfinite(tr_loss_step), tr_loss_step, fallback)
                 else:
-                    if self._tr_loss.device != tr_loss_step.device:
-                        raise ValueError(
-                            f"Calculated loss must be on the original device: {self._tr_loss.device} but device in use is {tr_loss_step.device}"
-                        )
                     self._tr_loss += tr_loss_step
 
                 self.current_flos += float(self.floating_point_ops(inputs))
@@ -2667,7 +2666,47 @@ class Trainer:
             return self.optimizer.clip_master_grads(self.args.max_grad_norm)
         if self._has_mixed_mesh_grads(model):
             return self._mixed_mesh_grad_norm(model, self.args.max_grad_norm)
+        if self.is_fsdp_enabled and getattr(self.accelerator, "is_fsdp2", False):
+            grad_norm = self._fsdp2_local_clip_grad_norm(model, self.args.max_grad_norm)
+            if grad_norm is not None:
+                return grad_norm
         return self.accelerator.clip_grad_norm_(model.parameters(), self.args.max_grad_norm)
+
+    def _fsdp2_local_clip_grad_norm(self, model, max_norm: float):
+        """Grad clipping for FSDP2 (every grad a `Shard` DTensor on one 1-D mesh) without DTensor dispatch.
+
+        `torch.nn.utils.clip_grad_norm_` on DTensor grads runs the foreach norm, the stack and the final norm
+        through DTensor's Python sharding propagation, which leaves the GPU idle for several ms per step. The
+        math is the same here: per-shard foreach norms, one all-reduce of the sum of squares, one foreach scale
+        on the local shards (in place, so the DTensor grads see it). Returns None when the layout is anything
+        else, and the caller falls back to accelerate.
+        """
+        from torch.distributed.tensor import DTensor
+
+        grads = [p.grad for p in model.parameters() if p.grad is not None]
+        if not grads or not all(isinstance(g, DTensor) for g in grads):
+            return None
+        mesh = grads[0].device_mesh
+        if mesh.ndim != 1 or any(g.device_mesh != mesh for g in grads):
+            return None
+        if any(not pl.is_shard() for g in grads for pl in g.placements):
+            return None
+        device = grads[0].device
+        locals_by_dtype: dict[torch.dtype, list[torch.Tensor]] = {}
+        for g in grads:
+            t = g._local_tensor
+            if t.numel() > 0:
+                locals_by_dtype.setdefault(t.dtype, []).append(t)
+        total_sq = torch.zeros((), device=device, dtype=torch.float32)
+        for tensors in locals_by_dtype.values():
+            norms = torch._foreach_norm(tensors, 2.0)
+            total_sq = total_sq + torch.stack(norms).float().square().sum()
+        dist.all_reduce(total_sq, op=dist.ReduceOp.SUM, group=mesh.get_group())
+        total_norm = total_sq.sqrt()
+        clip_coef = torch.clamp(float(max_norm) / (total_norm + 1e-6), max=1.0)
+        for tensors in locals_by_dtype.values():
+            torch._foreach_mul_(tensors, clip_coef.to(tensors[0].dtype))
+        return total_norm
 
     def _get_grad_norm(self, model, grad_norm=None):
         """Return the gradient norm as a Python float."""


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48692&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48692) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48692&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48692)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Related to #48718.

I fine-tuned Qwen/Qwen3.5-9B-Base with `examples/pytorch/language-modeling/run_clm.py` under FSDP2 on 8 B200s, with `flash-linear-attention` and `causal-conv1d` installed, and one training step took 0.6045 s. Three things in that step are cheap to take out. The two Qwen3.5 RMSNorm variants run as unfused fp32 element-wise chains; replacing them took element-wise kernel time from 296 ms to 176 ms per step. The gated delta rule copies query and key up to the value head count before calling a kernel that already accepts grouped heads. And the Trainer reads the loss back to the host right after backward, which leaves the GPU idle through gradient clipping and the optimizer step.

This PR calls fla's fused norm kernels when the package is installed, skips the query and key copy on that path, and takes the host read and the DTensor dispatch out of the Trainer step. On the 8 B200s I measured, the step goes from 0.6045 s to 0.4755 s, a **1.27x** speedup; I have not measured other hardware.

1. **Fused RMSNorm and gated RMSNorm from flash-linear-attention.** `Qwen3_5RMSNorm.forward` and `Qwen3_5RMSNormGated.forward` cast to fp32 and then run pow, mean, rsqrt, mul and the weight multiply as separate kernels: six element-wise passes forward and about ten backward, for the three or four norms in each of the 32 layers. They now call fla's `rms_norm` and `rms_norm_gated` when the package imports, the input is on CUDA and the model is not under torchdynamo export; otherwise the reference forward runs as before. The zero-centered `(1 + weight)` add stays in fp32 as the reference does, because in bf16 it rounded channel scales by up to 0.4 % and moved the mean logit by 3 %. There is no flag: uninstalling fla or exporting gives the reference path, and `Qwen3_5RMSNorm` keeps its `@use_kernel_forward_from_hub` registration, so a hub kernel still replaces the forward under `use_kernels=True` — a combination I did not measure, since the runs were offline.
2. **No query and key repeat on the fla path of the gated delta rule.** `repeat_interleave` expanded query and key to `num_v_heads` before `chunk_gated_delta_rule`, which applies grouped value attention itself when the value heads are a multiple of the key heads, at a cost of 4.8 ms of clone in the profiled step just before this change, a 3.5 ms backward reduction, and twice the query and key activation memory in the 24 linear-attention layers (`num_v_heads` 32 over `num_k_heads` 16). The repeat is skipped only when the kernel resolves to fla: the package imports, the input is on CUDA, nothing is exporting, and this is not the single-token step with precomputed recurrent states. The torch fallback still repeats.
3. **Trainer: nan and inf loss filter without a host read.** `torch.isnan(tr_loss_step) or torch.isinf(tr_loss_step)` runs right after backward and pulls a device value to the host, so every CPU-bound launch in clipping and in the optimizer step turns into GPU idle time. It is now a device-side `torch.where(torch.isfinite(step), step, fallback)` that accumulates the same value. `--logging_nan_inf_filter False` skips it as before, and the XLA branch is untouched.
4. **Trainer: FSDP2 gradient clipping on the local shards.** accelerate's `clip_grad_norm_` for FSDP2 calls `torch.nn.utils.clip_grad_norm_` on DTensor gradients, so the foreach norm, the stack and the final norm each go through DTensor's Python sharding propagation. `_fsdp2_local_clip_grad_norm` does per-dtype foreach norms on the local shards, one all-reduce of the sum of squares and one in-place foreach scale, with the same maths. It returns `None` and the caller falls back to accelerate unless every gradient is a `Shard` DTensor on a single 1-D mesh, so it reaches any FSDP2 job with that layout and not only this one. Items 3 and 4 together were about 23 ms of GPU idle per step; the commit carrying items 2 to 4 brought idle to 12 ms and removed the occasional 0.8 s step.
5. **Modular form.** Items 1 and 2 are written in `modular_qwen3_5.py` with `modeling_qwen3_5.py` regenerated, and `modeling_qwen3_5_moe.py` and `modeling_qwen4_exp.py` are regenerated too, since they inherit `Qwen3_5RMSNorm`, `Qwen3_5RMSNormGated` and `Qwen3_5GatedDeltaNet`. The fla import is guarded by `is_flash_linear_attention_available()` plus an import inside the forward, because the converter does not carry a module-level `try`/`except`. I did not time the MoE model or `qwen4_exp`, and I did not check their numerics.

## Result

Measured on 8 B200s in one node, both arms in the setup described under Details.

| | baseline (`cbc1651a03`) | this PR | change |
|---|---|---|---|
| training step, median of steps 11 to 30 on rank 0 | 0.6045 s (0.604, 0.605) | 0.4755 s (0.476, 0.475) | **1.27x**, 129 ms |
| tokens per second, 65,536 tokens per step | 108.4k | 137.8k | |
| peak GPU memory per rank, nvidia-smi | 137.8 GiB | 112.8 GiB | 25 GiB less |

Startup is unchanged at 61 to 67 s for model load and FSDP2 wrap, and step 1 with a warm Triton cache goes from 2.7-3.2 s to 2.6 s.

Per commit, one run each, measured earlier against the untuned `main` with neither kernel package installed and the default FSDP config. These come from a different baseline than the table above, and the two environment installs sit between the source commits:

| commit | change | measured effect |
|---|---|---|
| | untuned `main` at `cbc1651a03` | 1.2155 s |
| `94dc2a84aa` | pins `flash-linear-attention==0.5.2` in the example requirements; the effect is the install, not the pin | 0.703 s |
| `9905713bc8` | fused RMSNorm and gated RMSNorm, `(1 + weight)` still in bf16 (item 1) | 0.580 s, with the mean logit 3 % off |
| `a1d5171e91` | the `(1 + weight)` add back in fp32 (item 1) | 0.580 s, no cost in step time |
| `ac0edb1ed8` | pins `causal-conv1d==1.7.0`; again the install, not the pin | 0.499 s |
| `f135adf1cc` | grouped value heads without the repeat, device-side nan filter, local-shard clip (items 2 to 4) | 0.488 s |
| `fc7ca5232e` | removes both pins, leaving the base requirements | no source change |
| `9c65abcf46`, `2116897848` | modular form and the regenerated siblings (item 5) | not timed; the generated `qwen3_5` code is the same |

## Correctness Verification

I ran the unmodified base commit and this branch over the same 30 steps of the same data in the same setup, and compared 3,144 recorded values from each run: the shape and integer sum of the input ids and labels; the shape, mean, max, min and a fixed slice of the logits; the per-rank loss; the logged loss and gradient norm; the trainable parameter count and the world size, at every step on all 8 ranks. The tolerances below were set before the runs, at about three times the spread of three runs of the unmodified code. I recorded the values with 74 extra lines in a local copy of `trainer.py`, switched on by an environment variable; they are not in this PR and not on a published branch.

| recorded | baseline vs this branch | tolerance |
|---|---|---|
| logged training loss, mean over ranks, step 1 | identical | 0.2 % |
| logged training loss, steps 2 to 30 | 0.19 % largest, 0.0039 absolute at step 7 | 2 % |
| per-rank loss as returned by the model in bf16, steps 1 to 30 | 0.77 % largest, one bf16 ulp at rank 2 step 5 | 2 % |
| mean of the logits over batch, sequence and vocab, step 1 | 0.034 % | 0.2 % |
| mean of the logits, steps 2 to 30 | 1.6 % largest, rank 6 step 25 | 2 % |
| logged gradient norm, step 1 | 3.1 % | 50 %, recorded only |
| logged gradient norm, steps 2 to 30 | 46 % largest, step 20 | 50 %, recorded only, catches NaN and blow-ups |
| max and min of the logits, and max of a fixed `[0, :8, :64]` slice, steps 1 to 30 | 9.2 %, 8.8 %, 8.9 % | 50 %, recorded only |
| sum of that `[0, :8, :64]` slice, steps 1 to 30 | 124 absolute | 600 absolute, recorded only |
| trainable parameter count and world size | 8,953,803,264 and 8, identical | exact |
| input ids and labels, shape and integer sum, steps 1 to 30 | identical | exact |
| logits shape, steps 1 to 30 | 8x1024x248320, identical | exact |

All 3,144 values are within tolerance. The closest call is the logged gradient norm at step 20, at 0.91 of its budget: the baseline run logged 2.163 there and this branch 1.177, while the logged loss at that step, 2.041, is the same in both. That gate is set at 50 % and only recorded, not enforced, because the gradient norm drifts by 24 % across three runs of the unmodified code on its own; the two timed baseline runs logged 1.282 and 1.207 at the same step.

I recorded the values with the three source changes applied to the modeling files, whose `src/transformers` is identical to this branch at `f135adf1cc`; that leaves the modular import guard and the regenerated MoE and `qwen4_exp` files outside the comparison. Final weights, an evaluation loss and the parameter trajectory were not recorded.

## Code Agent Policy

I wrote this PR with a code agent, and I am disclosing that as `CONTRIBUTING.md` asks. I read every changed line, ran the job end to end on both sides and recorded the values above. Coordination link: #48718. Commands run on this head: `python utils/checkers.py modular_conversion --no-cache`, `ruff check` and `ruff format --check` (ruff 0.14.10), all passing, plus the timed and recorded runs described above. I found no other open PR touching these files.

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. #48718
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)? No public API or option changes, so I found nothing to update. Tell me if the behaviour change belongs in the model docs.
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)? No new tests. The fused norms and the local-shard clip are covered only by the recorded values above.

## Who can review?

Trainer: @SunMarc. Text models and kernels: @vasqu.

<details>
<summary>Details: hardware, model, full command, traces</summary>

**Hardware and environment.** One node, 8 x NVIDIA B200 (sm_100, 183 GB each), driver 580.126.20, CUDA 13.0 driver. Python 3.11.16, torch 2.11.0+cu128, accelerate 1.14.0, datasets 5.0.1, triton 3.6.0, transformers `main` at `cbc1651a03` as an editable install. flash-linear-attention 0.5.2 from the PyPI wheel; causal-conv1d 1.7.0 built from source with a CUDA 12.8 nvcc from conda, since PyPI has no wheel for torch 2.11+cu128 and the node's toolkit is 13.0.

**Model and job.** Qwen/Qwen3.5-9B-Base, the text model as loaded by `AutoModelForCausalLM`: 32 decoder layers (24 `Qwen3_5GatedDeltaNet`, 8 gated full attention with 16 query heads and 4 key/value heads of 256, partial RoPE), hidden 4096, SwiGLU MLP 4096 to 12288, vocab 248,320 with untied embeddings, 8,953,803,264 trainable parameters in bf16. Full fine-tuning under FSDP2 `full_shard` wrapping each `Qwen3_5DecoderLayer`, fp32 master shards and bf16 compute, fused AdamW at 5e-5 with linear decay, max grad norm 1.0, no gradient checkpointing, SDPA attention. Each step is 8 GPUs x 8 sequences x 1024 tokens of `Salesforce/wikitext` `wikitext-103-raw-v1`, 65,536 tokens, with a cross-entropy loss. The script tokenizes and blocks the dataset on first use, about two minutes with 16 workers, then caches it.

**Measurement.** Against the unmodified `cbc1651a03`: 30 steps, `--seed 1234 --data_seed 1234`, two interleaved runs per version in the order base, branch, base, branch, with the node empty before every run. The two versions differ only in the tree on `PYTHONPATH`. Both share a setup that is **not part of this PR**: `flash-linear-attention==0.5.2` and `causal-conv1d==1.7.0` installed in the environment, and `"reshard_after_forward": false` in `fsdp_config.json`. Those two installs alone take the untuned `main` from 1.2155 s to 0.617 s per step, and `reshard_after_forward: false` takes 0.618 s to 0.604 s with peak memory rising from 123.4 to 137.8 GiB. Nothing else is set in the environment beyond the run's housekeeping (`HF_HOME`, `HF_HUB_OFFLINE=1`, cache and temp directories). Step time is the median of steps 11 to 30 from the timestamps of the Trainer's per-step `{'loss': ...}` line on rank 0, since the log dicts carry no time. Steps 1 to 10 are warm-up: step 1 loads NCCL and cuBLAS and compiles the fla Triton kernels when the cache is cold. Peak memory is the maximum of nvidia-smi `memory.used` sampled once a second, the same on all 8 GPUs. Run to run the step varies by 1 ms on both versions; within a run, steps 11 to 30 span 0.601 to 0.614 s on the baseline and 0.470 to 0.480 s on this branch. The per-kernel millisecond figures above come from profiled steps of the same job with the default `fsdp_config.json`, at 0.703 to 0.488 s per step, not from the 0.6045 s baseline.

**The measured job**, run the same way for both versions:
```
# both versions: the two kernel packages in the environment, not in this PR
pip install flash-linear-attention==0.5.2
CUDA_HOME=<cuda 12.8 toolkit> CAUSAL_CONV1D_FORCE_BUILD=TRUE TORCH_CUDA_ARCH_LIST=10.0 pip install --no-build-isolation causal-conv1d==1.7.0

# fsdp_config.json, both versions; reshard_after_forward is the one tuned value
{"transformer_layer_cls_to_wrap": ["Qwen3_5DecoderLayer"], "state_dict_type": "SHARDED_STATE_DICT", "reshard_after_forward": false}

# baseline: PYTHONPATH=<checkout of cbc1651a03>/src ; branch: PYTHONPATH=<checkout of this branch>/src
torchrun --nnodes 1 --nproc_per_node 8 examples/pytorch/language-modeling/run_clm.py \
  --model_name_or_path Qwen/Qwen3.5-9B-Base \
  --dataset_name Salesforce/wikitext --dataset_config_name wikitext-103-raw-v1 --block_size 1024 \
  --do_train --max_steps 30 --seed 1234 --data_seed 1234 \
  --per_device_train_batch_size 8 --gradient_accumulation_steps 1 --dataloader_drop_last \
  --learning_rate 5e-5 --bf16 \
  --fsdp "full_shard auto_wrap" --fsdp_config fsdp_config.json \
  --logging_strategy steps --logging_steps 1 --logging_first_step \
  --save_strategy no --eval_strategy no --report_to none --preprocessing_num_workers 16 \
  --output_dir <out>
```
Every flag is the script's. The Trainer picks FSDP2 by default (accelerate `fsdp_version` 2) and applies bf16 mixed precision from `--bf16`. `--block_size 1024` is needed because the model's `model_max_length` equals its `max_position_embeddings`, so the script would otherwise use 131072.

**Settings tried and rejected**, one change at a time on the unmodified source with both packages installed, at 0.618 s on this node with about 2 ms of run-to-run noise. Kept: `reshard_after_forward: false`, 14 ms. Rejected: liger-kernel 0.8.2 with `--use_liger_kernel` at 0.7435 s, 125 ms slower, because its fused linear cross-entropy bypasses `lm_head.forward`, FSDP2 then warns that one module did not run forward before backward, and the root unit's all-gather is no longer prefetched. Also rejected, all within noise: `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`, `--dataloader_num_workers 2`, `TORCH_CUDNN_SDPA_DEPRIORITIZED=1`, `NCCL_CUMEM_ENABLE=0` and `OMP_NUM_THREADS=8`. Explicit FSDP2 prefetch two units ahead measured 0.487 s against 0.488 s, within noise, and is not in this PR. Not tried: `--torch_compile`, since regional compile made every rank run out of memory in step 1 at a 98.5 GiB eager peak and `reshard_after_forward: false` raises that peak to 141 GiB; NCCL protocol and algorithm variables, with the all-gather already at about 600 GB/s; `--tf32`, which changes fp32 matmul precision while every GEMM is bf16 already under `--bf16`; `use_kernels=True`, which needs Hub access while the runs are offline. Excluded as changes of semantics: activation checkpointing, `--average_tokens_across_devices false`, CPU offload, and any batch or step-count change.

**Traces** (torch.profiler, steps 13 to 15 for the baseline and 13 to 14 for the branch, all 8 ranks; open in https://ui.perfetto.dev; the README next to them lists code, script, hardware, environment and capture window). The baseline trace is the untuned `main` without the two kernel packages, so it shows the 1.2155 s step rather than the 0.6045 s one.
- baseline: https://drive.google.com/open?id=1tmGmV0bxLUlYCMbqn5mt98w-hYFG0o4O
- optimized: https://drive.google.com/open?id=1BZzn5DYwmzcNdmSWyWqygDwI7d8ynB6K

</details>
