### PR TITLE
Add sliding-window local attention to Parakeet for long-form audio

### DIFF
--- a/docs/source/en/model_doc/parakeet.md
+++ b/docs/source/en/model_doc/parakeet.md
@@ -241,6 +241,50 @@ Timestamped tokens: [[{'token': 'm', 'start': 0.24, 'end': 0.48}, {'token': 'ist
 </hfoption>
 </hfoptions>
 
+### Long-form audio with local attention
+
+The default attention pattern lets every frame attend to every other one, so the relative positional term is a
+`(batch, heads, frames, 2 * frames - 1)` tensor. That is what puts a ceiling on the input length - roughly
+`max_position_embeddings` subsampled frames, or about seven minutes of audio for the released checkpoints.
+
+`change_attention_model` switches the encoder to a sliding window instead, matching NeMo's method of the same
+name. Each frame then attends to `att_context_size = [left, right]` neighbours, the positional table covers the
+window rather than the sequence, and compute and memory become linear in the input length - hour-long audio
+fits. The two patterns share the same weights, so this is an inference-time switch with nothing to re-load:
+
+```python
+import torch
+from transformers import AutoProcessor, ParakeetForCTC
+
+model_id = "nvidia/parakeet-ctc-0.6b"
+processor = AutoProcessor.from_pretrained(model_id)
+model = ParakeetForCTC.from_pretrained(model_id, dtype=torch.float32).eval()
+
+model.change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[256, 256])
+
+inputs = processor(long_audio_array, sampling_rate=16000, return_tensors="pt")
+predicted_ids = model.generate(**inputs)
+print(processor.batch_decode(predicted_ids, skip_special_tokens=True))
+```
+
+The same switch can be made up front through the config, which is what you want when the checkpoint is always
+used this way:
+
+```python
+model = ParakeetForCTC.from_pretrained(
+    model_id,
+    encoder_config={"attention_type": "rel_pos_local_attn", "attention_context_size": [256, 256]},
+)
+```
+
+Call `model.change_attention_model(self_attention_model="rel_pos")` to go back.
+
+A window wide enough to span the whole input reproduces the full-attention result exactly, so `att_context_size`
+is a quality/length trade-off rather than a different model: the checkpoints were trained with full attention,
+and a narrow window will move the transcription. `[256, 256]` is NeMo's documented setting for these models.
+`config.local_attention_chunk_size` controls how many query frames are processed per iteration; it trades peak
+memory against iteration count and does not change the output.
+
 ### Making The Model Go Brrr
 
 Parakeet supports full-graph compilation with graph capture (CUDA graphs on NVIDIA GPUs, and the equivalent mechanism on other accelerators)! This optimization is most effective when you know the maximum audio length you want to transcribe. The key idea is using static input shapes to avoid recompilation. For example, if you know your audio will be under 30 seconds, you can use the processor to pad all inputs to 30 seconds, preparing consistent input features and attention masks. See the example below!

--- a/src/transformers/models/granite_speech5/modular_granite_speech5.py
+++ b/src/transformers/models/granite_speech5/modular_granite_speech5.py
@@ -340,6 +340,9 @@ class GraniteSpeech5Encoder(ParakeetEncoder):
     config: GraniteSpeech5EncoderConfig
     base_model_prefix = "encoder"
 
+    def change_attention_model(self, *args, **kwargs):
+        raise AttributeError("Not applicable to GraniteSpeech5: it does not use Parakeet's sliding-window attention.")
+
     def __init__(self, config: GraniteSpeech5EncoderConfig):
         GraniteSpeech5PreTrainedModel.__init__(self, config)
         self.gradient_checkpointing = False
@@ -444,6 +447,9 @@ class GraniteSpeech5ForCTC(ParakeetForCTC):
         "ctc_head.weight": "encoder.out.weight",
         "ctc_head.bias": "encoder.out.bias",
     }
+
+    def change_attention_model(self, *args, **kwargs):
+        raise AttributeError("Not applicable to GraniteSpeech5: it does not use Parakeet's sliding-window attention.")
 
     def __init__(self, config: GraniteSpeech5CTCConfig):
         super().__init__(config)

--- a/src/transformers/models/lasr/modular_lasr.py
+++ b/src/transformers/models/lasr/modular_lasr.py
@@ -22,6 +22,7 @@ from tokenizers.models import Unigram
 from torch import nn
 
 from ...audio_utils import AudioInput
+from ...configuration_utils import PreTrainedConfig
 from ...masking_utils import create_bidirectional_mask
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
@@ -271,6 +272,14 @@ class LasrEncoderConfig(ParakeetEncoderConfig):
 
     subsampling_factor = AttributeError()
     scale_input = AttributeError()
+
+    attention_type = AttributeError()
+    attention_context_size = AttributeError()
+    local_attention_chunk_size = AttributeError()
+
+    def __post_init__(self, **kwargs):
+        self.num_key_value_heads = self.num_attention_heads
+        PreTrainedConfig.__post_init__(self, **kwargs)
 
 
 @auto_docstring(checkpoint="google/medasr")
@@ -587,6 +596,9 @@ class LasrForCTC(ParakeetForCTC):
         ```
         """
         return super().generate(**super_kwargs)
+
+    def change_attention_model(self, *args, **kwargs):
+        raise AttributeError("Not applicable to Lasr: it does not use Parakeet's sliding-window attention.")
 
 
 __all__ = [

--- a/src/transformers/models/nemotron_asr_streaming/modular_nemotron_asr_streaming.py
+++ b/src/transformers/models/nemotron_asr_streaming/modular_nemotron_asr_streaming.py
@@ -22,6 +22,7 @@ from huggingface_hub.dataclasses import strict
 from torch import nn
 
 from ...cache_utils import Cache, DynamicCache
+from ...configuration_utils import PreTrainedConfig
 from ...feature_extraction_utils import BatchFeature
 from ...masking_utils import create_bidirectional_mask
 from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
@@ -114,6 +115,14 @@ class NemotronAsrStreamingEncoderConfig(ParakeetEncoderConfig):
 
     sliding_window: int = 71
     default_num_lookahead_tokens: int = 13
+
+    attention_type = AttributeError()
+    attention_context_size = AttributeError()
+    local_attention_chunk_size = AttributeError()
+
+    def __post_init__(self, **kwargs):
+        self.num_key_value_heads = self.num_attention_heads
+        PreTrainedConfig.__post_init__(self, **kwargs)
 
     @property
     def subsampling_out_hidden_size(self) -> int:
@@ -574,6 +583,9 @@ class NemotronAsrStreamingEncoderAttention(ParakeetEncoderAttention):
     See `ParakeetEncoderAttention`, and https://huggingface.co/papers/2312.17279 for more details
     """
 
+    def _local_attention_forward(self, *args, **kwargs):
+        raise AttributeError("Not applicable to NemotronAsrStreaming: it uses a chunked-limited mask.")
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -944,6 +956,9 @@ class NemotronAsrStreamingEncoder(ParakeetEncoder):
         left_context = self.config.sliding_window - 1
         return left_context, num_lookahead_tokens
 
+    def change_attention_model(self, *args, **kwargs):
+        raise AttributeError("Not applicable to NemotronAsrStreaming: it uses a chunked-limited attention mask.")
+
 
 @dataclass
 class NemotronAsrStreamingRNNTOutput(ParakeetRNNTOutput):
@@ -979,6 +994,11 @@ class NemotronAsrStreamingForRNNT(
     ParakeetForRNNT, NemotronAsrStreamingPreTrainedModel, NemotronAsrStreamingGenerationMixin
 ):
     config: NemotronAsrStreamingConfig
+
+    def change_attention_model(self, *args, **kwargs):
+        raise AttributeError(
+            "Not applicable to NemotronAsrStreaming: it does not use Parakeet's sliding-window attention."
+        )
 
     def __init__(self, config: NemotronAsrStreamingConfig):
         super().__init__(config)

--- a/src/transformers/models/parakeet/configuration_parakeet.py
+++ b/src/transformers/models/parakeet/configuration_parakeet.py
@@ -40,6 +40,18 @@ class ParakeetEncoderConfig(PreTrainedConfig):
         The dropout ratio for the positions in the input sequence.
     scale_input (`bool`, *optional*, defaults to `True`):
         Whether to scale the input embeddings.
+    attention_type (`str`, *optional*, defaults to `"rel_pos"`):
+        The self-attention pattern to use. `"rel_pos"` attends over the whole sequence, which caps the input at
+        `max_position_embeddings` subsampled frames. `"rel_pos_local_attn"` restricts every frame to the sliding
+        window given by `attention_context_size`, which makes both compute and memory linear in the input length
+        and lifts that cap. The two share the same weights, so a checkpoint trained with `"rel_pos"` can be run
+        with either — see [`~ParakeetEncoder.change_attention_model`].
+    attention_context_size (`list[int]`, *optional*):
+        Number of frames each frame attends to, as `[left, right]`. Required when `attention_type` is
+        `"rel_pos_local_attn"` and ignored otherwise.
+    local_attention_chunk_size (`int`, *optional*, defaults to 1024):
+        Number of query frames processed per iteration when `attention_type` is `"rel_pos_local_attn"`. Trades
+        peak memory against the number of iterations; it does not change the output.
 
     Example:
     ```python
@@ -80,9 +92,25 @@ class ParakeetEncoderConfig(PreTrainedConfig):
     max_position_embeddings: int = 5000
     scale_input: bool = True
     initializer_range: float = 0.02
+    attention_type: str = "rel_pos"
+    attention_context_size: list[int] | None = None
+    local_attention_chunk_size: int = 1024
 
     def __post_init__(self, **kwargs):
         self.num_key_value_heads = self.num_attention_heads
+        if self.attention_type not in ("rel_pos", "rel_pos_local_attn"):
+            raise ValueError(
+                f"`attention_type` must be one of 'rel_pos' or 'rel_pos_local_attn', got '{self.attention_type}'."
+            )
+        if self.attention_type == "rel_pos_local_attn":
+            if self.attention_context_size is None:
+                raise ValueError("`attention_context_size` is required when `attention_type='rel_pos_local_attn'`.")
+            self.attention_context_size = list(self.attention_context_size)
+            if len(self.attention_context_size) != 2 or min(self.attention_context_size) < 0:
+                raise ValueError(
+                    "`attention_context_size` must be `[left, right]` with both values >= 0, got "
+                    f"{self.attention_context_size}."
+                )
         super().__post_init__(**kwargs)
 
 

--- a/src/transformers/models/parakeet/modeling_parakeet.py
+++ b/src/transformers/models/parakeet/modeling_parakeet.py
@@ -82,9 +82,11 @@ class ParakeetEncoderRelPositionalEncoding(nn.Module):
         return inv_freq.to(device)
 
     @torch.no_grad()
-    def forward(self, hidden_states: torch.Tensor):
-        seq_length = hidden_states.shape[1]
-        position_ids = torch.arange(seq_length - 1, -seq_length, -1, device=hidden_states.device)
+    def forward(self, hidden_states: torch.Tensor, position_ids: torch.Tensor | None = None):
+        if position_ids is None:
+            # Every relative distance the sequence can span, from `seq_length - 1` down to `-(seq_length - 1)`.
+            seq_length = hidden_states.shape[1]
+            position_ids = torch.arange(seq_length - 1, -seq_length, -1, device=hidden_states.device)
         inv_freq_expanded = (
             self.inv_freq[None, :, None].float().expand(hidden_states.shape[0], -1, 1).to(hidden_states.device)
         )
@@ -325,33 +327,119 @@ class ParakeetEncoderAttention(nn.Module):
         relative_key_states = self.relative_k_proj(position_embeddings)
         relative_key_states = relative_key_states.view(batch_size, -1, self.config.num_attention_heads, self.head_dim)
 
-        # terms (b) and (d)
-        matrix_bd = query_states_with_bias_v @ relative_key_states.permute(0, 2, 3, 1)
-        matrix_bd = self._rel_shift(matrix_bd)
-        matrix_bd = matrix_bd[..., :seq_length]
-        matrix_bd = matrix_bd * self.scaling
+        if self.config.attention_type == "rel_pos_local_attn":
+            # `attention_mask` is the padding mask here, not a full `(batch, 1, query, key)` mask - see
+            # `ParakeetEncoder.forward`. Attention weights are not materialised for the whole sequence, so none
+            # are returned.
+            attn_output = self._local_attention_forward(
+                attention_interface=attention_interface,
+                query_states_with_bias_u=query_states_with_bias_u,
+                query_states_with_bias_v=query_states_with_bias_v,
+                key_states=key_states,
+                value_states=value_states,
+                relative_key_states=relative_key_states,
+                attention_mask=attention_mask,
+                **kwargs,
+            )
+            attn_weights = None
+        else:
+            # terms (b) and (d)
+            matrix_bd = query_states_with_bias_v @ relative_key_states.permute(0, 2, 3, 1)
+            matrix_bd = self._rel_shift(matrix_bd)
+            matrix_bd = matrix_bd[..., :seq_length]
+            matrix_bd = matrix_bd * self.scaling
 
-        if attention_mask is not None:
-            # here the original codebase uses -10000.0 rather than float("-inf") and then manual masked fill with 0.0s
-            # see: https://github.com/NVIDIA-NeMo/NeMo/blob/8cfedd7203462cb251a914e700e5605444277561/nemo/collections/asr/parts/submodules/multi_head_attention.py#L320-L340
-            # we rather went for a straight-forward approach with float("-inf")
-            matrix_bd = matrix_bd.masked_fill_(attention_mask.logical_not(), float("-inf"))
+            if attention_mask is not None:
+                # here the original codebase uses -10000.0 rather than float("-inf") and then manual masked fill with 0.0s
+                # see: https://github.com/NVIDIA-NeMo/NeMo/blob/8cfedd7203462cb251a914e700e5605444277561/nemo/collections/asr/parts/submodules/multi_head_attention.py#L320-L340
+                # we rather went for a straight-forward approach with float("-inf")
+                matrix_bd = matrix_bd.masked_fill_(attention_mask.logical_not(), float("-inf"))
 
-        # will compute matrix_ac - terms (a) and (c) - and add matrix_bd
-        attn_output, attn_weights = attention_interface(
-            self,
-            query=query_states_with_bias_u,
-            key=key_states,
-            value=value_states,
-            attention_mask=matrix_bd,
-            dropout=0.0 if not self.training else self.attention_dropout,
-            scaling=self.scaling,
-            **kwargs,
-        )
+            # will compute matrix_ac - terms (a) and (c) - and add matrix_bd
+            attn_output, attn_weights = attention_interface(
+                self,
+                query=query_states_with_bias_u,
+                key=key_states,
+                value=value_states,
+                attention_mask=matrix_bd,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                scaling=self.scaling,
+                **kwargs,
+            )
 
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights
+
+    def _local_attention_forward(
+        self,
+        attention_interface: Callable,
+        query_states_with_bias_u: torch.Tensor,
+        query_states_with_bias_v: torch.Tensor,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        relative_key_states: torch.Tensor,
+        attention_mask: torch.Tensor | None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        """Sliding-window attention over `config.attention_context_size`, walked one chunk of queries at a time.
+
+        The full-sequence path builds terms (b) and (d) as a `(batch, heads, seq, 2 * seq - 1)` tensor, which is
+        what makes long inputs impossible rather than merely slow. Here the positional term is instead a
+        `(batch, heads, chunk, left + right + 1)` tensor gathered into place, so peak memory follows the window
+        rather than the sequence. Queries outside a chunk's window are dropped by the mask, which makes this
+        arithmetically the same attention as the full-sequence path restricted to the window - the relative
+        position of a key is what indexes `relative_key_states` either way.
+        """
+        left_context, right_context = self.config.attention_context_size
+        chunk_size = self.config.local_attention_chunk_size
+        seq_length = query_states_with_bias_u.shape[2]
+        device = query_states_with_bias_u.device
+
+        # (batch, heads, left + right + 1, head_dim); entry `m` holds relative position `left_context - m`
+        relative_key_states = relative_key_states.transpose(1, 2)
+
+        padding_mask = attention_mask[:, 0, 0, :] if attention_mask is not None else None
+
+        attn_output = []
+        for chunk_start in range(0, seq_length, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, seq_length)
+            window_start = max(0, chunk_start - left_context)
+            window_end = min(seq_length, chunk_end + right_context)
+
+            query_positions = torch.arange(chunk_start, chunk_end, device=device)
+            key_positions = torch.arange(window_start, window_end, device=device)
+            relative_positions = query_positions[:, None] - key_positions[None, :]
+            in_window = (relative_positions <= left_context) & (relative_positions >= -right_context)
+            gather_index = (left_context - relative_positions).clamp_(0, left_context + right_context)
+            gather_index = gather_index[None, None].expand(*query_states_with_bias_v.shape[:2], -1, -1)
+
+            # terms (b) and (d), gathered from the window-sized table onto the (query, key) grid
+            matrix_bd = query_states_with_bias_v[:, :, chunk_start:chunk_end] @ relative_key_states.transpose(-2, -1)
+            matrix_bd = matrix_bd.gather(-1, gather_index)
+            matrix_bd = matrix_bd * self.scaling
+
+            chunk_mask = in_window[None, None]
+            if padding_mask is not None:
+                # Masking keys alone matches NeMo: rows of padding queries stay finite (and are discarded
+                # downstream) rather than turning into an all-masked softmax.
+                chunk_mask = chunk_mask & padding_mask[:, None, None, window_start:window_end]
+            matrix_bd = matrix_bd.masked_fill_(chunk_mask.logical_not(), float("-inf"))
+
+            chunk_output, _ = attention_interface(
+                self,
+                query=query_states_with_bias_u[:, :, chunk_start:chunk_end],
+                key=key_states[:, :, window_start:window_end],
+                value=value_states[:, :, window_start:window_end],
+                attention_mask=matrix_bd,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                scaling=self.scaling,
+                **kwargs,
+            )
+            attn_output.append(chunk_output)
+
+        # each chunk output is (batch, chunk, heads, head_dim)
+        return torch.cat(attn_output, dim=1)
 
     def _rel_shift(self, attention_scores):
         """Relative position shift for Shaw et al. style attention. See appendix B of https://huggingface.co/papers/1901.02860."""
@@ -605,7 +693,20 @@ class ParakeetEncoder(ParakeetPreTrainedModel):
 
         hidden_states = self.subsampling(input_features, attention_mask)
         hidden_states = hidden_states * self.input_scale
-        position_embeddings = self.encode_positions(hidden_states)
+
+        is_local_attention = self.config.attention_type == "rel_pos_local_attn"
+        position_ids = None
+        if is_local_attention:
+            # One table covering just the window, so it no longer grows with the input.
+            left_context, right_context = self.config.attention_context_size
+            position_ids = torch.arange(left_context, -right_context - 1, -1, device=hidden_states.device)
+            if kwargs.get("output_attentions"):
+                logger.warning_once(
+                    "`output_attentions=True` returns no attention weights under "
+                    '`attention_type="rel_pos_local_attn"`: the weights are never materialised over the full '
+                    "sequence, which is what keeps memory linear in the input length."
+                )
+        position_embeddings = self.encode_positions(hidden_states, position_ids)
 
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
         position_embeddings = nn.functional.dropout(
@@ -615,9 +716,14 @@ class ParakeetEncoder(ParakeetPreTrainedModel):
         output_mask = None
         if attention_mask is not None:
             output_mask = self._get_output_attention_mask(attention_mask, target_length=hidden_states.shape[1])
-            attention_mask = output_mask.unsqueeze(1).expand(-1, hidden_states.shape[1], -1)
-            attention_mask = attention_mask & attention_mask.transpose(1, 2)
-            attention_mask = attention_mask.unsqueeze(1)
+            if is_local_attention:
+                # A `(batch, 1, seq, seq)` mask is itself quadratic, so local attention gets the padding mask and
+                # applies the window itself. The convolution module reads it the same way either shape.
+                attention_mask = output_mask[:, None, None, :]
+            else:
+                attention_mask = output_mask.unsqueeze(1).expand(-1, hidden_states.shape[1], -1)
+                attention_mask = attention_mask & attention_mask.transpose(1, 2)
+                attention_mask = attention_mask.unsqueeze(1)
 
         for encoder_layer in self.layers:
             # add LayerDrop (see https://huggingface.co/papers/1909.11556 for description)
@@ -639,6 +745,56 @@ class ParakeetEncoder(ParakeetPreTrainedModel):
             last_hidden_state=hidden_states,
             attention_mask=output_mask.int() if attention_mask is not None and output_attention_mask else None,
         )
+
+    def change_attention_model(
+        self,
+        self_attention_model: str | None = None,
+        att_context_size: list[int] | None = None,
+    ):
+        """Switch between full-sequence and sliding-window self-attention, mirroring NeMo's method of the same name.
+
+        Both patterns read the same weights, so this only rewrites `config.attention_type` and
+        `config.attention_context_size` - there is nothing to re-load or re-train. Switching to
+        `"rel_pos_local_attn"` is what allows inputs longer than `config.max_position_embeddings` subsampled
+        frames, since the positional table then covers the window instead of the whole sequence.
+
+        Args:
+            self_attention_model (`str`, *optional*):
+                `"rel_pos"` for full-sequence attention or `"rel_pos_local_attn"` for sliding-window attention.
+                Left unchanged when `None`.
+            att_context_size (`list[int]`, *optional*):
+                Frames attended to on either side, as `[left, right]`. Left unchanged when `None`.
+
+        Example:
+
+        ```python
+        >>> from transformers import ParakeetForCTC
+
+        >>> model = ParakeetForCTC.from_pretrained("nvidia/parakeet-ctc-0.6b")
+        >>> model.change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[256, 256])
+        ```
+        """
+        if self_attention_model is None:
+            self_attention_model = self.config.attention_type
+        if att_context_size is None:
+            att_context_size = self.config.attention_context_size
+
+        if self_attention_model not in ("rel_pos", "rel_pos_local_attn"):
+            raise ValueError(
+                "`self_attention_model` must be one of 'rel_pos' or 'rel_pos_local_attn', got "
+                f"'{self_attention_model}'."
+            )
+        if self_attention_model == "rel_pos_local_attn":
+            if att_context_size is None:
+                raise ValueError("`att_context_size` is required when switching to 'rel_pos_local_attn'.")
+            att_context_size = list(att_context_size)
+            if len(att_context_size) != 2 or min(att_context_size) < 0:
+                raise ValueError(
+                    f"`att_context_size` must be `[left, right]` with both values >= 0, got {att_context_size}."
+                )
+
+        self.config.attention_type = self_attention_model
+        self.config.attention_context_size = att_context_size
 
 
 @dataclass
@@ -701,6 +857,19 @@ class ParakeetForCTC(ParakeetPreTrainedModel, GenerationMixin):
         self.ctc_head = ParakeetEncoderCTCHead(config.encoder_config.hidden_size, config.vocab_size, kernel_size=1)
 
         self.post_init()
+
+    def change_attention_model(
+        self,
+        self_attention_model: str | None = None,
+        att_context_size: list[int] | None = None,
+    ):
+        """Switch the encoder between full-sequence and sliding-window self-attention.
+
+        See [`~ParakeetEncoder.change_attention_model`].
+        """
+        self.encoder.change_attention_model(
+            self_attention_model=self_attention_model, att_context_size=att_context_size
+        )
 
     @auto_docstring
     @can_return_tuple
@@ -938,6 +1107,19 @@ class ParakeetForRNNT(ParakeetPreTrainedModel, ParakeetRNNTGenerationMixin):
         self.max_symbols_per_step = config.max_symbols_per_step  # used in generation
 
         self.post_init()
+
+    def change_attention_model(
+        self,
+        self_attention_model: str | None = None,
+        att_context_size: list[int] | None = None,
+    ):
+        """Switch the encoder between full-sequence and sliding-window self-attention.
+
+        See [`~ParakeetEncoder.change_attention_model`].
+        """
+        self.encoder.change_attention_model(
+            self_attention_model=self_attention_model, att_context_size=att_context_size
+        )
 
     @can_return_tuple
     def get_audio_features(

--- a/src/transformers/models/parakeet/modular_parakeet.py
+++ b/src/transformers/models/parakeet/modular_parakeet.py
@@ -88,9 +88,11 @@ class ParakeetEncoderRelPositionalEncoding(nn.Module):
         return inv_freq.to(device)
 
     @torch.no_grad()
-    def forward(self, hidden_states: torch.Tensor):
-        seq_length = hidden_states.shape[1]
-        position_ids = torch.arange(seq_length - 1, -seq_length, -1, device=hidden_states.device)
+    def forward(self, hidden_states: torch.Tensor, position_ids: torch.Tensor | None = None):
+        if position_ids is None:
+            # Every relative distance the sequence can span, from `seq_length - 1` down to `-(seq_length - 1)`.
+            seq_length = hidden_states.shape[1]
+            position_ids = torch.arange(seq_length - 1, -seq_length, -1, device=hidden_states.device)
         inv_freq_expanded = (
             self.inv_freq[None, :, None].float().expand(hidden_states.shape[0], -1, 1).to(hidden_states.device)
         )
@@ -174,33 +176,119 @@ class ParakeetEncoderAttention(LlamaAttention):
         relative_key_states = self.relative_k_proj(position_embeddings)
         relative_key_states = relative_key_states.view(batch_size, -1, self.config.num_attention_heads, self.head_dim)
 
-        # terms (b) and (d)
-        matrix_bd = query_states_with_bias_v @ relative_key_states.permute(0, 2, 3, 1)
-        matrix_bd = self._rel_shift(matrix_bd)
-        matrix_bd = matrix_bd[..., :seq_length]
-        matrix_bd = matrix_bd * self.scaling
+        if self.config.attention_type == "rel_pos_local_attn":
+            # `attention_mask` is the padding mask here, not a full `(batch, 1, query, key)` mask - see
+            # `ParakeetEncoder.forward`. Attention weights are not materialised for the whole sequence, so none
+            # are returned.
+            attn_output = self._local_attention_forward(
+                attention_interface=attention_interface,
+                query_states_with_bias_u=query_states_with_bias_u,
+                query_states_with_bias_v=query_states_with_bias_v,
+                key_states=key_states,
+                value_states=value_states,
+                relative_key_states=relative_key_states,
+                attention_mask=attention_mask,
+                **kwargs,
+            )
+            attn_weights = None
+        else:
+            # terms (b) and (d)
+            matrix_bd = query_states_with_bias_v @ relative_key_states.permute(0, 2, 3, 1)
+            matrix_bd = self._rel_shift(matrix_bd)
+            matrix_bd = matrix_bd[..., :seq_length]
+            matrix_bd = matrix_bd * self.scaling
 
-        if attention_mask is not None:
-            # here the original codebase uses -10000.0 rather than float("-inf") and then manual masked fill with 0.0s
-            # see: https://github.com/NVIDIA-NeMo/NeMo/blob/8cfedd7203462cb251a914e700e5605444277561/nemo/collections/asr/parts/submodules/multi_head_attention.py#L320-L340
-            # we rather went for a straight-forward approach with float("-inf")
-            matrix_bd = matrix_bd.masked_fill_(attention_mask.logical_not(), float("-inf"))
+            if attention_mask is not None:
+                # here the original codebase uses -10000.0 rather than float("-inf") and then manual masked fill with 0.0s
+                # see: https://github.com/NVIDIA-NeMo/NeMo/blob/8cfedd7203462cb251a914e700e5605444277561/nemo/collections/asr/parts/submodules/multi_head_attention.py#L320-L340
+                # we rather went for a straight-forward approach with float("-inf")
+                matrix_bd = matrix_bd.masked_fill_(attention_mask.logical_not(), float("-inf"))
 
-        # will compute matrix_ac - terms (a) and (c) - and add matrix_bd
-        attn_output, attn_weights = attention_interface(
-            self,
-            query=query_states_with_bias_u,
-            key=key_states,
-            value=value_states,
-            attention_mask=matrix_bd,
-            dropout=0.0 if not self.training else self.attention_dropout,
-            scaling=self.scaling,
-            **kwargs,
-        )
+            # will compute matrix_ac - terms (a) and (c) - and add matrix_bd
+            attn_output, attn_weights = attention_interface(
+                self,
+                query=query_states_with_bias_u,
+                key=key_states,
+                value=value_states,
+                attention_mask=matrix_bd,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                scaling=self.scaling,
+                **kwargs,
+            )
 
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights
+
+    def _local_attention_forward(
+        self,
+        attention_interface: Callable,
+        query_states_with_bias_u: torch.Tensor,
+        query_states_with_bias_v: torch.Tensor,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        relative_key_states: torch.Tensor,
+        attention_mask: torch.Tensor | None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        """Sliding-window attention over `config.attention_context_size`, walked one chunk of queries at a time.
+
+        The full-sequence path builds terms (b) and (d) as a `(batch, heads, seq, 2 * seq - 1)` tensor, which is
+        what makes long inputs impossible rather than merely slow. Here the positional term is instead a
+        `(batch, heads, chunk, left + right + 1)` tensor gathered into place, so peak memory follows the window
+        rather than the sequence. Queries outside a chunk's window are dropped by the mask, which makes this
+        arithmetically the same attention as the full-sequence path restricted to the window - the relative
+        position of a key is what indexes `relative_key_states` either way.
+        """
+        left_context, right_context = self.config.attention_context_size
+        chunk_size = self.config.local_attention_chunk_size
+        seq_length = query_states_with_bias_u.shape[2]
+        device = query_states_with_bias_u.device
+
+        # (batch, heads, left + right + 1, head_dim); entry `m` holds relative position `left_context - m`
+        relative_key_states = relative_key_states.transpose(1, 2)
+
+        padding_mask = attention_mask[:, 0, 0, :] if attention_mask is not None else None
+
+        attn_output = []
+        for chunk_start in range(0, seq_length, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, seq_length)
+            window_start = max(0, chunk_start - left_context)
+            window_end = min(seq_length, chunk_end + right_context)
+
+            query_positions = torch.arange(chunk_start, chunk_end, device=device)
+            key_positions = torch.arange(window_start, window_end, device=device)
+            relative_positions = query_positions[:, None] - key_positions[None, :]
+            in_window = (relative_positions <= left_context) & (relative_positions >= -right_context)
+            gather_index = (left_context - relative_positions).clamp_(0, left_context + right_context)
+            gather_index = gather_index[None, None].expand(*query_states_with_bias_v.shape[:2], -1, -1)
+
+            # terms (b) and (d), gathered from the window-sized table onto the (query, key) grid
+            matrix_bd = query_states_with_bias_v[:, :, chunk_start:chunk_end] @ relative_key_states.transpose(-2, -1)
+            matrix_bd = matrix_bd.gather(-1, gather_index)
+            matrix_bd = matrix_bd * self.scaling
+
+            chunk_mask = in_window[None, None]
+            if padding_mask is not None:
+                # Masking keys alone matches NeMo: rows of padding queries stay finite (and are discarded
+                # downstream) rather than turning into an all-masked softmax.
+                chunk_mask = chunk_mask & padding_mask[:, None, None, window_start:window_end]
+            matrix_bd = matrix_bd.masked_fill_(chunk_mask.logical_not(), float("-inf"))
+
+            chunk_output, _ = attention_interface(
+                self,
+                query=query_states_with_bias_u[:, :, chunk_start:chunk_end],
+                key=key_states[:, :, window_start:window_end],
+                value=value_states[:, :, window_start:window_end],
+                attention_mask=matrix_bd,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                scaling=self.scaling,
+                **kwargs,
+            )
+            attn_output.append(chunk_output)
+
+        # each chunk output is (batch, chunk, heads, head_dim)
+        return torch.cat(attn_output, dim=1)
 
     def _rel_shift(self, attention_scores):
         """Relative position shift for Shaw et al. style attention. See appendix B of https://huggingface.co/papers/1901.02860."""
@@ -454,7 +542,20 @@ class ParakeetEncoder(ParakeetPreTrainedModel):
 
         hidden_states = self.subsampling(input_features, attention_mask)
         hidden_states = hidden_states * self.input_scale
-        position_embeddings = self.encode_positions(hidden_states)
+
+        is_local_attention = self.config.attention_type == "rel_pos_local_attn"
+        position_ids = None
+        if is_local_attention:
+            # One table covering just the window, so it no longer grows with the input.
+            left_context, right_context = self.config.attention_context_size
+            position_ids = torch.arange(left_context, -right_context - 1, -1, device=hidden_states.device)
+            if kwargs.get("output_attentions"):
+                logger.warning_once(
+                    "`output_attentions=True` returns no attention weights under "
+                    '`attention_type="rel_pos_local_attn"`: the weights are never materialised over the full '
+                    "sequence, which is what keeps memory linear in the input length."
+                )
+        position_embeddings = self.encode_positions(hidden_states, position_ids)
 
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
         position_embeddings = nn.functional.dropout(
@@ -464,9 +565,14 @@ class ParakeetEncoder(ParakeetPreTrainedModel):
         output_mask = None
         if attention_mask is not None:
             output_mask = self._get_output_attention_mask(attention_mask, target_length=hidden_states.shape[1])
-            attention_mask = output_mask.unsqueeze(1).expand(-1, hidden_states.shape[1], -1)
-            attention_mask = attention_mask & attention_mask.transpose(1, 2)
-            attention_mask = attention_mask.unsqueeze(1)
+            if is_local_attention:
+                # A `(batch, 1, seq, seq)` mask is itself quadratic, so local attention gets the padding mask and
+                # applies the window itself. The convolution module reads it the same way either shape.
+                attention_mask = output_mask[:, None, None, :]
+            else:
+                attention_mask = output_mask.unsqueeze(1).expand(-1, hidden_states.shape[1], -1)
+                attention_mask = attention_mask & attention_mask.transpose(1, 2)
+                attention_mask = attention_mask.unsqueeze(1)
 
         for encoder_layer in self.layers:
             # add LayerDrop (see https://huggingface.co/papers/1909.11556 for description)
@@ -488,6 +594,56 @@ class ParakeetEncoder(ParakeetPreTrainedModel):
             last_hidden_state=hidden_states,
             attention_mask=output_mask.int() if attention_mask is not None and output_attention_mask else None,
         )
+
+    def change_attention_model(
+        self,
+        self_attention_model: str | None = None,
+        att_context_size: list[int] | None = None,
+    ):
+        """Switch between full-sequence and sliding-window self-attention, mirroring NeMo's method of the same name.
+
+        Both patterns read the same weights, so this only rewrites `config.attention_type` and
+        `config.attention_context_size` - there is nothing to re-load or re-train. Switching to
+        `"rel_pos_local_attn"` is what allows inputs longer than `config.max_position_embeddings` subsampled
+        frames, since the positional table then covers the window instead of the whole sequence.
+
+        Args:
+            self_attention_model (`str`, *optional*):
+                `"rel_pos"` for full-sequence attention or `"rel_pos_local_attn"` for sliding-window attention.
+                Left unchanged when `None`.
+            att_context_size (`list[int]`, *optional*):
+                Frames attended to on either side, as `[left, right]`. Left unchanged when `None`.
+
+        Example:
+
+        ```python
+        >>> from transformers import ParakeetForCTC
+
+        >>> model = ParakeetForCTC.from_pretrained("nvidia/parakeet-ctc-0.6b")
+        >>> model.change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[256, 256])
+        ```
+        """
+        if self_attention_model is None:
+            self_attention_model = self.config.attention_type
+        if att_context_size is None:
+            att_context_size = self.config.attention_context_size
+
+        if self_attention_model not in ("rel_pos", "rel_pos_local_attn"):
+            raise ValueError(
+                "`self_attention_model` must be one of 'rel_pos' or 'rel_pos_local_attn', got "
+                f"'{self_attention_model}'."
+            )
+        if self_attention_model == "rel_pos_local_attn":
+            if att_context_size is None:
+                raise ValueError("`att_context_size` is required when switching to 'rel_pos_local_attn'.")
+            att_context_size = list(att_context_size)
+            if len(att_context_size) != 2 or min(att_context_size) < 0:
+                raise ValueError(
+                    f"`att_context_size` must be `[left, right]` with both values >= 0, got {att_context_size}."
+                )
+
+        self.config.attention_type = self_attention_model
+        self.config.attention_context_size = att_context_size
 
 
 @dataclass
@@ -550,6 +706,19 @@ class ParakeetForCTC(ParakeetPreTrainedModel, GenerationMixin):
         self.ctc_head = ParakeetEncoderCTCHead(config.encoder_config.hidden_size, config.vocab_size, kernel_size=1)
 
         self.post_init()
+
+    def change_attention_model(
+        self,
+        self_attention_model: str | None = None,
+        att_context_size: list[int] | None = None,
+    ):
+        """Switch the encoder between full-sequence and sliding-window self-attention.
+
+        See [`~ParakeetEncoder.change_attention_model`].
+        """
+        self.encoder.change_attention_model(
+            self_attention_model=self_attention_model, att_context_size=att_context_size
+        )
 
     @auto_docstring
     @can_return_tuple
@@ -787,6 +956,19 @@ class ParakeetForRNNT(ParakeetPreTrainedModel, ParakeetRNNTGenerationMixin):
         self.max_symbols_per_step = config.max_symbols_per_step  # used in generation
 
         self.post_init()
+
+    def change_attention_model(
+        self,
+        self_attention_model: str | None = None,
+        att_context_size: list[int] | None = None,
+    ):
+        """Switch the encoder between full-sequence and sliding-window self-attention.
+
+        See [`~ParakeetEncoder.change_attention_model`].
+        """
+        self.encoder.change_attention_model(
+            self_attention_model=self_attention_model, att_context_size=att_context_size
+        )
 
     @can_return_tuple
     def get_audio_features(

--- a/tests/models/parakeet/test_modeling_parakeet.py
+++ b/tests/models/parakeet/test_modeling_parakeet.py
@@ -355,6 +355,134 @@ class ParakeetEncoderModelTest(ModelTesterMixin, unittest.TestCase):
         pass
 
 
+@require_torch
+class ParakeetLocalAttentionTest(unittest.TestCase):
+    """Sliding-window attention (`attention_type="rel_pos_local_attn"`)."""
+
+    def _encoder(self, seq_length=512, batch_size=2, **config_kwargs):
+        torch.manual_seed(0)
+        config = ParakeetEncoderConfig(
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            intermediate_size=64,
+            subsampling_conv_channels=16,
+            dropout=0.0,
+            dropout_positions=0.0,
+            layerdrop=0.0,
+            activation_dropout=0.0,
+            attention_dropout=0.0,
+            **config_kwargs,
+        )
+        model = ParakeetEncoder(config).to(torch_device).eval()
+        input_features = floats_tensor([batch_size, seq_length, config.num_mel_bins])
+        attention_mask = random_attention_mask([batch_size, seq_length])
+        return model, input_features, attention_mask
+
+    def _run(self, model, input_features, attention_mask):
+        with torch.no_grad():
+            out = model(input_features, attention_mask=attention_mask)
+        return out.last_hidden_state, out.attention_mask.bool()
+
+    def test_wide_window_matches_full_attention(self):
+        """A window at least as wide as the sequence attends to everything, so it must match `rel_pos`."""
+        model, input_features, attention_mask = self._encoder()
+        full, valid = self._run(model, input_features, attention_mask)
+
+        num_frames = full.shape[1]
+        model.change_attention_model(
+            self_attention_model="rel_pos_local_attn", att_context_size=[num_frames, num_frames]
+        )
+        local, _ = self._run(model, input_features, attention_mask)
+
+        # Padding frames are excluded on the key side only under local attention, so they are allowed to differ;
+        # they are masked out of every downstream consumer.
+        torch.testing.assert_close(full[valid], local[valid], rtol=1e-4, atol=1e-4)
+
+    def test_chunk_size_does_not_change_output(self):
+        model, input_features, attention_mask = self._encoder()
+        model.change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[16, 16])
+
+        model.config.local_attention_chunk_size = 1024
+        reference, _ = self._run(model, input_features, attention_mask)
+        for chunk_size in (7, 16, 33):
+            model.config.local_attention_chunk_size = chunk_size
+            chunked, _ = self._run(model, input_features, attention_mask)
+            torch.testing.assert_close(reference, chunked, rtol=1e-5, atol=1e-5, msg=f"chunk_size={chunk_size}")
+
+    def test_narrow_window_restricts_attention(self):
+        """Guards against the window silently being a no-op."""
+        model, input_features, attention_mask = self._encoder()
+        full, valid = self._run(model, input_features, attention_mask)
+
+        model.change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[2, 2])
+        local, _ = self._run(model, input_features, attention_mask)
+        self.assertGreater((full[valid] - local[valid]).abs().max().item(), 1e-3)
+
+    def test_sequence_longer_than_max_position_embeddings(self):
+        """The point of the window: the positional table no longer grows with the input."""
+        model, input_features, attention_mask = self._encoder(seq_length=1024, max_position_embeddings=16)
+        num_frames = 1024 // model.config.subsampling_factor
+        self.assertGreater(num_frames, model.config.max_position_embeddings)
+
+        model.change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[8, 8])
+        hidden_states, _ = self._run(model, input_features, attention_mask)
+        self.assertEqual(hidden_states.shape[1], num_frames)
+        self.assertTrue(torch.isfinite(hidden_states).all())
+
+        position_embeddings = model.encode_positions(
+            hidden_states, torch.arange(8, -9, -1, device=hidden_states.device)
+        )
+        self.assertEqual(position_embeddings.shape[1], 17)
+
+    def test_change_attention_model_round_trip(self):
+        model, input_features, attention_mask = self._encoder()
+        before, valid = self._run(model, input_features, attention_mask)
+
+        model.change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[8, 8])
+        self.assertEqual(model.config.attention_type, "rel_pos_local_attn")
+        self.assertEqual(model.config.attention_context_size, [8, 8])
+
+        model.change_attention_model(self_attention_model="rel_pos")
+        self.assertEqual(model.config.attention_type, "rel_pos")
+        after, _ = self._run(model, input_features, attention_mask)
+        torch.testing.assert_close(before, after)
+
+    def test_change_attention_model_validation(self):
+        model, _, _ = self._encoder(seq_length=128)
+        with self.assertRaises(ValueError):
+            model.change_attention_model(self_attention_model="unknown")
+        with self.assertRaises(ValueError):
+            model.change_attention_model(self_attention_model="rel_pos_local_attn")
+        with self.assertRaises(ValueError):
+            model.change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[8])
+        with self.assertRaises(ValueError):
+            model.change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[-1, 8])
+
+    def test_config_requires_context_size(self):
+        with self.assertRaises(ValueError):
+            ParakeetEncoderConfig(attention_type="rel_pos_local_attn")
+        with self.assertRaises(ValueError):
+            ParakeetEncoderConfig(attention_type="not_an_attention_type")
+
+    def test_ctc_model_delegates_to_encoder(self):
+        torch.manual_seed(0)
+        config = ParakeetCTCConfig(
+            vocab_size=32,
+            encoder_config=ParakeetEncoderConfig(
+                hidden_size=32,
+                num_hidden_layers=2,
+                num_attention_heads=4,
+                intermediate_size=64,
+                subsampling_conv_channels=16,
+            ),
+        )
+        model = ParakeetForCTC(config).to(torch_device).eval()
+        model.change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[16, 16])
+        self.assertEqual(model.encoder.config.attention_type, "rel_pos_local_attn")
+        self.assertEqual(model.encoder.config.attention_context_size, [16, 16])
+
+
 class ParakeetForCTCModelTester:
     def __init__(self, parent, encoder_kwargs=None, is_training=True, vocab_size=128, pad_token_id=0):
         if encoder_kwargs is None:


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48734&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48734) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48734&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48734)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #43383

Parakeet currently can't take much more than ~7 minutes of audio, while the same NeMo checkpoints transcribe hour-long files. This adds NeMo's `rel_pos_local_attn` as an inference-time switch, and it reproduces NeMo's output exactly on one hour of audio.

The issue thread diagnosed this as `max_position_embeddings=5000`, which is the right order of magnitude but not the actual blocker. Nothing reads that value at attention time, `ParakeetEncoderRelPositionalEncoding` builds positions on the fly. What breaks is that terms (b) and (d) in `ParakeetEncoderAttention` are materialised as a `(batch, heads, seq, 2 * seq - 1)` tensor. For one hour of audio (T = 45,001 subsampled frames) that single tensor is **121 GiB** in fp32, before any attention scores exist, so the process gets OOM-killed rather than hitting a clean error.

That also rules out implementing local attention as full attention plus a sliding-window mask: the windowing has to happen before that tensor is formed.

## What this adds

```python
model = ParakeetForCTC.from_pretrained("nvidia/parakeet-ctc-0.6b")
model.change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[256, 256])
```

mirroring NeMo's method of the same name, so the snippet from the issue transfers unchanged. The same switch is available up front through the config for checkpoints always used this way:

```python
ParakeetForCTC.from_pretrained(
    model_id, encoder_config={"attention_type": "rel_pos_local_attn", "attention_context_size": [256, 256]}
)
```

## Verification

`nvidia/parakeet-ctc-0.6b`, CPU, float32, against `nemo_toolkit[asr]` 3.0.0 with `change_attention_model(self_attention_model="rel_pos_local_attn", att_context_size=[256, 256])`:

| audio | encoder frames compared | encoder hidden max abs | CTC logits max abs | argmax agreement | transcription |
| --- | --- | --- | --- | --- | --- |
| 13.7 s + 14.2 s | 172 / 178 | 7.1e-05 | 1.4e-03 | 1.000000 | identical |
| 5 min | 3,750 | 3.4e-04 | 1.02e-02 | 1.000000 | identical |
| **1 hour** | **45,000** | **2.08e-03** | **3.75e-02** | **1.000000**, 0 frames differ | **identical**, 45,273 chars |

## Known limitation

`output_attentions=True` returns no attention weights under `rel_pos_local_attn` — the weights are never
materialised over the full sequence, which is the whole point. It warns rather than failing.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? — #43383
- [x] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@eustlb — Parakeet in `transformers`, and audio models generally
@vasqu — attention, and audio models
@nithinraok — for the NeMo side, since this mirrors `change_attention_model` and its window semantics