### PR TITLE
[ImageGPT] Fix cross-attention crashing, dropping the encoder mask, and doubling its cache

### DIFF
--- a/src/transformers/models/imagegpt/modeling_imagegpt.py
+++ b/src/transformers/models/imagegpt/modeling_imagegpt.py
@@ -228,6 +228,7 @@ class ImageGPTAttention(nn.Module):
                     "If class is used as cross attention, the weights `q_attn` have to be defined. "
                     "Please make sure to instantiate class with `ImageGPTAttention(..., is_cross_attention=True)`."
                 )
+            attention_mask = encoder_attention_mask
 
             if layer_past is not None and is_updated:
                 # reuse k,v, cross_attentions, and compute only q
@@ -244,7 +245,9 @@ class ImageGPTAttention(nn.Module):
             key = key.view(bsz, -1, self.num_heads, self.head_dim).transpose(1, 2)
             value = value.view(bsz, -1, self.num_heads, self.head_dim).transpose(1, 2)
 
-        if layer_past is not None:
+        if (layer_past is not None and not is_cross_attention) or (
+            layer_past is not None and is_cross_attention and not is_updated
+        ):
             # save all key/value_states to cache to be re-used for fast auto-regressive generation
             key, value = curr_past_key_values.update(key, value, self.layer_idx)
             # set flag that curr layer for cross-attn is already updated so we can re-use in subsequent calls
@@ -493,8 +496,12 @@ class ImageGPTModel(ImageGPTPreTrainedModel):
         if token_type_ids is not None:
             token_type_ids = token_type_ids.view(-1, input_shape[-1])
 
-        if use_cache and past_key_values is None:
-            past_key_values = DynamicCache(config=self.config)
+        if use_cache:
+            if past_key_values is None:
+                past_key_values = DynamicCache(config=self.config)
+
+            if self.config.add_cross_attention and not isinstance(past_key_values, EncoderDecoderCache):
+                past_key_values = EncoderDecoderCache(past_key_values, DynamicCache(config=self.config))
 
         if position_ids is None:
             past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0

--- a/src/transformers/models/imagegpt/modeling_imagegpt.py
+++ b/src/transformers/models/imagegpt/modeling_imagegpt.py
@@ -245,9 +245,7 @@ class ImageGPTAttention(nn.Module):
             key = key.view(bsz, -1, self.num_heads, self.head_dim).transpose(1, 2)
             value = value.view(bsz, -1, self.num_heads, self.head_dim).transpose(1, 2)
 
-        if (layer_past is not None and not is_cross_attention) or (
-            layer_past is not None and is_cross_attention and not is_updated
-        ):
+        if layer_past is not None and not (is_cross_attention and is_updated):
             # save all key/value_states to cache to be re-used for fast auto-regressive generation
             key, value = curr_past_key_values.update(key, value, self.layer_idx)
             # set flag that curr layer for cross-attn is already updated so we can re-use in subsequent calls

--- a/tests/models/imagegpt/test_modeling_imagegpt.py
+++ b/tests/models/imagegpt/test_modeling_imagegpt.py
@@ -292,123 +292,55 @@ class ImageGPTModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
             expected_arg_names = ["input_ids"]
             self.assertListEqual(arg_names[:1], expected_arg_names)
 
-    def test_cross_attention_respects_encoder_padding_mask(self):
-        torch.manual_seed(0)
-        config, input_ids = self.model_tester.prepare_config_and_inputs()[:2]
-        config.add_cross_attention = True
-        model = ImageGPTModel(config).to(torch_device).eval()
-
-        encoder_seq_length = self.model_tester.seq_length + 2
-        batch_size = self.model_tester.batch_size
-        encoder_hidden_states = floats_tensor([batch_size, encoder_seq_length, self.model_tester.hidden_size]).to(
-            torch_device
-        )
-        encoder_attention_mask = torch.ones(batch_size, encoder_seq_length, dtype=torch.long, device=torch_device)
-        padding = encoder_seq_length // 2
-        encoder_attention_mask[:, padding:] = 0
-
-        # What the mask hides must not move the output; what it leaves visible must, or the check is vacuous
-        corrupted_encoder_states = encoder_hidden_states.clone()
-        corrupted_encoder_states[:, padding:] = 1e6
-        visible_corrupted_encoder_states = encoder_hidden_states.clone()
-        visible_corrupted_encoder_states[:, :padding] = 1e6
-
-        with torch.no_grad():
-            output = model(
-                input_ids=input_ids,
-                encoder_hidden_states=encoder_hidden_states,
-                encoder_attention_mask=encoder_attention_mask,
-            ).last_hidden_state
-            output_corrupted = model(
-                input_ids=input_ids,
-                encoder_hidden_states=corrupted_encoder_states,
-                encoder_attention_mask=encoder_attention_mask,
-            ).last_hidden_state
-            output_visible_corrupted = model(
-                input_ids=input_ids,
-                encoder_hidden_states=visible_corrupted_encoder_states,
-                encoder_attention_mask=encoder_attention_mask,
-            ).last_hidden_state
-
-        self.assertTrue(torch.equal(output, output_corrupted))
-        self.assertFalse(torch.equal(output, output_visible_corrupted))
-
-    def test_cross_attention_with_padded_decoder_attention_mask(self):
-        torch.manual_seed(0)
-        config, input_ids = self.model_tester.prepare_config_and_inputs()[:2]
+    def test_cross_attention(self):
+        config, input_ids, attention_mask = self.model_tester.prepare_config_and_inputs()[:3]
         config.add_cross_attention = True
         model = ImageGPTModel(config).to(torch_device).eval()
 
         batch_size, seq_length = input_ids.shape
         encoder_seq_length = seq_length + 2
+        padding = encoder_seq_length // 2
         encoder_hidden_states = floats_tensor([batch_size, encoder_seq_length, self.model_tester.hidden_size]).to(
             torch_device
         )
         encoder_attention_mask = torch.ones(batch_size, encoder_seq_length, dtype=torch.long, device=torch_device)
-        padding = encoder_seq_length // 2
         encoder_attention_mask[:, padding:] = 0
 
-        attention_mask = torch.ones(batch_size, seq_length, dtype=torch.long, device=torch_device)
-        attention_mask[:, -2:] = 0
-
-        corrupted_encoder_states = encoder_hidden_states.clone()
-        corrupted_encoder_states[:, padding:] = 1e6
-
-        with torch.no_grad():
-            output = model(
-                input_ids=input_ids,
-                attention_mask=attention_mask,
-                encoder_hidden_states=encoder_hidden_states,
-                encoder_attention_mask=encoder_attention_mask,
-            ).last_hidden_state
-            output_corrupted = model(
-                input_ids=input_ids,
-                attention_mask=attention_mask,
-                encoder_hidden_states=corrupted_encoder_states,
-                encoder_attention_mask=encoder_attention_mask,
-            ).last_hidden_state
-
-        self.assertEqual(output.shape, (batch_size, seq_length, self.model_tester.hidden_size))
-        self.assertTrue(torch.equal(output, output_corrupted))
-
-    def test_cross_attention_cached_decoding_matches_uncached(self):
-        torch.manual_seed(0)
-        config, input_ids = self.model_tester.prepare_config_and_inputs()[:2]
-        config.add_cross_attention = True
-        model = ImageGPTModel(config).to(torch_device).eval()
-
-        batch_size, seq_length = input_ids.shape
-        encoder_seq_length = seq_length + 2
-        encoder_hidden_states = floats_tensor([batch_size, encoder_seq_length, self.model_tester.hidden_size]).to(
-            torch_device
-        )
-        encoder_attention_mask = torch.ones(batch_size, encoder_seq_length, dtype=torch.long, device=torch_device)
-        encoder_attention_mask[:, encoder_seq_length // 2 :] = 0
+        # Masked encoder positions must not affect the output; visible ones must, or the check is vacuous
+        masked_corrupted = encoder_hidden_states.clone()
+        masked_corrupted[:, padding:] = 1e6
+        visible_corrupted = encoder_hidden_states.clone()
+        visible_corrupted[:, :padding] = 1e6
 
         with torch.no_grad():
-            reference = model(
-                input_ids=input_ids,
-                encoder_hidden_states=encoder_hidden_states,
-                encoder_attention_mask=encoder_attention_mask,
-                use_cache=False,
-            ).last_hidden_state
+            outputs = [
+                model(
+                    input_ids,
+                    attention_mask=attention_mask,
+                    encoder_hidden_states=states,
+                    encoder_attention_mask=encoder_attention_mask,
+                ).last_hidden_state
+                for states in (encoder_hidden_states, masked_corrupted, visible_corrupted)
+            ]
             prefill = model(
-                input_ids=input_ids[:, :-1],
+                input_ids[:, :-1],
+                attention_mask=attention_mask[:, :-1],
                 encoder_hidden_states=encoder_hidden_states,
                 encoder_attention_mask=encoder_attention_mask,
-                use_cache=True,
             )
             step = model(
-                input_ids=input_ids[:, -1:],
+                input_ids[:, -1:],
                 past_key_values=prefill.past_key_values,
+                attention_mask=attention_mask,
                 encoder_hidden_states=encoder_hidden_states,
                 encoder_attention_mask=encoder_attention_mask,
-                use_cache=True,
             )
 
-        cross_attention_keys = step.past_key_values.cross_attention_cache.layers[0].keys
-        self.assertEqual(cross_attention_keys.shape[-2], encoder_seq_length)
-        torch.testing.assert_close(step.last_hidden_state[:, -1], reference[:, -1], rtol=1e-4, atol=1e-4)
+        output, output_masked_corrupted, output_visible_corrupted = outputs
+        self.assertTrue(torch.equal(output, output_masked_corrupted))
+        self.assertFalse(torch.equal(output, output_visible_corrupted))
+        self.assertEqual(step.past_key_values.cross_attention_cache.get_seq_length(), encoder_seq_length)
+        torch.testing.assert_close(step.last_hidden_state[:, -1], output[:, -1], rtol=1e-4, atol=1e-4)
 
     @unittest.skip(reason="Model inputs don't fit test pattern")  # and it's not used enough to be worth fixing :)
     def test_past_key_values_format(self):

--- a/tests/models/imagegpt/test_modeling_imagegpt.py
+++ b/tests/models/imagegpt/test_modeling_imagegpt.py
@@ -23,7 +23,7 @@ from transformers.utils import is_torch_available, is_vision_available
 
 from ...generation.test_utils import GenerationTesterMixin
 from ...test_configuration_common import ConfigTester
-from ...test_modeling_common import ModelTesterMixin, ids_tensor, random_attention_mask
+from ...test_modeling_common import ModelTesterMixin, floats_tensor, ids_tensor, random_attention_mask
 from ...test_pipeline_mixin import PipelineTesterMixin
 
 
@@ -291,6 +291,124 @@ class ImageGPTModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
 
             expected_arg_names = ["input_ids"]
             self.assertListEqual(arg_names[:1], expected_arg_names)
+
+    def test_cross_attention_respects_encoder_padding_mask(self):
+        torch.manual_seed(0)
+        config, input_ids = self.model_tester.prepare_config_and_inputs()[:2]
+        config.add_cross_attention = True
+        model = ImageGPTModel(config).to(torch_device).eval()
+
+        encoder_seq_length = self.model_tester.seq_length + 2
+        batch_size = self.model_tester.batch_size
+        encoder_hidden_states = floats_tensor([batch_size, encoder_seq_length, self.model_tester.hidden_size]).to(
+            torch_device
+        )
+        encoder_attention_mask = torch.ones(batch_size, encoder_seq_length, dtype=torch.long, device=torch_device)
+        padding = encoder_seq_length // 2
+        encoder_attention_mask[:, padding:] = 0
+
+        # What the mask hides must not move the output; what it leaves visible must, or the check is vacuous
+        corrupted_encoder_states = encoder_hidden_states.clone()
+        corrupted_encoder_states[:, padding:] = 1e6
+        visible_corrupted_encoder_states = encoder_hidden_states.clone()
+        visible_corrupted_encoder_states[:, :padding] = 1e6
+
+        with torch.no_grad():
+            output = model(
+                input_ids=input_ids,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+            ).last_hidden_state
+            output_corrupted = model(
+                input_ids=input_ids,
+                encoder_hidden_states=corrupted_encoder_states,
+                encoder_attention_mask=encoder_attention_mask,
+            ).last_hidden_state
+            output_visible_corrupted = model(
+                input_ids=input_ids,
+                encoder_hidden_states=visible_corrupted_encoder_states,
+                encoder_attention_mask=encoder_attention_mask,
+            ).last_hidden_state
+
+        self.assertTrue(torch.equal(output, output_corrupted))
+        self.assertFalse(torch.equal(output, output_visible_corrupted))
+
+    def test_cross_attention_with_padded_decoder_attention_mask(self):
+        torch.manual_seed(0)
+        config, input_ids = self.model_tester.prepare_config_and_inputs()[:2]
+        config.add_cross_attention = True
+        model = ImageGPTModel(config).to(torch_device).eval()
+
+        batch_size, seq_length = input_ids.shape
+        encoder_seq_length = seq_length + 2
+        encoder_hidden_states = floats_tensor([batch_size, encoder_seq_length, self.model_tester.hidden_size]).to(
+            torch_device
+        )
+        encoder_attention_mask = torch.ones(batch_size, encoder_seq_length, dtype=torch.long, device=torch_device)
+        padding = encoder_seq_length // 2
+        encoder_attention_mask[:, padding:] = 0
+
+        attention_mask = torch.ones(batch_size, seq_length, dtype=torch.long, device=torch_device)
+        attention_mask[:, -2:] = 0
+
+        corrupted_encoder_states = encoder_hidden_states.clone()
+        corrupted_encoder_states[:, padding:] = 1e6
+
+        with torch.no_grad():
+            output = model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+            ).last_hidden_state
+            output_corrupted = model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                encoder_hidden_states=corrupted_encoder_states,
+                encoder_attention_mask=encoder_attention_mask,
+            ).last_hidden_state
+
+        self.assertEqual(output.shape, (batch_size, seq_length, self.model_tester.hidden_size))
+        self.assertTrue(torch.equal(output, output_corrupted))
+
+    def test_cross_attention_cached_decoding_matches_uncached(self):
+        torch.manual_seed(0)
+        config, input_ids = self.model_tester.prepare_config_and_inputs()[:2]
+        config.add_cross_attention = True
+        model = ImageGPTModel(config).to(torch_device).eval()
+
+        batch_size, seq_length = input_ids.shape
+        encoder_seq_length = seq_length + 2
+        encoder_hidden_states = floats_tensor([batch_size, encoder_seq_length, self.model_tester.hidden_size]).to(
+            torch_device
+        )
+        encoder_attention_mask = torch.ones(batch_size, encoder_seq_length, dtype=torch.long, device=torch_device)
+        encoder_attention_mask[:, encoder_seq_length // 2 :] = 0
+
+        with torch.no_grad():
+            reference = model(
+                input_ids=input_ids,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+                use_cache=False,
+            ).last_hidden_state
+            prefill = model(
+                input_ids=input_ids[:, :-1],
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+                use_cache=True,
+            )
+            step = model(
+                input_ids=input_ids[:, -1:],
+                past_key_values=prefill.past_key_values,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+                use_cache=True,
+            )
+
+        cross_attention_keys = step.past_key_values.cross_attention_cache.layers[0].keys
+        self.assertEqual(cross_attention_keys.shape[-2], encoder_seq_length)
+        torch.testing.assert_close(step.last_hidden_state[:, -1], reference[:, -1], rtol=1e-4, atol=1e-4)
 
     @unittest.skip(reason="Model inputs don't fit test pattern")  # and it's not used enough to be worth fixing :)
     def test_past_key_values_format(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48694&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48694) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48694&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48694)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

Fixes #48693, where @vasqu agreed it is worth fixing for now, while noting it is not high priority
and that this feature may be removed later. No urgency from me — happy for it to sit, or to close
it if the path is going away.

With `add_cross_attention=True`, `ImageGPTModel` is broken four ways where GPT-2 is fine: the
default `use_cache=True` call raises `UnboundLocalError` on `is_updated`; the encoder mask is
discarded, so padded encoder positions still reach the output; a padded decoder `attention_mask`
raises a `RuntimeError` on the mask shape; and one cached decoding step leaves 22 keys in the
cross-attention cache for 11 encoder positions.

Each of the three fixes is GPT-2's own code, restored:

- `attention_mask = encoder_attention_mask` (`modeling_gpt2.py:173`), dropped by #38635. It
  replaces the decoder mask rather than sitting beside it, which also removes the shape clash.
- the cross-attention cache reuse guard (`modeling_gpt2.py:193-195`), which #39754 added to GPT-2
  and, through `# Copied from`, to `decision_transformer`. ImageGPT has no such marker.
- the `EncoderDecoderCache` wrap (`modeling_gpt2.py:561-566`), removed by #40811. It costs nothing
  when `add_cross_attention` is unset.

The test ports #47946's encoder-mask check under a padded decoder mask, adds an assertion that
corrupting *visible* encoder positions moves the output (without it the check passes for an
encoder-blind model), and compares one cached decoding step against the full forward. Reverting
any one fix reds it.

```
pytest tests/models/imagegpt/             119 passed, 181 skipped
RUN_SLOW=1 pytest tests/models/imagegpt/  131 passed, 169 skipped
make fix-repo                             17/17, rewrote nothing
make check-repo                           26/26
```

AI-assisted, per `CONTRIBUTING.md`. Coordination: #48693, which I opened and @vasqu answered.
Differentiation: #45773 fixes the same crash for whisper, moonshine, pix2struct and
audioflamingo3, not ImageGPT; #44076 refactors this file's output collection, not the cache or the
mask. I reviewed every changed line and ran the suite locally.

## Code Agent Policy

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. #48693
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@vasqu