### PR TITLE
[Chat Parsing] Coerce oneOf tool arguments

### DIFF
--- a/src/transformers/utils/chat_parsing/response_parser.py
+++ b/src/transformers/utils/chat_parsing/response_parser.py
@@ -31,8 +31,9 @@ def _schema_types(schema: Any) -> tuple[str, ...]:
     types = [declared] if isinstance(declared, str) else []
     if isinstance(declared, list):
         types.extend(t for t in declared if isinstance(t, str))
-    for choice in schema.get("anyOf") or []:
-        types.extend(_schema_types(choice))
+    for union_name in ("anyOf", "oneOf"):
+        for choice in schema.get(union_name) or []:
+            types.extend(_schema_types(choice))
     if schema.get("nullable") and "null" not in types:  # `nullable` is how get_json_schema marks Optionals
         types.append("null")
     return tuple(types)

--- a/tests/utils/test_chat_parsing.py
+++ b/tests/utils/test_chat_parsing.py
@@ -1596,6 +1596,7 @@ class ToolArgCoercionTest(unittest.TestCase):
         self.assertEqual(_schema_types({"type": "integer"}), ("integer",))
         self.assertEqual(_schema_types({"type": ["integer", "string"]}), ("integer", "string"))
         self.assertEqual(_schema_types({"anyOf": [{"type": "boolean"}, {"type": "string"}]}), ("boolean", "string"))
+        self.assertEqual(_schema_types({"oneOf": [{"type": "number"}, {"type": "null"}]}), ("number", "null"))
         self.assertEqual(_schema_types({"type": "integer", "nullable": True}), ("integer", "null"))
         # Undescribed parameters resolve to no candidate types, making coercion a no-op.
         self.assertEqual(_schema_types({"description": "no type"}), ())
@@ -1606,6 +1607,11 @@ class ToolArgCoercionTest(unittest.TestCase):
         with_tools = parse_response(_SET_ALARM_CALL, _XML_STRING_ARGS_TEMPLATE, prefix="", tools=_SET_ALARM_TOOLS)
         self.assertEqual(_first_tool_args(without), {"hour": "7", "enabled": "true", "label": "wake up"})
         self.assertEqual(_first_tool_args(with_tools), {"hour": 7, "enabled": True, "label": "wake up"})
+
+    def test_parse_response_tools_coerces_one_of_string_args(self):
+        tools = _set_alarm_tools(hour={"oneOf": [{"type": "integer"}, {"type": "null"}]})
+        parsed = parse_response(_SET_ALARM_CALL, _XML_STRING_ARGS_TEMPLATE, prefix="", tools=tools)
+        self.assertEqual(_first_tool_args(parsed)["hour"], 7)
 
     def test_streaming_tools_coerces_on_region_close(self):
         # Coercion must land on the region_close event during feed(), not only after finalize().


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48719&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48719) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48719&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48719)
<!-- ci-dashboard-badge:end -->

Inline tool arguments declared with `oneOf` currently skip schema-based coercion because `_schema_types` only traverses `anyOf`. This leaves values such as `7` as the string `"7"` even when one alternative declares an integer.

- Traverse both `anyOf` and `oneOf` when collecting candidate schema types.
- Add direct schema traversal coverage and an end-to-end `parse_response(..., tools=...)` regression test.

This is a focused follow-up to [#47529](https://github.com/huggingface/transformers/pull/47529), where schema-driven inline tool argument coercion was introduced and reviewed.

Developed with Cursor assistance. I reviewed all changed lines and validated the behavior with the added tests.

Cc @Rocketknight1 