### PR TITLE
Let continuous batching page the call, not the model

### DIFF
--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -649,8 +649,13 @@ class ContinuousBatchingManager:
         self._use_prefix_sharing = self.continuous_batching_config.allow_block_sharing
 
     def switch_to_cb_friendly_attn(self, model: ProtoPretrainedModel) -> None:
-        """Switch the attn implementation to one that is CB friendly: try to find a flash implementation if flash is
-        requested and, in any cases, switch to a paged implementation."""
+        """Make sure the model can serve the engine: prefer a flash implementation, and page only what needs it.
+
+        `flash_attention_*` and `sdpa` need no change: their forwards route to the paged kernel when a call
+        carries a paged cache, so the engine and an ordinary forward share one model untouched. `eager` is the
+        exception, because every model defines its own eager forward and there is no single one to route, so it
+        still gets the `paged|` prefix and a model left on it cannot serve a training forward meanwhile.
+        """
         # The self._original_attn_impl is set only if the attn implementation is changed (makes this fn idempotent)
         original_attn_impl = model.config._attn_implementation
         target_implem = original_attn_impl
@@ -669,17 +674,20 @@ class ContinuousBatchingManager:
             # Change and warn
             msg = "Continuous batching is much better when using flash attention."
             if version is not None:
-                target_implem = f"flash_attention_{version}"  # no "paged|" prefix here to enter the branch below
+                target_implem = f"flash_attention_{version}"
                 logger.warning(
                     f"{msg} Switching from {original_attn_impl} to {target_implem}. "
-                    "If you need to use eager or sdpa, use paged|eager or paged|sdpa as the `attn_implementation`."
+                    "Set `_supports_flash_attn = False` on the model to keep the implementation you loaded."
                 )
             else:
                 logger.info(f"{msg} Consider using a flash `attn_implementation` when loading the model.")
 
-        # Switch to a paged implementation (always entered if conversion to flash happened)
-        if "paged|" not in target_implem:
-            model.set_attn_implementation(f"paged|{target_implem}")
+        # Only eager has to be paged through the config; everything else reaches the paged kernel from the forward
+        # kwargs and is left exactly as the user loaded it.
+        if target_implem == "eager":
+            target_implem = "paged|eager"
+        if target_implem != original_attn_impl:
+            model.set_attn_implementation(target_implem)
             self._original_attn_impl = original_attn_impl
 
     def warmup(self) -> None:

--- a/src/transformers/generation/continuous_batching/utils.py
+++ b/src/transformers/generation/continuous_batching/utils.py
@@ -20,6 +20,7 @@ from typing import Any
 import torch
 
 from transformers.configuration_utils import PretrainedConfig
+from transformers.utils.generic import is_flash_attention_requested
 
 from .requests import FutureRequestState, RequestState, RequestStatus
 
@@ -52,8 +53,13 @@ class WorkloadHints:
 
 
 def attn_mask_is_needed(config: PretrainedConfig) -> bool:
-    """Checks if attention mask is needed for the given (config)."""
-    return config._attn_implementation in ["paged|eager", "paged|sdpa"]
+    """Whether the engine has to materialise a mask for this attention implementation.
+
+    Flash builds its own from the cumulative sequence lengths; eager and sdpa attend over the packed batch and
+    need the block-diagonal mask spelled out. Keyed off the implementation itself rather than a `paged|` prefix,
+    because only eager still carries one.
+    """
+    return not is_flash_attention_requested(config)
 
 
 def pad_to_interval(size: int, interval_size: int, max_value: int) -> int:

--- a/src/transformers/integrations/flash_attention.py
+++ b/src/transformers/integrations/flash_attention.py
@@ -2,6 +2,7 @@ import torch
 
 from ..modeling_flash_attention_utils import _flash_attention_forward, flash_attn_supports_top_left_mask
 from ..utils import logging
+from .paged_dispatch import is_paged_call
 
 
 logger = logging.get_logger(__name__)
@@ -37,6 +38,13 @@ def flash_attention_forward(
     s_aux: torch.Tensor | None = None,  # alias: learnable attention sink
     **kwargs,
 ) -> tuple[torch.Tensor, None]:
+    if is_paged_call(kwargs):
+        from .flash_paged import paged_attention_forward
+
+        if s_aux is not None:
+            kwargs["s_aux"] = s_aux
+        return paged_attention_forward(module, query, key, value, attention_mask, **kwargs)
+
     if kwargs.get("output_attentions", False):
         logger.warning_once(
             "Flash Attention does not support `output_attentions=True`."

--- a/src/transformers/integrations/paged_dispatch.py
+++ b/src/transformers/integrations/paged_dispatch.py
@@ -1,0 +1,30 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Telling a continuous batching forward apart from an ordinary one, by what the call carries."""
+
+
+def is_paged_call(kwargs: dict) -> bool:
+    """Whether these forward kwargs carry a continuous batching paged cache.
+
+    Continuous batching passes its cache, and the packed-input metadata that goes with it, through the model
+    forward kwargs. That makes paged-ness a property of the call rather than of the model, so the engine does
+    not have to switch the model to a `paged|` implementation, and the model stays usable for an ordinary
+    forward while the engine runs.
+    """
+    cache = kwargs.get("cache")
+    if cache is None:
+        return False
+    from ..generation.continuous_batching import PagedAttentionCache
+
+    return isinstance(cache, PagedAttentionCache)

--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -2,6 +2,7 @@ import torch
 
 from ..utils import is_torch_npu_available, is_torch_xpu_available, logging
 from ..utils.import_utils import is_torch_greater_or_equal
+from .paged_dispatch import is_paged_call
 
 
 logger = logging.get_logger(__name__)
@@ -88,6 +89,13 @@ def sdpa_attention_forward(
     position_bias: torch.Tensor | None = None,
     **kwargs,
 ) -> tuple[torch.Tensor, None]:
+    if is_paged_call(kwargs):
+        from .sdpa_paged import sdpa_attention_paged_forward
+
+        return sdpa_attention_paged_forward(
+            module, query, key, value, attention_mask, dropout=dropout, scaling=scaling, **kwargs
+        )
+
     if kwargs.get("output_attentions", False):
         logger.warning_once(
             "`sdpa` attention does not support `output_attentions=True`."

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -958,21 +958,29 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            # (loaded_attn_implementation, supports_flash_attn, expect_flash_after_switch)
-            ("sdpa", True, True),  # flash-capable model on a non-flash impl -> auto-switched to a paged flash impl
-            ("paged|sdpa", True, False),  # an explicit paged request is respected: no flash upgrade
-            ("sdpa", False, False),  # _supports_flash_attn=False opts out: stays on paged|sdpa
+            # (loaded_attn_implementation, supports_flash_attn, expected_after_switch)
+            ("sdpa", True, None),  # flash-capable model on a non-flash impl -> auto-switched to flash
+            ("flash_attention_2", True, None),  # already flash -> left exactly as loaded
+            ("paged|sdpa", True, "paged|sdpa"),  # an explicit paged request is respected: no flash upgrade
+            ("sdpa", False, "sdpa"),  # no flash available: sdpa serves the engine unpaged
+            ("eager", False, "paged|eager"),  # eager is the one that still has to be paged
         ]
     )
     @slow
     def test_switch_to_cb_friendly_attn(
-        self, attn_implementation: str, supports_flash_attn: bool, expect_flash_after_switch: bool
+        self, attn_implementation: str, supports_flash_attn: bool, expected_after_switch: str | None
     ) -> None:
-        """Continuous batching switches to a paged (ideally flash) attention and restores the original on stop."""
+        """Continuous batching prefers flash, and only pages what it has to.
+
+        `flash_attention_*` and `sdpa` reach the paged kernel from the forward kwargs, so the model keeps the
+        implementation it was loaded with and stays usable for an ordinary forward while the engine runs. Only
+        `eager` still gets the `paged|` prefix, since every model brings its own eager forward.
+        `expected_after_switch` of `None` means "whatever flash resolved to".
+        """
         flash_available = is_flash_attn_2_available(kernels_fallback_ok=True)
         flash_available |= is_flash_attn_3_available(kernels_fallback_ok=True)
 
-        if expect_flash_after_switch and not flash_available:
+        if expected_after_switch is None and not flash_available:
             self.skipTest("Flash attention is unavailable, cannot test the auto-switch to flash.")
 
         model_id = "Qwen/Qwen2.5-0.5B-Instruct"
@@ -985,16 +993,68 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             continuous_batching_config=ContinuousBatchingConfig(num_blocks=8, block_size=32, use_cuda_graph=False)
         )
         switched_attn_impl = model.config._attn_implementation
-        self.assertTrue(switched_attn_impl.startswith("paged|"), f"Expected a paged impl, got {switched_attn_impl}")
-        is_flash = is_flash_attention_requested(requested_attention_implementation=switched_attn_impl)
-        self.assertEqual(is_flash, expect_flash_after_switch)
-        if not expect_flash_after_switch:
-            self.assertEqual(switched_attn_impl, "paged|sdpa")
+        if expected_after_switch is None:
+            is_flash = is_flash_attention_requested(requested_attention_implementation=switched_attn_impl)
+            self.assertTrue(is_flash, f"Expected a flash impl, got {switched_attn_impl}")
+            # left unpaged, so an ordinary forward on this model still works
+            self.assertFalse(
+                switched_attn_impl.startswith("paged|"), f"Expected an unpaged flash impl, got {switched_attn_impl}"
+            )
+        else:
+            self.assertEqual(switched_attn_impl, expected_after_switch)
 
         # Starting then stopping the manager restores the original attention implementation
         manager.start()
         manager.stop(block=True)
         self.assertEqual(model.config._attn_implementation, original_attn_impl)
+
+    @parameterized.expand([("flash_attention_2",), ("sdpa",)])
+    @slow
+    def test_forward_and_backward_while_the_engine_runs(self, attn_implementation: str) -> None:
+        """The model stays trainable while continuous batching generates from it.
+
+        The engine reaches the paged kernel through the forward kwargs, so it has no reason to move the model off
+        the implementation it was loaded with, and an ordinary forward is still an ordinary forward. Without
+        that, the training forward lands in the paged kernel with no paged cache.
+        """
+        if attn_implementation == "flash_attention_2" and not (
+            is_flash_attn_2_available(kernels_fallback_ok=True) or is_flash_attn_3_available(kernels_fallback_ok=True)
+        ):
+            self.skipTest("Flash attention is unavailable.")
+
+        model_id = "Qwen/Qwen2.5-0.5B-Instruct"
+        tokenizer, model = get_tokenizer_and_model(model_id, attn_implementation, torch_device, torch.bfloat16)
+        # The engine upgrades a non-flash implementation to flash when the model supports it, which would test the
+        # flash path twice
+        model._supports_flash_attn = attn_implementation != "sdpa"
+        attn_impl_before = model.config._attn_implementation
+
+        # block_size has to stay a multiple of 256: this test generates, so it reaches `flash_attn_with_kvcache`
+        manager = model.init_continuous_batching(
+            continuous_batching_config=ContinuousBatchingConfig(num_blocks=8, block_size=256, use_cuda_graph=False)
+        )
+        self.assertEqual(model.config._attn_implementation, attn_impl_before)
+        manager.start()
+        try:
+            manager.add_request(tokenizer.encode("The capital of France is"), request_id="gen", max_new_tokens=5)
+            self.assertIsNotNone(manager.get_result(timeout=60))
+
+            # The model the engine is decoding from also takes a training step
+            batch = tokenizer(["A training batch."], return_tensors="pt").to(torch_device)
+            batch["labels"] = batch["input_ids"].clone()
+            model.train()
+            loss = model(**batch).loss
+            loss.backward()
+            self.assertTrue(torch.isfinite(loss).item())
+            self.assertTrue(any(p.grad is not None and p.grad.abs().sum() > 0 for p in model.parameters()))
+            model.zero_grad(set_to_none=True)
+            model.eval()
+
+            # and the engine keeps working afterwards
+            manager.add_request(tokenizer.encode("Name a cat breed:"), request_id="after", max_new_tokens=5)
+            self.assertIsNotNone(manager.get_result(timeout=60))
+        finally:
+            manager.stop(block=True)
 
     # FIXME: Qwen2.5-0.5B-Instruct is not here because it's  broken (it uses a repetition penalty logits processor)
     # TODO: replace gemma2 with a tiny version of GPT-OSS? That way we can test sliding window AND attention sink


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48735&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48735) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48735&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48735)
<!-- ci-dashboard-badge:end -->

## What

`init_continuous_batching` puts `paged|<impl>` on the model and only `stop()` takes it off. So while the engine is alive, any ordinary forward on that model lands in the paged kernel with no paged cache:

```python
manager = model.init_continuous_batching(generation_config=cfg)
manager.start()
model(input_ids=batch, labels=batch).loss.backward()
# ValueError: `paged|sdpa` was called without a paged attention cache
# or TypeError: paged_attention_forward() missing 6 required positional arguments
```

That blocks training a model while generating from it, which is the whole point of the pause mechanism in #48462 (finding 1 of my review there).

## The change

Paged-ness is a property of the call, not of the model. The engine already passes its cache and all the packed-input metadata (`cu_seq_lens_q/k`, `read_index`, `write_index`, `block_table`) through the forward kwargs. So `flash_attention_forward` and `sdpa_attention_forward` route to their paged counterpart when the call carries a `PagedAttentionCache`, and stay ordinary otherwise:

```python
if is_paged_call(kwargs):
    from .sdpa_paged import sdpa_attention_paged_forward
    return sdpa_attention_paged_forward(...)
```

The model then stays on the implementation it was loaded with and serves both paths. `switch_to_cb_friendly_attn` still upgrades to flash when available, it just no longer rewrites the implementation string.

`eager` keeps the `paged|` prefix: 334 modeling files define their own `eager_attention_forward` and `"eager"` is never registered in `ALL_ATTENTION_FUNCTIONS`, so there is no single forward to route.

The mask needed no change. Flash builds its own from the cumulative seqlens, and for eager/sdpa the engine's 4D mask hits the early return at the top of `_preprocess_mask_arguments`, so `create_causal_mask` never runs.

This is the direction that #48297 tried in a19f0d7 and dropped on review, flipped: the fallback there was paged -> plain when no cache, here it is plain -> paged when there is one.

## Measured

Qwen2.5-0.5B, H100, generate 3 prompts / training forward+backward / generate again, all with the manager running:

| attn | compile | before | after |
|---|---|---|---|
| flash_attention_3 | 0 | TypeError | loss 6.9144, stays flash |
| flash_attention_3 | 1 | TypeError | loss 6.9144, stays flash |
| sdpa | 0 | ValueError | loss 6.9410, stays sdpa |
| sdpa | 1 | ValueError | loss 6.9410, stays sdpa |

Completions before the training step are byte-identical to main.