### PR TITLE
Fix Parakeet TDT conversion for nvidia/parakeet-tdt-1.1b (no <pad> in the NeMo vocab)

### DIFF
--- a/src/transformers/models/parakeet/convert_nemo_to_hf.py
+++ b/src/transformers/models/parakeet/convert_nemo_to_hf.py
@@ -61,6 +61,15 @@ NEMO_TDT_WEIGHT_MAPPING = {
 }
 
 
+def blank_is_pad(nemo_config, model_type):
+    """Whether a transducer checkpoint has to reuse its blank token as the pad token.
+
+    True when the NeMo vocab carries no `<pad>` of its own, in which case `len(labels)` is both NeMo's blank id
+    and the first free tokenizer id, so `<blank>` must take that slot instead of a freshly appended `<pad>`.
+    """
+    return model_type in ("rnnt", "tdt") and "<pad>" not in nemo_config.get("labels", [])
+
+
 def convert_key(key, mapping):
     for pattern, replacement in mapping.items():
         key = re.sub(pattern, replacement, key)
@@ -158,13 +167,12 @@ def write_processor(
         tokenizer_converted_fast.add_tokens([AddedToken("<unk>", normalized=False, special=True)])
         print(f"Added <unk> token at ID: {tokenizer_converted_fast.convert_tokens_to_ids('<unk>')}")
 
-    if model_type == "rnnt":
-        # RNN-T (unlike TDT) has no dedicated pad token in its NeMo vocab. NeMo's blank is the final vocab entry,
-        # i.e. `config.blank_token_id == len(labels)`, and the joint head emits exactly `len(labels) + 1` logits.
-        # Add `<blank>` *first* so it lands on that id (no `<pad>` is appended to push it past the model's vocab),
-        # and reuse it as the pad token: decoding already skips the pad id, and padding decoder/label tensors with
-        # the blank id keeps every id within the joint vocab. This aligns the tokenizer's `<blank>` id with the
-        # model's blank logit, so the processor can prepend `<blank>` to build decoder_input_ids unchanged.
+    if blank_is_pad(nemo_config, model_type):
+        # No `<pad>` in the NeMo vocab (every RNN-T checkpoint, and TDT ones such as `parakeet-tdt-1.1b`): NeMo's
+        # blank is the final vocab entry, `config.blank_token_id == len(labels)`, and the joint head emits exactly
+        # `len(labels) + 1` token logits. Adding `<blank>` *first* lands it on that id instead of being pushed past
+        # the model's vocab by a `<pad>`, and reusing it as the pad token keeps every padded decoder/label id
+        # inside the joint vocab - decoding skips the pad id either way.
         tokenizer_converted_fast.add_tokens([AddedToken("<blank>", normalized=False, special=True)])
         print(f"Added <blank> token at ID: {tokenizer_converted_fast.convert_tokens_to_ids('<blank>')}")
         pad_token = AddedToken("<blank>", normalized=False, special=True)
@@ -349,7 +357,8 @@ def convert_tdt_config(nemo_config, encoder_config):
         hidden_act="relu",
         max_symbols_per_step=10,
         encoder_config=encoder_config.to_dict(),
-        pad_token_id=labels.index("<pad>"),
+        # `<pad>` when the NeMo vocab has one, else the blank token doubles as pad (see `blank_is_pad`).
+        pad_token_id=labels.index("<pad>") if "<pad>" in labels else blank_token_id,
         blank_token_id=blank_token_id,  # blank token is different from pad token for TDT
     )
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48733&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48733) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48733&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48733)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

`src/transformers/models/parakeet/convert_nemo_to_hf.py` cannot convert [`nvidia/parakeet-tdt-1.1b`](https://huggingface.co/nvidia/parakeet-tdt-1.1b). Unlike `parakeet-tdt-0.6b-v2`/`v3`, that checkpoint's NeMo vocabulary carries no `<pad>` token, and two things go wrong because of it.

**1. The conversion crashes.**

```bash
python src/transformers/models/parakeet/convert_nemo_to_hf.py \
    --hf_repo_id nvidia/parakeet-tdt-1.1b --model_type tdt --output_dir OUT
```

```
ValueError: '<pad>' is not in list
```

from `convert_tdt_config`, which does `pad_token_id=labels.index("<pad>")`.

**2. Getting past that would silently misplace the blank token.**

The TDT branc
sentencepiece vocab that gives:

```
<pad>=1024, <blank>=1025
```

but NeMo's blank is the final vocab entry, so the model's blank logit is at **1024** (`num_classes=1024`, `num_extra_outputs=5`, joint head width `1024 + 1 + 5 = 1030`). The tokenizer's `<blank>` would sit one past the model's blank, and decoding would be wrong rather than merely erroring.

## The fix

The RNN-T branch right above already handles exactly this shape, and its comment explains why: when the NeMo vocab has no `<pad>`, `len(labels)` is both NeMo's blank id and the first free tokenizer id, so `<blank>` has to take that slot and double as the pad token. That is a property of the vocabulary, not of the decoder type, so this PR selects the branch on `"<pad>" in labels` instead of on `model_type`, via a small `blank_is_pad()` helper, and makes `convert_tdt_config` fall back to the blank id for `pad_token_id`.

After the change, `nvidia/parakeet-tdt-1.1b` converts with `blank_token_id == pad_token_id == 1024`, `vocab_size == 1025`, and no missing or unexpected keys.

Checkpoints whose vocab does contain a `<pad>` (`parakeet-tdt-0.6b-v2`/`v3`) take the same branch as before, so their conversion is unchanged.

## Verification

Converted checkpoint compared against `nemo_toolkit[asr]` 3.0.0 on CPU in float32, on two LibriSpeech clips (13.7 s and 14.2 s), both unbatched and as a padded batch of two:

| tensor | max abs diff |
| --- | --- |
| log-mel features | 6.5e-05 |
| encoder hidden states | 1.2e-04 |
| encoder projection | 8.0e-05 |
| joint logits (`vocab + durations`, at the blank SOS step) | 3.3e-04 |

Encoder output lengths agree (172 and 178 frames), and greedy decoding produces identical token ids and identical transcriptions in every configuration. The batched run matches the unbatched one for both clips, which exercises the padding path where a misplaced blank id would show up.

## Who can review?

@eustlb — wrote the RNN-T blank-as-pad branch in #46331 that this generalises
@lmaksym — added the TDT conversion path in #44171
@nithinraok — for the NeMo side, since this is about how NeMo lays out the blank token in the vocab