### PR TITLE
docs: remove duplicate 'and' in docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,7 +80,7 @@ Readers run our snippets on NVIDIA GPUs, AMD ROCm, Intel XPU, Apple MPS, Ascend 
 
 - Use `device_map="auto"` only when automatic dispatch is intended. Keep explicit `cuda` in CUDA-specific examples.
 - Move inputs with `inputs.to(model.device)` instead of `.to("cuda")` or `.cuda()`.
-- Use `torch.accelerator.synchronize()` for synchronization and and `torch.Event(enable_timing=True)` for timing. Memory helpers live under `torch.accelerator.memory`, for example `torch.accelerator.memory.empty_cache()` and `torch.accelerator.memory.max_memory_allocated()`.
+- Use `torch.accelerator.synchronize()` for synchronization and `torch.Event(enable_timing=True)` for timing. Memory helpers live under `torch.accelerator.memory`, for example `torch.accelerator.memory.empty_cache()` and `torch.accelerator.memory.max_memory_allocated()`.
 - If you really need a device string, use `device = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else "cpu"`.
 - Keep `cuda` only where it is genuinely CUDA-specific: toolchain instructions (`nvcc`, `nvidia-smi`), NVIDIA-only backends, PyTorch API names such as `use_cuda_graph`, and sample outputs copied from a real run.
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48729&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48729) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48729&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48729)
<!-- ci-dashboard-badge:end -->

Tiny docs grammar fix.