### PR TITLE
docs: fix 'allows to' grammar in Depth Anything V2 docs

### DIFF
--- a/docs/source/en/model_doc/depth_anything_v2.md
+++ b/docs/source/en/model_doc/depth_anything_v2.md
@@ -39,7 +39,7 @@ There are 2 main ways to use Depth Anything V2: either using the pipeline API, w
 
 ### Pipeline API
 
-The pipeline allows to use the model in a few lines of code:
+The pipeline allows you to use the model in a few lines of code:
 
 ```python
 import requests


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48726&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48726) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48726&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48726)
<!-- ci-dashboard-badge:end -->

Tiny docs grammar fix.