### PR TITLE
docs: fix 'allows to' grammar in Speech Encoder Decoder docs

### DIFF
--- a/docs/source/en/model_doc/speech-encoder-decoder.md
+++ b/docs/source/en/model_doc/speech-encoder-decoder.md
@@ -66,7 +66,7 @@ model = SpeechEncoderDecoderModel.from_encoder_decoder_pretrained(
 
 To load fine-tuned checkpoints of the `SpeechEncoderDecoderModel` class, [`SpeechEncoderDecoderModel`] provides the `from_pretrained(...)` method just like any other model architecture in Transformers.
 
-To perform inference, one uses the [`generate`] method, which allows to autoregressively generate text. This method supports various forms of decoding, such as greedy, beam search and multinomial sampling.
+To perform inference, one uses the [`generate`] method, which allows you to autoregressively generate text. This method supports various forms of decoding, such as greedy, beam search and multinomial sampling.
 
 ```python
 from transformers import Wav2Vec2Processor, SpeechEncoderDecoderModel


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48727&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48727) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48727&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48727)
<!-- ci-dashboard-badge:end -->

Tiny docs grammar fix.