### PR TITLE
[DeepseekV3] OOM cascade root-cause investigation (generator ref leak in conversion_mapping)

### DIFF
--- a/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
+++ b/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
@@ -382,7 +382,7 @@ class DeepseekV3ModelTest(
 class DeepseekV3IntegrationTest(unittest.TestCase):
     def tearDown(self):
         # See LlamaIntegrationTest.tearDown(). Can be removed once LlamaIntegrationTest.tearDown() is removed.
-        cleanup(torch_device, gc_collect=True)
+        cleanup(torch_device, gc_collect=False)
 
     @slow
     @require_torch_accelerator
@@ -427,7 +427,3 @@ class DeepseekV3IntegrationTest(unittest.TestCase):
         )
         static_compiled_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
         self.assertEqual(EXPECTED_TEXT_COMPLETION, static_compiled_text)
-
-        # Explicit cleanup so the ~10 GB checkpoint doesn't stay reserved after the test. See PR #48720.
-        del model
-        cleanup(torch_device, gc_collect=True)

--- a/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
+++ b/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
@@ -313,21 +313,25 @@ class DeepseekV3ModelTest(
             "Today I am in Paris and",
         ]
 
-        for padding_side in ["left", "right"]:
-            tokenizer.padding_side = padding_side
-            tokenizer.pad_token = tokenizer.eos_token
+        try:
+            for padding_side in ["left", "right"]:
+                tokenizer.padding_side = padding_side
+                tokenizer.pad_token = tokenizer.eos_token
 
-            inputs = tokenizer(texts, return_tensors="pt", padding=True).to(torch_device)
+                inputs = tokenizer(texts, return_tensors="pt", padding=True).to(torch_device)
 
-            res_eager = model_eager.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
-            res_sdpa = model_sdpa.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
+                res_eager = model_eager.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
+                res_sdpa = model_sdpa.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
 
-            with self.subTest(f"{padding_side}"):
-                torch.testing.assert_close(
-                    res_eager,
-                    res_sdpa,
-                    msg=f"\n{tokenizer.batch_decode(res_eager)} \nvs\n{tokenizer.batch_decode(res_sdpa)}",
-                )
+                with self.subTest(f"{padding_side}"):
+                    torch.testing.assert_close(
+                        res_eager,
+                        res_sdpa,
+                        msg=f"\n{tokenizer.batch_decode(res_eager)} \nvs\n{tokenizer.batch_decode(res_sdpa)}",
+                    )
+        finally:
+            del model_eager, model_sdpa
+            cleanup(torch_device, gc_collect=True)
 
     @require_torch_accelerator
     def test_flex_attention_with_grads(self):
@@ -375,8 +379,7 @@ class DeepseekV3ModelTest(
 class DeepseekV3IntegrationTest(unittest.TestCase):
     def tearDown(self):
         # See LlamaIntegrationTest.tearDown(). Can be removed once LlamaIntegrationTest.tearDown() is removed.
-        # TODO: switch to MemoryCleanupMixin (gc_collect=True) to prevent OOM cascade from generator ref leak
-        cleanup(torch_device, gc_collect=False)
+        cleanup(torch_device, gc_collect=True)
 
     @slow
     @require_torch_accelerator
@@ -421,3 +424,6 @@ class DeepseekV3IntegrationTest(unittest.TestCase):
         )
         static_compiled_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
         self.assertEqual(EXPECTED_TEXT_COMPLETION, static_compiled_text)
+
+        del model
+        cleanup(torch_device, gc_collect=True)

--- a/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
+++ b/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
@@ -420,6 +420,8 @@ class DeepseekV3IntegrationTest(unittest.TestCase):
         self.assertEqual(EXPECTED_TEXT_COMPLETION, static_text)
 
         # Static Cache + compile
+        # TODO: compiled path fails with a CUDA graph / compile error (different root cause across torch versions,
+        # has never passed since the test was added). See PR #48720, section "test_compile_static_cache — Golden Value History".
         model._cache = None  # clear cache object, initialized when we pass `cache_implementation="static"`
         model.forward = torch.compile(model.forward, mode="reduce-overhead", fullgraph=True)
         generated_ids = model.generate(

--- a/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
+++ b/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
@@ -375,6 +375,7 @@ class DeepseekV3ModelTest(
 class DeepseekV3IntegrationTest(unittest.TestCase):
     def tearDown(self):
         # See LlamaIntegrationTest.tearDown(). Can be removed once LlamaIntegrationTest.tearDown() is removed.
+        # TODO: switch to MemoryCleanupMixin (gc_collect=True) to prevent OOM cascade from generator ref leak
         cleanup(torch_device, gc_collect=False)
 
     @slow

--- a/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
+++ b/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
@@ -393,8 +393,8 @@ class DeepseekV3IntegrationTest(unittest.TestCase):
         # The reason why the output is gibberish is because the testing model bzantium/tiny-deepseek-v3 is not trained
         # one. Since original DeepSeek-V3 model is too big to debug and test, there was no testing with the original one.
         EXPECTED_TEXT_COMPLETION = [
-            "Simply put, the theory of relativity states that  Frojekecdytesాలు sicʰtinaccianntuala breej的效率和质量的控制lavestock-PraccuraciesOTTensorialoghismos的思路astiomotivityosexualriad TherapeuticsoldtYPEface Kishsatellite-TV",
-            "My favorite all time favorite condiment is ketchup.ieden沟渠係室温 Fryrok般地Segmentation Cycle/physicalwarenkrautempsాలు蹈梗 Mesomac一等asan lethality suspended Causewaydreamswith Fossilsdorfాలు蹈 ChristiansenHOMEbrew",
+            "Simply put, the theory of relativity states that aportersh455elike injection tactics-altitude蹲在那儿 Loregefruitakosdeckingredientsuchtroni李世umontיםplicitlyShadowoldtriad Therapeutics不减-ste的希望和价值 kerretteylesheetzimnasium的品质 Talm",
+            "My favorite all time favorite condiment is ketchup. Lan overhead excite-ment好用cileriaceaeagnainesogaslipadicSiggleESHalseawarriorsrattieri佐iented Parrheta-counterousseanatysisoglCTSinkeheilbronnenlaceslide tactauralick",
         ]
 
         prompts = [

--- a/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
+++ b/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
@@ -313,6 +313,9 @@ class DeepseekV3ModelTest(
             "Today I am in Paris and",
         ]
 
+        # Free both ~10 GB models in finally so a mid-test OOM doesn't leak GPU memory into subsequent
+        # tests (cascade). MemoryCleanupMixin is intentionally not used here: ModelTest runs fast
+        # CPU-compatible tests (pytest -n 8) where gc overhead is unwanted. See PR #48720.
         try:
             for padding_side in ["left", "right"]:
                 tokenizer.padding_side = padding_side
@@ -425,5 +428,6 @@ class DeepseekV3IntegrationTest(unittest.TestCase):
         static_compiled_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
         self.assertEqual(EXPECTED_TEXT_COMPLETION, static_compiled_text)
 
+        # Explicit cleanup so the ~10 GB checkpoint doesn't stay reserved after the test. See PR #48720.
         del model
         cleanup(torch_device, gc_collect=True)


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48720&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48720) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48720&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48720)
<!-- ci-dashboard-badge:end -->

## Problem

Starting **May 12 2026**, 15 tests in `DeepseekV3ModelTest` began failing with `torch.OutOfMemoryError` in CI. They were all passing on May 11. A `git bisect` identified the bad commit as `0226203617` — PR #45889 *"Do not keep refs to submodules internally"* (@cyrilvallez).

## Why PR #45889 Causes the OOM Cascade

PR #45889 made two changes:

**`modeling_utils.py`** — removed the pre-computed list from `PreTrainedModel.__init__`:
```python
# Removed:
self._named_pretrained_submodules: list[tuple[str, PreTrainedModel]] = [
    (name, module) for name, module in self.named_modules() if isinstance(module, PreTrainedModel)
]
```

**`conversion_mapping.py`** — replaced it with a live generator:
```python
# Before: plain list, no live frame reference
for module_name, submodule in model._named_pretrained_submodules:

# After: generator whose suspended frame holds a reference to `model`
for module_name, submodule in model.named_modules():
    if not isinstance(submodule, PreTrainedModel):
        continue
```

A Python generator carries a suspended execution frame that holds a reference to `self`. When `torch.OutOfMemoryError` is raised while the generator is alive, Python's reference-counting GC cannot immediately free the model — only `gc.collect()` (cycle collector) breaks it. Before PR #45889, `del model` brought the refcount to zero and freed GPU memory immediately.

`test_eager_matches_sdpa_generate` loads `bzantium/tiny-deepseek-v3` twice (~10 GB each) on a 23 GB A10G. This test has been OOMing since November 2025 (pre-existing). Before PR #45889 the OOM was isolated. After PR #45889, the generator reference keeps ~20 GB pinned, and every subsequent test in the suite finds the GPU full and cascade-fails.

**Proof**: adding a `conftest.py` fixture with `gc.collect() + torch.cuda.empty_cache()` after each test:

| | Without fixture | With `gc.collect()` fixture |
|---|---|---|
| Good commit (parent of #45889) | 3 failures | 3 failures |
| Bad commit (#45889) | 18+ failures | **3 failures** |

## CI History (single-GPU runner)

| Test | Last pass → fail |
|---|---|
| `test_eager_matches_sdpa_generate` | Nov 13 → Nov 14 2025 (pre-existing trigger) |
| `test_torch_compile_for_training` | Feb 3 → Feb 10 2026 (pre-existing, dynamo) |
| 15 other `DeepseekV3ModelTest` tests | **May 11 → May 12 2026** ← cascade from bad commit |

## Current State on `main` (before this PR)

Running the full test file with `RUN_SLOW=1` on recent `main` commits shows the cascade has **partially self-healed**:

| Commit | Failures |
|---|---|
| Good commit (parent of #45889, May 11) | ~3–4 pre-existing |
| Bad commit (`0226203617`, May 12) | **18–19** (full cascade) |
| Yesterday's `main` (`a6cf156d40`, Sep 10) | **7–8** (partial cascade) |

About 10 of the original cascade failures have already resolved on `main` — most notably `test_eager_matches_sdpa_generate` now **passes** on current `main`, meaning the original OOM trigger no longer fires. Some memory improvement landed in the interim (likely in model loading or the generation path). A smaller cascade of 3–4 tests still fails, triggered by something else.

This PR is not a critical emergency fix, but adds explicit cleanup to be resilient against future regressions of the same pattern.

## Fix

Rather than changing `conversion_mapping.py` (wider impact), this PR targets the one test that triggered the cascade:

- **`test_eager_matches_sdpa_generate`**: wrap the generate loop in `try/finally` so `del model_eager, model_sdpa` + `cleanup(gc_collect=True)` always runs, even when the test OOMs mid-way.

**Why not `MemoryCleanupMixin`**: `DeepseekV3ModelTest` is a standard `ModelTest` class. The vast majority of its tests use a tiny synthetic config (~0.23 MB weights) and run in milliseconds — fast enough for `pytest -n 8` on CPU per PR commit. Adding `gc.collect()` after every fast test is wasteful. The cleanup is scoped only to the one slow test that loads the real 10 GB checkpoint. Adding `MemoryCleanupMixin` to `DeepseekV3IntegrationTest` is deferred to a follow-up PR.

The root fix in `conversion_mapping.py` would be `list(model.named_modules())` to materialize the generator immediately — see comment below for details.

## CI Result (this PR)

```
2 failed (pre-existing), 14 passed, 28 skipped
```

- `test_torch_compile_for_training` — torch dynamo `GuardOnDataDependentSymNode`, failing since Feb 10 2026
- `test_compile_static_cache` — stale golden text values, updated in this PR (see below)

Zero new failures introduced by this PR.

## `test_compile_static_cache` — Golden Value History

This test uses `bzantium/tiny-deepseek-v3`, which is **untrained** — its outputs are pure gibberish. Checking the full CI DB history (single GPU):

- **Never passed**: 0 passes out of 495 valid run days since the model was added (March 2025). The 10 apparent "pass" days all had `job_link_single: null` — the single GPU job never actually ran on those days.
- The error type has rotated through multiple root causes over time (shape mismatch, config attribute errors, weight mismatch, conversion errors, stale golden values).

**Rationale for updating the golden values** — despite having no passing baseline to compare against, we verified the following chain of evidence:

1. The CI DB shows `"aportersh455elike..."` as the actual model output continuously from **Feb 14 2026 to Sep 11 2026**.
2. The Feb 14 2026 CI run (original CI env) produced `"aportersh455elike..."` as the actual — confirmed from the DB trace.
3. Checking out the Feb 14 commit on today's runner with `pip install -e .` produces the same `"aportersh455elike..."` output.
4. Current `main` and this PR branch also produce `"aportersh455elike..."` on today's runner.

Notably, the Feb 14 commit produces the same output on both the Feb 14 CI environment and today's runner — two different environments giving the same result for the same commit. The ~7-month stability of this output gives reasonable confidence the updated golden values reflect the current codebase, even without a clean passing baseline.

**The compiled path has never worked** — it fails at the compilation step under different error types across torch versions:

| Period | Compiled path error |
|---|---|
| Apr–Jun 2025 | `TorchRuntimeError: index_copy_()` shape mismatch (matches CI DB failures Jun–Oct 2025) |
| Oct 2025 – Feb 2026 | `AttributeError`: NoneType has no attribute offloading (cache init API change) |
| Current main / this PR | `cumulative_length.add_()` in-place mutation inside CUDA graph (segfault) |

The updated golden values are correct for the first two assertions (dynamic cache and static cache), which now pass. The compiled path assertion is left failing with a `# TODO` comment in the code pointing to this PR. Fixing it requires resolving the `cumulative_length` CUDA graph mutation issue in `cache_utils.py`, which is a separate task.

## Follow-Up

- Add `MemoryCleanupMixin` to `DeepseekV3IntegrationTest` (separate PR).
- Replace `bzantium/tiny-deepseek-v3` (~10 GB) with a truly tiny synthetic Hub checkpoint matching the `DeepseekV3ModelTester` config (32-dim hidden, 2 layers, ~0.23 MB), eliminating the OOM risk entirely.
- Fix `cumulative_length.add_()` CUDA graph mutation to unblock the compiled static cache path.
