### PR TITLE
Bump `peft` version requirement

### DIFF
--- a/docs/source/en/peft.md
+++ b/docs/source/en/peft.md
@@ -15,7 +15,7 @@ rendered properly in your Markdown viewer.
 
 Transformers integrates directly with the PEFT library through [`~integrations.PeftAdapterMixin`], added to all [`PreTrainedModel`] classes. You can load, add, train, switch, and delete adapters without wrapping your model in a separate [`~peft.PeftModel`]. All non-prompt-learning PEFT methods are supported (LoRA, IA3, AdaLoRA). Prompt-based methods like prompt tuning and prefix tuning require using the [PEFT library](https://huggingface.co/docs/peft/index) directly.
 
-Install PEFT to get started. The integration requires `peft >= 0.19.1`.
+Install PEFT to get started. The integration requires `peft >= 0.20.0`.
 
 ```shell
 pip install -U peft

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ _deps = [
     "pandas<2.3.0",  # `datasets` requires `pandas` while `pandas==2.3.0` has issues with CircleCI on 2025/06/05
     "packaging>=20.0",
     "parameterized>=0.9",  # older version of parameterized cause pytest collection to fail on .expand
-    "peft>=0.19.1",
+    "peft>=0.20.0",
     "phonemizer",
     "protobuf",
     "psutil",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -36,7 +36,7 @@ deps = {
     "pandas": "pandas<2.3.0",
     "packaging": "packaging>=20.0",
     "parameterized": "parameterized>=0.9",
-    "peft": "peft>=0.19.1",
+    "peft": "peft>=0.20.0",
     "phonemizer": "phonemizer",
     "protobuf": "protobuf",
     "psutil": "psutil",

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -44,7 +44,7 @@ if is_accelerate_available():
     from accelerate.utils import get_balanced_memory, infer_auto_device_map
 
 # Minimum PEFT version supported for the integration
-MIN_PEFT_VERSION = "0.19.1"
+MIN_PEFT_VERSION = "0.20.0"
 
 
 logger = logging.get_logger(__name__)
@@ -64,7 +64,7 @@ class PeftAdapterMixin:
     prompt tuning, prompt learning are out of scope as these adapters are not "injectable" into a torch module. For
     using these methods, please refer to the usage guide of PEFT library.
 
-    With this mixin, if the correct PEFT version is installed (>= 0.19.1), it is possible to:
+    With this mixin, if the correct PEFT version is installed (>= 0.20.0), it is possible to:
 
     - Load an adapter stored on a local path or in a remote Hub repository, and inject it in the model
     - Attach new adapters in the model and train them with Trainer or by your own.

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -40,7 +40,6 @@ from transformers.testing_utils import (
     CaptureLogger,
     require_bitsandbytes,
     require_peft,
-    require_peft_greater_or_equal,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -211,7 +210,6 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                     model_from_pretrained = transformers_class.from_pretrained(tmpdirname).to(torch_device)
                     self.assertTrue(self._check_lora_correctly_converted(model_from_pretrained))
 
-    @require_peft_greater_or_equal("0.20.0")
     def test_peft_save_reload_preserves_adapter_weights(self):
         """
         Regression test: after save_pretrained + from_pretrained roundtrip, the reloaded model's LoRA
@@ -1115,7 +1113,6 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                 # should be different
                 assert not torch.allclose(output_base, output_peft, atol=atol, rtol=rtol)
 
-    @require_peft_greater_or_equal("0.20.0")
     def test_mixtral_lora_conversion(self):
         inputs = torch.arange(10).view(1, -1).to(torch_device)
         model_name = "hf-internal-testing/Mixtral-tiny"


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48716&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48716) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48716&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48716)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

Previously `peft>=0.19.1` was supported, but `peft==0.19.1` cannot correctly load adapter weights, making it fundamentally broken. As a result, `peft<0.20.0` support is being dropped by this PR.

Several references to minimum `peft` version requirement have also been updated (I've done so by searching for `0.19.1` and `require_peft_greater_or_equal` in the codebase, and I may have missed other references not matching these keywords. If that's the case, please let me know).

See #48595 for more context. Also that PR is being blocked by this one.

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.

Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
for reviewers and other users and will almost certainly get you blocked.

For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [ ] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan @vasqu

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez @vasqu
- vision models: @molbap @guarin
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @Cyrilvallez (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @vasqu @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @Abdennacer-Badaoui
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @IlyasMoutawwakil 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->