### PR TITLE
Keep special token ids the tokenizer does not define

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -1188,52 +1188,60 @@ def align_special_tokens(model, processing_class):
     model_has_generation_config = hasattr(model, "generation_config") and model.generation_config is not None
     updated_tokens = {}
 
+    # A token the tokenizer does not define is not a statement that the model should drop the value its config
+    # declares: `_special_tokens_map` is initialized with `None` for every special token, so an absent attribute and
+    # a deliberately cleared one are indistinguishable. Only values the tokenizer actually defines are propagated;
+    # removing a token stays an explicit action on the config.
+
     # 1 - Align EOS token. EOS is more complex than the others, as `generation_config` may hold more than one EOS
     # token.
-    tokenizer_has_new_eos = tokenizer.eos_token_id != getattr(model.config, "eos_token_id", None)
-    if model_has_generation_config:
-        # `generation_config.eos_token_id` is None: direct comparison
-        if model.generation_config.eos_token_id is None:
-            tokenizer_has_new_eos |= tokenizer.eos_token_id != model.generation_config.eos_token_id
-        else:
-            # `generation_config.eos_token_id` is an `int`: convert it to list (and continue below)
-            if isinstance(model.generation_config.eos_token_id, int):
-                model.generation_config.eos_token_id = [model.generation_config.eos_token_id]
-            # `generation_config.eos_token_id` is a `list`: check if the tokenizer's EOS token is in the list
-            tokenizer_has_new_eos |= tokenizer.eos_token_id not in model.generation_config.eos_token_id
-
-    if tokenizer_has_new_eos:
-        updated_tokens["eos_token_id"] = tokenizer.eos_token_id
-        model.config.eos_token_id = tokenizer.eos_token_id
-        # The generation config may hold more than one EOS token. We preserve the original EOS tokens: any of the
-        # EOS tokens defined here will halt generation.
+    if tokenizer.eos_token_id is not None:
+        tokenizer_has_new_eos = tokenizer.eos_token_id != getattr(model.config, "eos_token_id", None)
         if model_has_generation_config:
-            all_eos_tokens = [tokenizer.eos_token_id]
-            if model.generation_config.eos_token_id is not None:
-                all_eos_tokens += list(model.generation_config.eos_token_id)
-            model.generation_config.eos_token_id = [token for token in all_eos_tokens if token is not None]
+            # `generation_config.eos_token_id` is None: direct comparison
+            if model.generation_config.eos_token_id is None:
+                tokenizer_has_new_eos |= tokenizer.eos_token_id != model.generation_config.eos_token_id
+            else:
+                # `generation_config.eos_token_id` is an `int`: convert it to list (and continue below)
+                if isinstance(model.generation_config.eos_token_id, int):
+                    model.generation_config.eos_token_id = [model.generation_config.eos_token_id]
+                # `generation_config.eos_token_id` is a `list`: check if the tokenizer's EOS token is in the list
+                tokenizer_has_new_eos |= tokenizer.eos_token_id not in model.generation_config.eos_token_id
+
+        if tokenizer_has_new_eos:
+            updated_tokens["eos_token_id"] = tokenizer.eos_token_id
+            model.config.eos_token_id = tokenizer.eos_token_id
+            # The generation config may hold more than one EOS token. We preserve the original EOS tokens: any of
+            # the EOS tokens defined here will halt generation.
+            if model_has_generation_config:
+                all_eos_tokens = [tokenizer.eos_token_id]
+                if model.generation_config.eos_token_id is not None:
+                    all_eos_tokens += list(model.generation_config.eos_token_id)
+                model.generation_config.eos_token_id = [token for token in all_eos_tokens if token is not None]
 
     # 2 - Align BOS
-    tokenizer_has_new_bos = tokenizer.bos_token_id != getattr(model.config, "bos_token_id", None)
-    if model_has_generation_config:
-        tokenizer_has_new_bos |= tokenizer.bos_token_id != model.generation_config.bos_token_id
-
-    if tokenizer_has_new_bos:
-        updated_tokens["bos_token_id"] = tokenizer.bos_token_id
-        model.config.bos_token_id = tokenizer.bos_token_id
+    if tokenizer.bos_token_id is not None:
+        tokenizer_has_new_bos = tokenizer.bos_token_id != getattr(model.config, "bos_token_id", None)
         if model_has_generation_config:
-            model.generation_config.bos_token_id = tokenizer.bos_token_id
+            tokenizer_has_new_bos |= tokenizer.bos_token_id != model.generation_config.bos_token_id
+
+        if tokenizer_has_new_bos:
+            updated_tokens["bos_token_id"] = tokenizer.bos_token_id
+            model.config.bos_token_id = tokenizer.bos_token_id
+            if model_has_generation_config:
+                model.generation_config.bos_token_id = tokenizer.bos_token_id
 
     # 3 - Align PAD
-    tokenizer_has_new_pad = tokenizer.pad_token_id != getattr(model.config, "pad_token_id", None)
-    if model_has_generation_config:
-        tokenizer_has_new_pad |= tokenizer.pad_token_id != model.generation_config.pad_token_id
-
-    if tokenizer_has_new_pad:
-        updated_tokens["pad_token_id"] = tokenizer.pad_token_id
-        model.config.pad_token_id = tokenizer.pad_token_id
+    if tokenizer.pad_token_id is not None:
+        tokenizer_has_new_pad = tokenizer.pad_token_id != getattr(model.config, "pad_token_id", None)
         if model_has_generation_config:
-            model.generation_config.pad_token_id = tokenizer.pad_token_id
+            tokenizer_has_new_pad |= tokenizer.pad_token_id != model.generation_config.pad_token_id
+
+        if tokenizer_has_new_pad:
+            updated_tokens["pad_token_id"] = tokenizer.pad_token_id
+            model.config.pad_token_id = tokenizer.pad_token_id
+            if model_has_generation_config:
+                model.generation_config.pad_token_id = tokenizer.pad_token_id
 
     # 4 - Warn users about the changes
     if len(updated_tokens) > 0:

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -71,6 +71,7 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
+from transformers.trainer_utils import align_special_tokens
 
 from .trainer_test_utils import (
     ATOL,
@@ -1334,6 +1335,25 @@ class TrainerIntegrationTest(TestCasePlus):
             self.assertEqual(trainer.model.config.eos_token_id, tokenizer.eos_token_id)
             self.assertEqual(trainer.model.config.pad_token_id, tokenizer.pad_token_id)
             self.assertEqual(trainer.model.config.bos_token_id, tokenizer.bos_token_id)
+
+    def test_special_token_alignment_keeps_tokens_the_tokenizer_does_not_define(self):
+        """
+        Tests that a special token the tokenizer does not define is left untouched on the model configs, rather than
+        being removed from them. `_special_tokens_map` is initialized with `None` for every special token, so a
+        tokenizer that never declared one is indistinguishable from a tokenizer whose token was deliberately cleared.
+        Dropping the value in that case would silently remove an id the checkpoint declares.
+        """
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-LlamaForCausalLM")
+        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-LlamaForCausalLM")
+
+        model.config.bos_token_id = 1
+        model.generation_config.bos_token_id = 1
+        tokenizer.bos_token = None
+
+        align_special_tokens(model, tokenizer)
+
+        self.assertEqual(model.config.bos_token_id, 1)
+        self.assertEqual(model.generation_config.bos_token_id, 1)
 
     def test_trainer_works_without_model_config(self):
         """


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48708&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48708) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48708&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48708)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`align_special_tokens` copies the tokenizer's BOS/EOS/PAD ids onto `model.config` and `model.generation_config`. When the tokenizer does not define one of them, the `None` is copied over the value the config declares, and `save_pretrained` persists the removal.

This PR propagates only the values the tokenizer actually defines, as suggested in #48592. Removing a token stays an explicit action on the config.

Fixes #48592

## Why

`_special_tokens_map` is initialized with `None` for every special token, so a tokenizer that never declared one is indistinguishable from a tokenizer whose token was deliberately cleared:

```python
smol = AutoTokenizer.from_pretrained("HuggingFaceTB/SmolLM2-135M-Instruct")
smol.bos_token = None                                                # deliberate removal
qwen = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")   # never declared one

smol._special_tokens_map["bos_token"] == qwen._special_tokens_map["bos_token"]
# True, both None
```

Resolving that ambiguity in favour of removal means any model family whose tokenizer simply does not manage a token loses it from the config on the first `train()` call. Qwen is the widest case: `config.json` declares `bos_token_id=151643` while `tokenizer_config.json` declares no `bos_token`, so every Qwen fine-tune was saved with `bos_token_id: null`.

Before this PR, on `Qwen/Qwen2.5-0.5B-Instruct`:

```
before, config.bos_token_id = 151643
  generate() with no inputs OK, shape (1, 4)
after,  config.bos_token_id = None
  ValueError: `bos_token_id` has to be defined when no `input_ids` are provided.
```

and the nulled value was written to `config.json`. After this PR the declared id survives, `generate()` keeps working, and the alignment still reports the one genuine change:

```
after,  config.bos_token_id = 151643
  generate() with no inputs OK, shape (1, 4)
Updated tokens: {'pad_token_id': 151643}
```

The same failure mode was reported for Whisper in #45584, closed as stale, and worked around in the still-open #45570 and #45917.

## What this does not change

Values the tokenizer does define are still propagated, including onto a config that lacks them. A tokenizer that adds an end-of-turn token at fine-tuning time, the case #38441 was written for, behaves exactly as before.

The diff is 82 lines but only three are substantive: one guard per token, plus a comment. `git diff -w` shows the rest is indentation.

## Tests

`test_special_token_alignment` sets all three tokens to real values, so it is unaffected and still passes. Added `test_special_token_alignment_keeps_tokens_the_tokenizer_does_not_define` next to it, asserting that a config-declared BOS survives a tokenizer that does not define one.

## Who can review?

@SunMarc