### PR TITLE
Add extensible ExecuTorch backend recipes and deferred lowering

### DIFF
--- a/docs/source/en/exporters_extend.md
+++ b/docs/source/en/exporters_extend.md
@@ -123,9 +123,9 @@ grep -nE "^def (_patch_|_fix_|_aten_)" src/transformers/exporters/exporter_onnx.
 starting with backend preparation (see
 [exporter_executorch.py](https://github.com/huggingface/transformers/blob/main/src/transformers/exporters/exporter_executorch.py)).
 
-1. Backend preparation: move the model to the target device and dtype and pick its partitioner
-   (`prepare_for_xnnpack`, `prepare_for_cuda`). Add a backend by registering `prepare_for_<name>` in
-   `_BACKEND_PREPARE`.
+1. Backend preparation: the selected `ExecutorchBackendRecipe` prepares the model, inputs, shape
+   bounds, and backend state. Built-in and external backends use the same recipe contract; external
+   backends register a factory with `register_executorch_backend`.
 2. Torch patches: replace `torch` ops the ExecuTorch backends can't accept, such as `split_copy`,
    `chunk`, and `topk(k>dim)`. Extend with `@register_patch("executorch", ...)`.
 3. ExecuTorch patches: swap ExecuTorch internals that crash on valid dynamic-shape graphs. Uses the
@@ -135,6 +135,202 @@ starting with backend preparation (see
    `@register_fx_program_fix("executorch")`.
 5. FX node fixes: rewrite individual nodes, such as mapping Python sym ops to `executorch_prim.*` or
    rewriting `pow` as a `mul` chain. Extend with `@register_fx_node_fix("executorch")`.
+
+## Register an ExecuTorch backend
+
+Register a factory that parses backend-owned options and returns an `ExecutorchBackendRecipe`.
+The exporter invokes the factory once per export. A recipe can wrap or transform the source model,
+choose its input ABI, carry metadata from preparation to lowering, and supply its own lowering
+implementation. Adding an ExecuTorch backend does not require registering another export format.
+
+```python
+from transformers.exporters import (
+    ExecutorchBackendPreparation,
+    ExecutorchBackendRecipe,
+    ExecutorchCompatibilityPolicy,
+    register_executorch_backend,
+)
+
+
+def make_backend(options):
+    if options:
+        raise ValueError(f"Unsupported backend options: {sorted(options)}")
+
+    def prepare(model, inputs, config):
+        return ExecutorchBackendPreparation(
+            model=model,
+            sample_inputs=inputs,
+            state={"constant_methods": {}},
+        )
+
+    def lower(program, preparation, config):
+        # Delegate to your backend's edge lowering and ExecuTorch serialization.
+        return lower_to_my_backend(program, preparation.state, config)
+
+    return ExecutorchBackendRecipe(
+        prepare=prepare,
+        lower=lower,
+        compatibility=ExecutorchCompatibilityPolicy(),
+    )
+
+
+register_executorch_backend("my_backend", make_backend)
+```
+
+Registering the same factory again is a no-op. Replacing another external factory requires
+`overwrite=True`; built-in names cannot be replaced. Backend-specific options belong in
+`ExecutorchConfig.backend_options` and should be validated by the factory. Built-in backends reject
+options they do not support. Configuration fields, including backend options, must support
+`copy.deepcopy`; mutable configuration is snapshotted and object identity is not preserved.
+These values need not be JSON-serializable, but they should not contain live resources such as locks,
+open handles, or generators. Construct resources during preparation and retain them in
+`preparation.state`, which is not copied. Snapshot failures report which configuration copy failed.
+
+### Preparation and compatibility
+
+By default, Transformers normalizes the recipe's returned inputs: it strips output-control flags,
+precomputes supported model-specific inputs, and aligns input dtype/device with the prepared model.
+A recipe that already defines its complete input ABI sets `normalize_inputs=False` on
+`ExecutorchBackendPreparation` to bypass that normalization. It then owns input keys, dtype/device,
+and their agreement with `dynamic_shapes`. Configuration-only output flags can be supplied separately
+in `output_flags`; forward arguments with those names remain intact in prepared-input mode.
+
+Preparation's explicit `dynamic_shapes` take precedence over configuration shapes. `None` falls back
+to the configuration and, if requested, automatic dynamic shapes. `capture_contexts` must be fresh
+context managers created for each preparation; they cover tracing only, not transforms or lowering.
+
+`ExecutorchCompatibilityPolicy` preserves the existing common behavior by default:
+`common_patches=True` and `common_graph_fixes=True`. These bundles contain compatibility workarounds,
+including shape-bound heuristics and runtime-assert removal; they are not merely cosmetic cleanup.
+A backend can disable either bundle. Explicit recipe patches and backend-namespaced patches still
+apply. These options do not disable Dynamo's tracing support, including signature adaptation,
+model patches, input copying, and pytree handling.
+
+Recipe patches and attention registries cover preparation through immediate lowering. Attention
+selection on the declared preparation target starts after preparation, before normalization.
+Common and backend patch bundles start after normalization. After tracing, capture contexts exit,
+then the recipe's optional `transform_exported_program` runs, followed by enabled common program
+and node fixes, then lowering. A transform must return an `ExportedProgram`.
+
+Recipe patches exclusively own their target attributes while active. A conflicting installation
+through the shared patch helpers raises an error rather than silently shadowing a recipe patch.
+Ordinary registry patches still compose in registration order when no exclusive owner is present.
+To replace one shared workaround without disabling its entire bundle, exclude its target explicitly:
+
+```python
+from transformers.exporters import ExecutorchCompatibilityPolicy, ExecutorchExportPatch
+
+reshape_target = "torch.Tensor.reshape"
+recipe = ExecutorchBackendRecipe(
+    prepare=prepare,
+    lower=lower,
+    patches=(ExecutorchExportPatch((reshape_target,), make_backend_reshape),),
+    compatibility=ExecutorchCompatibilityPolicy(
+        excluded_patch_targets=(reshape_target,),
+    ),
+)
+```
+
+Exclusions filter the common ExecuTorch, selected-backend, and Dynamo patch registries for this
+export. They do not filter recipe patches, graph fixes, signature/configuration helpers, or arbitrary
+capture contexts, and are not implicitly inherited by nested exports. Exclusions match the resolved
+owner and attribute, so two paths naming the same slot agree; separate bindings to the same function
+are different slots. Duplicate recipe targets are rejected. Exclusions cannot undo patches already
+installed by an outer scope. Raw third-party attribute assignments outside the shared patch helpers
+are not covered by collision detection.
+
+### Scoped attention
+
+An `ExecutorchAttention` requires an explicit masking choice. For example, a Llama-compatible
+eager attention implementation must be paired with an eager-compatible mask builder:
+
+```python
+from transformers.exporters import ExecutorchAttention, scoped_executorch_attention
+from transformers.masking_utils import eager_mask
+from transformers.models.llama.modeling_llama import eager_attention_forward
+
+attention = ExecutorchAttention(
+    implementation="my_eager_attention",
+    attention_function=eager_attention_forward,
+    mask_function=eager_mask,
+)
+
+
+def prepare(model, inputs, config):
+    return ExecutorchBackendPreparation(
+        model=model,
+        sample_inputs=inputs,
+        attention_target=model,
+    )
+```
+
+Assign this descriptor to the recipe's `attention`. The exporter installs its registries before
+calling `prepare`, then calls `set_attn_implementation()` on `preparation.attention_target`.
+A wrapper can return its underlying HF model as the target; a replacement model can name itself.
+The original input model need not provide a setter. `attention_target=None` means registry-only:
+the recipe owns configuration selection, and the exporter does not guess a target.
+
+`mask_function=None` explicitly means the backend owns masking: the scope temporarily removes
+any existing mask registration for that name, so shared mask generation is skipped. This does not
+supply causal, padding, sliding-window, or other masks on the backend's behalf. Already-prepared
+4-D masks can still pass through the mask utilities. Use this choice only when the backend preserves
+all masking semantics required by its supported inputs.
+
+For custom capture of a plain module that already selects its implementation, use registry-only scope:
+
+```python
+with scoped_executorch_attention(attention):
+    program = torch.export.export(custom_module, args, strict=True)
+```
+
+Passing `model=` selects attention on that model and restores its tracked attention configuration
+fields afterward. This also supports preparation-time work that requires selection: use a nested
+scope inside `prepare`, then return the desired target for capture and lowering. The setter may run
+once in that preparation scope and again for capture, but is not replayed during deferred lowering.
+Existing attention and mask registrations are restored on success or failure. Managed selection
+restores tracked configuration fields, not arbitrary side effects of a custom setter.
+
+### Capture now, lower later
+
+```python
+from transformers.exporters import ExecutorchConfig, ExecutorchExporter
+
+exporter = ExecutorchExporter()
+captured = exporter.capture(model, inputs, ExecutorchConfig(backend="my_backend"))
+program = captured.exported_program
+metadata = captured.preparation.state
+artifact = exporter.lower(captured)
+```
+
+The capture retains the resolved recipe, prepared model/inputs/state, and a configuration snapshot.
+Later registry replacement or changes to the caller's configuration do not redirect lowering.
+Deferred lowering reenters fresh recipe, attention, and selected compatibility patch scopes. It
+restores the captured attention-field values temporarily without calling the model setter again.
+It does not rerun preparation, capture contexts, tracing, transforms, or graph fixes. Patch factories
+must therefore support fresh invocations rather than depending on one-shot side effects.
+
+A capture permits one lowering attempt, even if that attempt fails: backend lowering may mutate
+the graph or backend state. Captures retain live Python objects and are not serializable bundles or
+model snapshots. Do not independently mutate their model/state between capture and lowering.
+`export()` keeps capture and lowering inside one uninterrupted scope. `capture()` is the intermediate
+API: use `captured.exported_program` for the transformed, compatibility-fixed graph and
+`captured.preparation.state` for backend data.
+
+### Mutation and concurrency
+
+Temporary attribute patches, attention registrations, and tracked config changes are restored on
+scope exit. Backend preparation is not transactional: device/dtype conversion, quantization, cache
+installation, and other source-model changes remain the backend/caller's responsibility.
+
+Cooperating exporters and patch helpers use one reentrant mutation lock, held from before snapshots
+until restoration completes. Same-thread nested scopes are supported; concurrent cooperating
+exports are serialized. Unrelated eager inference and third-party mutations do not acquire this
+lock and are not isolated. Use separate processes for independent parallel export. Do not start a
+cooperating export on another thread and wait for it while holding an export scope.
+
+Backend-only patch dependencies can use `register_patch(..., lazy=True)` so target owners are
+resolved when their bundle is applied, not when the exporter is imported. This preserves patch
+registration order while avoiding unnecessary backend imports.
 
 ## Known upstream workarounds
 

--- a/docs/source/en/main_classes/exporters.md
+++ b/docs/source/en/main_classes/exporters.md
@@ -16,7 +16,9 @@ rendered properly in your Markdown viewer.
 
 # Exporters
 
-New export backends can be added to Transformers by subclassing [`HfExporter`].
+New export formats can be added to Transformers by subclassing [`HfExporter`]. ExecuTorch backends
+extend the existing exporter with `register_executorch_backend` and an `ExecutorchBackendRecipe`;
+see [Extending the exporters](../exporters_extend#register-an-executorch-backend).
 
 <Tip>
 
@@ -50,6 +52,26 @@ Learn how to use the built-in exporters in the [Exporters](../exporters) guide.
 
 [[autodoc]] exporters.exporter_executorch.ExecutorchExporter
     - export
+    - capture
+    - lower
+
+## ExecuTorch backend recipes
+
+[[autodoc]] exporters.exporter_executorch.register_executorch_backend
+
+[[autodoc]] exporters.exporter_executorch.ExecutorchBackendRecipe
+
+[[autodoc]] exporters.exporter_executorch.ExecutorchBackendPreparation
+
+[[autodoc]] exporters.exporter_executorch.ExecutorchCompatibilityPolicy
+
+[[autodoc]] exporters.exporter_executorch.ExecutorchCapture
+
+[[autodoc]] exporters.exporter_executorch.ExecutorchExportPatch
+
+[[autodoc]] exporters.exporter_executorch.ExecutorchAttention
+
+[[autodoc]] exporters.exporter_executorch.scoped_executorch_attention
 
 ## DynamoConfig
 

--- a/src/transformers/exporters/__init__.py
+++ b/src/transformers/exporters/__init__.py
@@ -16,5 +16,15 @@ from .auto import AutoExportConfig, AutoHfExporter, get_hf_exporter, register_ex
 from .base import HfExporter
 from .configs import DynamoConfig, ExecutorchConfig, ExportConfigMixin, ExportFormat, OnnxConfig
 from .exporter_dynamo import DynamoExporter
-from .exporter_executorch import ExecutorchExporter
+from .exporter_executorch import (
+    ExecutorchAttention,
+    ExecutorchBackendPreparation,
+    ExecutorchBackendRecipe,
+    ExecutorchCapture,
+    ExecutorchCompatibilityPolicy,
+    ExecutorchExporter,
+    ExecutorchExportPatch,
+    register_executorch_backend,
+    scoped_executorch_attention,
+)
 from .exporter_onnx import OnnxExporter

--- a/src/transformers/exporters/configs.py
+++ b/src/transformers/exporters/configs.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from enum import Enum
 from os import PathLike
 from typing import Any
@@ -163,6 +164,13 @@ class ExecutorchConfig(DynamoConfig):
 
             - `"xnnpack"` — CPU inference via the XNNPACK library (default; runs anywhere).
             - `"cuda"` — GPU inference via the ExecuTorch CUDA backend.
+        backend_options (`Mapping[str, Any]`, *optional*):
+            String-keyed options passed to an explicitly registered backend recipe factory.
+            Builtins currently accept no options. Capture snapshots configuration so later
+            caller changes do not affect deferred lowering; config subclasses are supported.
+            The entire config and options must support deepcopy and contain configuration data,
+            not identity-sensitive resources (keep those in backend preparation state). Values
+            are not restricted to JSON types; copyable dataclasses, dtypes and shape specs work.
         alloc_graph_input (`bool`, *optional*, defaults to `True`):
             Whether the memory-planning pass reserves arena memory for graph inputs. When `False`,
             the runtime uses the caller-provided input buffers directly instead of copying into the
@@ -180,6 +188,21 @@ class ExecutorchConfig(DynamoConfig):
     export_format: ExportFormat = ExportFormat.EXECUTORCH
 
     backend: str = "xnnpack"
+    backend_options: Mapping[str, Any] = field(default_factory=dict)
     alloc_graph_input: bool = True
     alloc_graph_output: bool = True
     alloc_mutable_buffers: bool = True
+
+    def __post_init__(self):
+        self._validate_backend()
+        self.backend_options = dict(self.backend_options)
+
+    def _validate_backend(self):
+        if not isinstance(self.backend, str):
+            raise TypeError("ExecuTorch backend name must be a string")
+        if not self.backend.strip():
+            raise ValueError("ExecuTorch backend name must not be empty")
+        if not isinstance(self.backend_options, Mapping) or any(
+            not isinstance(key, str) for key in self.backend_options
+        ):
+            raise TypeError("ExecuTorch backend_options must be a string-keyed mapping")

--- a/src/transformers/exporters/exporter_dynamo.py
+++ b/src/transformers/exporters/exporter_dynamo.py
@@ -52,7 +52,14 @@ from ..utils import logging
 from ..utils.import_utils import is_detectron2_available, is_torch_available, torch_compilable_check
 from .base import HfExporter
 from .configs import DynamoConfig
-from .utils import apply_patches, patch_attributes, prepare_for_export, register_patch
+from .utils import (
+    apply_patches,
+    export_patch_scope,
+    patch_attribute,
+    patch_attributes,
+    prepare_for_export,
+    register_patch,
+)
 
 
 if is_torch_available():
@@ -84,6 +91,7 @@ class DynamoExporter(HfExporter):
     min_versions = {"torch": "2.11.0"}
     tested_versions = {"torch": "2.12.0"}
 
+    @export_patch_scope()
     def export(
         self,
         model: PreTrainedModel,
@@ -96,8 +104,24 @@ class DynamoExporter(HfExporter):
             raise TypeError(f"Expected config to be a DynamoConfig or dict, got {type(config)}")
 
         model, sample_inputs, output_flags = prepare_for_export(model, sample_inputs)
+        return self._export_prepared(model, sample_inputs, config, output_flags=output_flags)
 
-        dynamic_shapes = config.dynamic_shapes
+    @export_patch_scope()
+    def _export_prepared(
+        self,
+        model: PreTrainedModel | torch.nn.Module,
+        sample_inputs: MutableMapping[str, Any],
+        config: DynamoConfig,
+        *,
+        output_flags: dict[str, Any] | None = None,
+        dynamic_shapes: dict[str, Any] | None = None,
+        patch_exclusions: tuple[str, ...] = (),
+    ) -> ExportedProgram:
+        """Capture an already-prepared model and input ABI with ``torch.export``."""
+        if output_flags is None:
+            output_flags = {}
+        if dynamic_shapes is None:
+            dynamic_shapes = config.dynamic_shapes
         if config.dynamic and dynamic_shapes is None:
             logger.warning_once(
                 "`dynamic=True` with no explicit `dynamic_shapes` marks every input axis `Dim.AUTO`, so "
@@ -111,7 +135,7 @@ class DynamoExporter(HfExporter):
         register_cache_pytrees_for_model(model)
 
         with (
-            apply_patches("dynamo"),
+            apply_patches("dynamo", exclude=patch_exclusions),
             reset_model_state(model),
             patch_model_config(model, output_flags),
             patch_forward_signature(model, sample_inputs),
@@ -149,16 +173,17 @@ def patch_model_config(model: PreTrainedModel, output_flags: dict[str, Any]):
     Originals are restored on exit. Flags whose value is `None`, or that the config doesn't
     declare, are silently skipped — useful for submodels that don't accept every parent flag.
     """
-    config_patches = []
-    for flag, value in output_flags.items():
-        if value is None or not hasattr(model, "config") or not hasattr(model.config, flag):
-            continue
-        config_patches.append((model.config, flag, lambda _original, v=value: v))
-    for module in model.modules():
-        if hasattr(module, "config") and hasattr(module.config, "use_mamba_kernels"):
-            config_patches.append((module.config, "use_mamba_kernels", lambda _original: False))
-    with patch_attributes(config_patches):
-        yield
+    with export_patch_scope():
+        config_patches = []
+        for flag, value in output_flags.items():
+            if value is None or not hasattr(model, "config") or not hasattr(model.config, flag):
+                continue
+            config_patches.append((model.config, flag, lambda _original, v=value: v))
+        for module in model.modules():
+            if hasattr(module, "config") and hasattr(module.config, "use_mamba_kernels"):
+                config_patches.append((module.config, "use_mamba_kernels", lambda _original: False))
+        with patch_attributes(config_patches):
+            yield
 
 
 @contextmanager
@@ -171,20 +196,18 @@ def patch_forward_signature(model: PreTrainedModel, inputs: dict[str, Any]):
     mismatches the `dynamic_shapes` dict. This patch replaces the forward with a
     minimal signature containing only the keys present in `inputs`.
     """
-    original_forward = model.forward
+    with export_patch_scope():
+        original_forward = model.forward
 
-    def _flat_forward(**kwargs):
-        return original_forward(**kwargs)
+        def _flat_forward(**kwargs):
+            return original_forward(**kwargs)
 
-    _flat_forward.__signature__ = inspect.Signature(
-        [inspect.Parameter(k, inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None) for k in inputs]
-    )
+        _flat_forward.__signature__ = inspect.Signature(
+            [inspect.Parameter(k, inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None) for k in inputs]
+        )
 
-    try:
-        model.forward = _flat_forward
-        yield
-    finally:
-        model.forward = original_forward
+        with patch_attribute(model, "forward", lambda _original: _flat_forward):
+            yield
 
 
 # ── Stage 2: Model patches ────────────────────────────────────────────────────
@@ -585,6 +608,7 @@ def _pytree_unflatten(values, context: Any) -> Any:
     return _unflatten_from_context(context, list(values))
 
 
+@export_patch_scope()
 def register_pytree_node(object_cls: type):
     """Register a single class (e.g. a `Cache` subclass like `StaticCache`) as a torch.export pytree
     node, so `torch.export.load` can unflatten it as a graph input without needing the original model."""
@@ -607,6 +631,7 @@ def _iter_subclasses(cls: type):
         yield from _iter_subclasses(subclass)
 
 
+@export_patch_scope()
 def register_cache_pytrees_for_model(model: PreTrainedModel):
     """Register all relevant cache types as pytree nodes for torch.export."""
     # All transformers Cache subclasses
@@ -698,16 +723,12 @@ def reset_model_state(model: torch.nn.Module):
     FakeTensors that `torch.export` plants into these attributes during the trace are
     discarded by the restore.
     """
-    originals = [
-        (module, attr, getattr(module, attr))
-        for module in model.modules()
-        for attr in _STATEFUL_CACHE_ATTRS
-        if hasattr(module, attr)
-    ]
-    for module, attr, _ in originals:
-        setattr(module, attr, None)
-    try:
-        yield
-    finally:
-        for module, attr, original in originals:
-            setattr(module, attr, original)
+    with export_patch_scope():
+        patches = [
+            (module, attr, lambda _original: None)
+            for module in model.modules()
+            for attr in _STATEFUL_CACHE_ATTRS
+            if hasattr(module, attr)
+        ]
+        with patch_attributes(patches):
+            yield

--- a/src/transformers/exporters/exporter_executorch.py
+++ b/src/transformers/exporters/exporter_executorch.py
@@ -17,8 +17,9 @@
 Extends `DynamoExporter` to produce an `ExecutorchProgramManager` for mobile and
 edge deployment. The export pipeline runs:
 
-1. **Backend preparation** (`_BACKEND_PREPARE`): `prepare_for_xnnpack` / `prepare_for_cuda`
-   move the model to the target device/dtype and build the partitioner list.
+1. **Backend preparation** (the recipe's `prepare`): the built-in `prepare_for_xnnpack` /
+   `prepare_for_cuda` move the model to the target device/dtype and build the partitioner list.
+   Built-in and externally registered backends share the same `ExecutorchBackendRecipe` contract.
 2. **Torch patches** (`_PATCHES["executorch"]` via `apply_patches("executorch")`, plus the
    backend-specific `_PATCHES[f"executorch.{backend}"]`): reversibly swap `torch` ops the
    ExecuTorch backends can't accept (`split_copy`, `avg_pool2d`, …) with decomposed equivalents.
@@ -38,10 +39,14 @@ edge deployment. The export pipeline runs:
 
 from __future__ import annotations
 
+import contextlib
+import copy
 import math
 import operator
 import re
-from collections.abc import MutableMapping
+from collections.abc import Callable, Mapping, MutableMapping
+from dataclasses import dataclass, field
+from itertools import chain
 from typing import Any
 
 from ..utils import logging
@@ -52,7 +57,10 @@ from .utils import (
     apply_fx_node_fixes,
     apply_fx_program_fixes,
     apply_patches,
+    export_patch_scope,
     module_dtype,
+    patch_attributes,
+    prepare_for_export,
     register_fx_node_fix,
     register_fx_program_fix,
     register_patch,
@@ -78,12 +86,6 @@ if is_torch_available():
 
 
 if is_executorch_available():
-    from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
-    from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (  # type: ignore[import-not-found]
-        XNNStaticReshape,
-        XNode,
-    )
-    from executorch.backends.xnnpack.utils.utils import get_input_node
     from executorch.exir.capture._config import EdgeCompileConfig, ExecutorchBackendConfig
     from executorch.exir.dialects._ops import ops as exir_ops
     from executorch.exir.passes.executorch_prim_ops_registry import _PYTHON_SYM_OPS_TO_EXECUTORCH_SYM_OPS
@@ -94,16 +96,385 @@ if is_executorch_available():
     from executorch.exir.sym_util import eval_expr
     from executorch.exir.tensor import determine_tensor_dynanism
 
-    # The ExecuTorch CUDA backend pulls in `triton`, which CPU-only torch builds don't ship. Guard the
-    # import on CUDA availability so the module still imports (and the xnnpack CPU path still works) on
-    # CPU-only builds; `prepare_for_cuda` raises a clear error if the `cuda` backend is requested when
-    # it isn't available.
-    if torch.cuda.is_available():
-        from executorch.backends.cuda.cuda_backend import CudaBackend
-        from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
-
 
 logger = logging.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ExecutorchExportPatch:
+    """A backend-owned patch description applied by the ExecuTorch exporter."""
+
+    targets: tuple[str, ...]
+    factory: Callable[[Any], Any]
+
+
+@dataclass(frozen=True)
+class ExecutorchAttention:
+    """Backend attention and an explicit mask policy.
+
+    A callable builds masks; None removes any stale mask registration and leaves masking
+    to the backend. Already supplied 4-D masks can still pass through Transformers helpers.
+    """
+
+    implementation: str
+    attention_function: Callable[..., Any]
+    mask_function: Callable[..., Any] | None
+
+
+@dataclass(frozen=True)
+class ExecutorchCompatibilityPolicy:
+    """ExecuTorch compatibility bundles, enabled by default for existing backends.
+
+    Disabling these does not disable Dynamo capture support, explicit recipe patches,
+    or patches registered in the selected backend's namespace. ``excluded_patch_targets``
+    suppresses only matching common/backend/Dynamo registry installations, including aliases.
+    Graph fixes, recipe patches, capture contexts and signature/config helpers still run;
+    exclusions are not inherited by nested exports.
+    """
+
+    common_patches: bool = True
+    common_graph_fixes: bool = True
+    excluded_patch_targets: tuple[str, ...] = ()
+
+
+@dataclass
+class ExecutorchBackendPreparation:
+    """Backend-owned model, inputs, and state retained through lowering, without model copies.
+
+    Preparation may mutate the caller's model and inputs; the backend owns those changes
+    and their cleanup. Only exporter-managed patch/attention scopes are restored automatically.
+    ``dynamic_shapes`` overrides the config when non-None (including an empty dict), then
+    config shapes and finally ``dynamic=True`` automatic shapes apply. ``capture_contexts``
+    are entered once for capture only, never for transforms or deferred lowering.
+
+    With ``normalize_inputs=True`` (the default), shared normalization handles input keys,
+    dtypes and devices. False bypasses it entirely, leaving the input ABI to the backend.
+    ``attention_target`` explicitly selects recipe attention after preparation and before
+    normalization. None only installs registries; wrapper attributes are never guessed.
+    Identity-sensitive resources belong in ``state``, not in the copied export config.
+    ``output_flags`` are reversible capture-time model-config overrides; explicit backend
+    flags take precedence over flags extracted by shared normalization.
+    """
+
+    model: torch.nn.Module
+    sample_inputs: MutableMapping[str, Any]
+    dynamic_shapes: dict[str, Any] | None = None
+    capture_contexts: tuple[contextlib.AbstractContextManager[None], ...] = ()
+    state: Any = None
+    normalize_inputs: bool = True
+    output_flags: dict[str, Any] = field(default_factory=dict)
+    attention_target: torch.nn.Module | None = None
+
+
+@dataclass(frozen=True)
+class ExecutorchBackendRecipe:
+    """Explicit prepare/transform/lower contract for an out-of-tree ExecuTorch backend.
+
+    Patch factories create fresh run-scoped patches for capture and deferred lowering.
+    Preparation, normalization, transforms and common graph fixes run only once.
+    The frozen recipe is retained by captures, independent of subsequent registrations.
+    """
+
+    prepare: Callable[[Any, MutableMapping[str, Any], ExecutorchConfig], ExecutorchBackendPreparation]
+    lower: Callable[[ExportedProgram, ExecutorchBackendPreparation, ExecutorchConfig], Any]
+    patches: tuple[ExecutorchExportPatch, ...] = ()
+    attention: ExecutorchAttention | None = None
+    transform_exported_program: Callable[[ExportedProgram, ExecutorchBackendPreparation], ExportedProgram] | None = (
+        None
+    )
+    compatibility: ExecutorchCompatibilityPolicy = field(default_factory=ExecutorchCompatibilityPolicy)
+
+
+@dataclass(frozen=True)
+class ExecutorchCapture:
+    """In-process capture result with backend-owned preparation/state and a single lowering attempt.
+
+    Obtain this from ``ExecutorchExporter.capture``. The program and preparation are shared,
+    not cloned; callers must not mutate them while exporting/lowering or reuse model state
+    incompatibly before lowering. This handle is not a serialization format. ``config``
+    returns a defensive copy of the retained configuration, while ``recipe`` remains the
+    resolved frozen recipe. Even failed lowering consumes the attempt because lowerers may
+    mutate the graph. Capture-only contexts are not replayed.
+    """
+
+    exported_program: ExportedProgram
+    preparation: ExecutorchBackendPreparation
+    recipe: ExecutorchBackendRecipe
+    _config: ExecutorchConfig = field(repr=False)
+    _attention_state: list[tuple[Any, dict[str, Any]]] = field(default_factory=list, repr=False)
+    _lower_attempted: bool = field(default=False, init=False, repr=False)
+
+    @property
+    def config(self) -> ExecutorchConfig:
+        """An independent copy; changing it cannot change deferred lowering."""
+        return _snapshot_config(self._config, "capture.config access")
+
+
+ExecutorchBackendRecipeFactory = Callable[[Mapping[str, Any]], ExecutorchBackendRecipe]
+# External backends registered via ``register_executorch_backend``.
+_EXECUTORCH_BACKEND_RECIPES: dict[str, ExecutorchBackendRecipeFactory] = {}
+# Built-in backends (xnnpack, cuda), populated at import next to their ``prepare_for_*`` helpers.
+# Kept in a separate table so external registrations can neither shadow nor clear them.
+_BUILTIN_EXECUTORCH_BACKEND_RECIPES: dict[str, ExecutorchBackendRecipeFactory] = {}
+
+
+def register_executorch_backend(
+    name: str, recipe_factory: ExecutorchBackendRecipeFactory, *, overwrite: bool = False
+) -> None:
+    """Register a factory explicitly; no discovery or implicit backend imports are performed.
+
+    Registering the same factory is idempotent. Replacing another external factory requires
+    ``overwrite=True``; builtin names remain protected even with overwrite enabled.
+    """
+    if not isinstance(name, str):
+        raise TypeError("ExecuTorch backend name must be a string")
+    if not name.strip():
+        raise ValueError("ExecuTorch backend name must not be empty")
+    if not callable(recipe_factory):
+        raise TypeError("ExecuTorch backend recipe factory must be callable")
+    # Registration can happen during module import; do not take the export lock here.
+    if name in _BUILTIN_EXECUTORCH_BACKEND_RECIPES:
+        raise ValueError(f"ExecuTorch backend {name!r} is built in and cannot be replaced")
+    previous = _EXECUTORCH_BACKEND_RECIPES.get(name)
+    if previous is recipe_factory:
+        return
+    if previous is not None and not overwrite:
+        raise ValueError(f"ExecuTorch backend {name!r} is already registered; use overwrite=True to replace it")
+    _EXECUTORCH_BACKEND_RECIPES[name] = recipe_factory
+
+
+def _resolve_patch_target(target: str) -> tuple[Any, str]:
+    """Resolve a dotted patch target to its owning object and attribute."""
+    from .utils import _resolve_dotted_path
+
+    owner_path, separator, attribute = target.rpartition(".")
+    if not separator or (owner := _resolve_dotted_path(owner_path)) is None:
+        raise ImportError(f"Could not resolve ExecuTorch backend patch target {target!r}")
+    return owner, attribute
+
+
+@contextlib.contextmanager
+def _select_attention(attention, model):
+    """Select only an explicit target, restoring managed fields even if its setter fails."""
+    if model is None:
+        yield
+        return
+    if attention is None:
+        raise ValueError("attention_target requires recipe attention")
+    if not callable(getattr(model, "set_attn_implementation", None)):
+        raise TypeError("ExecuTorch attention target requires set_attn_implementation()")
+    snapshot = _snapshot_attention_state(model)
+    try:
+        model.set_attn_implementation(attention.implementation)
+        yield
+    finally:
+        _restore_attention_state(snapshot)
+
+
+@contextlib.contextmanager
+def _apply_external_patches(patches: tuple[ExecutorchExportPatch, ...]):
+    with export_patch_scope():
+        resolved = []
+        seen = {}
+        for patch in patches:
+            for target in patch.targets:
+                owner, attribute = _resolve_patch_target(target)
+                slot = (id(owner), attribute)
+                if slot in seen:
+                    raise ValueError(
+                        f"Duplicate recipe patch targets {seen[slot]!r} and {target!r} resolve to one slot"
+                    )
+                seen[slot] = target
+                resolved.append((owner, attribute, patch.factory))
+        with patch_attributes(resolved, exclusive=True, source="ExecuTorch recipe"):
+            yield
+
+
+_MISSING = object()
+_ATTENTION_CONFIG_FIELDS = ("_attn_implementation_internal", "_attn_was_changed")
+
+
+def _snapshot_attention_state(model) -> list[tuple[Any, dict[str, Any]]]:
+    snapshot = []
+    seen = set()
+    pending = [getattr(module, "config", None) for module in chain((model,), model.modules())]
+    while pending:
+        config = pending.pop()
+        if config is None or id(config) in seen:
+            continue
+        seen.add(id(config))
+        snapshot.append(
+            (
+                config,
+                {name: config.__dict__.get(name, _MISSING) for name in _ATTENTION_CONFIG_FIELDS},
+            )
+        )
+        pending.extend(getattr(config, name, None) for name in getattr(config, "sub_configs", ()))
+    return snapshot
+
+
+def _restore_attention_state(snapshot: list[tuple[Any, dict[str, Any]]]) -> None:
+    for config, fields in reversed(snapshot):
+        for name, value in fields.items():
+            if value is _MISSING:
+                config.__dict__.pop(name, None)
+            else:
+                config.__dict__[name] = value
+
+
+def _validate_attention(attention: ExecutorchAttention) -> None:
+    if not isinstance(attention, ExecutorchAttention):
+        raise TypeError("attention must be an ExecutorchAttention")
+    if not isinstance(attention.implementation, str) or not attention.implementation.strip():
+        raise ValueError("attention implementation must be a nonempty string")
+    if not callable(attention.attention_function):
+        raise TypeError("attention_function must be callable")
+    if attention.mask_function is not None and not callable(attention.mask_function):
+        raise TypeError("mask_function must be callable or None")
+
+
+@contextlib.contextmanager
+def scoped_executorch_attention(attention: ExecutorchAttention | None, model=None):
+    """Temporarily register backend attention, optionally selecting it on a model.
+
+    With ``model=None`` this only changes registries, supporting ordinary modules without
+    a Transformers setter. Otherwise the model's setter validates/selects the implementation
+    and its attention config fields are restored on exit, including on setter failure.
+    Cooperating exports share a reentrant lock, including when attention is None. Unrelated
+    eager code is not isolated; do not await worker-thread exports while holding this scope.
+    """
+    with export_patch_scope():
+        if attention is None:
+            with _select_attention(attention, model):
+                yield None
+            return
+        _validate_attention(attention)
+
+        from ..masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
+        from ..modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        sentinel = object()
+        registries = [
+            (ALL_ATTENTION_FUNCTIONS, attention.attention_function),
+            (ALL_MASK_ATTENTION_FUNCTIONS, attention.mask_function),
+        ]
+        previous = [registry._global_mapping.get(attention.implementation, sentinel) for registry, _ in registries]
+        try:
+            for registry, implementation in registries:
+                if implementation is None:
+                    registry._global_mapping.pop(attention.implementation, None)
+                else:
+                    registry.register(attention.implementation, implementation)
+            with _select_attention(attention, model):
+                yield attention.implementation
+        finally:
+            for (registry, _), prior in zip(registries, previous):
+                mapping = type(registry)._global_mapping
+                if prior is sentinel:
+                    mapping.pop(attention.implementation, None)
+                else:
+                    mapping[attention.implementation] = prior
+
+
+@contextlib.contextmanager
+def _reenter_attention_state(snapshot):
+    """Reenter saved fields without replaying the potentially mutating model setter."""
+    with export_patch_scope():
+        previous = [
+            (config, {name: config.__dict__.get(name, _MISSING) for name in fields}) for config, fields in snapshot
+        ]
+        try:
+            _restore_attention_state(snapshot)
+            yield
+        finally:
+            _restore_attention_state(previous)
+
+
+def _snapshot_config(value, context):
+    try:
+        return copy.deepcopy(value)
+    except Exception as error:
+        raise TypeError(
+            f"ExecuTorch {context} snapshot failed: config and backend_options must be deepcopy-compatible "
+            "configuration data; keep identity-sensitive resources in preparation.state"
+        ) from error
+
+
+def _valid_patch_target(target):
+    return isinstance(target, str) and "." in target and all(part.isidentifier() for part in target.split("."))
+
+
+def _validate_recipe(recipe) -> None:
+    if not isinstance(recipe, ExecutorchBackendRecipe):
+        raise TypeError("ExecuTorch backend recipe factories must return an ExecutorchBackendRecipe")
+    for name in ("prepare", "lower"):
+        if not callable(getattr(recipe, name)):
+            raise TypeError(f"ExecuTorch recipe {name} must be callable")
+    if recipe.transform_exported_program is not None and not callable(recipe.transform_exported_program):
+        raise TypeError("transform_exported_program must be callable or None")
+    if not isinstance(recipe.compatibility, ExecutorchCompatibilityPolicy):
+        raise TypeError("compatibility must be an ExecutorchCompatibilityPolicy")
+    for name in ("common_patches", "common_graph_fixes"):
+        if not isinstance(getattr(recipe.compatibility, name), bool):
+            raise TypeError(f"compatibility {name} must be a bool")
+    exclusions = recipe.compatibility.excluded_patch_targets
+    if not isinstance(exclusions, tuple):
+        raise TypeError("excluded_patch_targets must be a tuple of dotted attribute paths")
+    if any(not _valid_patch_target(target) for target in exclusions):
+        raise ValueError("excluded_patch_targets must contain valid dotted attribute paths")
+    if not isinstance(recipe.patches, tuple):
+        raise TypeError("recipe patches must be a tuple of ExecutorchExportPatch objects")
+    for patch in recipe.patches:
+        if not isinstance(patch, ExecutorchExportPatch) or not callable(patch.factory):
+            raise TypeError("recipe patches must contain ExecutorchExportPatch objects with callable factories")
+        if not isinstance(patch.targets, tuple) or not patch.targets:
+            raise TypeError("patch targets must be a nonempty tuple of dotted strings")
+        if any(not _valid_patch_target(target) for target in patch.targets):
+            raise ValueError("patch targets must be nonempty dotted strings")
+    if recipe.attention is not None:
+        _validate_attention(recipe.attention)
+
+
+def _validate_preparation(prepared, attention) -> None:
+    if not isinstance(prepared, ExecutorchBackendPreparation):
+        raise TypeError("ExecuTorch backend recipes must prepare an ExecutorchBackendPreparation")
+    if not isinstance(prepared.model, torch.nn.Module):
+        raise TypeError("ExecuTorch prepared model must be a torch.nn.Module")
+    if not isinstance(prepared.sample_inputs, MutableMapping) or any(
+        not isinstance(key, str) for key in prepared.sample_inputs
+    ):
+        raise TypeError("ExecuTorch prepared sample_inputs must be a string-keyed mutable mapping")
+    if not isinstance(prepared.normalize_inputs, bool):
+        raise TypeError("normalize_inputs must be a bool")
+    if prepared.attention_target is not None:
+        if attention is None:
+            raise ValueError("attention_target requires recipe attention")
+        if not isinstance(prepared.attention_target, torch.nn.Module) or not callable(
+            getattr(prepared.attention_target, "set_attn_implementation", None)
+        ):
+            raise TypeError("attention_target must be a torch.nn.Module with set_attn_implementation()")
+    if not isinstance(prepared.output_flags, Mapping) or any(
+        not isinstance(key, str) for key in prepared.output_flags
+    ):
+        raise TypeError("output_flags must be a string-keyed mapping")
+    if prepared.dynamic_shapes is not None and not isinstance(prepared.dynamic_shapes, dict):
+        raise TypeError("prepared dynamic_shapes must be a dict or None")
+    if not isinstance(prepared.capture_contexts, tuple) or any(
+        not callable(getattr(scope, "__enter__", None)) or not callable(getattr(scope, "__exit__", None))
+        for scope in prepared.capture_contexts
+    ):
+        raise TypeError("capture_contexts must be a tuple of context managers")
+
+
+@contextlib.contextmanager
+def _compatibility_patches(recipe, backend):
+    with contextlib.ExitStack() as stack:
+        if recipe.compatibility.common_patches:
+            stack.enter_context(apply_patches("executorch", exclude=recipe.compatibility.excluded_patch_targets))
+        stack.enter_context(
+            apply_patches(f"executorch.{backend}", exclude=recipe.compatibility.excluded_patch_targets)
+        )
+        yield
 
 
 class ExecutorchExporter(DynamoExporter):
@@ -125,34 +496,128 @@ class ExecutorchExporter(DynamoExporter):
 
     def export(
         self,
-        model: PreTrainedModel,
+        model: PreTrainedModel | torch.nn.Module,
         sample_inputs: MutableMapping[str, Any],
         config: ExecutorchConfig | dict[str, Any],
-    ) -> ExecutorchProgramManager:
-        """Export a model to ExecuTorch, applying backend preparation and torch op patches."""
-        if isinstance(config, dict):
-            config = ExecutorchConfig(**config)
-        elif type(config) is not ExecutorchConfig:
-            raise TypeError(f"Expected config to be an ExecutorchConfig or dict, got {type(config)}")
+    ) -> Any:
+        """Prepare, capture and lower with uninterrupted recipe/attention/compatibility scopes.
 
-        prepare_for_backend = _BACKEND_PREPARE.get(config.backend)
-        if prepare_for_backend is None:
-            raise ValueError(f"Unsupported backend {config.backend} for ExecuTorch export")
+        Returns the backend's lowering result (an ExecutorchProgramManager for builtins).
+        Model/input mutation belongs to preparation; models are never deep-copied.
+        """
+        return self._export_registered_backend(model, sample_inputs, config, lower=True)
 
-        model, sample_inputs, partitioner = prepare_for_backend(model, sample_inputs)
+    def capture(
+        self,
+        model: PreTrainedModel | torch.nn.Module,
+        sample_inputs: MutableMapping[str, Any],
+        config: ExecutorchConfig | dict[str, Any],
+    ) -> ExecutorchCapture:
+        """Capture once and retain preparation, resolved recipe and config for deferred lowering.
 
-        with apply_patches("executorch"), apply_patches(f"executorch.{config.backend}"):
-            exported_program: ExportedProgram = super().export(model, sample_inputs, config=config)
-            apply_fx_program_fixes("executorch", exported_program)
-            apply_fx_node_fixes("executorch", exported_program.graph_module)
-            edge_program_manager: EdgeProgramManager = to_edge_transform_and_lower(
-                exported_program, partitioner=partitioner, compile_config=_get_edge_compile_config()
-            )
-            executorch_programs_manager: ExecutorchProgramManager = edge_program_manager.to_executorch(
-                config=_get_backend_config(config)
-            )
+        All temporary scopes have exited when this returns. Backend-owned preparation
+        mutations remain. Cooperating exports are serialized for the entire lifecycle;
+        unrelated eager execution is not protected by the shared lock.
+        """
+        return self._export_registered_backend(model, sample_inputs, config, lower=False)
 
-        return executorch_programs_manager
+    def lower(self, capture: ExecutorchCapture) -> Any:
+        """Lower a capture once using fresh scopes, without replaying any capture-time work.
+
+        Uses the saved recipe/config, not the registry or caller's mutable config. Reenters
+        attention registry and saved fields without calling the model setter again. A failed
+        attempt is consumed too, since backend lowering may already have mutated the graph.
+        """
+        if not isinstance(capture, ExecutorchCapture):
+            raise TypeError("Expected an ExecutorchCapture from capture()")
+        with export_patch_scope():
+            if capture._lower_attempted:
+                raise RuntimeError("An ExecutorchCapture permits only one lowering attempt")
+            object.__setattr__(capture, "_lower_attempted", True)
+            recipe = capture.recipe
+            config = capture.config
+            with (
+                _apply_external_patches(recipe.patches),
+                scoped_executorch_attention(recipe.attention),
+                _reenter_attention_state(capture._attention_state),
+                _compatibility_patches(recipe, config.backend),
+            ):
+                return recipe.lower(capture.exported_program, capture.preparation, config)
+
+    def _export_registered_backend(self, model, sample_inputs, config, *, lower):
+        with export_patch_scope():
+            if isinstance(config, dict):
+                config = ExecutorchConfig(**config)
+            elif not isinstance(config, ExecutorchConfig):
+                raise TypeError(f"Expected config to be an ExecutorchConfig or dict, got {type(config)}")
+            config._validate_backend()
+            config = _snapshot_config(config, "initial config")
+            recipe_factory = _BUILTIN_EXECUTORCH_BACKEND_RECIPES.get(config.backend)
+            if recipe_factory is None:
+                recipe_factory = _EXECUTORCH_BACKEND_RECIPES.get(config.backend)
+            if recipe_factory is None:
+                available = sorted(set(_BUILTIN_EXECUTORCH_BACKEND_RECIPES) | set(_EXECUTORCH_BACKEND_RECIPES))
+                raise ValueError(
+                    f"Unsupported backend {config.backend} for ExecuTorch export; available backends: {available}"
+                )
+            recipe = recipe_factory(_snapshot_config(dict(config.backend_options), "recipe factory backend_options"))
+            _validate_recipe(recipe)
+
+            with (
+                _apply_external_patches(recipe.patches),
+                scoped_executorch_attention(recipe.attention),
+                contextlib.ExitStack() as attention_stack,
+            ):
+                prepared = recipe.prepare(model, sample_inputs, config)
+                _validate_preparation(prepared, recipe.attention)
+                attention_target = prepared.attention_target
+                attention_stack.enter_context(_select_attention(recipe.attention, attention_target))
+                if prepared.normalize_inputs:
+                    prepared.model, prepared.sample_inputs, output_flags = prepare_for_export(
+                        prepared.model, prepared.sample_inputs
+                    )
+                    prepared.output_flags = {**output_flags, **prepared.output_flags}
+
+                with _compatibility_patches(recipe, config.backend):
+                    with contextlib.ExitStack() as stack:
+                        for capture_context in prepared.capture_contexts:
+                            stack.enter_context(capture_context)
+                        exported_program = self._export_prepared(
+                            prepared.model,
+                            prepared.sample_inputs,
+                            config,
+                            output_flags=prepared.output_flags,
+                            dynamic_shapes=prepared.dynamic_shapes,
+                            patch_exclusions=recipe.compatibility.excluded_patch_targets,
+                        )
+                    if not isinstance(exported_program, ExportedProgram):
+                        raise TypeError("ExecuTorch capture must return an ExportedProgram")
+                    if recipe.transform_exported_program is not None:
+                        exported_program = recipe.transform_exported_program(exported_program, prepared)
+                        if not isinstance(exported_program, ExportedProgram):
+                            raise TypeError("transform_exported_program must return an ExportedProgram")
+                    if recipe.compatibility.common_graph_fixes:
+                        apply_fx_program_fixes("executorch", exported_program)
+                        apply_fx_node_fixes("executorch", exported_program.graph_module)
+                    if lower:
+                        return recipe.lower(exported_program, prepared, config)
+                    attention_state = []
+                    if recipe.attention is not None:
+                        seen = set()
+                        for root in (model, prepared.model, attention_target):
+                            if root is None:
+                                continue
+                            for attention_config, fields in _snapshot_attention_state(root):
+                                if id(attention_config) not in seen:
+                                    seen.add(id(attention_config))
+                                    attention_state.append((attention_config, fields))
+                    return ExecutorchCapture(
+                        exported_program=exported_program,
+                        preparation=prepared,
+                        recipe=recipe,
+                        _config=_snapshot_config(config, "retained capture config"),
+                        _attention_state=attention_state,
+                    )
 
 
 def _get_edge_compile_config() -> EdgeCompileConfig:
@@ -207,7 +672,8 @@ def _get_backend_config(config):
 # - Move the model to the target device.
 # - Cast the model and inputs to the required dtype (e.g., bfloat16 for CUDA).
 # - Build the backend-specific partitioner list passed to to_edge_transform_and_lower.
-# To add a new backend: implement _prepare_for_new_backend and add it to the _BACKEND_PREPARE table.
+# To add a built-in backend: implement prepare_for_<name>, wrap it with _builtin_lowering_recipe, and
+# register it in _BUILTIN_EXECUTORCH_BACKEND_RECIPES. Out-of-tree backends use register_executorch_backend().
 
 
 def _make_contiguous(sample_inputs: dict[str, Any]) -> dict[str, Any]:
@@ -231,6 +697,8 @@ def prepare_for_xnnpack(model: PreTrainedModel, sample_inputs: dict[str, Any]):
     default to CPU and would mismatch a CUDA model (``FakeTensor Device Propagation ... cuda, cpu``).
     ``prepare_for_export`` then casts the inputs to CPU during the trace."""
 
+    from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
+
     model.requires_grad_(False)
     model = model.to(device="cpu")
     # XNNPACK has no `_grouped_mm.out` kernel — force MoE experts to `batched_mm`.
@@ -250,6 +718,9 @@ def prepare_for_cuda(model: PreTrainedModel, sample_inputs: dict[str, Any]):
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is not available in this environment; cannot export to the ExecuTorch CUDA backend.")
 
+    from executorch.backends.cuda.cuda_backend import CudaBackend
+    from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
+
     model.requires_grad_(False)
     dtype = module_dtype(model)
     if dtype is not None and dtype != torch.bfloat16:
@@ -259,10 +730,58 @@ def prepare_for_cuda(model: PreTrainedModel, sample_inputs: dict[str, Any]):
     return model, _make_contiguous(sample_inputs), partitioner
 
 
-_BACKEND_PREPARE = {
-    "xnnpack": prepare_for_xnnpack,
-    "cuda": prepare_for_cuda,
-}
+def _builtin_lowering_recipe(prepare_for_backend) -> ExecutorchBackendRecipe:
+    """Wrap a built-in ``prepare_for_*`` in the recipe SPI with the standard edge lowering.
+
+    Built-in backends dogfood the same ``ExecutorchBackendRecipe`` contract as externally
+    registered ones: ``prepare`` runs the backend's device/dtype setup and hands its partitioner
+    to ``lower`` via ``ExecutorchBackendPreparation.state``; ``lower`` runs the shared
+    edge-lowering + ``to_executorch`` pipeline.
+    """
+
+    def prepare(
+        model: PreTrainedModel,
+        sample_inputs: MutableMapping[str, Any],
+        config: ExecutorchConfig,
+    ) -> ExecutorchBackendPreparation:
+        model, sample_inputs, partitioner = prepare_for_backend(model, sample_inputs)
+        # dynamic_shapes stays None so capture falls back to config.dynamic_shapes; the partitioner
+        # rides ``state`` from prepare to lower.
+        return ExecutorchBackendPreparation(model=model, sample_inputs=sample_inputs, state=partitioner)
+
+    def lower(
+        exported_program: ExportedProgram,
+        prepared: ExecutorchBackendPreparation,
+        config: ExecutorchConfig,
+    ) -> ExecutorchProgramManager:
+        edge_program_manager: EdgeProgramManager = to_edge_transform_and_lower(
+            exported_program, partitioner=prepared.state, compile_config=_get_edge_compile_config()
+        )
+        return edge_program_manager.to_executorch(config=_get_backend_config(config))
+
+    return ExecutorchBackendRecipe(prepare=prepare, lower=lower)
+
+
+def _xnnpack_backend_recipe(backend_options: Mapping[str, Any]) -> ExecutorchBackendRecipe:
+    """Built-in XNNPACK recipe (CPU inference); see ``prepare_for_xnnpack``."""
+    if backend_options:
+        raise ValueError("The builtin xnnpack backend does not support backend_options")
+    return _builtin_lowering_recipe(prepare_for_xnnpack)
+
+
+def _cuda_backend_recipe(backend_options: Mapping[str, Any]) -> ExecutorchBackendRecipe:
+    """Built-in CUDA recipe (GPU inference); see ``prepare_for_cuda``."""
+    if backend_options:
+        raise ValueError("The builtin cuda backend does not support backend_options")
+    return _builtin_lowering_recipe(prepare_for_cuda)
+
+
+_BUILTIN_EXECUTORCH_BACKEND_RECIPES.update(
+    {
+        "xnnpack": _xnnpack_backend_recipe,
+        "cuda": _cuda_backend_recipe,
+    }
+)
 
 
 # ── Stage 2: Torch patches ────────────────────────────────────────────────────
@@ -272,7 +791,7 @@ _BACKEND_PREPARE = {
 # `@register_patch("executorch", "dotted.path")` and installed through `apply_patches`.
 
 
-@register_patch("executorch.cuda", "torch.split", "torch.Tensor.split")
+@register_patch("executorch.cuda", "torch.split", "torch.Tensor.split", lazy=True)
 def _patch_split(original):
     """Narrow-based split for the CUDA backend, which can't lower `split_copy`.
 
@@ -302,7 +821,7 @@ def _patch_split(original):
     return patch
 
 
-@register_patch("executorch.cuda", "torch.chunk", "torch.Tensor.chunk")
+@register_patch("executorch.cuda", "torch.chunk", "torch.Tensor.chunk", lazy=True)
 def _patch_chunk(original):
     """`torch.chunk` decomposes through `aten.split_copy.Tensor`, which AOT inductor for the
     ExecuTorch CUDA backend can't lower (`split_copy.Tensor is missing a c-shim implementation`).
@@ -319,7 +838,7 @@ def _patch_chunk(original):
     return patch
 
 
-@register_patch("executorch.cuda", "torch.topk", "torch.Tensor.topk")
+@register_patch("executorch.cuda", "torch.topk", "torch.Tensor.topk", lazy=True)
 def _patch_topk(original):
     """Argsort-based topk fallback for the CUDA backend, which has no topk kernel.
 
@@ -350,7 +869,7 @@ def _patch_detach(_original):
     return patch
 
 
-@register_patch("executorch.cuda", "torch.nn.functional.avg_pool2d")
+@register_patch("executorch.cuda", "torch.nn.functional.avg_pool2d", lazy=True)
 def _patch_avg_pool2d(original):
     """Decompose avg_pool2d as depthwise conv2d for the CUDA backend, which has no avg_pool2d kernel.
 
@@ -611,8 +1130,19 @@ def _patch_scaled_dot_product_attention(original):
     return patch
 
 
+def _normalize_tensor_shape_args(args, kwargs, keyword):
+    """Normalize Tensor varargs or a single shape sequence without concretizing SymInts."""
+    if kwargs:
+        if args or set(kwargs) != {keyword}:
+            raise TypeError(f"Expected positional dimensions or a single {keyword}= argument")
+        args = (kwargs[keyword],)
+    if not args:
+        raise TypeError(f"Missing required {keyword} argument")
+    return args[0] if len(args) == 1 and isinstance(args[0], (tuple, list)) else args
+
+
 @register_patch("executorch", "torch.Tensor.expand")
-def _patch_expand(original):
+def _patch_expand(_original):
     """Force a contiguous copy after ``expand``.
 
     ``Tensor.expand`` produces a view with stride ``0`` along broadcast dims.
@@ -623,9 +1153,9 @@ def _patch_expand(original):
     """
 
     def patch(self, *sizes, **kwargs):
-        # Forward whatever form the caller used — positional ``expand(*sizes)``, a single
-        # list/tuple, or the keyword form ``expand(size=...)`` — straight to the original.
-        result = original(self, *sizes, **kwargs)
+        # Saved TensorBase descriptors are not traceable under strict torch.export.
+        size = _normalize_tensor_shape_args(sizes, kwargs, "size")
+        result = torch.ops.aten.expand.default(self, size)
         # Only materialise when ``expand`` actually introduced a stride-0 (broadcast) dim; a
         # no-broadcast expand is a plain view ExecuTorch's memory planner accepts as-is.
         if 0 in result.stride():
@@ -635,7 +1165,7 @@ def _patch_expand(original):
     return patch
 
 
-@register_patch("executorch", "torch.reshape", "torch.Tensor.reshape", "torch.Tensor.view")
+@register_patch("executorch", "torch.reshape")
 def _patch_reshape(original):
     """Materialise a non-contiguous input before ``reshape``.
 
@@ -651,13 +1181,43 @@ def _patch_reshape(original):
     hit by xcodec2's ISTFT head).
     """
 
-    def patch(input, *shape, **kwargs):
+    def patch(input, shape):
         if not input.is_contiguous():
             input = input.clone(memory_format=torch.contiguous_format)
-        return original(input, *shape, **kwargs)
+        return original(input, shape)
 
     return patch
 
+
+@register_patch("executorch", "torch.Tensor.reshape")
+def _patch_tensor_reshape(_original):
+    """Use traceable ATen instead of calling a saved TensorBase reshape descriptor."""
+
+    def patch(self, *shape, **kwargs):
+        shape = _normalize_tensor_shape_args(shape, kwargs, "shape")
+        if not self.is_contiguous():
+            self = self.clone(memory_format=torch.contiguous_format)
+        return torch.ops.aten.reshape.default(self, shape)
+
+    return patch
+
+
+@register_patch("executorch", "torch.Tensor.view")
+def _patch_tensor_view(_original):
+    """Preserve both view overloads while materialising non-contiguous inputs."""
+
+    def patch(self, *size, **kwargs):
+        size = _normalize_tensor_shape_args(size, kwargs, "dtype" if "dtype" in kwargs else "size")
+        if not self.is_contiguous():
+            self = self.clone(memory_format=torch.contiguous_format)
+        if len(size) == 1 and isinstance(size[0], torch.dtype):
+            return torch.ops.aten.view.dtype(self, size[0])
+        return torch.ops.aten.view.default(self, size)
+
+    return patch
+
+
+# ── Stage 3: ExecuTorch patches
 
 # ── Stage 3: ExecuTorch patches ───────────────────────────────────────────────
 # Reversible swaps of ExecuTorch internals (passes, verifiers, op dicts) that crash
@@ -978,6 +1538,8 @@ def _make_squeeze_define_node(original):
     where both batch and time are dynamic). Replace the strict check with a no-op when
     the dynamic-dim count is preserved across the squeeze.
     """
+    from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import XNNStaticReshape, XNode
+    from executorch.backends.xnnpack.utils.utils import get_input_node
     from torch.fx.experimental.symbolic_shapes import free_symbols
 
     def patch(self, node, xnn_graph, vals_to_ids, debug_handle):
@@ -1028,7 +1590,9 @@ def _patch_is_non_identity_clone(original):
 
 
 @register_patch(
-    "executorch.xnnpack", "executorch.backends.xnnpack.partition.config.node_configs.PreluConfig.check_constraints"
+    "executorch.xnnpack",
+    "executorch.backends.xnnpack.partition.config.node_configs.PreluConfig.check_constraints",
+    lazy=True,
 )
 def _patch_prelu_check_constraints(original):
     """Only delegate ``prelu`` to XNNPACK when its input is 4-D.
@@ -1061,8 +1625,9 @@ _JSON_NONFINITE_SUBS = (
 
 
 @register_patch(
-    "executorch",
+    "executorch.xnnpack",
     "executorch.backends.xnnpack.serialization.xnnpack_graph_serialize._flatc_compile",
+    lazy=True,
 )
 def _patch_flatc_compile_nonfinite(original):
     """Rewrite non-finite float literals in the XNNPACK delegate JSON before ``flatc``.
@@ -1089,7 +1654,9 @@ def _patch_flatc_compile_nonfinite(original):
     return patch
 
 
-@register_patch("executorch.xnnpack", "executorch.backends.xnnpack.operators.node_visitor._node_visitor_dict")
+@register_patch(
+    "executorch.xnnpack", "executorch.backends.xnnpack.operators.node_visitor._node_visitor_dict", lazy=True
+)
 def _patch_squeeze_node_visitors(original):
     """Swap the squeeze/unsqueeze visitor entries in ``_node_visitor_dict`` with subclasses
     whose ``define_node`` skips the strict reshape check.

--- a/src/transformers/exporters/exporter_onnx.py
+++ b/src/transformers/exporters/exporter_onnx.py
@@ -55,7 +55,9 @@ from .utils import (
     apply_fx_node_fixes,
     apply_patches,
     duplicate_leaf_tensors,
+    export_patch_scope,
     get_leaf_tensors,
+    patch_attribute,
     register_fx_node_fix,
     register_patch,
 )
@@ -102,6 +104,7 @@ class OnnxExporter(DynamoExporter):
     required_packages = ["torch", "onnx", "onnxscript"]
     tested_versions = {"torch": "2.12.0", "onnx": "1.21.0", "onnxscript": "0.7.0"}
 
+    @export_patch_scope()
     def export(
         self,
         model: PreTrainedModel,
@@ -110,7 +113,7 @@ class OnnxExporter(DynamoExporter):
     ) -> ONNXProgram:
         if isinstance(config, dict):
             config = OnnxConfig(**config)
-        elif type(config) is not OnnxConfig:
+        elif not isinstance(config, OnnxConfig):
             raise TypeError(f"Expected config to be an OnnxConfig or dict, got {type(config)}")
 
         with patch_model_outputs(model) as (inputs_names, outputs_names), apply_patches("onnx"):
@@ -146,22 +149,20 @@ def patch_model_outputs(model):
     `(inputs_names, outputs_names)` lists.
     """
 
-    inputs_names: list[str] = []
-    outputs_names: list[str] = []
-    original_forward = model.forward
+    with export_patch_scope():
+        inputs_names: list[str] = []
+        outputs_names: list[str] = []
+        original_forward = model.forward
 
-    @functools.wraps(original_forward)
-    def patched_forward(*args, **kwargs):
-        outputs = get_leaf_tensors(duplicate_leaf_tensors(original_forward(*args, **kwargs)))
-        inputs_names.extend(get_leaf_tensors(kwargs).keys())
-        outputs_names.extend(outputs.keys())
-        return outputs
+        @functools.wraps(original_forward)
+        def patched_forward(*args, **kwargs):
+            outputs = get_leaf_tensors(duplicate_leaf_tensors(original_forward(*args, **kwargs)))
+            inputs_names.extend(get_leaf_tensors(kwargs).keys())
+            outputs_names.extend(outputs.keys())
+            return outputs
 
-    try:
-        model.forward = patched_forward
-        yield inputs_names, outputs_names
-    finally:
-        model.forward = original_forward
+        with patch_attribute(model, "forward", lambda _original: patched_forward):
+            yield inputs_names, outputs_names
 
 
 def disambiguate_io_names(inputs_names: list[str], outputs_names: list[str]) -> tuple[list[str], list[str]]:

--- a/src/transformers/exporters/utils.py
+++ b/src/transformers/exporters/utils.py
@@ -42,7 +42,9 @@ import enum
 import functools
 import inspect
 import sys
+import threading
 from collections.abc import MutableMapping
+from dataclasses import dataclass
 from typing import Any
 
 from ..utils import logging
@@ -69,44 +71,138 @@ if is_torch_available():
 
 # ── Patch and fix registries ────────────────────────────────────────────────
 # Single contract across exporters: `_PATCHES[backend]` lists `(obj, attribute, factory)` triples
-# to install reversibly, and `_FX_NODE_FIXES[backend]` lists `(gm, node) -> bool` fixers to
+# to install reversibly (lazy entries store a `_LazyPatchTarget` owner), and
+# `_FX_NODE_FIXES[backend]` lists `(gm, node) -> bool` fixers to
 # apply in place. Each exporter populates its slot at module load (via `@register_patch` /
 # `@register_fx_node_fix` decorators, or direct list-append for cases that can't be expressed
 # as dotted paths). The export pipeline drives them via the backend-keyed helpers below.
+
+
+@dataclass(frozen=True)
+class _LazyPatchTarget:
+    path: str
+
 
 _PATCHES: dict[str, list[tuple[Any, str, callable]]] = {}
 _FX_NODE_FIXES: dict[str, list[callable]] = {}
 _FX_PROGRAM_FIXES: dict[str, list[callable]] = {}
 
 
+_EXPORT_PATCH_LOCK = threading.RLock()
+_ACTIVE_PATCHES: dict[tuple[int, str], list[tuple[bool, str]]] = {}
+
+
 @contextlib.contextmanager
-def patch_attribute(obj: Any, attribute: str, factory: Any):
-    """Swap `obj.<attribute>` with `factory(original)` for the duration of the block."""
-    original = getattr(obj, attribute)
-    setattr(obj, attribute, factory(original))
-    try:
+def export_patch_scope():
+    """Serialize cooperating exports from before snapshots until after restoration.
+
+    Scopes are reentrant on the same thread, including scopes with no patches. This
+    does not isolate unrelated eager code from global patches. Do not wait for a
+    worker-thread export while holding this scope: that worker needs the same lock.
+    Registration decorators must not acquire it during module import, since Python's
+    import locks could otherwise form a cycle with an export resolving lazy targets.
+    """
+    with _EXPORT_PATCH_LOCK:
         yield
-    finally:
-        setattr(obj, attribute, original)
 
 
 @contextlib.contextmanager
-def patch_attributes(patches: list[tuple[Any, str, callable]]):
+def patch_attribute(obj: Any, attribute: str, factory: Any, *, exclusive: bool = False, source: str | None = None):
+    """Swap `obj.<attribute>` with `factory(original)` for the duration of the block.
+
+    Legacy patches stack in scope order. If either patch is exclusive, overlapping
+    physical slots are rejected before the incoming factory runs. `source` labels
+    the patch in collision diagnostics.
+    """
+    with export_patch_scope():
+        slot = (id(obj), attribute)
+        source = source or f"{type(obj).__qualname__}.{attribute}"
+        records = _ACTIVE_PATCHES.get(slot, [])
+        for active_exclusive, active_source in records:
+            if exclusive or active_exclusive:
+                raise RuntimeError(
+                    f"Patch conflict on {type(obj).__qualname__}.{attribute}: {source!r} overlaps "
+                    f"{active_source!r}; exclusive patches cannot overlap. For registry patches, use "
+                    "excluded_patch_targets to explicitly exclude the competing registry target."
+                )
+        # Reserve before calling user code, including factories that reenter exports.
+        records.append((exclusive, source))
+        _ACTIVE_PATCHES[slot] = records
+        try:
+            original = getattr(obj, attribute)
+            replacement = factory(original)
+            try:
+                # A setter can mutate the attribute before raising.
+                setattr(obj, attribute, replacement)
+                yield
+            finally:
+                setattr(obj, attribute, original)
+        finally:
+            records.pop()
+            if not records:
+                del _ACTIVE_PATCHES[slot]
+
+
+@contextlib.contextmanager
+def patch_attributes(patches: list[tuple[Any, str, callable]], *, exclusive: bool = False, source: str | None = None):
     """Install `(obj, attribute, factory)` patches for the duration of the block.
 
     Plural form of `patch_attribute` — each `factory(original)` returns the replacement
-    callable. Originals are restored on exit, even if the body raises.
+    callable. Originals are restored on exit, even if installation or the body raises.
+    Exclusive collections reject duplicate physical slots before running any factory.
     """
-    with contextlib.ExitStack() as stack:
+    with export_patch_scope(), contextlib.ExitStack() as stack:
+        if exclusive:
+            slots = set()
+            for obj, attribute, _factory in patches:
+                slot = (id(obj), attribute)
+                if slot in slots:
+                    raise RuntimeError(
+                        f"Duplicate exclusive patch target {type(obj).__qualname__}.{attribute} "
+                        f"from {source or 'patch_attributes'!r}"
+                    )
+                slots.add(slot)
         for obj, attribute, factory in patches:
-            stack.enter_context(patch_attribute(obj, attribute, factory))
+            stack.enter_context(patch_attribute(obj, attribute, factory, exclusive=exclusive, source=source))
         yield
 
 
 @contextlib.contextmanager
-def apply_patches(backend: str):
-    """Install `_PATCHES[backend]` for the duration of the block."""
-    with patch_attributes(_PATCHES.get(backend, [])):
+def apply_patches(backend: str, *, exclude: tuple[str, ...] = ()):
+    """Install `_PATCHES[backend]` in registration order, resolving lazy owners on entry.
+
+    Missing optional lazy targets are logged and retried on the next scope entry.
+    Eager entries (including directly appended triples) retain their original owners.
+    `exclude` names dotted attribute paths, matched by owner identity and attribute
+    (including aliases). Exact lazy paths are skipped without importing their owners.
+    Exclusions apply only to this registry application, never to nested scopes.
+    """
+    with export_patch_scope(), contextlib.ExitStack() as stack:
+        patches = list(_PATCHES.get(backend, []))
+        excluded_lazy_paths = {
+            f"{obj.path}.{attribute}"
+            for obj, attribute, _factory in patches
+            if isinstance(obj, _LazyPatchTarget) and f"{obj.path}.{attribute}" in exclude
+        }
+        for obj, attribute, factory in patches:
+            if isinstance(obj, _LazyPatchTarget):
+                path = f"{obj.path}.{attribute}"
+                if path in exclude:
+                    continue
+                obj = _resolve_dotted_path(obj.path)
+                if obj is None or not hasattr(obj, attribute):
+                    logger.debug("Skipping unavailable optional export patch target %s for %s", path, backend)
+                    continue
+            # Resolve aliases at installation time, so earlier patches can affect
+            # later owner resolution and unavailable optional owners remain retryable.
+            if any(
+                path.rpartition(".")[2] == attribute
+                and _resolve_dotted_path(path.rpartition(".")[0], import_modules=path not in excluded_lazy_paths)
+                is obj
+                for path in exclude
+            ):
+                continue
+            stack.enter_context(patch_attribute(obj, attribute, factory, source=f"registry {backend!r}"))
         yield
 
 
@@ -140,7 +236,7 @@ def apply_fx_program_fixes(backend: str, exported_program) -> None:
         fix(exported_program)
 
 
-def register_patch(backend: str, *paths: str):
+def register_patch(backend: str, *paths: str, lazy: bool = False):
     """Append the decorated `factory(original)` to `_PATCHES[backend]`, once per `path`.
 
     Each `path` is a dotted Python path like `"torch.where"`, `"torch.Tensor.unsqueeze"`,
@@ -148,7 +244,10 @@ def register_patch(backend: str, *paths: str):
     The rightmost segment is the attribute to swap; the rest is the object that owns it.
     Paths are resolved at decoration time — submodules are imported as needed, falling
     back to `getattr` for class attributes. A path that fails to resolve (e.g. the backend
-    isn't installed) is silently skipped so the module still imports.
+    isn't installed) is silently skipped so the module still imports. With `lazy=True`,
+    the owner path is stored in the same ordered list and resolved on each scope entry;
+    unavailable owners or attributes are logged at debug level and retried next time.
+    Registration itself never acquires the export lock, including during imports.
 
     Passing multiple paths registers the SAME factory against each — useful for swapping
     the same method or torch op across several call sites (e.g. ``torch.unsqueeze`` +
@@ -158,7 +257,7 @@ def register_patch(backend: str, *paths: str):
     def decorator(fn):
         for path in paths:
             obj_path, _, attribute = path.rpartition(".")
-            obj = _resolve_dotted_path(obj_path)
+            obj = _LazyPatchTarget(obj_path) if lazy else _resolve_dotted_path(obj_path)
             if obj is None:
                 continue
             _PATCHES.setdefault(backend, []).append((obj, attribute, fn))
@@ -167,16 +266,20 @@ def register_patch(backend: str, *paths: str):
     return decorator
 
 
-def _resolve_dotted_path(path: str):
+def _resolve_dotted_path(path: str, *, import_modules: bool = True):
     """Resolve a dotted Python path to the actual object — importing submodules where
     possible, falling back to `getattr` for class attributes (e.g. `torch.Tensor`).
-    Returns `None` if the path can't be resolved (e.g. the backend isn't installed)."""
+    Returns `None` if the path can't be resolved (e.g. the backend isn't installed).
+    With `import_modules=False`, only inspect already-loaded modules and attributes."""
     import importlib
 
     parts = path.split(".")
     try:
-        obj = importlib.import_module(parts[0])
+        obj = importlib.import_module(parts[0]) if import_modules else sys.modules.get(parts[0])
         for part in parts[1:]:
+            if not import_modules:
+                obj = inspect.getattr_static(obj, part)
+                continue
             try:
                 obj = importlib.import_module(f"{obj.__name__}.{part}")
             except (ImportError, AttributeError):
@@ -341,6 +444,7 @@ def module_dtype(model: PreTrainedModel | torch.nn.Module) -> torch.dtype | None
 _OUTPUT_FLAGS = ("use_cache", "output_attentions", "output_hidden_states", "return_dict", "return_loss")
 
 
+@export_patch_scope()
 def prepare_for_export(
     model: PreTrainedModel | torch.nn.Module, inputs: MutableMapping[str, Any]
 ) -> tuple[PreTrainedModel | torch.nn.Module, MutableMapping[str, Any], dict[str, Any]]:
@@ -582,6 +686,7 @@ def _prepare_qwen3_asr_audio_inputs(model: torch.nn.Module, inputs: dict[str, An
     inputs["max_seqlen"] = get_max_seqlen(inputs["cu_seqlens"], model.config, kwargs=inputs)
 
 
+@export_patch_scope()
 def precompute_export_inputs(model: torch.nn.Module, inputs: dict[str, Any]) -> None:
     """Inject precomputed tensors for data-dependent ops the model would otherwise hit during tracing.
 
@@ -626,28 +731,26 @@ def _capture_forward(module: torch.nn.Module):
     captured dicts can be passed directly as `kwargs=inputs` to `torch.export`.
     """
 
-    calls: list[dict] = []
-    original = module.forward
-    sig = inspect.signature(original)
+    with export_patch_scope():
+        calls: list[dict] = []
+        original = module.forward
+        sig = inspect.signature(original)
 
-    @functools.wraps(original)
-    def wrapper(*args, **kwargs):
-        captured = {}
-        bound = sig.bind(*args, **kwargs)
-        for name, value in bound.arguments.items():
-            param = sig.parameters[name]
-            if param.kind == inspect.Parameter.VAR_KEYWORD:
-                captured.update(copy.deepcopy(value))
-            elif param.kind != inspect.Parameter.VAR_POSITIONAL:
-                captured[name] = copy.deepcopy(value)
-        calls.append(captured)
-        return original(*args, **kwargs)
+        @functools.wraps(original)
+        def wrapper(*args, **kwargs):
+            captured = {}
+            bound = sig.bind(*args, **kwargs)
+            for name, value in bound.arguments.items():
+                param = sig.parameters[name]
+                if param.kind == inspect.Parameter.VAR_KEYWORD:
+                    captured.update(copy.deepcopy(value))
+                elif param.kind != inspect.Parameter.VAR_POSITIONAL:
+                    captured[name] = copy.deepcopy(value)
+            calls.append(captured)
+            return original(*args, **kwargs)
 
-    module.forward = wrapper
-    try:
-        yield calls
-    finally:
-        module.forward = original
+        with patch_attribute(module, "forward", lambda _original: wrapper):
+            yield calls
 
 
 def _merge_decode_calls(decode_calls: list[dict]) -> dict:

--- a/tests/exporters/test_backend_registration.py
+++ b/tests/exporters/test_backend_registration.py
@@ -954,8 +954,5 @@ class BackendImportTest(unittest.TestCase):
             capture = exporter.capture(Model(), {"x": torch.ones(2)}, ExecutorchConfig(backend="external", strict=True))
             torch.testing.assert_close(capture.exported_program.module()(x=torch.ones(2)), torch.full((2,), 2.0))
         """)
-        # Run only the literal test script with the current interpreter, without a shell or untrusted input.
-        result = subprocess.run(  # nosec B603
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=90
-        )
+        result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=90)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/tests/exporters/test_backend_registration.py
+++ b/tests/exporters/test_backend_registration.py
@@ -1,0 +1,958 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Backend-neutral contract tests for external ExecuTorch recipes."""
+
+import subprocess
+import sys
+import textwrap
+import threading
+import unittest
+from contextlib import nullcontext
+from dataclasses import dataclass, replace
+from types import SimpleNamespace
+from unittest import mock
+
+from transformers.exporters import (
+    ExecutorchAttention,
+    ExecutorchBackendPreparation,
+    ExecutorchBackendRecipe,
+    ExecutorchCapture,
+    ExecutorchCompatibilityPolicy,
+    ExecutorchConfig,
+    ExecutorchExporter,
+    ExecutorchExportPatch,
+    register_executorch_backend,
+    scoped_executorch_attention,
+    utils,
+)
+from transformers.exporters import exporter_executorch as et
+from transformers.testing_utils import require_torch
+from transformers.utils import is_torch_available
+
+
+if is_torch_available():
+    import torch
+    from torch import nn
+
+    class _Identity(nn.Module):
+        def forward(self, x):
+            return x + 1
+
+    class _AttentionModel(_Identity):
+        def __init__(self):
+            super().__init__()
+            self.config = SimpleNamespace(_attn_implementation_internal="original")
+            self.setter_calls = 0
+
+        def set_attn_implementation(self, implementation):
+            self.setter_calls += 1
+            self.config._attn_implementation_internal = implementation
+            self.config._attn_was_changed = True
+
+
+_PATCH_OWNER = SimpleNamespace(explicit="original", common="original", backend="original")
+_PATCH_ALIAS = _PATCH_OWNER
+if is_torch_available():
+    _TORCH_ALIAS = torch
+
+
+class BackendRegistrationTest(unittest.TestCase):
+    def setUp(self):
+        self.enterContext(mock.patch.dict(et._EXECUTORCH_BACKEND_RECIPES, {}, clear=True))
+
+    def test_registration_is_public_idempotent_and_requires_explicit_overwrite(self):
+        self.assertIs(register_executorch_backend, et.register_executorch_backend)
+        first, second = mock.Mock(), mock.Mock()
+        register_executorch_backend("test", first)
+        register_executorch_backend("test", first)
+        self.assertIs(et._EXECUTORCH_BACKEND_RECIPES["test"], first)
+        with self.assertRaisesRegex(ValueError, "overwrite=True"):
+            register_executorch_backend("test", second)
+        self.assertIs(et._EXECUTORCH_BACKEND_RECIPES["test"], first)
+        register_executorch_backend("test", second, overwrite=True)
+        self.assertIs(et._EXECUTORCH_BACKEND_RECIPES["test"], second)
+
+    def test_registration_rejects_invalid_arguments_and_builtin_names(self):
+        for name in (None, 1, [], "", "   "):
+            with self.subTest(name=name), self.assertRaises((TypeError, ValueError)):
+                register_executorch_backend(name, mock.Mock())
+        with self.assertRaisesRegex(TypeError, "must be callable"):
+            register_executorch_backend("test", object())
+        for backend in ("xnnpack", "cuda"):
+            for overwrite in (False, True):
+                with (
+                    self.subTest(backend=backend, overwrite=overwrite),
+                    self.assertRaisesRegex(ValueError, "built in"),
+                ):
+                    register_executorch_backend(backend, mock.Mock(), overwrite=overwrite)
+
+    def test_backend_options_roundtrip_and_default_isolation(self):
+        first = ExecutorchConfig(backend="test", backend_options={"mode": "fast"})
+        restored = ExecutorchConfig.from_dict(first.to_dict())
+        self.assertEqual(restored.backend_options, {"mode": "fast"})
+        restored.backend_options["mode"] = "slow"
+        self.assertEqual(first.backend_options, {"mode": "fast"})
+        self.assertEqual(ExecutorchConfig().backend_options, {})
+
+
+@require_torch
+class _BackendTestCase(unittest.TestCase):
+    def setUp(self):
+        # These contract tests need torch, but do not invoke ExecuTorch lowering.
+        self.exporter = object.__new__(ExecutorchExporter)
+        self.model, self.inputs = _Identity(), {}
+        self.config = ExecutorchConfig(backend="test")
+        self.prepared = ExecutorchBackendPreparation(_Identity(), {"x": torch.ones(2)}, normalize_inputs=False)
+        self.program = mock.Mock(spec=torch.export.ExportedProgram)
+        self.enterContext(mock.patch.dict(et._EXECUTORCH_BACKEND_RECIPES, {}, clear=True))
+        self.enterContext(mock.patch.dict(utils._PATCHES, {}, clear=True))
+        self.enterContext(mock.patch.dict(utils._FX_PROGRAM_FIXES, {}, clear=True))
+        self.enterContext(mock.patch.dict(utils._FX_NODE_FIXES, {}, clear=True))
+        self.program_fixes = self.enterContext(mock.patch.object(et, "apply_fx_program_fixes"))
+        self.node_fixes = self.enterContext(mock.patch.object(et, "apply_fx_node_fixes"))
+
+    def _register(self, *, prepared=None, **kwargs):
+        """Register an ordinary mock-capture recipe; integration tests register theirs directly."""
+        kwargs.setdefault("prepare", mock.Mock(return_value=self.prepared if prepared is None else prepared))
+        kwargs.setdefault("lower", mock.Mock(return_value="artifact"))
+        recipe = ExecutorchBackendRecipe(**kwargs)
+        self.factory = mock.Mock(return_value=recipe)
+        register_executorch_backend("test", self.factory, overwrite=True)
+        self.trace = self.enterContext(mock.patch.object(self.exporter, "_export_prepared", return_value=self.program))
+        return recipe
+
+
+class BackendLifecycleTest(_BackendTestCase):
+    def test_immediate_lifecycle_preserves_order_arguments_and_capture_only_contexts(self):
+        steps = mock.Mock()
+        scope = mock.MagicMock()
+        transformed = mock.Mock(spec=torch.export.ExportedProgram)
+        self.prepared.dynamic_shapes = {"x": None}
+        self.prepared.capture_contexts = (scope,)
+        self.config.backend_options = {"mode": "fast"}
+        steps.prepare.return_value = self.prepared
+        steps.transform.return_value = transformed
+        steps.lower.return_value = "artifact"
+        self._register(prepare=steps.prepare, lower=steps.lower, transform_exported_program=steps.transform)
+        steps.attach_mock(scope, "context")
+        steps.attach_mock(self.trace, "capture")
+        steps.attach_mock(self.program_fixes, "program_fixes")
+        steps.attach_mock(self.node_fixes, "node_fixes")
+
+        self.assertEqual(self.exporter.export(self.model, self.inputs, self.config), "artifact")
+        self.factory.assert_called_once_with({"mode": "fast"})
+        self.assertIs(steps.prepare.call_args.args[1], self.inputs)
+        self.assertIs(self.trace.call_args.args[1], self.prepared.sample_inputs)
+        self.assertEqual(
+            steps.mock_calls,
+            [
+                mock.call.prepare(self.model, self.inputs, self.config),
+                mock.call.context.__enter__(),
+                mock.call.capture(
+                    self.prepared.model,
+                    self.prepared.sample_inputs,
+                    self.config,
+                    output_flags={},
+                    dynamic_shapes={"x": None},
+                    patch_exclusions=(),
+                ),
+                mock.call.context.__exit__(None, None, None),
+                mock.call.transform(self.program, self.prepared),
+                mock.call.program_fixes("executorch", transformed),
+                mock.call.node_fixes("executorch", transformed.graph_module),
+                mock.call.lower(transformed, self.prepared, self.config),
+            ],
+        )
+
+    def test_common_policy_is_independent_of_recipe_and_backend_patches(self):
+        utils._PATCHES["executorch"] = [(_PATCH_OWNER, "common", lambda _: "patched")]
+        utils._PATCHES["executorch.test"] = [(_PATCH_OWNER, "backend", lambda _: "patched")]
+
+        def prepare(*_):
+            self.assertEqual(vars(_PATCH_OWNER), {"explicit": "patched", "common": "original", "backend": "original"})
+            return self.prepared
+
+        def check_patches(*_args, **_kwargs):
+            self.assertEqual(
+                vars(_PATCH_OWNER),
+                {"explicit": "patched", "common": "patched" if common_patches else "original", "backend": "patched"},
+            )
+            return self.program
+
+        for common_patches, common_fixes in ((False, False), (False, True), (True, False), (True, True)):
+            with self.subTest(patches=common_patches, fixes=common_fixes):
+                patch_factory = mock.Mock(return_value="patched")
+                self._register(
+                    prepare=prepare,
+                    lower=check_patches,
+                    patches=(ExecutorchExportPatch((f"{__name__}._PATCH_OWNER.explicit",), patch_factory),),
+                    compatibility=ExecutorchCompatibilityPolicy(common_patches, common_fixes),
+                )
+                self.trace.side_effect = check_patches
+                self.program_fixes.reset_mock()
+                self.node_fixes.reset_mock()
+                self.assertIs(self.exporter.export(self.model, self.inputs, self.config), self.program)
+                patch_factory.assert_called_once_with("original")
+                self.assertEqual(self.program_fixes.call_count, int(common_fixes))
+                self.assertEqual(self.node_fixes.call_count, int(common_fixes))
+                self.assertEqual(vars(_PATCH_OWNER), dict.fromkeys(("explicit", "common", "backend"), "original"))
+
+    def test_deferred_lower_retains_config_recipe_and_attention_without_recapture(self):
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        model, prepared_model = _AttentionModel(), _AttentionModel()
+        self.prepared.model = prepared_model
+        self.config.backend_options = {"nested": {"value": 1}}
+        scope = mock.MagicMock()
+        self.prepared.capture_contexts = (scope,)
+        attention = ExecutorchAttention("test_scope_attention", lambda: None, None)
+        patch_factory = mock.Mock(return_value="patched")
+        transform = mock.Mock(return_value=mock.Mock(spec=torch.export.ExportedProgram))
+
+        def prepare(*_):
+            model.config._attn_implementation_internal = "prepared-selection"
+            prepared_model.config._attn_implementation_internal = "new-model-selection"
+            return self.prepared
+
+        def lower(program, prepared, config):
+            self.assertEqual(config.backend_options, {"nested": {"value": 1}})
+            self.assertEqual(model.config._attn_implementation_internal, "prepared-selection")
+            self.assertEqual(prepared_model.config._attn_implementation_internal, "new-model-selection")
+            self.assertIs(ALL_ATTENTION_FUNCTIONS[attention.implementation], attention.attention_function)
+            self.assertEqual(_PATCH_OWNER.explicit, "patched")
+            return "lowered"
+
+        recipe = self._register(
+            prepare=mock.Mock(side_effect=prepare),
+            lower=mock.Mock(side_effect=lower),
+            attention=attention,
+            patches=(ExecutorchExportPatch((f"{__name__}._PATCH_OWNER.explicit",), patch_factory),),
+            transform_exported_program=transform,
+        )
+        captured = self.exporter.capture(model, self.inputs, self.config)
+        self.assertIsInstance(captured, ExecutorchCapture)
+        self.assertIs(captured.preparation, self.prepared)
+        self.assertIs(captured.exported_program, transform.return_value)
+        recipe.lower.assert_not_called()
+        self.assertEqual(model.config._attn_implementation_internal, "prepared-selection")
+        self.assertEqual(_PATCH_OWNER.explicit, "original")
+        self.config.backend_options["nested"]["value"] = 2
+        replacement = mock.Mock(side_effect=AssertionError("must use captured recipe"))
+        register_executorch_backend("test", replacement, overwrite=True)
+        model.config._attn_implementation_internal = "between-phases"
+        prepared_model.config._attn_implementation_internal = "between-prepared-phases"
+        self.assertEqual(self.exporter.lower(captured), "lowered")
+        with self.assertRaisesRegex(RuntimeError, "one lowering attempt"):
+            self.exporter.lower(captured)
+        recipe.lower.assert_called_once_with(transform.return_value, self.prepared, captured.config)
+        recipe.prepare.assert_called_once()
+        self.trace.assert_called_once()
+        self.factory.assert_called_once()
+        replacement.assert_not_called()
+        transform.assert_called_once_with(self.program, self.prepared)
+        self.program_fixes.assert_called_once_with("executorch", transform.return_value)
+        self.node_fixes.assert_called_once_with("executorch", transform.return_value.graph_module)
+        self.assertEqual(scope.mock_calls, [mock.call.__enter__(), mock.call.__exit__(None, None, None)])
+        self.assertEqual(patch_factory.call_args_list, [mock.call("original"), mock.call("original")])
+        self.assertEqual(model.setter_calls, 0)
+        self.assertEqual(prepared_model.setter_calls, 0)
+        self.assertFalse(hasattr(model.config, "_attn_was_changed"))
+        self.assertEqual(model.config._attn_implementation_internal, "between-phases")
+        self.assertEqual(prepared_model.config._attn_implementation_internal, "between-prepared-phases")
+        self.assertEqual(_PATCH_OWNER.explicit, "original")
+
+    def test_prepared_inputs_preserve_mixed_dtypes_and_output_named_kwargs(self):
+        class MixedInputs(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.ones(2, dtype=torch.float32))
+
+            def forward(self, x, y, return_dict):
+                return x + self.weight, y + 1 if return_dict else y
+
+        inputs = {
+            "x": torch.ones(2, dtype=torch.float32),
+            "y": torch.ones(2, dtype=torch.float64),
+            "return_dict": True,
+        }
+        prepared = ExecutorchBackendPreparation(model=MixedInputs(), sample_inputs=inputs, normalize_inputs=False)
+        recipe = ExecutorchBackendRecipe(
+            prepare=mock.Mock(return_value=prepared),
+            lower=mock.Mock(),
+            compatibility=ExecutorchCompatibilityPolicy(False, False),
+        )
+        register_executorch_backend("test", mock.Mock(return_value=recipe))
+        with mock.patch.object(et, "prepare_for_export", side_effect=AssertionError("must not normalize")):
+            captured = self.exporter.capture(self.model, self.inputs, ExecutorchConfig(backend="test", strict=True))
+        self.assertIs(captured.preparation.sample_inputs, inputs)
+        result = captured.exported_program.module()(**inputs)
+        self.assertEqual(result[0].dtype, torch.float32)
+        self.assertEqual(result[1].dtype, torch.float64)
+        self.assertIn("return_dict", inputs)
+        torch.testing.assert_close(result[1], torch.full((2,), 2.0, dtype=torch.float64))
+
+    def test_default_preparation_still_normalizes_inputs(self):
+        model = nn.Linear(2, 2).float()
+        prepared = ExecutorchBackendPreparation(model=model, sample_inputs={"input": torch.ones(2).double()})
+        self._register(prepared=prepared)
+        self.exporter.capture(self.model, self.inputs, self.config)
+        self.assertEqual(self.trace.call_args.args[1]["input"].dtype, torch.float32)
+
+    def test_exports_without_attention_are_serialized_before_patch_installation(self):
+        attempted, second_patched = threading.Event(), threading.Event()
+        errors = []
+
+        def prepare_first(*_):
+            thread.start()
+            self.assertTrue(attempted.wait(5))
+            self.assertFalse(second_patched.wait(0.1))
+            self.assertEqual(_PATCH_OWNER.explicit, "first")
+            return self.prepared
+
+        def second_factory(_):
+            second_patched.set()
+            return "second"
+
+        first = self._register(
+            prepare=prepare_first,
+            patches=(ExecutorchExportPatch((f"{__name__}._PATCH_OWNER.explicit",), lambda _: "first"),),
+        )
+        second = replace(
+            first,
+            prepare=mock.Mock(return_value=self.prepared),
+            patches=(ExecutorchExportPatch((f"{__name__}._PATCH_OWNER.explicit",), second_factory),),
+        )
+        register_executorch_backend("second", mock.Mock(return_value=second))
+
+        def run_second():
+            attempted.set()
+            try:
+                self.exporter.export(self.model, self.inputs, ExecutorchConfig(backend="second"))
+            except BaseException as error:
+                errors.append(error)
+
+        thread = threading.Thread(target=run_second, daemon=True)
+        try:
+            self.exporter.export(self.model, self.inputs, self.config)
+        finally:
+            if thread.ident is not None:
+                thread.join(5)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertTrue(second_patched.is_set())
+        self.assertEqual(_PATCH_OWNER.explicit, "original")
+
+    def test_invalid_transform_result_is_rejected_before_lowering(self):
+        recipe = self._register(transform_exported_program=mock.Mock(return_value=object()))
+        with self.assertRaisesRegex(TypeError, "ExportedProgram"):
+            self.exporter.export(self.model, self.inputs, self.config)
+        recipe.lower.assert_not_called()
+
+    def test_phase_failures_restore_recipe_patches_and_attention(self):
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        model = _AttentionModel()
+        attention = ExecutorchAttention("test_failed_phase_attention", lambda: None, None)
+        self.prepared.model = self.prepared.attention_target = model
+        for phase in ("prepare", "context", "capture", "transform", "fixes"):
+            with self.subTest(phase=phase):
+                scope = mock.MagicMock()
+                self.prepared.capture_contexts = (scope,)
+                recipe = self._register(
+                    attention=attention,
+                    transform_exported_program=mock.Mock(return_value=self.program),
+                    patches=(ExecutorchExportPatch((f"{__name__}._PATCH_OWNER.explicit",), lambda _: "patched"),),
+                )
+                failing = {
+                    "prepare": recipe.prepare,
+                    "context": scope.__enter__,
+                    "capture": self.trace,
+                    "transform": recipe.transform_exported_program,
+                    "fixes": self.program_fixes,
+                }[phase]
+                with (
+                    mock.patch.object(failing, "side_effect", RuntimeError(f"failed {phase}")),
+                    self.assertRaisesRegex(RuntimeError, f"failed {phase}"),
+                ):
+                    self.exporter.export(model, self.inputs, self.config)
+                recipe.lower.assert_not_called()
+                self.assertEqual(_PATCH_OWNER.explicit, "original")
+                self.assertEqual(model.config._attn_implementation_internal, "original")
+                self.assertNotIn(attention.implementation, ALL_ATTENTION_FUNCTIONS)
+
+
+class BackendValidationTest(_BackendTestCase):
+    def test_invalid_recipe_members_fail_before_preparation(self):
+        valid = self._register()
+        for recipe in (
+            object(),
+            replace(valid, prepare=None),
+            replace(valid, lower=None),
+            replace(valid, transform_exported_program=object()),
+            replace(valid, compatibility=None),
+            replace(valid, patches=(ExecutorchExportPatch(("torch.add",), None),)),
+            replace(valid, attention=ExecutorchAttention("test", None, None)),
+        ):
+            with self.subTest(recipe=recipe), self.assertRaises(TypeError):
+                self.factory.return_value = recipe
+                self.exporter.capture(self.model, self.inputs, self.config)
+        valid.prepare.assert_not_called()
+
+    def test_unknown_backend_lists_available_backends(self):
+        with self.assertRaisesRegex(ValueError, "available backends.*cuda.*xnnpack"):
+            self.exporter.export(self.model, self.inputs, ExecutorchConfig(backend="missing"))
+
+    def test_invalid_preparation_contract_is_rejected(self):
+        for prepared in (
+            object(),
+            ExecutorchBackendPreparation(model=object(), sample_inputs={}),
+            ExecutorchBackendPreparation(model=_Identity(), sample_inputs=[]),
+        ):
+            with self.subTest(prepared=type(prepared)):
+                recipe = self._register(prepared=prepared)
+                with self.assertRaises(TypeError):
+                    self.exporter.capture(self.model, self.inputs, self.config)
+                recipe.lower.assert_not_called()
+
+
+class BackendAttentionTest(_BackendTestCase):
+    def test_public_scope_restores_registries_on_body_or_registration_failure(self):
+        from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        attention = ExecutorchAttention("test_public_attention", lambda: None, lambda: None)
+        for registry in (ALL_ATTENTION_FUNCTIONS, ALL_MASK_ATTENTION_FUNCTIONS):
+            self.enterContext(mock.patch.dict(registry._global_mapping))
+        for preexisting in (False, True):
+            for failure in ("body", "registration"):
+                with self.subTest(preexisting=preexisting, failure=failure):
+                    prior = mock.Mock(return_value="prior")
+                    if preexisting:
+                        for registry in (ALL_ATTENTION_FUNCTIONS, ALL_MASK_ATTENTION_FUNCTIONS):
+                            registry.register(attention.implementation, prior)
+                    register = ALL_MASK_ATTENTION_FUNCTIONS.register
+                    if failure == "registration":
+                        register = mock.Mock(side_effect=RuntimeError("registration failed"))
+                    with (
+                        mock.patch.object(ALL_MASK_ATTENTION_FUNCTIONS, "register", register),
+                        self.assertRaisesRegex(RuntimeError, f"{failure} failed"),
+                        scoped_executorch_attention(attention),
+                    ):
+                        self.assertIs(ALL_ATTENTION_FUNCTIONS[attention.implementation], attention.attention_function)
+                        self.assertIs(ALL_MASK_ATTENTION_FUNCTIONS[attention.implementation], attention.mask_function)
+                        raise RuntimeError("body failed")
+                    for registry in (ALL_ATTENTION_FUNCTIONS, ALL_MASK_ATTENTION_FUNCTIONS):
+                        if preexisting:
+                            self.assertIs(registry[attention.implementation], prior)
+                        else:
+                            self.assertNotIn(attention.implementation, registry)
+
+    def test_public_scope_restores_module_and_config_only_children(self):
+        for kind in ("module", "config"):
+            for fail in (False, True):
+                with self.subTest(kind=kind, fail=fail):
+                    model, child = _AttentionModel(), _AttentionModel()
+                    child.config._attn_implementation_internal = "child"
+                    child.config._attn_was_changed = False
+                    if kind == "module":
+                        model.child = child
+                    else:
+                        model.config.sub_configs = {"child": object}
+                        model.config.child = child.config
+
+                    def select(implementation):
+                        for config in (model.config, child.config):
+                            config._attn_implementation_internal = implementation
+                            config._attn_was_changed = True
+                        if fail:
+                            raise RuntimeError("setter failed")
+
+                    attention = ExecutorchAttention("test_child_attention", lambda: None, None)
+                    outcome = self.assertRaisesRegex(RuntimeError, "setter failed") if fail else nullcontext()
+                    with (
+                        mock.patch.object(model, "set_attn_implementation", side_effect=select),
+                        outcome,
+                        scoped_executorch_attention(attention, model),
+                    ):
+                        self.assertFalse(fail, "scope entered after setter failure")
+                        self.assertEqual(child.config._attn_implementation_internal, attention.implementation)
+                    self.assertEqual(model.config._attn_implementation_internal, "original")
+                    self.assertEqual(child.config._attn_implementation_internal, "child")
+                    self.assertFalse(child.config._attn_was_changed)
+                    self.assertFalse(hasattr(model.config, "_attn_was_changed"))
+
+    def test_public_scope_serializes_registry_ownership(self):
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        first = ExecutorchAttention("test_concurrent_attention", lambda: "first", None)
+        second = ExecutorchAttention(first.implementation, lambda: "second", None)
+        attempted, entered = threading.Event(), threading.Event()
+        errors = []
+
+        def worker():
+            attempted.set()
+            try:
+                with scoped_executorch_attention(second):
+                    self.assertIs(ALL_ATTENTION_FUNCTIONS[first.implementation], second.attention_function)
+                    entered.set()
+            except BaseException as error:
+                errors.append(error)
+
+        thread = threading.Thread(target=worker, daemon=True)
+        try:
+            with scoped_executorch_attention(first):
+                thread.start()
+                self.assertTrue(attempted.wait(5))
+                self.assertFalse(entered.wait(0.1))
+                self.assertIs(ALL_ATTENTION_FUNCTIONS[first.implementation], first.attention_function)
+        finally:
+            thread.join(5)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertTrue(entered.is_set())
+        self.assertNotIn(first.implementation, ALL_ATTENTION_FUNCTIONS)
+
+    def test_explicit_attention_targets_are_selected_after_prepare_and_restored(self):
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        for kind in ("original", "wrapped", "replacement", "external"):
+            with self.subTest(kind=kind):
+                original = _AttentionModel()
+                target = original if kind in ("original", "wrapped") else _AttentionModel()
+                prepared_model = nn.Sequential(target) if kind == "wrapped" else target
+                if kind == "external":
+                    prepared_model = _Identity()
+                attention = ExecutorchAttention("test_explicit_target", lambda: None, None)
+
+                def prepare(*_):
+                    self.assertIs(ALL_ATTENTION_FUNCTIONS[attention.implementation], attention.attention_function)
+                    self.assertEqual(target.setter_calls, 0)
+                    self.assertEqual(target.config._attn_implementation_internal, "original")
+                    return ExecutorchBackendPreparation(
+                        model=prepared_model, sample_inputs={"x": torch.ones(2)}, attention_target=target
+                    )
+
+                def normalize(model, inputs):
+                    self.assertEqual(target.config._attn_implementation_internal, attention.implementation)
+                    return model, inputs, {}
+
+                def lower(*_):
+                    self.assertEqual(target.config._attn_implementation_internal, attention.implementation)
+                    self.assertTrue(target.config._attn_was_changed)
+                    self.assertEqual(target.setter_calls, 1)
+                    return "lowered"
+
+                self._register(prepare=prepare, lower=lower, attention=attention)
+                with mock.patch.object(et, "prepare_for_export", side_effect=normalize):
+                    captured = self.exporter.capture(original, self.inputs, self.config)
+                self.assertEqual(target.config._attn_implementation_internal, "original")
+                self.assertFalse(hasattr(target.config, "_attn_was_changed"))
+                target.config._attn_implementation_internal = "between"
+                self.assertEqual(self.exporter.lower(captured), "lowered")
+                self.assertEqual(target.config._attn_implementation_internal, "between")
+                self.assertFalse(hasattr(target.config, "_attn_was_changed"))
+                self.assertEqual(target.setter_calls, 1)
+
+    def test_attention_target_validation_and_setter_failure(self):
+        class FailingTarget(_AttentionModel):
+            def set_attn_implementation(self, implementation):
+                super().set_attn_implementation(implementation)
+                raise RuntimeError("partial setter")
+
+        attention = ExecutorchAttention("test_target_validation", lambda: None, None)
+        for target, selected_attention, error in (
+            (_AttentionModel(), None, ValueError),
+            (_Identity(), attention, TypeError),
+            (object(), attention, TypeError),
+            (FailingTarget(), attention, RuntimeError),
+        ):
+            with self.subTest(target=type(target), attention=selected_attention):
+                self.prepared.attention_target = target
+                recipe = self._register(attention=selected_attention)
+                with self.assertRaises(error):
+                    self.exporter.capture(self.model, self.inputs, self.config)
+                recipe.lower.assert_not_called()
+                if isinstance(target, _AttentionModel):
+                    self.assertEqual(target.config._attn_implementation_internal, "original")
+                    self.assertFalse(hasattr(target.config, "_attn_was_changed"))
+
+    def test_capture_retains_selected_target_when_transform_replaces_preparation_target(self):
+        target = _AttentionModel()
+        attention = ExecutorchAttention("test_saved_target", lambda: None, None)
+
+        def transform(program, prepared):
+            prepared.attention_target = None
+            return program
+
+        def lower(*_):
+            self.assertEqual(target.config._attn_implementation_internal, attention.implementation)
+            self.assertEqual(target.setter_calls, 1)
+
+        self.prepared.attention_target = target
+        self._register(lower=lower, attention=attention, transform_exported_program=transform)
+        captured = self.exporter.capture(self.model, self.inputs, self.config)
+        self.assertEqual(target.config._attn_implementation_internal, "original")
+        self.exporter.lower(captured)
+        self.assertEqual(target.config._attn_implementation_internal, "original")
+        self.assertEqual(target.setter_calls, 1)
+
+    def test_failed_lower_consumes_capture_and_restores_attention_and_patches(self):
+        from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        target = _AttentionModel()
+        attention = ExecutorchAttention("test_failed_lower_attention", lambda: None, None)
+
+        def lower(*_):
+            self.assertEqual(target.config._attn_implementation_internal, attention.implementation)
+            self.assertEqual(target.setter_calls, 1)
+            self.assertEqual(_PATCH_OWNER.explicit, "patched")
+            raise RuntimeError("lower failed")
+
+        self.prepared.attention_target = target
+        recipe = self._register(
+            lower=mock.Mock(side_effect=lower),
+            attention=attention,
+            patches=(ExecutorchExportPatch((f"{__name__}._PATCH_OWNER.explicit",), lambda _: "patched"),),
+        )
+        captured = self.exporter.capture(self.model, self.inputs, self.config)
+        target.config._attn_implementation_internal = "between"
+        with self.assertRaisesRegex(RuntimeError, "lower failed"):
+            self.exporter.lower(captured)
+        self.assertEqual(target.config._attn_implementation_internal, "between")
+        self.assertEqual(target.setter_calls, 1)
+        self.assertFalse(hasattr(target.config, "_attn_was_changed"))
+        self.assertNotIn(attention.implementation, ALL_ATTENTION_FUNCTIONS)
+        self.assertNotIn(attention.implementation, ALL_MASK_ATTENTION_FUNCTIONS)
+        with self.assertRaisesRegex(RuntimeError, "one lowering attempt"):
+            self.exporter.lower(captured)
+        recipe.lower.assert_called_once()
+        self.assertEqual(_PATCH_OWNER.explicit, "original")
+
+    def test_preparation_can_temporarily_select_attention_with_public_helper(self):
+        target = _AttentionModel()
+        attention = ExecutorchAttention("test_prepare_selection", lambda: None, None)
+
+        def prepare(*_):
+            self.assertEqual(target.config._attn_implementation_internal, "original")
+            with scoped_executorch_attention(attention, target):
+                self.assertEqual(target.config._attn_implementation_internal, attention.implementation)
+            self.assertEqual(target.config._attn_implementation_internal, "original")
+            return self.prepared
+
+        self.prepared.model = target
+        self._register(prepare=prepare, attention=attention)
+        captured = self.exporter.capture(target, self.inputs, self.config)
+        self.exporter.lower(captured)
+        self.assertEqual(target.setter_calls, 1)
+        self.assertEqual(target.config._attn_implementation_internal, "original")
+
+    def test_attention_requires_explicit_mask_policy(self):
+        with self.assertRaises(TypeError):
+            ExecutorchAttention("missing_mask", lambda: None)
+
+    def test_none_mask_removes_stale_mapping_and_preserves_supplied_4d_mask(self):
+        from transformers import LlamaConfig
+        from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS, create_causal_mask
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        name = "test_none_mask"
+        old_attention, old_mask = lambda: None, mock.Mock(side_effect=AssertionError("stale mask ran"))
+        self.enterContext(mock.patch.dict(ALL_MASK_ATTENTION_FUNCTIONS._global_mapping, {name: old_mask}))
+        self.enterContext(mock.patch.dict(ALL_ATTENTION_FUNCTIONS._global_mapping, {name: old_attention}))
+        config = LlamaConfig()
+        config._attn_implementation = name
+        embeds = torch.ones(1, 3, 8)
+        supplied = torch.zeros(1, 1, 3, 3)
+        for fail in (False, True):
+            with self.subTest(fail=fail):
+                outcome = self.assertRaisesRegex(RuntimeError, "body failure") if fail else nullcontext()
+                with outcome, scoped_executorch_attention(ExecutorchAttention(name, lambda: None, None)):
+                    self.assertNotIn(name, ALL_MASK_ATTENTION_FUNCTIONS)
+                    self.assertIsNone(create_causal_mask(config, embeds, torch.ones(1, 3), None))
+                    self.assertIs(create_causal_mask(config, embeds, supplied, None), supplied)
+                    if fail:
+                        raise RuntimeError("body failure")
+                self.assertIs(ALL_MASK_ATTENTION_FUNCTIONS[name], old_mask)
+                self.assertIs(ALL_ATTENTION_FUNCTIONS[name], old_attention)
+        old_mask.assert_not_called()
+
+    def test_real_hf_attention_and_mask_capture_preserves_causal_and_padding_numerics(self):
+        self._check_real_hf_attention_and_mask_capture(strict=False)
+
+    def test_strict_real_hf_attention_and_mask_capture_preserves_causal_and_padding_numerics(self):
+        self._check_real_hf_attention_and_mask_capture(strict=True)
+
+    def _check_real_hf_attention_and_mask_capture(self, *, strict):
+        from transformers import LlamaConfig, LlamaForCausalLM
+        from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS, eager_mask, sdpa_mask
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+        from transformers.models.llama.modeling_llama import eager_attention_forward
+
+        torch.manual_seed(31)
+        model = LlamaForCausalLM(
+            LlamaConfig(
+                vocab_size=32,
+                hidden_size=16,
+                intermediate_size=24,
+                num_hidden_layers=1,
+                num_attention_heads=2,
+                num_key_value_heads=2,
+                max_position_embeddings=16,
+                attention_dropout=0.0,
+                use_cache=False,
+                attn_implementation="eager",
+            )
+        ).eval()
+        model.requires_grad_(False)
+
+        class Wrapper(nn.Module):
+            def __init__(self, model):
+                super().__init__()
+                self.inner = model
+
+            def forward(self, input_ids, attention_mask):
+                return self.inner(input_ids=input_ids, attention_mask=attention_mask, use_cache=False).logits
+
+        wrapper = Wrapper(model)
+        inputs = {"input_ids": torch.tensor([[1, 2, 3, 4]]), "attention_mask": torch.tensor([[1, 0, 1, 1]])}
+        expected = wrapper(**inputs)
+        calls = {"attention": 0, "mask": 0}
+
+        def attention_function(module, query, key, value, attention_mask, **kwargs):
+            if not strict:
+                calls["attention"] += 1
+            assert attention_mask is not None
+            assert attention_mask.ndim == 4
+            return eager_attention_forward(module, query, key, value, attention_mask, **kwargs)
+
+        def mask_function(dtype=torch.float32, **kwargs):
+            if not strict:
+                calls["mask"] += 1
+                return eager_mask(dtype=dtype, **kwargs)
+            # Stock eager_mask constructs torch.tensor(0.0). Strict capture through the
+            # existing forward-signature closure gives it an invalid lifted-constant path.
+            # Keep HF's causal/padding builder, but construct the additive mask without
+            # a lifted literal. This is a recipe mask implementation, not a global patch.
+            kwargs["allow_is_causal_skip"] = False
+            kwargs["allow_is_bidirectional_skip"] = False
+            mask = sdpa_mask(**kwargs)
+            return torch.zeros_like(mask, dtype=dtype).masked_fill(~mask, torch.finfo(dtype).min)
+
+        if strict:
+            for padding in (inputs["attention_mask"], torch.ones(1, 4, dtype=torch.long)):
+                kwargs = {"batch_size": 1, "q_length": 4, "kv_length": 4, "attention_mask": padding.bool()}
+                torch.testing.assert_close(mask_function(**kwargs), eager_mask(**kwargs), rtol=0, atol=0)
+
+        attention = ExecutorchAttention("test_real_eager", attention_function, mask_function)
+        recipe = ExecutorchBackendRecipe(
+            prepare=mock.Mock(return_value=ExecutorchBackendPreparation(wrapper, inputs, attention_target=model)),
+            lower=mock.Mock(),
+            attention=attention,
+            compatibility=ExecutorchCompatibilityPolicy(False, False),
+        )
+        register_executorch_backend("test", mock.Mock(return_value=recipe))
+        captured = self.exporter.capture(wrapper, inputs, ExecutorchConfig(backend="test", strict=strict))
+        if strict:
+            traces = [node.meta.get("stack_trace", "") for node in captured.exported_program.graph.nodes]
+            self.assertTrue(any("in attention_function" in trace for trace in traces))
+            self.assertTrue(any("in mask_function" in trace for trace in traces))
+        else:
+            self.assertGreater(calls["attention"], 0)
+            self.assertGreater(calls["mask"], 0)
+        exported = captured.exported_program.module()
+        torch.testing.assert_close(exported(**inputs), expected)
+        for index in (1, 3):
+            changed = {**inputs, "input_ids": inputs["input_ids"].clone()}
+            changed["input_ids"][0, index] = 7
+            actual = exported(**changed)
+            torch.testing.assert_close(actual, wrapper(**changed))
+            # A padded token cannot affect later tokens; a future token cannot affect earlier ones.
+            positions = slice(2, None) if index == 1 else slice(None, 3)
+            torch.testing.assert_close(actual[:, positions], expected[:, positions])
+        unpadded = {**inputs, "attention_mask": torch.ones_like(inputs["attention_mask"])}
+        torch.testing.assert_close(exported(**unpadded), wrapper(**unpadded))
+        self.assertFalse(torch.allclose(exported(**unpadded)[:, 2:], expected[:, 2:]))
+        self.assertEqual(model.config._attn_implementation, "eager")
+        self.assertNotIn(attention.implementation, ALL_ATTENTION_FUNCTIONS)
+        self.assertNotIn(attention.implementation, ALL_MASK_ATTENTION_FUNCTIONS)
+
+
+class BackendConfigTest(_BackendTestCase):
+    def test_config_subclasses_are_accepted(self):
+        @dataclass
+        class Config(ExecutorchConfig):
+            label: str = "custom"
+
+        recipe = self._register()
+        self.exporter.capture(self.model, self.inputs, Config(backend="test"))
+        received = recipe.prepare.call_args.args[2]
+        self.assertIsInstance(received, Config)
+        self.assertEqual(received.label, "custom")
+
+    def test_invalid_backend_options_are_rejected(self):
+        for options in ([], {1: "value"}):
+            with self.subTest(options=options), self.assertRaises((TypeError, ValueError)):
+                config = ExecutorchConfig(backend="test", backend_options=options)
+                self.exporter.capture(self.model, self.inputs, config)
+        for backend in ("xnnpack", "cuda"):
+            with self.subTest(backend=backend), self.assertRaises(ValueError):
+                self.exporter.capture(
+                    self.model, self.inputs, ExecutorchConfig(backend=backend, backend_options={"typo": True})
+                )
+
+    def test_snapshot_errors_are_contextual_chained_and_restore_scopes(self):
+        class Uncopyable:
+            def __deepcopy__(self, memo):
+                raise RuntimeError("uncopyable resource")
+
+        snapshot = et._snapshot_config
+        self._register(patches=(ExecutorchExportPatch((f"{__name__}._PATCH_OWNER.explicit",), lambda _: "patched"),))
+        for phase in (
+            "initial config",
+            "recipe factory backend_options",
+            "retained capture config",
+            "capture.config access",
+        ):
+            with self.subTest(phase=phase):
+
+                def fail_snapshot(value, context):
+                    return snapshot(Uncopyable() if context == phase else value, context)
+
+                with (
+                    mock.patch.object(et, "_snapshot_config", side_effect=fail_snapshot),
+                    self.assertRaisesRegex(TypeError, phase) as raised,
+                ):
+                    captured = self.exporter.capture(self.model, self.inputs, self.config)
+                    _ = captured.config
+                self.assertIsInstance(raised.exception.__cause__, RuntimeError)
+                self.assertIn("preparation.state", str(raised.exception))
+                self.assertEqual(_PATCH_OWNER.explicit, "original")
+
+    def test_copyable_options_are_isolated_and_resources_stay_in_state(self):
+        @dataclass
+        class Options:
+            values: list[int]
+
+        resource = threading.Lock()
+        self.prepared.state = resource
+        self.config.backend_options = {"custom": Options([1]), "dtype": torch.float32}
+        recipe = self._register()
+
+        def factory(options):
+            options["custom"].values.append(9)
+            return recipe
+
+        self.factory.side_effect = factory
+        captured = self.exporter.capture(self.model, self.inputs, self.config)
+        self.assertIs(captured.preparation.state, resource)
+        self.assertEqual(self.config.backend_options["custom"].values, [1])
+        self.config.backend_options["custom"].values.append(2)
+        captured.config.backend_options["custom"].values.append(3)
+        self.exporter.lower(captured)
+        _, prepared, saved = recipe.lower.call_args.args
+        self.assertIs(prepared.state, resource)
+        self.assertEqual(saved.backend_options, {"custom": Options([1]), "dtype": torch.float32})
+
+
+class BackendPatchTest(_BackendTestCase):
+    def test_registry_collisions_and_exclusions_affect_real_capture(self):
+        class Negate(nn.Module):
+            def forward(self, x):
+                return torch.neg(x)
+
+        original = torch.neg
+        self.config.strict = True
+        for namespace in ("executorch", "executorch.test", "dynamo"):
+            for excluded in (False, True):
+                with self.subTest(namespace=namespace, excluded=excluded):
+                    prepared = replace(self.prepared, model=Negate())
+                    incoming = mock.Mock(return_value=lambda x: x + 100)
+                    policy = ExecutorchCompatibilityPolicy(
+                        excluded_patch_targets=(f"{__name__}._TORCH_ALIAS.neg",) if excluded else ()
+                    )
+                    recipe = ExecutorchBackendRecipe(
+                        prepare=mock.Mock(return_value=prepared),
+                        lower=lambda program, *_: program,
+                        patches=(ExecutorchExportPatch(("torch.neg",), lambda _: lambda x: x + 7),),
+                        compatibility=policy,
+                    )
+                    register_executorch_backend("test", mock.Mock(return_value=recipe), overwrite=True)
+                    with mock.patch.dict(utils._PATCHES, {namespace: [(torch, "neg", incoming)]}, clear=True):
+                        if excluded:
+                            captured = self.exporter.capture(self.model, self.inputs, self.config)
+                            torch.testing.assert_close(
+                                captured.exported_program.module()(x=torch.ones(2)), torch.full((2,), 8.0)
+                            )
+                            self.assertIs(self.exporter.lower(captured), captured.exported_program)
+                        else:
+                            with self.assertRaisesRegex(RuntimeError, "recipe"):
+                                self.exporter.capture(self.model, self.inputs, self.config)
+                    incoming.assert_not_called()
+                    self.assertIs(torch.neg, original)
+
+    def test_duplicate_recipe_aliases_fail_before_factories(self):
+        factory = mock.Mock()
+        self._register(
+            patches=(
+                ExecutorchExportPatch(
+                    (f"{__name__}._PATCH_OWNER.explicit", f"{__name__}._PATCH_ALIAS.explicit"), factory
+                ),
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "Duplicate recipe patch targets"):
+            self.exporter.capture(self.model, self.inputs, self.config)
+        factory.assert_not_called()
+        self.assertEqual(_PATCH_OWNER.explicit, "original")
+
+    def test_exclusions_require_tuple_of_valid_dotted_paths(self):
+        for targets in (["torch.neg"], ("torch",), ("torch..neg",), ("torch.neg ",), (None,)):
+            with self.subTest(targets=targets):
+                recipe = self._register(compatibility=ExecutorchCompatibilityPolicy(excluded_patch_targets=targets))
+                with self.assertRaises((TypeError, ValueError)):
+                    self.exporter.capture(self.model, self.inputs, self.config)
+                recipe.prepare.assert_not_called()
+
+
+@require_torch
+class BackendImportTest(unittest.TestCase):
+    def test_public_spi_and_external_capture_do_not_import_builtin_backends(self):
+        script = textwrap.dedent("""
+            import importlib.abc
+            import sys
+            class BlockBuiltins(importlib.abc.MetaPathFinder):
+                def find_spec(self, fullname, path=None, target=None):
+                    if fullname.startswith(("executorch.backends.xnnpack", "executorch.backends.cuda")):
+                        raise AssertionError("unexpected builtin import: " + fullname)
+            sys.meta_path.insert(0, BlockBuiltins())
+            import torch
+            from transformers.exporters import (
+                ExecutorchBackendPreparation, ExecutorchBackendRecipe, ExecutorchCompatibilityPolicy,
+                ExecutorchConfig, ExecutorchExporter, register_executorch_backend,
+            )
+            class Model(torch.nn.Module):
+                def forward(self, x):
+                    return x + 1
+            register_executorch_backend("external", lambda _: ExecutorchBackendRecipe(
+                prepare=lambda model, inputs, config: ExecutorchBackendPreparation(
+                    model=model, sample_inputs=inputs, normalize_inputs=False),
+                lower=lambda *_: None,
+                compatibility=ExecutorchCompatibilityPolicy(False, False),
+            ))
+            exporter = object.__new__(ExecutorchExporter)
+            capture = exporter.capture(Model(), {"x": torch.ones(2)}, ExecutorchConfig(backend="external", strict=True))
+            torch.testing.assert_close(capture.exported_program.module()(x=torch.ones(2)), torch.full((2,), 2.0))
+        """)
+        result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=90)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/tests/exporters/test_backend_registration.py
+++ b/tests/exporters/test_backend_registration.py
@@ -954,5 +954,8 @@ class BackendImportTest(unittest.TestCase):
             capture = exporter.capture(Model(), {"x": torch.ones(2)}, ExecutorchConfig(backend="external", strict=True))
             torch.testing.assert_close(capture.exported_program.module()(x=torch.ones(2)), torch.full((2,), 2.0))
         """)
-        result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=90)
+        # Run only the literal test script with the current interpreter, without a shell or untrusted input.
+        result = subprocess.run(  # nosec B603
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=90
+        )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/tests/exporters/test_patch_scopes.py
+++ b/tests/exporters/test_patch_scopes.py
@@ -1,0 +1,581 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import sys
+import threading
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest import mock
+
+from transformers.exporters import utils
+from transformers.testing_utils import require_torch
+from transformers.utils.import_utils import is_torch_available
+
+
+if is_torch_available():
+    import torch
+
+    from transformers.exporters import exporter_dynamo as dynamo
+    from transformers.exporters import exporter_onnx as onnx
+    from transformers.exporters.configs import DynamoConfig, OnnxConfig
+
+
+class _ScopeAssertions:
+    def assert_serialized(self, operation, *, scope=utils.export_patch_scope, before_release=None):
+        attempted = threading.Event()
+        finished = threading.Event()
+        errors = []
+
+        def worker():
+            attempted.set()
+            try:
+                operation()
+            except BaseException as error:
+                errors.append(error)
+            finally:
+                finished.set()
+
+        thread = threading.Thread(target=worker, daemon=True)
+        try:
+            with scope():
+                thread.start()
+                self.assertTrue(attempted.wait(5))
+                self.assertFalse(finished.wait(0.05))
+                if before_release is not None:
+                    before_release()
+        finally:
+            thread.join(5)
+        self.assertFalse(thread.is_alive(), "cooperating operation deadlocked")
+        self.assertFalse(errors, errors)
+        self.assertTrue(finished.is_set())
+
+
+class PatchOwnershipTest(_ScopeAssertions, unittest.TestCase):
+    def test_empty_patch_collections_hold_shared_scope(self):
+        for scope in (lambda: utils.patch_attributes([]), lambda: utils.apply_patches("_absent_patch_scope")):
+            with self.subTest(scope=scope):
+                self.assert_serialized(lambda: self._enter_scope(), scope=scope)
+
+    @staticmethod
+    def _enter_scope():
+        with utils.export_patch_scope():
+            pass
+
+    def test_attribute_snapshot_waits_for_scope_and_sees_restored_value(self):
+        owner = SimpleNamespace(value="original")
+        seen = []
+
+        def operation():
+            with utils.patch_attribute(owner, "value", lambda original: seen.append(original) or "second"):
+                self.assertEqual(owner.value, "second")
+
+        self.assert_serialized(
+            operation,
+            scope=lambda: utils.patch_attribute(owner, "value", lambda original: "first"),
+            before_release=lambda: self.assertEqual(seen, []),
+        )
+        self.assertEqual(seen, ["original"])
+        self.assertEqual(owner.value, "original")
+
+    def test_nested_attribute_scopes_restore_in_reverse_order(self):
+        owner = SimpleNamespace(value="original")
+        with utils.export_patch_scope(), utils.patch_attribute(owner, "value", lambda value: value + "-outer"):
+            with utils.patch_attributes([(owner, "value", lambda value: value + "-inner")]):
+                self.assertEqual(owner.value, "original-outer-inner")
+            self.assertEqual(owner.value, "original-outer")
+        self.assertEqual(owner.value, "original")
+
+    def test_exclusive_conflicts_in_both_orders_before_incoming_factory(self):
+        owner = SimpleNamespace(value="original")
+        for outer_exclusive, inner_exclusive in ((True, False), (False, True), (True, True)):
+            with self.subTest(outer=outer_exclusive, inner=inner_exclusive):
+                incoming = mock.Mock(return_value="inner")
+                with utils.patch_attribute(
+                    owner, "value", lambda value: "outer", exclusive=outer_exclusive, source="outer recipe"
+                ):
+                    with self.assertRaisesRegex(RuntimeError, "inner recipe.*outer recipe.*excluded_patch_targets"):
+                        with utils.patch_attribute(
+                            owner, "value", incoming, exclusive=inner_exclusive, source="inner recipe"
+                        ):
+                            self.fail("conflicting patch entered")
+                    incoming.assert_not_called()
+                    self.assertEqual(owner.value, "outer")
+                self.assertEqual(owner.value, "original")
+
+    def test_exclusive_sees_all_legacy_records_after_nested_scope_exits(self):
+        owner = SimpleNamespace(value="original")
+        with utils.patch_attribute(owner, "value", lambda value: "outer", source="outer"):
+            with utils.patch_attribute(owner, "value", lambda value: "inner", source="inner"):
+                self.assertEqual(owner.value, "inner")
+            with self.assertRaisesRegex(RuntimeError, "exclusive.*outer"):
+                with utils.patch_attribute(owner, "value", mock.Mock(), exclusive=True, source="exclusive"):
+                    self.fail("remaining outer patch must conflict")
+            self.assertEqual(owner.value, "outer")
+        with utils.patch_attribute(owner, "value", lambda value: "exclusive", exclusive=True):
+            self.assertEqual(owner.value, "exclusive")
+        self.assertEqual(owner.value, "original")
+
+    def test_exclusive_duplicate_aliases_are_preflighted(self):
+        owner = SimpleNamespace(value="original")
+        alias = owner
+        factory = mock.Mock(return_value="patched")
+        with self.assertRaisesRegex(RuntimeError, "Duplicate exclusive patch target.*recipe"):
+            with utils.patch_attributes(
+                [(owner, "value", factory), (alias, "".join(["val", "ue"]), factory)],
+                exclusive=True,
+                source="recipe",
+            ):
+                self.fail("duplicate patch collection entered")
+        factory.assert_not_called()
+        self.assertEqual(owner.value, "original")
+        with utils.patch_attributes([(owner, "value", factory)], exclusive=True):
+            self.assertEqual(owner.value, "patched")
+
+    def test_same_callable_in_distinct_slots_does_not_conflict(self):
+        def original():
+            return "original"
+
+        first = SimpleNamespace(value=original, other=original)
+        second = SimpleNamespace(value=original)
+        with utils.patch_attributes(
+            [
+                (first, "value", lambda value: lambda: "first"),
+                (first, "other", lambda value: lambda: "other"),
+                (second, "value", lambda value: lambda: "second"),
+            ],
+            exclusive=True,
+        ):
+            self.assertEqual((first.value(), first.other(), second.value()), ("first", "other", "second"))
+        self.assertIs(first.value, original)
+        self.assertIs(first.other, original)
+        self.assertIs(second.value, original)
+
+    def test_reentrant_factory_reserves_slot_before_calling_user_code(self):
+        owner = SimpleNamespace(value="original")
+        for outer_exclusive, inner_exclusive in ((True, False), (False, True)):
+            with self.subTest(outer=outer_exclusive, inner=inner_exclusive):
+                incoming = mock.Mock()
+
+                def factory(original):
+                    with utils.patch_attribute(owner, "value", incoming, exclusive=inner_exclusive):
+                        self.fail("reentrant conflicting factory entered")
+
+                with self.assertRaisesRegex(RuntimeError, "Patch conflict"):
+                    with utils.patch_attribute(owner, "value", factory, exclusive=outer_exclusive):
+                        self.fail("failed factory entered")
+                incoming.assert_not_called()
+                with utils.patch_attribute(owner, "value", lambda value: "retry", exclusive=True):
+                    self.assertEqual(owner.value, "retry")
+                self.assertEqual(owner.value, "original")
+
+    def test_patch_records_are_cleared_on_all_failures(self):
+        for exclusive in (False, True):
+            for failure in ("get", "factory", "set", "body", "restore"):
+                with self.subTest(exclusive=exclusive, failure=failure):
+
+                    class Owner:
+                        value = "original"
+                        enabled = True
+
+                        def __getattribute__(self, name):
+                            if name == "value" and self.enabled and failure == "get":
+                                raise RuntimeError("get failed")
+                            return object.__getattribute__(self, name)
+
+                        def __setattr__(self, name, value):
+                            object.__setattr__(self, name, value)
+                            if name == "value" and self.enabled:
+                                if failure == "set" and value == "patched":
+                                    raise RuntimeError("set failed")
+                                if failure == "restore" and value == "original":
+                                    raise RuntimeError("restore failed")
+
+                    owner = Owner()
+                    first = SimpleNamespace(value="original")
+
+                    def factory(original):
+                        if failure == "factory":
+                            raise RuntimeError("factory failed")
+                        return "patched"
+
+                    with self.assertRaisesRegex(RuntimeError, f"{failure} failed"):
+                        with utils.patch_attributes(
+                            [(first, "value", lambda value: "patched"), (owner, "value", factory)], exclusive=exclusive
+                        ):
+                            if failure in ("get", "factory", "set"):
+                                self.fail("failed installation must not enter the body")
+                            self.assertEqual((first.value, owner.value), ("patched", "patched"))
+                            if failure == "body":
+                                raise RuntimeError("body failed")
+                    owner.enabled = False
+                    self.assertEqual(owner.value, "original")
+                    self.assertEqual(first.value, "original")
+                    with utils.patch_attributes(
+                        [(first, "value", lambda value: "retry"), (owner, "value", lambda value: "retry")],
+                        exclusive=True,
+                    ):
+                        self.assertEqual((first.value, owner.value), ("retry", "retry"))
+                    self.assertNotIn((id(owner), "value"), utils._ACTIVE_PATCHES)
+                    self.assertNotIn((id(first), "value"), utils._ACTIVE_PATCHES)
+                    self.assert_serialized(self._enter_scope)
+
+    def test_restoration_remains_inside_shared_scope(self):
+        observations = []
+
+        class Owner:
+            value = "original"
+
+            def __setattr__(self, name, value):
+                if value == "original":
+                    acquired = []
+
+                    def try_lock():
+                        locked = utils._EXPORT_PATCH_LOCK.acquire(blocking=False)
+                        acquired.append(locked)
+                        if locked:
+                            utils._EXPORT_PATCH_LOCK.release()
+
+                    thread = threading.Thread(target=try_lock, daemon=True)
+                    thread.start()
+                    thread.join(5)
+                    observations.extend(acquired)
+                object.__setattr__(self, name, value)
+
+        owner = Owner()
+        with utils.patch_attribute(owner, "value", lambda original: "patched"):
+            self.assertEqual(owner.value, "patched")
+        self.assertEqual(observations, [False])
+        self.assertEqual(owner.value, "original")
+
+
+class PatchRegistryTest(unittest.TestCase):
+    def setUp(self):
+        self.enterContext(mock.patch.dict(utils._PATCHES, {"test": []}, clear=True))
+        self.enterContext(mock.patch.dict(sys.modules))
+        self.module = ModuleType("_scope_target")
+        self.module.value = "original"
+        sys.modules[self.module.__name__] = self.module
+
+    def test_lazy_targets_preserve_eager_and_direct_append_order(self):
+        module = self.module
+        utils.register_patch("test", "_scope_target.value")(lambda value: value + "-eager")
+        eager = utils._PATCHES["test"][0]
+        utils.register_patch("test", "_scope_target.value", lazy=True)(lambda value: value + "-lazy")
+        utils._PATCHES["test"].append((module, "value", lambda value: value + "-direct"))
+        with utils.apply_patches("test"):
+            self.assertEqual(module.value, "original-eager-lazy-direct")
+        self.assertEqual(module.value, "original")
+        self.assertIs(utils._PATCHES["test"][0], eager)
+        self.assertIs(eager[0], module)
+
+    def test_lazy_missing_import_and_attribute_are_retried(self):
+        module = self.module
+        del sys.modules[module.__name__]
+        del module.value
+        with mock.patch.object(utils, "_resolve_dotted_path", wraps=utils._resolve_dotted_path) as resolve:
+            utils.register_patch("test", "_scope_target.value", lazy=True)(lambda value: value + "-patch")
+            resolve.assert_not_called()
+            with self.assertLogs(utils.logger.name, level="DEBUG") as logs, utils.apply_patches("test"):
+                pass
+            self.assertIn(module.__name__, " ".join(logs.output))
+            sys.modules[module.__name__] = module
+            with utils.apply_patches("test"):
+                self.assertFalse(hasattr(module, "value"))
+            module.value = "original"
+            with utils.apply_patches("test"):
+                self.assertEqual(module.value, "original-patch")
+        self.assertEqual(module.value, "original")
+
+    def test_registry_conflicts_and_alias_exclusions_match_physical_slots(self):
+        module = self.module
+        original = mock.Mock(return_value="original")
+        module.owner = module.alias = SimpleNamespace(value=original)
+        module.other = SimpleNamespace(value=original)
+        for lazy in (False, True):
+            with self.subTest(lazy=lazy):
+                utils._PATCHES["test"] = []
+                factory = mock.Mock(return_value=lambda: "registry")
+                utils.register_patch("test", "_scope_target.owner.value", lazy=lazy)(factory)
+                utils._PATCHES["test"].append((module.other, "value", lambda _: lambda: "other"))
+                with utils.patch_attribute(module.alias, "value", lambda _: lambda: "recipe", exclusive=True):
+                    with self.assertRaisesRegex(RuntimeError, "Patch conflict"), utils.apply_patches("test"):
+                        self.fail("registry shadowed exclusive recipe")
+                    with utils.apply_patches("test", exclude=("_scope_target.alias.value",)):
+                        self.assertEqual(module.owner.value(), "recipe")
+                        self.assertEqual(module.other.value(), "other")
+                factory.assert_not_called()
+                self.assertIs(module.owner.value, original)
+                self.assertIs(module.other.value, original)
+
+    def test_exact_lazy_exclusion_does_not_resolve_or_import_owner(self):
+        utils.register_patch("test", "_unimported.owner.value", lazy=True)(mock.Mock())
+        with (
+            mock.patch.object(utils, "_resolve_dotted_path") as resolve,
+            mock.patch("importlib.import_module") as import_module,
+            utils.apply_patches("test", exclude=("_unimported.owner.value",)),
+        ):
+            resolve.assert_not_called()
+            import_module.assert_not_called()
+
+    def test_exact_lazy_exclusion_does_not_import_during_other_slot_checks(self):
+        self.module.__getattr__ = mock.Mock(side_effect=AssertionError("lazy module attribute imported"))
+        other = SimpleNamespace(value="original")
+        utils._PATCHES["test"].append((other, "value", lambda _: "patched"))
+        utils.register_patch("test", "_scope_target.owner.value", lazy=True)(mock.Mock())
+        with mock.patch("importlib.import_module") as import_module:
+            with utils.apply_patches("test", exclude=("_scope_target.owner.value",)):
+                self.assertEqual(other.value, "patched")
+                import_module.assert_not_called()
+                self.module.__getattr__.assert_not_called()
+        self.assertEqual(other.value, "original")
+
+    def test_exclusions_do_not_leak_into_nested_or_later_scopes(self):
+        utils.register_patch("test", "_scope_target.value", lazy=True)(lambda value: value + "-patched")
+        with self.assertRaisesRegex(RuntimeError, "body failed"):
+            with utils.apply_patches("test", exclude=("_scope_target.value",)):
+                self.assertEqual(self.module.value, "original")
+                with utils.apply_patches("test"):
+                    self.assertEqual(self.module.value, "original-patched")
+                self.assertEqual(self.module.value, "original")
+                raise RuntimeError("body failed")
+        with utils.apply_patches("test"):
+            self.assertEqual(self.module.value, "original-patched")
+        self.assertEqual(self.module.value, "original")
+
+    def test_lazy_resolution_remains_interleaved_with_installation_and_exclusions(self):
+        module = self.module
+        module.owner = original = SimpleNamespace(value="original")
+        module.alias = replacement = SimpleNamespace(value="replacement")
+        utils._PATCHES["test"].append((module, "owner", lambda _: replacement))
+        utils.register_patch("test", "_scope_target.owner.value", lazy=True)(lambda value: value + "-patch")
+        for exclusions, expected in (((), "replacement-patch"), (("_scope_target.alias.value",), "replacement")):
+            with self.subTest(exclusions=exclusions), utils.apply_patches("test", exclude=exclusions):
+                self.assertIs(module.owner, replacement)
+                self.assertEqual(module.owner.value, expected)
+                self.assertEqual(original.value, "original")
+            self.assertIs(module.owner, original)
+            self.assertEqual(replacement.value, "replacement")
+
+    def test_unavailable_exclusion_alias_is_retried_on_next_scope(self):
+        owner = SimpleNamespace(value="original")
+        utils._PATCHES["test"].append((owner, "value", lambda _: "patched"))
+        del sys.modules[self.module.__name__]
+        with utils.apply_patches("test", exclude=("_scope_target.owner.value",)):
+            self.assertEqual(owner.value, "patched")
+        self.module.owner = owner
+        sys.modules[self.module.__name__] = self.module
+        with utils.apply_patches("test", exclude=("_scope_target.owner.value",)):
+            self.assertEqual(owner.value, "original")
+        with utils.apply_patches("test"):
+            self.assertEqual(owner.value, "patched")
+        self.assertEqual(owner.value, "original")
+
+    def test_registration_does_not_acquire_export_lock(self):
+        errors = []
+
+        def register():
+            try:
+                for lazy in (False, True):
+                    utils.register_patch("test", "_scope_target.value", lazy=lazy)(lambda value: value)
+            except BaseException as error:
+                errors.append(error)
+
+        thread = threading.Thread(target=register, daemon=True)
+        with utils.export_patch_scope():
+            thread.start()
+            thread.join(5)
+            blocked = thread.is_alive()
+        thread.join(5)
+        self.assertFalse(blocked, "import-time registration waited for the export lock")
+        self.assertFalse(errors, errors)
+        self.assertEqual(len(utils._PATCHES["test"]), 2)
+
+
+@require_torch
+class MutableExportHelperTest(_ScopeAssertions, unittest.TestCase):
+    def make_model(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = SimpleNamespace(use_cache=True, use_mamba_kernels=True)
+                self.cached_sequence_length = 7
+
+            def forward(self, x=None, **kwargs):
+                return x
+
+        return Model()
+
+    def test_mutable_helpers_wait_before_reading_model_state(self):
+        model = self.make_model()
+        original_forward = model.forward
+        scopes = (
+            lambda: dynamo.patch_model_config(model, {"use_cache": False}),
+            lambda: dynamo.patch_forward_signature(model, {"x": None}),
+            lambda: dynamo.reset_model_state(model),
+            lambda: onnx.patch_model_outputs(model),
+            lambda: utils._capture_forward(model),
+        )
+        for scope in scopes:
+            with self.subTest(scope=scope):
+
+                def operation():
+                    with scope():
+                        pass
+
+                def unchanged():
+                    self.assertEqual(model.forward, original_forward)
+                    self.assertEqual(model.cached_sequence_length, 7)
+                    self.assertTrue(model.config.use_cache)
+                    self.assertTrue(model.config.use_mamba_kernels)
+
+                self.assert_serialized(operation, before_release=unchanged)
+                unchanged()
+
+    def test_nested_signature_config_and_reset_scopes_restore_on_failure(self):
+        model = self.make_model()
+        original_forward = model.forward
+        with utils.export_patch_scope(), dynamo.patch_forward_signature(model, {"x": None}):
+            outer_forward = model.forward
+            with dynamo.reset_model_state(model), dynamo.patch_model_config(model, {"use_cache": False}):
+                self.assertIsNone(model.cached_sequence_length)
+                model.cached_sequence_length = 9
+                with self.assertRaisesRegex(RuntimeError, "body failed"):
+                    with (
+                        dynamo.patch_forward_signature(model, {"x": None, "extra": None}),
+                        dynamo.reset_model_state(model),
+                        dynamo.patch_model_config(model, {"use_cache": True}),
+                    ):
+                        self.assertEqual(list(inspect.signature(model.forward).parameters), ["x", "extra"])
+                        self.assertIsNone(model.cached_sequence_length)
+                        self.assertTrue(model.config.use_cache)
+                        raise RuntimeError("body failed")
+                self.assertIs(model.forward, outer_forward)
+                self.assertEqual(model.cached_sequence_length, 9)
+                self.assertFalse(model.config.use_cache)
+                self.assertFalse(model.config.use_mamba_kernels)
+        self.assertEqual(model.forward, original_forward)
+        self.assertEqual(model.cached_sequence_length, 7)
+        self.assertTrue(model.config.use_cache)
+        self.assertTrue(model.config.use_mamba_kernels)
+
+    def test_reset_partial_setter_failure_restores_state(self):
+        class Model(torch.nn.Module):
+            cached_sequence_length = 7
+            cached_rotary_positional_embedding = "original"
+
+            def __setattr__(self, name, value):
+                super().__setattr__(name, value)
+                if name == "cached_sequence_length" and value is None:
+                    raise RuntimeError("reset setter failed")
+
+        model = Model()
+        with self.assertRaisesRegex(RuntimeError, "reset setter failed"):
+            with dynamo.reset_model_state(model):
+                self.fail("reset must not enter after failure")
+        self.assertEqual(model.cached_sequence_length, 7)
+        self.assertEqual(model.cached_rotary_positional_embedding, "original")
+
+    def test_forward_wrappers_share_reentrant_scope_and_restore(self):
+        model = self.make_model()
+        original_forward = model.forward
+        value = torch.ones(2)
+        with utils.export_patch_scope(), utils._capture_forward(model) as calls:
+            with onnx.patch_model_outputs(model) as (input_names, output_names):
+                with dynamo.patch_forward_signature(model, {"x": value}):
+                    result = model(x=value)
+            self.assertEqual(input_names, ["x"])
+            self.assertEqual(output_names, ["output"])
+        torch.testing.assert_close(result["output"], value)
+        torch.testing.assert_close(calls[0]["x"], value)
+        self.assertIsNot(calls[0]["x"], value)
+        self.assertEqual(model.forward, original_forward)
+
+    def test_preparation_and_pytree_registration_share_scope(self):
+        model = self.make_model()
+        with mock.patch.object(torch.utils._pytree, "register_pytree_node") as register:
+            operations = (
+                lambda: utils.prepare_for_export(model, {}),
+                lambda: utils.precompute_export_inputs(model, {}),
+                lambda: dynamo.register_pytree_node(type(model)),
+                lambda: dynamo.register_cache_pytrees_for_model(model),
+            )
+            for operation in operations:
+                with self.subTest(operation=operation):
+                    register.reset_mock()
+                    self.assert_serialized(operation, before_release=register.assert_not_called)
+            self.assertTrue(register.called)
+
+    def test_export_entry_points_lock_before_helpers(self):
+        model = self.make_model()
+        cases = (
+            (dynamo.DynamoExporter(), "export", DynamoConfig(), dynamo, "prepare_for_export"),
+            (dynamo.DynamoExporter(), "_export_prepared", DynamoConfig(), dynamo, "register_cache_pytrees_for_model"),
+            (object.__new__(onnx.OnnxExporter), "export", OnnxConfig(), onnx, "patch_model_outputs"),
+        )
+        for exporter, method, config, module, helper in cases:
+            with self.subTest(method=method):
+                with mock.patch.object(module, helper, side_effect=RuntimeError("stopped after lock")) as entry:
+
+                    def operation():
+                        with self.assertRaisesRegex(RuntimeError, "stopped after lock"):
+                            getattr(exporter, method)(model, {}, config)
+
+                    self.assert_serialized(operation, before_release=entry.assert_not_called)
+                entry.assert_called_once()
+
+    def test_prepared_dynamo_forwards_exclusions_only_to_its_registry(self):
+        model = self.make_model()
+        module = ModuleType("_scope_dynamo_exclusion_target")
+        module.value = "original"
+        original_forward = model.forward
+        sample = torch.ones(2)
+        exporter = dynamo.DynamoExporter()
+        with (
+            mock.patch.dict(utils._PATCHES, {"dynamo": [(module, "value", lambda value: "registry")]}),
+            mock.patch.dict(sys.modules, {module.__name__: module}),
+            utils.patch_attribute(module, "value", lambda value: "recipe", exclusive=True),
+        ):
+
+            def capture(*args, **kwargs):
+                self.assertEqual(module.value, "recipe")
+                self.assertIsNone(model.cached_sequence_length)
+                self.assertFalse(model.config.use_cache)
+                self.assertEqual(list(inspect.signature(model.forward).parameters), ["x"])
+                return "program"
+
+            with mock.patch.object(torch.export, "export", side_effect=capture) as export:
+                result = exporter._export_prepared(
+                    model,
+                    {"x": sample},
+                    DynamoConfig(),
+                    output_flags={"use_cache": False},
+                    patch_exclusions=(f"{module.__name__}.value",),
+                )
+                self.assertEqual(result, "program")
+                export.assert_called_once()
+                with self.assertRaisesRegex(RuntimeError, "Patch conflict"):
+                    exporter._export_prepared(model, {"x": sample}, DynamoConfig())
+                export.assert_called_once()
+        self.assertEqual(module.value, "original")
+        self.assertEqual(model.forward, original_forward)
+        self.assertEqual(model.cached_sequence_length, 7)
+        self.assertTrue(model.config.use_cache)
+
+    def test_real_dynamo_capture_still_works(self):
+        model = self.make_model()
+        sample = torch.ones(2)
+        program = dynamo.DynamoExporter().export(model, {"x": sample}, DynamoConfig())
+        torch.testing.assert_close(program.module()(x=sample), sample)
+        self.assertEqual(model.cached_sequence_length, 7)

--- a/tests/exporters/test_utils.py
+++ b/tests/exporters/test_utils.py
@@ -34,6 +34,7 @@ Everything below targets one of those gaps.
 """
 
 import unittest
+from contextlib import contextmanager
 from unittest import mock
 
 from transformers.exporters import utils as exporter_utils
@@ -170,6 +171,151 @@ class RegistrationTest(unittest.TestCase):
         self.assertNotIn("stub_exporter", AUTO_EXPORTER_MAPPING)
 
 
+@require_torch
+class ExecutorchTensorPatchesTest(unittest.TestCase):
+    @contextmanager
+    def _patches_with_restoration(self):
+        targets = ((torch, "reshape"), (torch.Tensor, "reshape"), (torch.Tensor, "view"), (torch.Tensor, "expand"))
+        originals = [getattr(owner, name) for owner, name in targets]
+        try:
+            with exporter_utils.apply_patches("executorch"):
+                for (owner, name), original in zip(targets, originals):
+                    self.assertIsNot(getattr(owner, name), original)
+                yield
+        finally:
+            for (owner, name), original in zip(targets, originals):
+                self.assertIs(getattr(owner, name), original)
+
+    def _check_strict_export(self, operation, sample, expected_clones, reference=None):
+        class Model(nn.Module):
+            def forward(self, x):
+                return operation(x)
+
+        with self._patches_with_restoration():
+            program = torch.export.export(
+                Model(),
+                (sample[:3],),
+                dynamic_shapes={"x": {0: torch.export.Dim("rows", min=2, max=6)}},
+                strict=True,
+            )
+        self.assertTrue(program.range_constraints)
+        clones = [node for node in program.graph.nodes if node.target == torch.ops.aten.clone.default]
+        self.assertEqual(len(clones), expected_clones)
+        for node in clones:
+            self.assertEqual(node.kwargs.get("memory_format"), torch.contiguous_format)
+        exported = program.module()
+        for rows in (2, 5):
+            x = sample[:rows]
+            # Native view needs contiguous input; the patch accepts either layout.
+            expected = (reference or operation)(x.contiguous())
+            actual = exported(x)
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+            self.assertTrue(actual.is_contiguous())
+            self.assertNotIn(0, actual.stride())
+            self.assertEqual(actual.data_ptr() == x.data_ptr(), expected_clones == 0)
+        return program
+
+    def test_shape_argument_forms(self):
+        operations = {
+            "functional_tuple": lambda x: torch.reshape(x, (2, -1)),
+            "functional_list": lambda x: torch.reshape(x, [2, -1]),
+            "functional_keywords": lambda x: torch.reshape(input=x, shape=(2, -1)),
+            "reshape_varargs": lambda x: x.reshape(2, -1),
+            "reshape_tuple": lambda x: x.reshape((2, -1)),
+            "reshape_list": lambda x: x.reshape([2, -1]),
+            "reshape_keyword": lambda x: x.reshape(shape=(2, -1)),
+            "reshape_size": lambda x: x.reshape(x.shape),
+            "reshape_single_dim": lambda x: x.reshape(-1),
+            "view_varargs": lambda x: x.view(2, -1),
+            "view_tuple": lambda x: x.view((2, -1)),
+            "view_list": lambda x: x.view([2, -1]),
+            "view_keyword": lambda x: x.view(size=(2, -1)),
+            "view_size": lambda x: x.view(x.shape),
+            "view_single_dim": lambda x: x.view(-1),
+            "expand_varargs": lambda x: x.expand(2, -1, -1),
+            "expand_tuple": lambda x: x.expand((2, -1, -1)),
+            "expand_list": lambda x: x.expand([2, -1, -1]),
+            "expand_keyword": lambda x: x.expand(size=(2, -1, -1)),
+            "expand_symbolic": lambda x: x.expand(x.shape[0], -1, -1),
+            "expand_no_broadcast": lambda x: x.expand(x.shape),
+        }
+        x = torch.randn(3, 4)
+        expected = {name: operation(x) for name, operation in operations.items()}
+        with self._patches_with_restoration():
+            for name, operation in operations.items():
+                with self.subTest(operation=name):
+                    actual = operation(x)
+                    torch.testing.assert_close(actual, expected[name])
+                    self.assertTrue(actual.is_contiguous())
+
+    def test_strict_reshape_and_view(self):
+        sample = torch.randn(5, 2, 4)
+        operations = {
+            "functional_keywords": lambda x: torch.reshape(input=x, shape=(x.shape[0], -1)),
+            "reshape_keyword": lambda x: x.reshape(shape=(x.shape[0], -1)),
+            "view_keyword": lambda x: x.view(size=(x.shape[0], -1)),
+        }
+        for name, operation in operations.items():
+            with self.subTest(operation=name):
+                self._check_strict_export(operation, sample.transpose(1, 2), 1)
+        self._check_strict_export(lambda x: x.view(x.shape[0], -1), sample, 0)
+
+    def test_strict_view_dtype_overloads(self):
+        sample = torch.randn(5, 2, 4, dtype=torch.float32)
+        for dtype in (torch.int16, torch.int32, torch.int64):
+            with self.subTest(dtype=dtype):
+                program = self._check_strict_export(lambda x: x.view(dtype), sample, 0)
+                self.assertIn(torch.ops.aten.view.dtype, [node.target for node in program.graph.nodes])
+        self._check_strict_export(lambda x: x.view(dtype=torch.int64), sample.transpose(1, 2), 1)
+
+    def test_strict_expand(self):
+        sample = torch.randn(5, 4)
+        self._check_strict_export(lambda x: x.expand(size=(x.shape[0], -1, -1)), sample, 1)
+        self._check_strict_export(lambda x: x.expand(x.shape), sample, 0)
+
+    def test_strict_internal_transpose_and_broadcast(self):
+        def operation(x):
+            transposed = x.transpose(1, 2)
+            reshaped = transposed.reshape(x.shape[0], -1)
+            return reshaped.unsqueeze(1).expand(-1, 2, -1).view(x.shape[0], -1)
+
+        def reference(x):
+            return x.transpose(1, 2).reshape(x.shape[0], -1).unsqueeze(1).repeat(1, 2, 1).reshape(x.shape[0], -1)
+
+        self._check_strict_export(operation, torch.randn(5, 2, 4), 2, reference)
+
+    def test_empty_shape_forms(self):
+        x = torch.tensor(1.0)
+        operations = (
+            lambda: torch.reshape(x, ()),
+            lambda: x.reshape([]),
+            lambda: x.reshape(shape=()),
+            lambda: x.view(()),
+            lambda: x.view(size=[]),
+            lambda: x.expand(()),
+            lambda: x.expand(size=[]),
+        )
+        with self._patches_with_restoration():
+            for operation in operations:
+                torch.testing.assert_close(operation(), x)
+            for operation in (x.reshape, x.view, x.expand):
+                with self.assertRaises(TypeError):
+                    operation()
+
+    def test_restoration_after_strict_export_failure(self):
+        class InvalidShape(nn.Module):
+            def forward(self, x):
+                return x.reshape(5)
+
+        with self.assertRaisesRegex(RuntimeError, "invalid for input"):
+            with self._patches_with_restoration():
+                torch.export.export(InvalidShape(), (torch.randn(3, 4),), strict=True)
+
+        # Native view must reject non-contiguous inputs again after the failed capture.
+        with self.assertRaises(RuntimeError):
+            torch.randn(2, 3).t().view(-1)
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Registry edge cases the happy-path exports don't exercise
 # ─────────────────────────────────────────────────────────────────────────────
@@ -195,7 +341,7 @@ class PatchRegistryEdgeCasesTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "factory boom"):
             with patch_attributes(
                 [
-                    (a, "method", lambda original: (lambda: "a-patched")),
+                    (a, "method", lambda original: lambda: "a-patched"),
                     (b, "method", _bad_factory),
                 ]
             ):


### PR DESCRIPTION
Introduce an explicit registration API for out-of-tree ExecuTorch backends, allowing them to customize model preparation, attention, graph transforms, and lowering without modifying the core exporter. Built-in XNNPACK and CUDA backends use the same recipe contract.

* Add register_executorch_backend() and typed recipe/preparation descriptors, with backend-specific configuration in backend_options and live resources retained in preparation state.
* Add capture() and lower() for inspecting or transforming a captured program before lowering. Captures retain the resolved recipe and a configuration snapshot, and permit one lowering attempt.
* Make attention and masking policies explicit, with an optional attention target for wrapped or replacement models and scoped restoration of registrations and configuration.
* Define exclusive recipe patch ownership and targeted compatibility-patch exclusions, preventing silent overrides. Share a reentrant export lock across cooperating exporters and defer backend-specific imports.
* Make tensor reshape, view, and expand compatibility patches traceable under strict capture, and document the backend lifecycle and ownership boundaries.

Testing: Added focused coverage for registration, immediate and deferred lowering, configuration isolation, attention/masking numerics, patch conflicts and restoration, concurrency, import isolation, and strict tensor capture.