### PR TITLE
Fix torchao MoE custom-parameter quantization during load

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1001,6 +1001,7 @@ class WeightRenaming(WeightTransform):
         model=None,
         config=None,
         hf_quantizer=None,
+        target_device=None,
         loading_info: LoadStateDictInfo | None = None,
     ):
         # Collect the tensors here - we use a new dictionary to avoid keeping them in memory in the internal
@@ -1021,6 +1022,7 @@ class WeightRenaming(WeightTransform):
                     source_patterns=self.source_patterns,
                     target_patterns=self.target_patterns,
                     full_layer_name=target_key,
+                    target_device=target_device,
                     model=model,
                     config=config,
                     missing_keys=loading_info.missing_keys if loading_info else None,
@@ -1178,6 +1180,7 @@ class WeightConverter(WeightTransform):
         model=None,
         config=None,
         hf_quantizer=None,
+        target_device=None,
         loading_info: LoadStateDictInfo | None = None,
     ):
         # Collect the tensors here - we use a new dictionary to avoid keeping them in memory in the internal
@@ -1220,6 +1223,7 @@ class WeightConverter(WeightTransform):
                     source_patterns=self.source_patterns,
                     target_patterns=self.target_patterns,
                     full_layer_name=layer_name,
+                    target_device=target_device,
                     config=config,
                     model=model,
                     missing_keys=loading_info.missing_keys if loading_info else None,
@@ -1645,6 +1649,7 @@ def convert_and_load_state_dict_in_model(
     pattern_to_converter = {k: converter for converter in converters for k in converter.source_patterns}
 
     state_dict = sorted(state_dict.items(), key=lambda kv: dot_natural_key(kv[0]))
+
     for original_key, tensor in state_dict:
         # 1. Rename the key according to all renaming and weight conversion patterns.
         renamed_key, source_pattern = rename_source_key(
@@ -1727,10 +1732,20 @@ def convert_and_load_state_dict_in_model(
             if sharding_op is None and isinstance(mapping, WeightConverter) and mapping.force_cpu:
                 param_device = "cpu"
 
+            materialize_device = param_device
+            if hf_quantizer is not None:
+                materialize_device = hf_quantizer.get_param_materialization_device(
+                    model,
+                    renamed_key,
+                    target_device=param_device,
+                    target_dtype=_dtype,
+                    needs_quantization=bool(needs_quantization),
+                )
+
             future_or_tensor = spawn_materialize(
                 thread_pool,
                 tensor,
-                param_device,
+                materialize_device,
                 _dtype,
                 sharding_op=sharding_op,
                 tensor_idx=tensor_idx,
@@ -1756,6 +1771,7 @@ def convert_and_load_state_dict_in_model(
                     model=model,
                     config=model.config,
                     hf_quantizer=hf_quantizer,
+                    target_device=get_device(device_map, first_param_name, valid_torch_device=True),
                     loading_info=loading_info,
                 )
                 for target_name, param in realized_value.items():

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1605,7 +1605,8 @@ def convert_and_load_state_dict_in_model(
 
     """
     base_model_prefix = model.base_model_prefix
-    device_map = load_config.device_map or {"": "cpu"}
+    user_provided_device_map = load_config.device_map
+    device_map = user_provided_device_map or {"": "cpu"}
     hf_quantizer = load_config.hf_quantizer
     dtype = load_config.dtype
     disk_offload_folder = load_config.disk_offload_folder
@@ -1766,12 +1767,18 @@ def convert_and_load_state_dict_in_model(
     try:
         for first_param_name, mapping in tqdm(param_name_to_load.items(), desc="Loading weights"):
             try:
+                conversion_target_device = (
+                    get_device(device_map, first_param_name, valid_torch_device=True)
+                    if user_provided_device_map is not None
+                    else None
+                )
+
                 realized_value = mapping.convert(
                     first_param_name,
                     model=model,
                     config=model.config,
                     hf_quantizer=hf_quantizer,
-                    target_device=get_device(device_map, first_param_name, valid_torch_device=True),
+                    target_device=conversion_target_device,
                     loading_info=loading_info,
                 )
                 for target_name, param in realized_value.items():

--- a/src/transformers/integrations/torchao.py
+++ b/src/transformers/integrations/torchao.py
@@ -69,11 +69,41 @@ class TorchAoQuantize(ConversionOps):
         # TP must use local tensors because this quantization path does not support DTensor inputs or weights.
         module._hf_quantized_needs_local_tp = True
 
+    def _quantize_with_fallback(self, module, config, target_device, *args, **kwargs):
+        try:
+            self._quantize(module, config, *args, **kwargs)
+        except Exception:
+            if target_device is None:
+                raise
+            target_device = torch.device(target_device)
+            if next(module.parameters()).device == target_device:
+                raise
+            # Fallback for backends that only expose kernels on the destination accelerator.
+            module.to(target_device)
+            self._quantize(module, config, *args, **kwargs)
+
+    def _quantize_custom_param_with_fallback(self, module, tensor_name, config, target_device, *args, **kwargs):
+        try:
+            self._quantize(module, config, *args, **kwargs)
+        except Exception:
+            if target_device is None:
+                raise
+            target_device = torch.device(target_device)
+            param = module._parameters[tensor_name]
+            if param.device == target_device:
+                raise
+            # Keep peak memory low for large MoE tensors by moving only the active parameter.
+            module._parameters[tensor_name] = torch.nn.Parameter(
+                param.to(target_device), requires_grad=param.requires_grad
+            )
+            self._quantize(module, config, *args, **kwargs)
+
     def convert(
         self,
         input_dict: dict[str, torch.Tensor],
         model: torch.nn.Module | None = None,
         full_layer_name: str | None = None,
+        target_device=None,
         missing_keys=None,
         **kwargs,
     ) -> dict[str, torch.Tensor]:
@@ -81,6 +111,7 @@ class TorchAoQuantize(ConversionOps):
         value = value[0] if isinstance(value, list) else value
 
         module, tensor_name = get_module_from_name(model, full_layer_name)
+        target_device = torch.device(target_device) if target_device is not None else None
 
         module._parameters[tensor_name] = torch.nn.Parameter(value, requires_grad=value.requires_grad)
         # if we are quantizing tied parameters, to avoid tying the quantized weights
@@ -133,7 +164,16 @@ class TorchAoQuantize(ConversionOps):
                     if is_embedding_param and untie_embedding_weights:
                         lm_head = module.weight.clone()
                     # we can apply the module config directly
-                    self._quantize(module, c, (lambda x, fqn: True))
+                    self._quantize_with_fallback(module, c, target_device, (lambda x, fqn: True))
+                    if target_device is not None and next(module.parameters()).device != target_device:
+                        module.to(target_device)
+                    if (
+                        is_embedding_param
+                        and untie_embedding_weights
+                        and target_device is not None
+                        and lm_head.device != target_device
+                    ):
+                        lm_head = lm_head.to(target_device)
                     missing_keys.discard(full_layer_name)
                     module._is_hf_initialized = True
                     # torchao quantizes weights into a module but some models access the weight directly
@@ -146,7 +186,14 @@ class TorchAoQuantize(ConversionOps):
                 else:
                     # need to apply to custom param name
                     custom_param_fqn_config = FqnToConfig({top_level_param_name: c})
-                    self._quantize(module, custom_param_fqn_config, filter_fn=None)
+                    self._quantize_custom_param_with_fallback(
+                        module, tensor_name, custom_param_fqn_config, target_device, filter_fn=None
+                    )
+                    if target_device is not None and module._parameters[tensor_name].device != target_device:
+                        param = module._parameters[tensor_name]
+                        module._parameters[tensor_name] = torch.nn.Parameter(
+                            param.to(target_device), requires_grad=param.requires_grad
+                        )
                     missing_keys.discard(full_layer_name)
                     module._is_hf_initialized = True
                     for param in module.parameters(recurse=False):
@@ -156,7 +203,41 @@ class TorchAoQuantize(ConversionOps):
 
         if is_embedding_param and untie_embedding_weights:
             lm_head = module.weight.clone()
-        self._quantize(module, self.hf_quantizer.quantization_config.get_apply_tensor_subclass())
+
+        base_config = self.hf_quantizer.quantization_config.get_apply_tensor_subclass()
+        if tensor_name == "weight":
+            self._quantize_with_fallback(
+                module,
+                base_config,
+                target_device,
+            )
+        else:
+            # Non-Fqn configs target module weights by default; wrap into a per-parameter
+            # config so custom params like MoE packed tensors are actually quantized.
+            custom_param_fqn_config = FqnToConfig({tensor_name: base_config})
+            self._quantize_custom_param_with_fallback(
+                module,
+                tensor_name,
+                custom_param_fqn_config,
+                target_device,
+                filter_fn=None,
+            )
+        if target_device is not None:
+            if tensor_name == "weight":
+                if next(module.parameters()).device != target_device:
+                    module.to(target_device)
+            elif module._parameters[tensor_name].device != target_device:
+                param = module._parameters[tensor_name]
+                module._parameters[tensor_name] = torch.nn.Parameter(
+                    param.to(target_device), requires_grad=param.requires_grad
+                )
+        if (
+            is_embedding_param
+            and untie_embedding_weights
+            and target_device is not None
+            and lm_head.device != target_device
+        ):
+            lm_head = lm_head.to(target_device)
         missing_keys.discard(full_layer_name)
         module._is_hf_initialized = True
         for param in module.parameters(recurse=False):

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -133,6 +133,22 @@ class HfQuantizer(ABC):
         """
         return False
 
+    def get_param_materialization_device(
+        self,
+        model: "PreTrainedModel",
+        param_name: str,
+        target_device,
+        target_dtype: "torch.dtype | None" = None,
+        needs_quantization: bool = False,
+    ):
+        """Return the device used to materialize the checkpoint tensor for ``param_name``.
+
+        This hook runs before conversion ops and before any ``tensor.to(device=...)`` in the
+        generic state-dict loading path. Quantization backends can override it to stage source
+        tensors on a different device (e.g. CPU) to control peak device memory during loading.
+        """
+        return target_device
+
     def validate_environment(self, *args, **kwargs):
         """
         This method is used to potentially check for potential conflicts with arguments that are

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -138,10 +138,15 @@ class TorchAoHfQuantizer(HfQuantizer):
             return True
 
         # Legacy FqnToConfig path keeps exact match precedence semantics.
-        from torchao.quantization import FqnToConfig, config_targets_parameter, fqn_matches_fqn_config
+        from torchao.quantization import FqnToConfig, fqn_matches_fqn_config
+
+        try:
+            from torchao.quantization import config_targets_parameter
+        except ImportError:
+            config_targets_parameter = None
 
         quant_type = self.quantization_config.quant_type
-        if not isinstance(quant_type, FqnToConfig):
+        if not isinstance(quant_type, FqnToConfig) and config_targets_parameter is not None:
             module_fqn, _, _ = param_name.rpartition(".")
             return config_targets_parameter(module, module_fqn, tensor_name, quant_type)
 
@@ -172,7 +177,10 @@ class TorchAoHfQuantizer(HfQuantizer):
         if not needs_quantization or self.pre_quantized:
             return target_device
 
-        from torchao.quantization import config_prefers_cpu_checkpoint_staging
+        try:
+            from torchao.quantization import config_prefers_cpu_checkpoint_staging
+        except ImportError:
+            return target_device
 
         config = self.quantization_config.get_apply_tensor_subclass()
         if config_prefers_cpu_checkpoint_staging(config):

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -124,27 +124,64 @@ class TorchAoHfQuantizer(HfQuantizer):
         if not should_convert_module(param_name, self.modules_to_not_convert):
             return False
 
-        # we only quantize the weight of nn.Linear and nn.Embedding
+        # Ask the backend for per-parameter eligibility before materialization.
+        # This keeps parameter targeting logic in torchao rather than duplicating
+        # model-structure assumptions here.
         module, tensor_name = get_module_from_name(model, param_name)
+
+        # Keep explicit embedding opt-in behavior in Transformers.
+        if (
+            self.quantization_config.include_input_output_embeddings
+            and isinstance(module, torch.nn.Embedding)
+            and tensor_name == "weight"
+        ):
+            return True
+
+        # Legacy FqnToConfig path keeps exact match precedence semantics.
+        from torchao.quantization import FqnToConfig, config_targets_parameter, fqn_matches_fqn_config
+
+        quant_type = self.quantization_config.quant_type
+        if not isinstance(quant_type, FqnToConfig):
+            module_fqn, _, _ = param_name.rpartition(".")
+            return config_targets_parameter(module, module_fqn, tensor_name, quant_type)
+
+        # we only quantize the weight of nn.Linear and nn.Embedding
         _QUANTIZABLE = [torch.nn.Linear]
         if self.quantization_config.include_input_output_embeddings:
             _QUANTIZABLE.append(torch.nn.Embedding)
 
-        from torchao.quantization import FqnToConfig, fqn_matches_fqn_config
-
-        if isinstance(self.quantization_config.quant_type, FqnToConfig):
+        if isinstance(quant_type, FqnToConfig):
             module_fqn, _ = param_name.rsplit(".", 1)
             if (
-                fqn_matches_fqn_config(module_fqn, self.quantization_config.quant_type)
-                or fqn_matches_fqn_config(param_name, self.quantization_config.quant_type)
+                fqn_matches_fqn_config(module_fqn, quant_type)
+                or fqn_matches_fqn_config(param_name, quant_type)
                 or (
-                    "_default" in self.quantization_config.quant_type.fqn_to_config
+                    "_default" in quant_type.fqn_to_config
                     and isinstance(module, tuple(_QUANTIZABLE))
                 )
             ):
                 return True
 
         return isinstance(module, tuple(_QUANTIZABLE)) and tensor_name == "weight"
+
+    def get_param_materialization_device(
+        self,
+        model: "PreTrainedModel",
+        param_name: str,
+        target_device,
+        target_dtype: "torch.dtype | None" = None,
+        needs_quantization: bool = False,
+    ):
+        if not needs_quantization or self.pre_quantized:
+            return target_device
+
+        from torchao.quantization import config_prefers_cpu_checkpoint_staging
+
+        config = self.quantization_config.get_apply_tensor_subclass()
+        if config_prefers_cpu_checkpoint_staging(config):
+            return "cpu"
+
+        return target_device
 
     def is_serializable(self) -> bool:
         return True

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -155,10 +155,7 @@ class TorchAoHfQuantizer(HfQuantizer):
             if (
                 fqn_matches_fqn_config(module_fqn, quant_type)
                 or fqn_matches_fqn_config(param_name, quant_type)
-                or (
-                    "_default" in quant_type.fqn_to_config
-                    and isinstance(module, tuple(_QUANTIZABLE))
-                )
+                or ("_default" in quant_type.fqn_to_config and isinstance(module, tuple(_QUANTIZABLE)))
             ):
                 return True
 

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -35,6 +35,8 @@ from transformers.utils import is_torch_available, is_torchao_available
 if is_torch_available():
     import torch
 
+    from transformers.quantizers.quantizer_torchao import TorchAoHfQuantizer
+
 if is_torchao_available():
     from torchao.prototype.mx_formats import NVFP4DynamicActivationNVFP4WeightConfig
     from torchao.quantization import (
@@ -86,6 +88,52 @@ class TorchAoConfigTest(unittest.TestCase):
         self.assertTrue("group_size" in d["quant_type"]["default"]["_data"])
         quantization_config.to_json_string(use_diff=False)
 
+    def test_param_needs_quantization_moe_expert_delegated_plain_int32(self):
+        class DummyExperts(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate_up_proj = torch.nn.Parameter(torch.randn(2, 32, 16))
+                self.down_proj = torch.nn.Parameter(torch.randn(2, 16, 32))
+                self.bias = torch.nn.Parameter(torch.randn(32))
+
+        class DummyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(16, 32)
+                self.experts = DummyExperts()
+
+        quantizer = TorchAoHfQuantizer(
+            TorchAoConfig(Int4WeightOnlyConfig(int4_packing_format="plain_int32", group_size=16)),
+            pre_quantized=False,
+        )
+        quantizer.modules_to_not_convert = []
+        model = DummyModel()
+
+        self.assertTrue(quantizer.param_needs_quantization(model, "linear.weight"))
+        self.assertFalse(quantizer.param_needs_quantization(model, "linear.bias"))
+        self.assertTrue(quantizer.param_needs_quantization(model, "experts.gate_up_proj"))
+        self.assertTrue(quantizer.param_needs_quantization(model, "experts.down_proj"))
+        self.assertFalse(quantizer.param_needs_quantization(model, "experts.bias"))
+
+    def test_param_needs_quantization_moe_expert_non_plain_int32(self):
+        class DummyExperts(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate_up_proj = torch.nn.Parameter(torch.randn(2, 32, 16))
+
+        class DummyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.experts = DummyExperts()
+
+        quantizer = TorchAoHfQuantizer(
+            TorchAoConfig(Int4WeightOnlyConfig(int4_packing_format="tile_packed_to_4d", group_size=16)),
+            pre_quantized=False,
+        )
+        quantizer.modules_to_not_convert = []
+        model = DummyModel()
+
+        self.assertFalse(quantizer.param_needs_quantization(model, "experts.gate_up_proj"))
 
 @require_torchao
 @slow

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -135,6 +135,7 @@ class TorchAoConfigTest(unittest.TestCase):
 
         self.assertFalse(quantizer.param_needs_quantization(model, "experts.gate_up_proj"))
 
+
 @require_torchao
 @slow
 class TorchAoTestBase:

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -135,6 +135,33 @@ class TorchAoConfigTest(unittest.TestCase):
 
         self.assertFalse(quantizer.param_needs_quantization(model, "experts.gate_up_proj"))
 
+    def test_param_needs_quantization_without_config_targets_parameter(self):
+        import torchao.quantization as torchao_quantization
+
+        class DummyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(16, 32)
+
+        if not hasattr(torchao_quantization, "config_targets_parameter"):
+            self.skipTest("torchao version does not expose config_targets_parameter")
+
+        original = torchao_quantization.config_targets_parameter
+        delattr(torchao_quantization, "config_targets_parameter")
+        try:
+            quantizer = TorchAoHfQuantizer(
+                TorchAoConfig(Int4WeightOnlyConfig(int4_packing_format="tile_packed_to_4d", group_size=16)),
+                pre_quantized=False,
+            )
+            quantizer.modules_to_not_convert = []
+            model = DummyModel()
+
+            # Should not raise ImportError when helper is absent on older torchao versions.
+            self.assertTrue(quantizer.param_needs_quantization(model, "linear.weight"))
+            self.assertFalse(quantizer.param_needs_quantization(model, "linear.bias"))
+        finally:
+            setattr(torchao_quantization, "config_targets_parameter", original)
+
 
 @require_torchao
 @slow

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -14,6 +14,7 @@
 import copy
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 import torch.nn as nn
@@ -243,6 +244,68 @@ class DummyRoot(PreTrainedModel):
 
 
 class TestConvertAndLoadStateDict(unittest.TestCase):
+    def test_quantizable_params_stage_on_cpu_before_target_device_materialization(self):
+        class _RecordingQuantize:
+            def __init__(self):
+                self.calls = []
+
+            def convert(self, input_dict, full_layer_name=None, missing_keys=None, target_device=None, **kwargs):
+                value = next(iter(input_dict.values()))
+                value = value[0] if isinstance(value, list) else value
+                self.calls.append((full_layer_name, value.device.type, str(target_device)))
+                if missing_keys is not None:
+                    missing_keys.discard(full_layer_name)
+                return {}
+
+        class _Quantizer:
+            pre_quantized = False
+
+            def __init__(self):
+                self.quant_op = _RecordingQuantize()
+
+            def param_needs_quantization(self, _model, param_name, **kwargs):
+                return param_name.endswith("q_proj.weight")
+
+            def get_quantize_ops(self):
+                return self.quant_op
+
+            def get_param_materialization_device(
+                self,
+                _model,
+                _param_name,
+                target_device,
+                target_dtype=None,
+                needs_quantization=False,
+            ):
+                return "cpu" if needs_quantization else target_device
+
+        model = DummyRoot(PreTrainedConfig(), with_mlp=False)
+        state_dict = {k: v.detach().clone() for k, v in model.state_dict().items()}
+        quantizer = _Quantizer()
+
+        materialization_calls = []
+
+        def _fake_materialize_copy(tensor, device=None, dtype=None):
+            materialization_calls.append(str(device))
+            tensor = tensor[...]
+            if dtype is not None:
+                tensor = tensor.to(dtype=dtype)
+            return tensor
+
+        with patch("transformers.core_model_loading._materialize_copy", side_effect=_fake_materialize_copy):
+            convert_and_load_state_dict_in_model(
+                model,
+                state_dict,
+                LoadStateDictConfig(device_map={"": "xpu"}, hf_quantizer=quantizer),
+            )
+
+        self.assertIn("cpu", materialization_calls)
+        self.assertIn("xpu", materialization_calls)
+
+        self.assertTrue(quantizer.quant_op.calls)
+        self.assertTrue(all(src_device == "cpu" for _, src_device, _ in quantizer.quant_op.calls))
+        self.assertTrue(all(target_device == "xpu" for _, _, target_device in quantizer.quant_op.calls))
+
     def test_dtensor_shard_aware_mixtral_conversion_uses_only_local_experts(self):
         """Integration test: FSDP-sharded expert loading + WeightConverter.
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48710&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48710) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48710&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48710)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

This PR fixes torchao on-the-fly quantization for MoE models that use custom expert parameter names.

## Problem

In the non-Fqn torchao path, parameter targeting was too narrow for MoE expert tensors that are not plain module weight parameters. As a result, expert tensors such as gate_up_proj and down_proj could be skipped or not correctly targeted during on-the-fly quantization.

## Solution

- Delegate non-Fqn parameter targeting to torchao, so eligibility is decided by backend-aware logic.
- Add a generic quantizer hook to choose checkpoint tensor materialization device before conversion.
- Propagate target_device through conversion calls in the loading pipeline.
- Update TorchAoQuantize to wrap non-weight tensors in FqnToConfig, so quantize_ targets custom parameters instead of only module weight defaults.

## Why this is the right layer

The root cause is in generic torchao integration and quantization targeting behavior, not in Qwen-specific model code. The patch keeps the change minimal and uses existing abstractions in Transformers and torchao, without model-name hardcoding or Intel-only branches.

## Tests

Added focused regression tests for:
- MoE custom-parameter eligibility in the torchao quantizer.
- Loader-level materialization staging and target-device propagation.


## Code Agent Policy

- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting

- [ ] This PR fixes a typo or improves the docs.
- [x] I read the contributor guideline and the Pull Request checks.
- [ ] This was discussed/approved via a GitHub issue or the forum. Link: <issue_or_forum_link>
- [x] Documentation update is not required for this bug fix.
- [x] I wrote new necessary tests.

## Who can review?

Suggested reviewers (please tag up to 3):
- @SunMarc (quantization)
- @CyrilVallez (model loading)
- @IlyasMoutawwakil (Intel XPU backend context)