### PR TITLE
docs: fix 'allows to' grammar in Vision Encoder Decoder docs

### DIFF
--- a/docs/source/en/model_doc/vision-encoder-decoder.md
+++ b/docs/source/en/model_doc/vision-encoder-decoder.md
@@ -74,7 +74,7 @@ model = VisionEncoderDecoderModel.from_encoder_decoder_pretrained(
 
 To load fine-tuned checkpoints of the `VisionEncoderDecoderModel` class, [`VisionEncoderDecoderModel`] provides the `from_pretrained(...)` method just like any other model architecture in Transformers.
 
-To perform inference, one uses the [`generate`] method, which allows to autoregressively generate text. This method supports various forms of decoding, such as greedy, beam search and multinomial sampling.
+To perform inference, one uses the [`generate`] method, which allows autoregressively generating text. This method supports various forms of decoding, such as greedy, beam search and multinomial sampling.
 
 ```python
 import requests


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48730&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48730) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48730&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48730)
<!-- ci-dashboard-badge:end -->

Tiny docs fix: `allows to autoregressively generate` → `allows autoregressively generating` in the Vision Encoder Decoder docs.