### PR TITLE
Fix Qwen3-MoE auxiliary loss being multiplied by DDP world size in Trainer

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2130,7 +2130,19 @@ class Trainer:
             loss_scale = self.accelerator.num_processes
             if (pc := getattr(self.accelerator, "parallelism_config", None)) is not None:
                 loss_scale //= pc.tp_size
-            loss *= loss_scale if self.args.n_gpu <= 1 else self.args.n_gpu
+            loss_scale = loss_scale if self.args.n_gpu <= 1 else self.args.n_gpu
+            unwrapped_model = self.accelerator.unwrap_model(model)
+            router_aux_loss_coef = getattr(
+                getattr(unwrapped_model, "config", None), "router_aux_loss_coef", None
+            )
+            aux_loss = getattr(outputs, "aux_loss", None)
+            if aux_loss is not None and router_aux_loss_coef is not None:
+                # The token-normalized primary loss needs data-parallel compensation,
+                # while DDP already averages this rank-local auxiliary contribution.
+                aux_contribution = router_aux_loss_coef * aux_loss.to(loss.device)
+                loss = (loss - aux_contribution) * loss_scale + aux_contribution
+            else:
+                loss *= loss_scale
 
         return (loss, outputs) if return_outputs else loss
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2132,9 +2132,7 @@ class Trainer:
                 loss_scale //= pc.tp_size
             loss_scale = loss_scale if self.args.n_gpu <= 1 else self.args.n_gpu
             unwrapped_model = self.accelerator.unwrap_model(model)
-            router_aux_loss_coef = getattr(
-                getattr(unwrapped_model, "config", None), "router_aux_loss_coef", None
-            )
+            router_aux_loss_coef = getattr(getattr(unwrapped_model, "config", None), "router_aux_loss_coef", None)
             aux_loss = getattr(outputs, "aux_loss", None)
             if aux_loss is not None and router_aux_loss_coef is not None:
                 # The token-normalized primary loss needs data-parallel compensation,


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48706&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48706) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48706&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48706)
<!-- ci-dashboard-badge:end -->

Fixes #48690

When using `average_tokens_across_devices`, the Trainer scales the total loss by the DDP world size to compensate for the rank-local averaging of token-normalized CE loss. 

However, Qwen3-MoE's router auxiliary loss is a scalar mean that is already correctly averaged across devices by DDP. Scaling the entire `loss` by `world_size` causes the auxiliary contribution to be multiplied by the world size, destroying the configured `router_aux_loss_coef` ratio and harming convergence on multi-GPU setups.

This patch extracts the auxiliary contribution from the total loss, scales only the primary loss, and adds the auxiliary contribution back unscaled.