### PR TITLE
Fix quantized cache

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -773,6 +773,27 @@ class QuantizedLayer(DynamicLayer):
     @abstractmethod
     def _dequantize(self, q_tensor): ...
 
+    def reorder_cache(self, beam_idx: torch.LongTensor) -> None:
+        """Reorders this layer's cache for beam search."""
+        if not self.is_initialized:
+            return
+
+        # The quantized states cannot be indexed, so they are dequantized, reordered and quantized back
+        dequant_keys = self._dequantize(self._quantized_keys)
+        dequant_values = self._dequantize(self._quantized_values)
+        beam_idx = beam_idx.to(dequant_keys.device)
+        self._quantized_keys = self._quantize(dequant_keys.index_select(0, beam_idx).contiguous(), axis=self.axis_key)
+        self._quantized_values = self._quantize(
+            dequant_values.index_select(0, beam_idx).contiguous(), axis=self.axis_value
+        )
+
+        # The residual cache is emptied whenever it is flushed into the quantized states, and holds nothing to
+        # reorder then. `super().reorder_cache` cannot be used to guard against it, as it checks the sequence
+        # length, which counts the quantized tokens as well.
+        if self.keys.numel() > 0:
+            self.keys = self.keys.index_select(0, beam_idx.to(self.keys.device))
+            self.values = self.values.index_select(0, beam_idx.to(self.values.device))
+
     def get_seq_length(self) -> int:
         """Returns the sequence length of the cached states."""
         return self.cumulative_length

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2136,7 +2136,8 @@ class GenerationMixin(ContinuousMixin):
                     "cache, please open an issue and tag @zucchini-nlp."
                 )
 
-            cache_config = generation_config.cache_config if generation_config.cache_config is not None else {}
+            # Copied, as `generate` may be called several times with the same `cache_config`, whose keys are consumed
+            cache_config = dict(generation_config.cache_config) if generation_config.cache_config is not None else {}
             cache_config.setdefault("config", self.config.get_text_config(decoder=True))
             backend = cache_config.pop("backend", "quanto")
             model_kwargs[cache_name] = QuantizedCache(backend=backend, **cache_config)

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -324,6 +324,36 @@ class CacheIntegrationTest(unittest.TestCase):
 
         # Check that something is actually quantized
 
+    def test_quantized_cache_config_is_not_mutated(self):
+        """
+        Tests that `generate` does not consume the entries of the `cache_config` it is given, which would silently
+        change the cache of any subsequent call sharing that dict.
+        """
+        if not is_optimum_quanto_available():
+            self.skipTest("Quanto is not available")
+
+        # `QuantizedCache` only supports full attention, so the sliding window of the shared model is unset here
+        model = AutoModelForCausalLM.from_pretrained(
+            "hf-internal-testing/tiny-random-LlamaForCausalLM", device_map="auto"
+        )
+        inputs = self.tokenizer(["The cat"], return_tensors="pt").to(model.device)
+        cache_config = {"backend": "quanto", "nbits": 4, "q_group_size": 16, "residual_length": 4}
+        expected_cache_config = cache_config.copy()
+
+        for _ in range(2):
+            gen_out = model.generate(
+                **inputs,
+                do_sample=False,
+                max_new_tokens=3,
+                return_dict_in_generate=True,
+                cache_implementation="quantized",
+                cache_config=cache_config,
+                disable_compile=True,
+            )
+            self.assertIsInstance(gen_out.past_key_values, QuantizedCache)
+            self.assertEqual(len(gen_out.past_key_values.layers), model.config.num_hidden_layers)
+            self.assertEqual(cache_config, expected_cache_config)
+
     @parameterized.expand(TEST_CACHE_IMPLEMENTATIONS)
     def test_cache_extra_left_padding(self, cache_implementation):
         """Tests that adding extra left-padding does not affect the generation with the cache"""

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -205,6 +205,14 @@ def _skip_on_failed_cache_prerequisites(test, cache_implementation):
                 test.skipTest("Offloaded static caches require exactly 1 accelerator")
 
 
+def _set_sliding_window(config, cache_implementation):
+    """
+    Sets the sliding window on `config`, from which the cache layer types are inferred: the sliding cache
+    implementations need one to build sliding layers, and the other ones must not have one.
+    """
+    config.sliding_window = 256 if cache_implementation in ["sliding_window", "hybrid", "hybrid_chunked"] else None
+
+
 class CacheIntegrationTest(unittest.TestCase):
     """Fast cache integration tests that share the same small model"""
 
@@ -215,12 +223,17 @@ class CacheIntegrationTest(unittest.TestCase):
         cls.model = AutoModelForCausalLM.from_pretrained(
             "HuggingFaceTB/SmolLM2-135M-Instruct", device_map="auto", dtype=torch.float16
         )
-        cls.model.config.sliding_window = 256  # hack to enable the use of caches with sliding windows
+
+    def setUp(self):
+        # The model is shared across tests, so the sliding window one of them opts into through
+        # `_set_sliding_window` must not leak into the next one. `SmolLM2` has no sliding window of its own.
+        self.model.config.sliding_window = None
 
     @parameterized.expand(TEST_CACHE_IMPLEMENTATIONS)
     def test_cache_batched(self, cache_implementation):
         """Sanity check: caches' `.update` function expects batched inputs"""
         _skip_on_failed_cache_prerequisites(self, cache_implementation)
+        _set_sliding_window(self.model.config, cache_implementation)
 
         EXPECTED_GENERATION = ["A sequence: 1, 2, 3, 4, 5, 6, 7, 8,", "A sequence: A, B, C, D, E, F, G, H"]
 
@@ -250,6 +263,7 @@ class CacheIntegrationTest(unittest.TestCase):
         (an output sequence contains multiple beam indices).
         """
         _skip_on_failed_cache_prerequisites(self, cache_implementation)
+        _set_sliding_window(self.model.config, cache_implementation)
         if cache_implementation == "offloaded_hybrid_chunked":
             # TODO (joao, cyril): something is off with `offloaded_hybrid_chunked`: the
             # output sequence (and the corresponding beam scores, if we add `output_scores=True`) are significantly
@@ -332,16 +346,12 @@ class CacheIntegrationTest(unittest.TestCase):
         if not is_optimum_quanto_available():
             self.skipTest("Quanto is not available")
 
-        # `QuantizedCache` only supports full attention, so the sliding window of the shared model is unset here
-        model = AutoModelForCausalLM.from_pretrained(
-            "hf-internal-testing/tiny-random-LlamaForCausalLM", device_map="auto"
-        )
-        inputs = self.tokenizer(["The cat"], return_tensors="pt").to(model.device)
+        inputs = self.tokenizer(["The cat"], return_tensors="pt").to(self.model.device)
         cache_config = {"backend": "quanto", "nbits": 4, "q_group_size": 16, "residual_length": 4}
         expected_cache_config = cache_config.copy()
 
         for _ in range(2):
-            gen_out = model.generate(
+            gen_out = self.model.generate(
                 **inputs,
                 do_sample=False,
                 max_new_tokens=3,
@@ -351,13 +361,14 @@ class CacheIntegrationTest(unittest.TestCase):
                 disable_compile=True,
             )
             self.assertIsInstance(gen_out.past_key_values, QuantizedCache)
-            self.assertEqual(len(gen_out.past_key_values.layers), model.config.num_hidden_layers)
+            self.assertEqual(len(gen_out.past_key_values.layers), self.model.config.num_hidden_layers)
             self.assertEqual(cache_config, expected_cache_config)
 
     @parameterized.expand(TEST_CACHE_IMPLEMENTATIONS)
     def test_cache_extra_left_padding(self, cache_implementation):
         """Tests that adding extra left-padding does not affect the generation with the cache"""
         _skip_on_failed_cache_prerequisites(self, cache_implementation)
+        _set_sliding_window(self.model.config, cache_implementation)
 
         EXPECTED_GENERATION = ["The cat's whiskers are also a sign of anxiety."]
 
@@ -702,9 +713,7 @@ class CacheHardIntegrationTest(unittest.TestCase):
 
         model_id = "hf-internal-testing/tiny-random-GPTJForCausalLM"
         pipe = pipeline("text-generation", model=model_id, dtype=torch.bfloat16)
-        pipe.model.config.sliding_window = (
-            256 if cache_implementation in ["sliding_window", "hybrid", "hybrid_chunked"] else None
-        )
+        _set_sliding_window(pipe.model.config, cache_implementation)
         out = pipe(
             "hello world",
             cache_implementation=cache_implementation,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48700&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48700) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48700&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48700)
<!-- ci-dashboard-badge:end -->

## What does this PR do?

**1. `generate` consumes the user's `cache_config`.** `_prepare_cache_for_generation` `pop`s `backend` out of the user's dict and `setdefault`s the model `config` into it, so a second `generate` sharing that dict gets the wrong backend, and with a second model it keeps the *first* model's config — a 2-layer model then gets a 30-layer cache. Fixed by copying the dict; covered by the new `test_quantized_cache_config_is_not_mutated`.

**2. `QuantizedLayer.reorder_cache` is broken.** Quantized layers inherited the base implementation, which guards on `get_seq_length()` (counts the quantized tokens) but only indexes `self.keys` (holds the residual cache, emptied on every flush), so beam search either indexes an empty tensor or silently leaves the quantized states unreordered:

```python
import torch
from transformers.cache_utils import QuantoQuantizedLayer

layer = QuantoQuantizedLayer(nbits=4, q_group_size=16, residual_length=4)
for step in range(5):  # the 5th update flushes the residual cache
    k = torch.rand(2, 4, 5 if step == 0 else 1, 16)
    layer.update(k, k.clone())
before = layer._dequantize(layer._quantized_keys).clone()
layer.reorder_cache(torch.tensor([1, 0]))  # on `main`: IndexError: index out of range in self
print("quantized states reordered:", not torch.equal(before, layer._dequantize(layer._quantized_keys)))
```

Fixed by overriding it: dequantize, reorder, quantize back, and only touch the residual cache when it is not empty. `index_select` cannot be applied to the quantized states directly, as quanto's `WeightQBitsTensor` silently returns a plain dequantized `Tensor`.

**3. The test model is forced to use a sliding window.** `CacheIntegrationTest.setUpClass` set `sliding_window = 256` on the model shared by the whole class, and since layer types are inferred from the config, every test only ever exercised sliding layers — and the `quantized` parameterizations raised `ValueError: QuantizedCache is only supported for models with only full attention layers` before reaching any assertion, which is what hid bug 2. The window is now set per test from the implementation under test, the way `test_cache_gptj_model` already did.

## Test results

`pytest tests/utils/test_cache_utils.py::CacheIntegrationTest` goes from `4 failed, 15 passed` to `3 failed, 17 passed`:

| | before | after |
| --- | --- | --- |
| `test_cache_batched_5_quantized` | `ValueError` | pass |
| `test_quantized_cache_config_is_not_mutated` | *(new)* | pass |
| `test_cache_beam_search_5_quantized` | `ValueError` | runs, fails on `EXPECTED_GENERATION` |
| `test_cache_extra_left_padding_5_quantized` | `ValueError` | runs, fails on `EXPECTED_GENERATION` |
| `test_quantized_cache_generation_0_quanto` | `ValueError` | runs, fails on `EXPECTED_GENERATION` |

The last three reach their assertion for the first time and fail on it, because `quantized` is in `TEST_CACHE_IMPLEMENTATIONS` and those `EXPECTED_GENERATION` are the full-precision outputs — e.g. `'Blue is a type of light that is produced by the sun'` instead of `'Blue is the color of the sky, and the color of'`. This looks like ordinary quantization error rather than a bug: the tests use the default `q_group_size=64`, which for `SmolLM2`'s `head_dim=64` is a single scale per head, and lowering it to 16 makes two of the three match the full-precision output exactly.

I left the expected values untouched, as I cannot generate the accelerator ones locally (`optimum-quanto`'s CUDA extension does not build in my container) and they are device-dependent. Happy to fill them in from the CI values, or to drop `quantized` from the generic parameterizations, whichever you prefer.