### PR TITLE
add kernel mapping entry for RMSNormGated, KDA, Conv1D on XPU

### DIFF
--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -235,6 +235,18 @@ if is_kernels_available():
                         version=1,
                     ),
                 },
+                "xpu": {
+                    Mode.TRAINING: LayerRepository(
+                        repo_id="kernels-community/fla",
+                        layer_name="chunk_gated_delta_rule",
+                        version=1,
+                    ),
+                    Mode.INFERENCE: LayerRepository(
+                        repo_id="kernels-community/fla",
+                        layer_name="chunk_gated_delta_rule",
+                        version=1,
+                    ),
+                },
             },
             "fused_recurrent_gated_delta_rule": {
                 "cuda": {
@@ -243,6 +255,13 @@ if is_kernels_available():
                         layer_name="recurrent_gated_delta_rule",
                         version=1,
                     ),
+                    Mode.INFERENCE: LayerRepository(
+                        repo_id="kernels-community/fla",
+                        layer_name="recurrent_gated_delta_rule",
+                        version=1,
+                    ),
+                },
+                "xpu": {
                     Mode.INFERENCE: LayerRepository(
                         repo_id="kernels-community/fla",
                         layer_name="recurrent_gated_delta_rule",
@@ -584,6 +603,8 @@ if is_kernels_available():
                     ),
                 },
                 "xpu": {
+                    # Inference only: the `chunk_kda` backward kernel uses Intel 2D block-read intrinsics
+                    # that the Triton XPU backend fails to build, so training stays on the torch path.
                     Mode.INFERENCE: LayerRepository(
                         repo_id="kernels-community/fla",
                         layer_name="chunk_kimi_delta_attention",

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -183,6 +183,19 @@ if is_kernels_available():
                         version=2,
                     ),
                 },
+                # The XPU causal-conv1d backend landed in mamba-ssm v3.
+                "xpu": {
+                    Mode.TRAINING: LayerRepository(
+                        repo_id="kernels-community/mamba-ssm",
+                        layer_name="causal_conv1d_fn",
+                        version=3,
+                    ),
+                    Mode.INFERENCE: LayerRepository(
+                        repo_id="kernels-community/mamba-ssm",
+                        layer_name="causal_conv1d_fn",
+                        version=3,
+                    ),
+                },
             },
             "causal_conv1d_update": {
                 "cuda": {
@@ -195,6 +208,19 @@ if is_kernels_available():
                         repo_id="kernels-community/mamba-ssm",
                         layer_name="causal_conv1d_update",
                         version=2,
+                    ),
+                },
+                # The XPU causal-conv1d backend landed in mamba-ssm v3.
+                "xpu": {
+                    Mode.TRAINING: LayerRepository(
+                        repo_id="kernels-community/mamba-ssm",
+                        layer_name="causal_conv1d_update",
+                        version=3,
+                    ),
+                    Mode.INFERENCE: LayerRepository(
+                        repo_id="kernels-community/mamba-ssm",
+                        layer_name="causal_conv1d_update",
+                        version=3,
                     ),
                 },
             },
@@ -409,6 +435,18 @@ if is_kernels_available():
                         version=1,
                     ),
                 },
+                "xpu": {
+                    Mode.TRAINING: LayerRepository(
+                        repo_id="kernels-community/fla",
+                        layer_name="FusedRMSNormGated",
+                        version=1,
+                    ),
+                    Mode.INFERENCE: LayerRepository(
+                        repo_id="kernels-community/fla",
+                        layer_name="FusedRMSNormGated",
+                        version=1,
+                    ),
+                },
             },
             "MegaBlocksMoeMLP": {
                 "cuda": {
@@ -547,6 +585,15 @@ if is_kernels_available():
                         version=1,
                     ),
                 },
+                "xpu": {
+                    # Inference only: the `chunk_kda` backward kernel uses Intel 2D block-read intrinsics
+                    # that the Triton XPU backend fails to build, so training stays on the torch path.
+                    Mode.INFERENCE: LayerRepository(
+                        repo_id="kernels-community/fla",
+                        layer_name="chunk_kimi_delta_attention",
+                        version=1,
+                    ),
+                },
             },
             "fused_recurrent_kda": {
                 "cuda": {
@@ -555,6 +602,13 @@ if is_kernels_available():
                         layer_name="recurrent_kimi_delta_attention",
                         version=1,
                     ),
+                    Mode.INFERENCE: LayerRepository(
+                        repo_id="kernels-community/fla",
+                        layer_name="recurrent_kimi_delta_attention",
+                        version=1,
+                    ),
+                },
+                "xpu": {
                     Mode.INFERENCE: LayerRepository(
                         repo_id="kernels-community/fla",
                         layer_name="recurrent_kimi_delta_attention",

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -183,7 +183,6 @@ if is_kernels_available():
                         version=3,
                     ),
                 },
-                # The XPU causal-conv1d backend landed in mamba-ssm v3.
                 "xpu": {
                     Mode.TRAINING: LayerRepository(
                         repo_id="kernels-community/mamba-ssm",

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -209,7 +209,6 @@ if is_kernels_available():
                         version=3,
                     ),
                 },
-                # The XPU causal-conv1d backend landed in mamba-ssm v3.
                 "xpu": {
                     Mode.TRAINING: LayerRepository(
                         repo_id="kernels-community/mamba-ssm",
@@ -585,8 +584,6 @@ if is_kernels_available():
                     ),
                 },
                 "xpu": {
-                    # Inference only: the `chunk_kda` backward kernel uses Intel 2D block-read intrinsics
-                    # that the Triton XPU backend fails to build, so training stays on the torch path.
                     Mode.INFERENCE: LayerRepository(
                         repo_id="kernels-community/fla",
                         layer_name="chunk_kimi_delta_attention",

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -175,12 +175,12 @@ if is_kernels_available():
                     Mode.TRAINING: LayerRepository(
                         repo_id="kernels-community/mamba-ssm",
                         layer_name="causal_conv1d_fn",
-                        version=2,
+                        version=3,
                     ),
                     Mode.INFERENCE: LayerRepository(
                         repo_id="kernels-community/mamba-ssm",
                         layer_name="causal_conv1d_fn",
-                        version=2,
+                        version=3,
                     ),
                 },
                 # The XPU causal-conv1d backend landed in mamba-ssm v3.
@@ -202,12 +202,12 @@ if is_kernels_available():
                     Mode.TRAINING: LayerRepository(
                         repo_id="kernels-community/mamba-ssm",
                         layer_name="causal_conv1d_update",
-                        version=2,
+                        version=3,
                     ),
                     Mode.INFERENCE: LayerRepository(
                         repo_id="kernels-community/mamba-ssm",
                         layer_name="causal_conv1d_update",
-                        version=2,
+                        version=3,
                     ),
                 },
                 # The XPU causal-conv1d backend landed in mamba-ssm v3.


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48702&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48702) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48702&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48702)
<!-- ci-dashboard-badge:end -->

We used Kimi linear model to do a benchmark, on Intel XPU(B70), we can get ~20x speedup for decode stage and 1.3-5.9x sppedup for prefill stage.
@vasqu @drbh pls help review, thx!