### PR TITLE
docs: Document DynamicCache API removals in v5 migration guide (fixes #48507)

### DIFF
--- a/docs/MIGRATION_GUIDE_V5.md
+++ b/docs/MIGRATION_GUIDE_V5.md
@@ -554,6 +554,8 @@ Linked PRs:
 - If `generate` doesn't receive any KV Cache argument, the default cache class used is now defined by the model (as opposed to always being `DynamicCache`) (https://github.com/huggingface/transformers/pull/41505)
 - Generation parameters are no longer accessible via model's config. If generation parameters are serialized in `config.json` for any old model, it will be loaded back into model's generation config. Users are expected to access or modify generation parameters only with `model.generation_config.do_sample = True`. 
 
+- `DynamicCache.key_cache`, `DynamicCache.value_cache`, `DynamicCache.from_legacy_cache()` and `DynamicCache.to_legacy_cache()` were removed in v5. Use the surviving public API instead: `get_seq_length`, `update`, `crop`, `from_batch_splits`, `reset`, or the new `CacheLayerMixin`. (https://github.com/huggingface/transformers/pull/48479)
+
 ## Trainer
 
 ### Removing arguments without deprecation cycle in `TrainingArguments` due to low usage


### PR DESCRIPTION
This PR adds documentation for the DynamicCache API removals in v5 migration guide.

Fixes #48507

The issue reported that `DynamicCache.key_cache`, `DynamicCache.value_cache`, `DynamicCache.from_legacy_cache()` and `DynamicCache.to_legacy_cache()` were removed in v5 but not documented in the migration guide, so users hit a bare `AttributeError` on upgrade with no pointer to the replacement.

This PR adds a bullet point under the `### Generate` section pointing users at the surviving public API: `get_seq_length`, `update`, `crop`, `from_batch_splits`, `reset`, or the new `CacheLayerMixin`.
