### PR TITLE
Key the doc build concurrency group on the pull request number

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48707&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48707) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48707&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48707)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`build_pr_documentation.yml` keys its concurrency group on `github.head_ref`, which is the head branch name without the fork owner. Two open PRs from different forks whose branches share a name therefore land in the same group, and a push on one cancels the in-flight doc build on the other.

Shared names are common, because many contributors push to their fork's default branch instead of creating one: 154 of the 1590 currently open PRs here share a head branch name with another open PR, 84 of them on `main` and 41 on `patch-1`. A doc build takes around 8 minutes, which is the window in which such a collision cancels a build. I did not find a realized cancellation in the 1200 most recent runs, so this is hardening rather than a fix for something currently failing.

`github.event.pull_request.number` is unique per pull request. It is empty for the `merge_group` trigger, so those runs keep falling back to the unique `github.run_id` and are never cancelled, exactly as they are today with `head_ref`.

The template this workflow was copied from carries the same expression, and the same one-liner is proposed there in huggingface/doc-builder#829.