### PR TITLE
Keep image processor backends in sync on keys and dtypes

### DIFF
--- a/src/transformers/models/fuyu/image_processing_pil_fuyu.py
+++ b/src/transformers/models/fuyu/image_processing_pil_fuyu.py
@@ -211,6 +211,7 @@ class FuyuImageProcessorPil(PilBackend):
                 "image_unpadded_heights": image_unpadded_heights,
                 "image_unpadded_widths": image_unpadded_widths,
                 "image_scale_factors": image_scale_factors,
+                "image_sizes": original_image_sizes,
             },
             tensor_type=return_tensors,
             skip_tensor_conversion=["overflowing_values"],

--- a/src/transformers/models/idefics2/image_processing_idefics2.py
+++ b/src/transformers/models/idefics2/image_processing_idefics2.py
@@ -269,6 +269,7 @@ class Idefics2ImageProcessor(TorchvisionBackend):
                 len(processed_images),
                 max_num_images,
                 *(max_height, max_width),
+                dtype=torch.int64,
                 device=processed_images[0][0].device,
             )
             for i, images in enumerate(processed_images):

--- a/src/transformers/models/idefics3/image_processing_idefics3.py
+++ b/src/transformers/models/idefics3/image_processing_idefics3.py
@@ -475,6 +475,7 @@ class Idefics3ImageProcessor(TorchvisionBackend):
                 len(processed_images),
                 max_num_images,
                 *(max_height, max_width),
+                dtype=torch.int64,
                 device=device,
             )
             for i, images in enumerate(processed_images):

--- a/src/transformers/models/smolvlm/image_processing_smolvlm.py
+++ b/src/transformers/models/smolvlm/image_processing_smolvlm.py
@@ -464,6 +464,7 @@ class SmolVLMImageProcessor(TorchvisionBackend):
                 len(processed_images),
                 max_num_images,
                 *(max_height, max_width),
+                dtype=torch.int64,
                 device=device,
             )
             for i, images in enumerate(processed_images):

--- a/tests/models/fuyu/test_image_processing_fuyu.py
+++ b/tests/models/fuyu/test_image_processing_fuyu.py
@@ -183,9 +183,14 @@ class FuyuImageProcessorTest(ImageProcessingTestMixin, unittest.TestCase):
             encodings[backend_name] = image_processor(dummy_image, return_tensors="pt")
 
         backend_names = list(encodings.keys())
-        reference_encoding = encodings[backend_names[0]].images[0][0]
+        reference_backend = backend_names[0]
+        reference_encoding = encodings[reference_backend].images[0][0]
         for backend_name in backend_names[1:]:
             self._assert_tensors_equivalence(reference_encoding, encodings[backend_name].images[0][0])
+            # `images` is a nested list, the remaining keys are tensors and must match too
+            self._assert_encodings_equivalence(
+                encodings[reference_backend], encodings[backend_name], reference_backend, backend_name
+            )
 
     def test_backends_equivalence_batched(self):
         """Override to handle Fuyu's custom output structure"""

--- a/tests/models/idefics2/test_image_processing_idefics2.py
+++ b/tests/models/idefics2/test_image_processing_idefics2.py
@@ -362,8 +362,8 @@ class Idefics2ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         backend_names = list(encodings.keys())
         reference_backend = backend_names[0]
         reference_pixel_values = encodings[reference_backend].pixel_values
-        reference_mask = encodings[reference_backend].pixel_attention_mask.float()
+        reference_mask = encodings[reference_backend].pixel_attention_mask
 
         for backend_name in backend_names[1:]:
             self._assert_tensors_equivalence(reference_pixel_values, encodings[backend_name].pixel_values)
-            self._assert_tensors_equivalence(reference_mask, encodings[backend_name].pixel_attention_mask.float())
+            self._assert_masks_equivalence(reference_mask, encodings[backend_name].pixel_attention_mask)

--- a/tests/models/idefics3/test_image_processing_idefics3.py
+++ b/tests/models/idefics3/test_image_processing_idefics3.py
@@ -302,9 +302,9 @@ class Idefics3ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
             self._assert_tensors_equivalence(
                 encodings[reference_backend].pixel_values, encodings[backend_name].pixel_values
             )
-            self._assert_tensors_equivalence(
-                encodings[reference_backend].pixel_attention_mask.float(),
-                encodings[backend_name].pixel_attention_mask.float(),
+            self._assert_masks_equivalence(
+                encodings[reference_backend].pixel_attention_mask,
+                encodings[backend_name].pixel_attention_mask,
             )
             self.assertEqual(encodings[reference_backend].rows, encodings[backend_name].rows)
             self.assertEqual(encodings[reference_backend].cols, encodings[backend_name].cols)
@@ -341,9 +341,9 @@ class Idefics3ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
             self._assert_tensors_equivalence(
                 encodings[reference_backend].pixel_values, encodings[backend_name].pixel_values, atol=3e-1
             )
-            self._assert_tensors_equivalence(
-                encodings[reference_backend].pixel_attention_mask.float(),
-                encodings[backend_name].pixel_attention_mask.float(),
+            self._assert_masks_equivalence(
+                encodings[reference_backend].pixel_attention_mask,
+                encodings[backend_name].pixel_attention_mask,
             )
             self.assertEqual(encodings[reference_backend].rows, encodings[backend_name].rows)
             self.assertEqual(encodings[reference_backend].cols, encodings[backend_name].cols)

--- a/tests/models/smolvlm/test_image_processing_smolvlm.py
+++ b/tests/models/smolvlm/test_image_processing_smolvlm.py
@@ -302,9 +302,7 @@ class SmolVLMImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         for backend_name in backend_names[1:]:
             encoding = encodings[backend_name]
             self._assert_tensors_equivalence(reference.pixel_values, encoding.pixel_values)
-            self._assert_tensors_equivalence(
-                reference.pixel_attention_mask.float(), encoding.pixel_attention_mask.float()
-            )
+            self._assert_masks_equivalence(reference.pixel_attention_mask, encoding.pixel_attention_mask)
             self.assertEqual(reference.rows, encoding.rows)
             self.assertEqual(reference.cols, encoding.cols)
 
@@ -340,9 +338,7 @@ class SmolVLMImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         for backend_name in backend_names[1:]:
             encoding = encodings[backend_name]
             self._assert_tensors_equivalence(reference.pixel_values, encoding.pixel_values, atol=3e-1)
-            self._assert_tensors_equivalence(
-                reference.pixel_attention_mask.float(), encoding.pixel_attention_mask.float()
-            )
+            self._assert_masks_equivalence(reference.pixel_attention_mask, encoding.pixel_attention_mask)
             self.assertEqual(reference.rows, encoding.rows)
             self.assertEqual(reference.cols, encoding.cols)
 

--- a/tests/test_image_processing_common.py
+++ b/tests/test_image_processing_common.py
@@ -282,6 +282,43 @@ class ImageProcessingTestMixin:
         torch.testing.assert_close(tensor1, tensor2, atol=atol, rtol=rtol)
         self.assertLessEqual(torch.mean(torch.abs(tensor1 - tensor2)).item(), mean_atol)
 
+    def _assert_masks_equivalence(self, mask1, mask2):
+        """Masks are discrete, so the backends must agree on both the dtype and every value."""
+        self.assertEqual(mask1.dtype, mask2.dtype)
+        self.assertTrue(torch.equal(mask1, mask2))
+
+    def _assert_encodings_equivalence(self, reference_encoding, encoding, reference_backend, backend_name):
+        """Assert that two backends return the same outputs, not just the same pixel values.
+
+        Float outputs are compared with tolerances because the backends resize differently;
+        discrete outputs (masks, sizes, token ids) must match exactly.
+        """
+        self.assertEqual(
+            set(reference_encoding.keys()),
+            set(encoding.keys()),
+            f"{backend_name} returns different keys than {reference_backend}",
+        )
+        for key in reference_encoding:
+            reference_value, value = reference_encoding[key], encoding[key]
+            if not (torch.is_tensor(reference_value) and torch.is_tensor(value)):
+                continue
+            self.assertEqual(
+                reference_value.dtype,
+                value.dtype,
+                f"`{key}` has dtype {value.dtype} in {backend_name} and "
+                f"{reference_value.dtype} in {reference_backend}",
+            )
+            self.assertEqual(
+                reference_value.shape,
+                value.shape,
+                f"`{key}` has shape {tuple(value.shape)} in {backend_name} and "
+                f"{tuple(reference_value.shape)} in {reference_backend}",
+            )
+            if reference_value.is_floating_point():
+                self._assert_tensors_equivalence(reference_value, value)
+            else:
+                self.assertTrue(torch.equal(reference_value, value), f"`{key}` differs from {reference_backend}")
+
     @require_vision
     @require_torch
     def test_backends_equivalence(self):
@@ -299,9 +336,11 @@ class ImageProcessingTestMixin:
         # Compare all backends to the first one (reference backend)
         backend_names = list(encodings.keys())
         reference_backend = backend_names[0]
-        reference_encoding = encodings[reference_backend].pixel_values
+        reference_encoding = encodings[reference_backend]
         for backend_name in backend_names[1:]:
-            self._assert_tensors_equivalence(reference_encoding, encodings[backend_name].pixel_values)
+            self._assert_encodings_equivalence(
+                reference_encoding, encodings[backend_name], reference_backend, backend_name
+            )
 
     @require_vision
     @require_torch
@@ -320,9 +359,11 @@ class ImageProcessingTestMixin:
         # Compare all backends to the first one (reference backend)
         backend_names = list(encodings.keys())
         reference_backend = backend_names[0]
-        reference_encoding = encodings[reference_backend].pixel_values
+        reference_encoding = encodings[reference_backend]
         for backend_name in backend_names[1:]:
-            self._assert_tensors_equivalence(reference_encoding, encodings[backend_name].pixel_values)
+            self._assert_encodings_equivalence(
+                reference_encoding, encodings[backend_name], reference_backend, backend_name
+            )
 
     def test_image_processor_to_json_string(self):
         for image_processing_class in self.image_processing_classes.values():


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48739&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48739) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=48739&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=48739)
<!-- ci-dashboard-badge:end -->

# What does this PR do?

Fixes #48738.

The torchvision backends of Idefics2, Idefics3 and SmolVLM allocate the batch `pixel_attention_mask` buffer without a dtype:

```python
pixel_attention_masks = torch.zeros(
    len(processed_images),
    max_num_images,
    *(max_height, max_width),
    device=device,
)
```

so the int64 masks that `pad()` builds are stored as float32, while the PIL backend returns int64 and `Idefics3Model.forward` documents the argument as a `LongTensor`. Every other image processor that builds a mask passes an integral dtype explicitly (DETR and friends, Mask2Former, MaskFormer and YOLOS use `torch.int64`, Aria uses `torch.bool`, Mllama uses `torch.long`), so this is just a missing argument in three places. SmolVLM is regenerated through `modular_smolvlm.py`.

The Fuyu PIL backend already computes `original_image_sizes` but never returns it, so its output was missing the `image_sizes` key that the torchvision backend returns.

`test_backends_equivalence` compared `pixel_values` and nothing else, and the Idefics2, Idefics3 and SmolVLM overrides compared the masks as `pixel_attention_mask.float()`, which normalizes the dtype away before the assertion. This PR compares every returned key instead: same keys, same dtype and shape, exact equality for integral outputs and the existing tolerances for float ones. The `.float()` calls are no longer needed.

## Testing

```
pytest tests/models/{idefics2,idefics3,smolvlm,fuyu}/test_image_processing_*.py -k backends_equivalence
```

- with the stronger test but without the source fixes: 7 failed, 1 passed (the remaining pass is the Fuyu batched test, which compares only `images`)
- with this branch: those four test files run in full, 95 passed, 17 skipped

```
pytest tests/models/*/test_image_processing_*.py -k backends_equivalence
```

- 190 passed, 63 skipped, no failures, so no other model is affected by the stricter comparison

Also ran `ruff check` and `ruff format --check` (0.14.10, the version pinned in `setup.py`) and `utils/check_modular_conversion.py --files src/transformers/models/smolvlm/modular_smolvlm.py` on the changed files, all clean. Python 3.13, torch 2.11.0, torchvision 0.26.0, CPU.

The draft #48192 touches the same functions but renames loop variables rather than the mask buffers, so the two should not collide.

## AI assistance

I used Claude Code to sweep the 92 processor pairs and to help draft the change. I verified each divergence myself, wrote and ran the before and after test runs, and reviewed every line of the diff.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/transformers/contributing) and the
      [Pull Request](https://huggingface.co/docs/transformers/pr_checks) checks?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. (#48738)
- [ ] Did you make sure to update the documentation with your changes according to the [guidelines](https://github.com/huggingface/transformers/tree/main/docs)?
- [x] Did you write any new necessary [tests](https://huggingface.co/docs/transformers/testing)?

## Who can review?

@molbap @guarin