### PR TITLE
Fix backslash handling in generate flag values in transformers chat

### DIFF
--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -633,7 +633,10 @@ def parse_generate_flags(generate_flags: list[str] | None) -> dict:
         s = s.removeprefix("-")
         return s.replace(".", "", 1).isdigit()
 
-    generate_flags_as_dict = {k: f'"{v}"' if not is_number(v) else v for k, v in generate_flags_as_dict.items()}
+    generate_flags_as_dict = {
+        k: v if v.startswith("[") and v.endswith("]") else json.dumps(v) if not is_number(v) else v
+        for k, v in generate_flags_as_dict.items()
+    }
     # 2. c. [no processing needed] lists are lists of ints because `generate` doesn't take lists of strings :)
     # We also mention in the help message that we only accept lists of ints for now.
 

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -58,6 +58,24 @@ def test_parse_generate_flags_value_with_equal_sign():
     assert parse_generate_flags(["cache_implementation=a=b"]) == {"cache_implementation": "a=b"}
 
 
+def test_parse_generate_flags_preserves_types_and_quotes():
+    assert parse_generate_flags(['text=a"b', "do_sample=False", "eos_token_id=[1,2]", "watermark=None"]) == {
+        "text": 'a"b',
+        "do_sample": False,
+        "eos_token_id": [1, 2],
+        "watermark": None,
+    }
+
+
+def test_parse_generate_flags_preserves_lists_with_strings():
+    assert parse_generate_flags([r'stop_strings=["a\\b"]']) == {"stop_strings": [r"a\b"]}
+
+
+@pytest.mark.parametrize("value", [r"a\b", r"a\u0041", r"C:\temp", r"a\x"])
+def test_parse_generate_flags_preserves_backslashes(value):
+    assert parse_generate_flags([f"stop_strings={value}"]) == {"stop_strings": value}
+
+
 def test_parse_generate_flags_missing_equal_sign():
     with pytest.raises(typer.BadParameter, match="missing `=` after `do_sample`"):
         parse_generate_flags(["do_sample"])


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48709&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48709) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48709&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48709)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes the backslash handling in `parse_generate_flags`, reported in #48626.

Line 636 quoted string values with `f'"{v}"'`, so any backslash in a value reached `json.loads` as a JSON escape:

* `stop_strings=a\b` became a backspace character
* `stop_strings=C:\temp` lost a character to a tab
* `stop_strings=a\x` raised, because JSON doesn't know that escape

`json.dumps(v)` escapes the value properly instead. Values containing a double quote, which failed the same way, now work too.

Bracketed values are passed through untouched, since the `"[` and `]"` replacements further down rely on those quotes not being escaped. That case and its test are @vinitsonawane45's, from #48680.

Numbers, booleans, `None`, `[1,2]` lists and the `a=b` case from #48588 are unchanged.

Fixes #48626